### PR TITLE
Issue #161: complete apu_mixer test suite

### DIFF
--- a/src/blargg_tests.rs
+++ b/src/blargg_tests.rs
@@ -455,12 +455,6 @@ mod tests {
         test_apu_test_1,
         "roms/blargg/apu_test/rom_singles/1-len_ctr.nes"
     );
-
-    blargg_test!(
-        test_apu_mixer_triangle,
-        "roms/blargg/apu_mixer/triangle.nes",
-        60 * 10
-    );
     blargg_test!(
         test_apu_test_2,
         "roms/blargg/apu_test/rom_singles/2-len_table.nes"
@@ -491,5 +485,19 @@ mod tests {
     );
 
     blargg_test!(test_apu_mixer_dmc, "roms/blargg/apu_mixer/dmc.nes", 60 * 10);
-    blargg_test!(test_apu_mixer_noise, "roms/blargg/apu_mixer/noise.nes", 60 * 10);
+    blargg_test!(
+        test_apu_mixer_noise,
+        "roms/blargg/apu_mixer/noise.nes",
+        60 * 10
+    );
+    blargg_test!(
+        test_apu_mixer_triangle,
+        "roms/blargg/apu_mixer/triangle.nes",
+        60 * 10
+    );
+    blargg_test!(
+        test_apu_mixer_square,
+        "roms/blargg/apu_mixer/square.nes",
+        60 * 10
+    );
 }


### PR DESCRIPTION
Closes #161.

Adds automated blargg status-byte tests for the remaining apu_mixer ROMs:
- `roms/blargg/apu_mixer/triangle.nes`
- `roms/blargg/apu_mixer/square.nes`

Also reorders the apu_mixer tests so they are grouped together at the end of `src/blargg_tests.rs`.

Verification:
- `cargo test test_apu_mixer_ -- --nocapture`
