### PR TITLE
Implement $4015 status register read

### DIFF
--- a/src/apu/noise.rs
+++ b/src/apu/noise.rs
@@ -172,6 +172,11 @@ impl Noise {
             self.length_counter = 0;
         }
     }
+
+    /// Get the current length counter value
+    pub fn get_length_counter(&self) -> u8 {
+        self.length_counter
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Overview

Implements reading from the $4015 status register to report channel and interrupt status, completing issue #98.

## Changes

### Status Register Read
- ✅ Added `read_status()` method to Apu
- ✅ Returns status bits for all 5 channels (pulse1, pulse2, triangle, noise, DMC)
- ✅ Returns interrupt flags (frame counter IRQ, DMC IRQ)
- ✅ Side effect: Clears frame counter interrupt flag (but not DMC IRQ)
- ✅ Defined status bit constants for clarity

### Supporting Changes
- ✅ Added `get_length_counter()` method to Noise channel
- ✅ Matches existing pattern from Pulse and Triangle channels

### Testing
- ✅ 6 new unit tests for status register
  - `test_status_all_channels_inactive` - All channels start inactive
  - `test_status_pulse1_active` - Pulse 1 bit set when active
  - `test_status_pulse2_active` - Pulse 2 bit set when active
  - `test_status_triangle_active` - Triangle bit set when active
  - `test_status_noise_active` - Noise bit set when active
  - `test_status_all_channels_active` - All channel bits set
- ✅ All 23 APU tests passing

## Technical Details

**Status Register Format ($4015 read):** `IF-D NT21`
- Bit 7 (I): DMC interrupt flag
- Bit 6 (F): Frame counter interrupt flag
- Bit 5: Open bus (returns 0)
- Bit 4 (D): DMC active (bytes remaining > 0)
- Bit 3 (N): Noise length counter > 0
- Bit 2 (T): Triangle length counter > 0
- Bit 1 (2): Pulse 2 length counter > 0
- Bit 0 (1): Pulse 1 length counter > 0

## Test Results
```
running 23 tests
test apu::apu::tests::test_apu_new ... ok
test apu::apu::tests::test_both_pulse_channels_get_clocked ... ok
test apu::apu::tests::test_dmc_channel_accessible ... ok
test apu::apu::tests::test_dmc_channel_mutable ... ok
test apu::apu::tests::test_dmc_timer_gets_clocked ... ok
test apu::apu::tests::test_envelope_gets_clocked ... ok
test apu::apu::tests::test_frame_counter_advances ... ok
test apu::apu::tests::test_frame_counter_mode_change ... ok
test apu::apu::tests::test_length_counter_gets_clocked ... ok
test apu::apu::tests::test_noise_channel_integrated ... ok
test apu::apu::tests::test_noise_envelope_gets_clocked ... ok
test apu::apu::tests::test_noise_length_counter_gets_clocked ... ok
test apu::apu::tests::test_pulse1_uses_ones_complement_for_sweep ... ok
test apu::apu::tests::test_pulse2_uses_twos_complement_for_sweep ... ok
test apu::apu::tests::test_status_all_channels_active ... ok
test apu::apu::tests::test_status_all_channels_inactive ... ok
test apu::apu::tests::test_status_noise_active ... ok
test apu::apu::tests::test_status_pulse1_active ... ok
test apu::apu::tests::test_status_pulse2_active ... ok
test apu::apu::tests::test_status_triangle_active ... ok
test apu::apu::tests::test_sweep_gets_clocked ... ok
test apu::apu::tests::test_triangle_length_counter_gets_clocked ... ok
test apu::apu::tests::test_triangle_linear_counter_gets_clocked ... ok

test result: ok. 23 passed
```

Part of #69 (APU Main Module Integration)

Closes #98