### PR TITLE
Sub-issue (158): enable blargg_apu_2005.07.30 01.len_ctr

### DIFF
--- a/src/blargg_tests.rs
+++ b/src/blargg_tests.rs
@@ -483,4 +483,9 @@ mod tests {
         test_apu_test_8,
         "roms/blargg/apu_test/rom_singles/8-dmc_rates.nes"
     );
+
+    blargg_console_test!(
+        test_blargg_apu_2005_01_len_ctr,
+        "roms/blargg/blargg_apu_2005.07.30/01.len_ctr.nes"
+    );
 }


### PR DESCRIPTION
Closes #158.

Enables a blargg console-based integration test for `roms/blargg/blargg_apu_2005.07.30/01.len_ctr.nes`.

Verification:
- `cargo test blargg_tests::tests::test_blargg_apu_2005_01_len_ctr -- --nocapture`
- `cargo test`
