### PR TITLE
Implement $4015 enable register write

### DIFF
--- a/src/apu/dmc.rs
+++ b/src/apu/dmc.rs
@@ -204,6 +204,11 @@ impl Dmc {
         self.interrupt_flag
     }
 
+    /// Clear the IRQ flag (side effect of writing to $4015)
+    pub fn clear_irq_flag(&mut self) {
+        self.interrupt_flag = false;
+    }
+
     /// Check if the channel has bytes remaining (for status register $4015 bit 4)
     pub fn has_bytes_remaining(&self) -> bool {
         self.bytes_remaining > 0


### PR DESCRIPTION
## Overview

Implements writing to the $4015 enable register to control which channels are active, completing issue #99.

## Changes

### Enable Register Write
- ✅ Added `write_enable()` method to Apu
- ✅ Enable/disable all 5 channels via status bits
- ✅ Writing 0 to pulse/triangle/noise halts their length counters
- ✅ DMC: Writing 0 clears bytes_remaining, writing 1 restarts sample if empty
- ✅ Side effect: Clears DMC interrupt flag on every write

### Supporting Changes
- ✅ Added `clear_irq_flag()` method to DMC channel

### Testing
- ✅ 7 new unit tests for enable register
  - `test_enable_disable_pulse1` - Disable clears length counter
  - `test_enable_pulse1_with_enable_bit` - Enable allows loading
  - `test_enable_all_channels` - All channels can be enabled
  - `test_disable_clears_length_counters` - Disable clears all counters
  - `test_enable_dmc_restarts_sample_when_empty` - DMC restart behavior
  - `test_disable_dmc_clears_bytes_remaining` - DMC disable behavior
  - `test_write_enable_clears_dmc_interrupt` - IRQ flag cleared
- ✅ All 30 APU tests passing

## Technical Details

**Enable Register Format ($4015 write):** `---D NT21`
- Bit 4 (D): Enable DMC
- Bit 3 (N): Enable Noise
- Bit 2 (T): Enable Triangle
- Bit 1 (2): Enable Pulse 2
- Bit 0 (1): Enable Pulse 1

**Behavior:**
- Writing 0: Silences channel, halts length counter (sets to 0)
- Writing 1: Enables channel
- DMC special: If enabled with bytes_remaining=0, restarts sample
- Side effect: Always clears DMC interrupt flag

## Test Results
```
running 30 tests
test apu::apu::tests::test_apu_new ... ok
test apu::apu::tests::test_both_pulse_channels_get_clocked ... ok
test apu::apu::tests::test_dmc_channel_accessible ... ok
test apu::apu::tests::test_dmc_channel_mutable ... ok
test apu::apu::tests::test_dmc_timer_gets_clocked ... ok
test apu::apu::tests::test_disable_clears_length_counters ... ok
test apu::apu::tests::test_disable_dmc_clears_bytes_remaining ... ok
test apu::apu::tests::test_enable_all_channels ... ok
test apu::apu::tests::test_enable_disable_pulse1 ... ok
test apu::apu::tests::test_enable_dmc_restarts_sample_when_empty ... ok
test apu::apu::tests::test_enable_pulse1_with_enable_bit ... ok
test apu::apu::tests::test_envelope_gets_clocked ... ok
test apu::apu::tests::test_frame_counter_advances ... ok
test apu::apu::tests::test_frame_counter_mode_change ... ok
test apu::apu::tests::test_length_counter_gets_clocked ... ok
test apu::apu::tests::test_noise_channel_integrated ... ok
test apu::apu::tests::test_noise_envelope_gets_clocked ... ok
test apu::apu::tests::test_noise_length_counter_gets_clocked ... ok
test apu::apu::tests::test_pulse1_uses_ones_complement_for_sweep ... ok
test apu::apu::tests::test_pulse2_uses_twos_complement_for_sweep ... ok
test apu::apu::tests::test_status_all_channels_active ... ok
test apu::apu::tests::test_status_all_channels_inactive ... ok
test apu::apu::tests::test_status_noise_active ... ok
test apu::apu::tests::test_status_pulse1_active ... ok
test apu::apu::tests::test_status_pulse2_active ... ok
test apu::apu::tests::test_status_triangle_active ... ok
test apu::apu::tests::test_sweep_gets_clocked ... ok
test apu::apu::tests::test_triangle_length_counter_gets_clocked ... ok
test apu::apu::tests::test_triangle_linear_counter_gets_clocked ... ok
test apu::apu::tests::test_write_enable_clears_dmc_interrupt ... ok

test result: ok. 30 passed
```

Part of #69 (APU Main Module Integration)

Closes #99