### PR TITLE
Sub-issue (162): enable apu_mixer dmc.nes

### DIFF
--- a/src/blargg_tests.rs
+++ b/src/blargg_tests.rs
@@ -483,4 +483,6 @@ mod tests {
         test_apu_test_8,
         "roms/blargg/apu_test/rom_singles/8-dmc_rates.nes"
     );
+
+    blargg_test!(test_apu_mixer_dmc, "roms/blargg/apu_mixer/dmc.nes", 60 * 10);
 }


### PR DESCRIPTION
Closes #162.

Enable automated blargg status-byte test for `roms/blargg/apu_mixer/dmc.nes`.

Verification:
- `cargo test blargg_tests::tests::test_apu_mixer_dmc -- --nocapture`
