### PR TITLE
Document MMC5 split-screen limitations

### DIFF
--- a/MMC5_STATUS.md
+++ b/MMC5_STATUS.md
@@ -58,7 +58,7 @@ MMC5 is a complex mapper with many advanced features. This document tracks what 
 
 ### Infrastructure
 - ✅ Memory controller routes $5000-$5FFF to mapper
-- ✅ Split-screen registers ($5200-$5202) accept writes (functionality not implemented)
+- ⚠️ Split-screen registers ($5200-$5202) - simplified vertical implementation (see below)
 
 ## Missing Features ❌
 
@@ -124,21 +124,38 @@ background graphics should now render with correct CHR tile selection.
 - ✅ Writes to fill-mode nametable addresses are handled (no-op, not backed by RAM)
 
 ### 6. Split-Screen Support
-**Status**: Registers exist, no functionality
+**Status**: ⚠️ Simplified vertical implementation (not accurate)
 
-**What's needed**:
-- $5200: Split mode and scroll control
-- $5201: Split Y coordinate (scanline to split at)
-- $5202: CHR bank for split region
-- During rendering, switch CHR banking at specified scanline
-- Can also affect scroll position for split region
+**Implemented**:
+- ✅ Split mode registers ($5200, $5201, $5202) accept writes
+- ✅ Basic CHR bank switching in mode 1 when split_active is set
+- ✅ Simplified vertical threshold based on scanline position
 
-**Required changes**:
-- PPU must query mapper for CHR bank on each scanline
-- Mapper returns different CHR banks before/after split point
-- Complex interaction with normal CHR banking
+**Hardware behavior (NOT fully implemented)**:
+Real MMC5 split-screen is a **horizontal** split based on tile fetch count per
+scanline (0-33 tiles), not a vertical/scanline-based split:
+- **Left split** (bit 6=0): Tiles 0 to T-1 use split region, T+ use normal
+- **Right split** (bit 6=1): Tiles 0 to T-1 use normal, T+ use split region
 
-**Impact**: Games using split-screen effects won't work
+When in split region:
+- Nametable data always comes from ExRAM (regardless of $5105 mapping)
+- CHR bank uses $5202 (4KB bank) for all CHR modes
+- Vertical scroll uses $5201 value
+- Split is disabled when ExRAM mode ($5104) is 2 or 3
+
+**Games using split-screen**:
+Only 2 games are documented to use this feature:
+- **Uchuu Keibitai SDF** - during intro sequence
+- **Bandit Kings of Ancient China** - during ending sequence
+
+**Castlevania III does NOT use split-screen.**
+
+**Current limitation**:
+Our simplified implementation interprets bits 0-4 of $5200 as a Y tile row
+(vertical threshold) rather than an X tile count (horizontal threshold).
+This allows basic testing but won't work correctly for the two games above.
+
+**Impact**: Low - only affects 2 obscure games, not Castlevania III
 
 ### 7. Expansion Audio
 **Status**: Not implemented

--- a/src/cartridge/mmc5.rs
+++ b/src/cartridge/mmc5.rs
@@ -251,19 +251,50 @@ impl MMC5Mapper {
         }
     }
 
+    /// Check if split-screen mode is enabled (bit 7 of $5200).
+    ///
+    /// # Hardware behavior (NOT fully implemented)
+    /// Real MMC5 split-screen is a **horizontal** split based on tile fetch count per
+    /// scanline (0-33), not a vertical/scanline-based split. The threshold in bits 0-4
+    /// specifies which tile column triggers the split:
+    /// - Left split (bit 6=0): Tiles 0 to T-1 use split region, T+ use normal
+    /// - Right split (bit 6=1): Tiles 0 to T-1 use normal, T+ use split region
+    ///
+    /// When in split region:
+    /// - Nametable data comes from ExRAM (regardless of $5105)
+    /// - CHR bank uses $5202 (4KB bank) for all CHR modes
+    /// - Vertical scroll uses $5201
+    ///
+    /// Split mode is disabled when ExRAM mode ($5104) is 2 or 3.
+    ///
+    /// # Games using split-screen
+    /// Only two games are documented to use this feature:
+    /// - Uchuu Keibitai SDF (during intro)
+    /// - Bandit Kings of Ancient China (during ending sequence)
+    ///
+    /// Castlevania III does NOT use split-screen.
+    ///
+    /// # Current implementation
+    /// We use a simplified **vertical** interpretation where bits 0-4 specify a Y tile
+    /// row, and split activates for all scanlines at or below that row. This is
+    /// sufficient for basic testing but not accurate for the games listed above.
     fn split_enabled(&self) -> bool {
         (self.split_mode & 0x80) != 0
     }
 
+    /// Get the split threshold interpreted as a Y tile row (simplified implementation).
+    /// Real hardware interprets this as X tile count per scanline.
     fn split_y_tiles(&self) -> u8 {
-        // For our current minimal implementation, interpret the low 5 bits as the split Y tile row.
         self.split_mode & 0x1F
     }
 
+    /// Convert Y tile row to scanline number (simplified implementation).
     fn split_start_scanline(&self) -> u16 {
         (self.split_y_tiles() as u16) * 8
     }
 
+    /// Update split_active state based on current scanline (simplified implementation).
+    /// Real hardware tracks horizontal tile fetch position, not scanline.
     fn update_split_active(&mut self, scanline: u16, rendering_enabled: bool) {
         if !rendering_enabled {
             self.split_active = false;


### PR DESCRIPTION
Documents the MMC5 split-screen implementation limitations and identifies the games that use this feature.

## Changes
- Added detailed documentation comments in mmc5.rs explaining:
  - Real hardware behavior (horizontal tile-fetch based)
  - Current simplified implementation (vertical scanline-based)
  - Games using split-screen (Uchuu Keibitai SDF, Bandit Kings of Ancient China)
  - That Castlevania III does NOT use this feature

- Updated MMC5_STATUS.md with comprehensive split-screen status

## Rationale
Full split-screen implementation would require tracking horizontal tile fetch position per scanline, which is complex. Since only 2 games use this feature and neither is Castlevania III (our primary target), we document the limitation rather than implement the full feature.

Closes #237