### PR TITLE
Sub-issue (163): enable apu_mixer noise.nes

### DIFF
--- a/src/blargg_tests.rs
+++ b/src/blargg_tests.rs
@@ -485,4 +485,5 @@ mod tests {
     );
 
     blargg_test!(test_apu_mixer_dmc, "roms/blargg/apu_mixer/dmc.nes", 60 * 10);
+    blargg_test!(test_apu_mixer_noise, "roms/blargg/apu_mixer/noise.nes", 60 * 10);
 }


### PR DESCRIPTION
Closes #163.

Enable automated blargg status-byte test for `roms/blargg/apu_mixer/noise.nes`.

Verification:
- `cargo test blargg_tests::tests::test_apu_mixer_noise -- --nocapture`
