### PR TITLE
Issue #95: DMC DMA stalling (minimal hook)

### DIFF
--- a/src/apu/dmc.rs
+++ b/src/apu/dmc.rs
@@ -46,6 +46,8 @@ pub struct Dmc {
 
     memory_bus: Weak<RefCell<MemController>>,
 
+    dma_fetch_requests: u8,
+
     // IRQ
     interrupt_flag: bool,
 }
@@ -67,8 +69,16 @@ impl Dmc {
             current_address: 0,
             bytes_remaining: 0,
             memory_bus: Weak::new(),
+            dma_fetch_requests: 0,
             interrupt_flag: false,
         }
+    }
+
+    /// Take and clear the number of DMC sample-byte DMA fetches accumulated since last call.
+    pub fn take_dma_fetch_requests(&mut self) -> u8 {
+        let requests = self.dma_fetch_requests;
+        self.dma_fetch_requests = 0;
+        requests
     }
 
     /// Provide a handle to the CPU memory bus so the DMC can fetch sample bytes.
@@ -148,6 +158,8 @@ impl Dmc {
             .upgrade()
             .map(|bus| bus.borrow().read(self.current_address))
             .unwrap_or(0x00);
+
+        self.dma_fetch_requests = self.dma_fetch_requests.saturating_add(1);
 
         self.sample_buffer = Some(sample);
 
@@ -629,6 +641,9 @@ mod sample_tests {
         // Assert: once the DMC reads 0xFF from $C000, output should have increased above 0.
         // This currently FAILS because the DMC memory reader is stubbed (uses 0x00).
         let output = nes.apu.borrow().dmc().output();
-        assert!(output > 0, "expected DMC output to be > 0 after reading sample; got {output}");
+        assert!(
+            output > 0,
+            "expected DMC output to be > 0 after reading sample; got {output}"
+        );
     }
 }

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -221,6 +221,19 @@ impl Cpu {
         Some(dma_cycles)
     }
 
+    /// Apply an external stall for the given number of CPU cycles.
+    ///
+    /// This is used for synthetic cycles where the CPU does not execute instructions
+    /// but the PPU/APU must continue to advance (e.g., DMA stalls).
+    pub fn apply_external_stall(&mut self, cpu_cycles: u16) {
+        if cpu_cycles == 0 {
+            return;
+        }
+
+        self.tick_ppu_apu_for_cpu_cycles(cpu_cycles);
+        self.add_cycles(cpu_cycles as u64);
+    }
+
     fn tick_ppu_apu_for_cpu_cycles(&mut self, cpu_cycles: u16) {
         let cpu_divider = self.oob_master_clock.cpu_divider();
         let master_ticks_to_add = cpu_divider * cpu_cycles as u64;

--- a/src/nes.rs
+++ b/src/nes.rs
@@ -154,6 +154,16 @@ impl Nes {
         // Execute exactly one CPU instruction.
         self.cpu.execute();
 
+        // DMC sample DMA reads stall the CPU for 1-4 cycles. For now we model this as
+        // a fixed 4-cycle stall per sample fetch.
+        const DMC_DMA_STALL_CYCLES_PER_FETCH: u16 = 4;
+        let dmc_dma_fetches = self.apu.borrow_mut().dmc_mut().take_dma_fetch_requests();
+        if dmc_dma_fetches > 0 {
+            self.cpu.apply_external_stall(
+                DMC_DMA_STALL_CYCLES_PER_FETCH.saturating_mul(dmc_dma_fetches as u16),
+            );
+        }
+
         // IRQ/NMI are handled by the CPU itself (Mesen-style) at the end of `execute()`.
 
         if self.ppu.borrow_mut().poll_frame_complete() {
@@ -1123,6 +1133,36 @@ mod tests {
             apu_cycles_elapsed == 513 || apu_cycles_elapsed == 514,
             "APU should be clocked 513 or 514 times during OAM DMA, got {}",
             apu_cycles_elapsed
+        );
+    }
+
+    #[test]
+    fn test_dmc_dma_stalls_cpu_on_sample_fetch() {
+        // DMC DMA reads should stall the CPU (RDY low) for 1-4 cycles.
+        // With a 2-cycle NOP instruction, this means the first tick should cost 3-6 cycles.
+        let mut nes = Nes::new(TvSystem::Ntsc);
+
+        let rom_data = create_minimal_nrom_rom();
+        let cartridge = crate::cartridge::Cartridge::new(&rom_data).unwrap();
+        nes.insert_cartridge(cartridge);
+        nes.reset(false);
+
+        // Configure DMC to play 1 byte starting at $C000, at the fastest rate.
+        // The sample buffer starts empty, so the DMC should attempt a memory fetch
+        // immediately when the APU is clocked.
+        {
+            let mut apu = nes.apu.borrow_mut();
+            apu.dmc_mut().write_flags_and_rate(0x0F);
+            apu.dmc_mut().write_sample_address(0x00);
+            apu.dmc_mut().write_sample_length(0x00);
+            apu.write_enable(0x10);
+        }
+
+        let cpu_cycles = nes.run_cpu_tick();
+
+        assert!(
+            (3..=6).contains(&cpu_cycles),
+            "expected DMC DMA stalling to add 1-4 cycles to a 2-cycle NOP; got {cpu_cycles}"
         );
     }
 


### PR DESCRIPTION
Implements a minimal end-to-end DMC DMA stalling hook:
- DMC records when it performs a sample-byte fetch.
- NES applies a fixed 4 CPU-cycle stall per fetch by advancing PPU/APU via Cpu::apply_external_stall.

This is intentionally a first increment (fixed stall) to get the plumbing + tests in place before modeling 1-4 cycle timing, conflicts (+2), and PAL nuances.

Closes #95.

Test:
- cargo test test_dmc_dma_stalls_cpu_on_sample_fetch
- cargo test test_dmc_reads_sample_byte_from_cpu_memory
- cargo test test_apu_clocked_during_oam_dma