### PR TITLE
Implement interrupt hijacking for BRK instruction

### DIFF
--- a/src/newcpu/decoder.rs
+++ b/src/newcpu/decoder.rs
@@ -130,7 +130,7 @@ pub fn decode_opcode(
         // BRK - Break
         0x00 => (
             Box::new(Implied),
-            Box::new(NOP),
+            Box::new(BRK),
             InstructionType::Control,
             7,
         ),


### PR DESCRIPTION
Implements 6502 interrupt hijacking behavior where NMI can hijack BRK/IRQ during execution, as documented in NesDev wiki.

## Changes

- **decoder.rs**: Changed opcode 0x00 from NOP to BRK operation
- **sequencer.rs**: Added nmi_pending parameter, implemented BRK in Execute phase with vector address constants
- **cpu.rs**: Updated to pass nmi_pending flag through call chain, improved vector constant documentation
- **operations.rs**: Modified execute_brk to only prepare values (not modify SP), improved documentation

## Behavior

When NMI is asserted during BRK execution:
- B flag is still set on stack (distinguishes from hardware interrupt)
- Execution jumps to NMI vector (0xFFFA) instead of IRQ/BRK vector (0xFFFE)
- Vector selection happens during fetch (cycles 6-7), not at sequence start

## Tests

- ✅ test_brk_basic_execution: Verifies basic BRK execution to IRQ vector
- ✅ test_nmi_hijacks_brk_uses_nmi_vector_but_sets_b_flag: Verifies hijacking behavior
- ✅ Updated 4 existing BRK unit tests in operations.rs
- ✅ All 146 newcpu tests pass

Fixes #131