### PR TITLE
Implement Mapper 16 (Bandai FCG) - Phase 1 core

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@
   - Why: Faster debugging (bisect issues), reproducible bug reports, and enables automated “resume from known point” tests.
   - Done when: Loading a state returns to identical execution (deterministic within the same build), state format is versioned, and at least one regression test uses save-states to validate a previously flaky scenario.
 
+
 ### Completed
 
 - [x] Add an automated `nestest.nes` “golden trace” test (CPU regs + PC + flags per instruction) to catch subtle CPU regressions.

--- a/src/cartridge/bandai_fcg.rs
+++ b/src/cartridge/bandai_fcg.rs
@@ -1,0 +1,380 @@
+//! # Mapper 16 (Bandai FCG) Implementation
+//!
+//! Used by Dragon Ball, SD Gundam, and other Bandai games.
+//!
+//! ## Banks
+//! - PRG: 16KB switchable at $8000-$BFFF, fixed last bank at $C000-$FFFF
+//! - CHR: 8 × 1KB switchable banks
+//!
+//! ## Registers (submapper 5 / LZ93D50, $8000-$800F range)
+//! - $8000-$8007: CHR bank select (1KB each)
+//! - $8008: PRG bank select (16KB at $8000-$BFFF)
+//! - $8009: Mirroring (0=V, 1=H, 2=1A, 3=1B)
+//! - $800A: IRQ control (bit 0 = enable, write copies latch to counter)
+//! - $800B: IRQ latch low byte
+//! - $800C: IRQ latch high byte
+//!
+//! ## References
+//! - <https://www.nesdev.org/wiki/INES_Mapper_016>
+
+use crate::cartridge::cartridge::MirroringMode;
+use crate::cartridge::mapper::Mapper;
+
+pub struct BandaiFcgMapper {
+    prg_rom: Vec<u8>,
+    chr_rom: Vec<u8>,
+    chr_ram: Vec<u8>,
+    mirroring: MirroringMode,
+
+    // PRG banking
+    prg_bank: u8, // 16KB bank at $8000-$BFFF
+
+    // CHR banking (8 x 1KB)
+    chr_banks: [u8; 8],
+
+    // IRQ
+    irq_enabled: bool,
+    irq_counter: u16,
+    irq_latch: u16,
+    irq_pending: bool,
+}
+
+impl BandaiFcgMapper {
+    const PRG_BANK_SIZE: usize = 16 * 1024; // 16KB
+    const CHR_BANK_SIZE: usize = 1024; // 1KB
+
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: MirroringMode) -> Self {
+        let chr_ram = if chr_rom.is_empty() {
+            vec![0u8; 8 * 1024]
+        } else {
+            Vec::new()
+        };
+
+        Self {
+            prg_rom,
+            chr_rom,
+            chr_ram,
+            mirroring,
+            prg_bank: 0,
+            chr_banks: [0; 8],
+            irq_enabled: false,
+            irq_counter: 0,
+            irq_latch: 0,
+            irq_pending: false,
+        }
+    }
+
+    fn prg_bank_count(&self) -> usize {
+        self.prg_rom.len() / Self::PRG_BANK_SIZE
+    }
+
+    fn last_prg_bank(&self) -> usize {
+        self.prg_bank_count().saturating_sub(1)
+    }
+
+    fn chr_bank_count(&self) -> usize {
+        if !self.chr_rom.is_empty() {
+            self.chr_rom.len() / Self::CHR_BANK_SIZE
+        } else {
+            self.chr_ram.len() / Self::CHR_BANK_SIZE
+        }
+    }
+
+    fn read_chr_byte(&self, bank: u8, offset: usize) -> u8 {
+        let bank_count = self.chr_bank_count();
+        if bank_count == 0 {
+            return 0;
+        }
+        let bank_index = (bank as usize) % bank_count;
+        let addr = bank_index * Self::CHR_BANK_SIZE + offset;
+
+        if !self.chr_rom.is_empty() {
+            self.chr_rom.get(addr).copied().unwrap_or(0)
+        } else {
+            self.chr_ram.get(addr).copied().unwrap_or(0)
+        }
+    }
+
+    fn write_chr_byte(&mut self, bank: u8, offset: usize, value: u8) {
+        if self.chr_rom.is_empty() {
+            let bank_count = self.chr_bank_count();
+            if bank_count == 0 {
+                return;
+            }
+            let bank_index = (bank as usize) % bank_count;
+            let addr = bank_index * Self::CHR_BANK_SIZE + offset;
+            if let Some(slot) = self.chr_ram.get_mut(addr) {
+                *slot = value;
+            }
+        }
+    }
+}
+
+impl Mapper for BandaiFcgMapper {
+    fn read_prg(&self, addr: u16) -> u8 {
+        match addr {
+            0x8000..=0xBFFF => {
+                // Switchable 16KB bank
+                let bank_count = self.prg_bank_count();
+                if bank_count == 0 {
+                    return 0;
+                }
+                let bank_index = (self.prg_bank as usize) % bank_count;
+                let offset = (addr - 0x8000) as usize;
+                self.prg_rom
+                    .get(bank_index * Self::PRG_BANK_SIZE + offset)
+                    .copied()
+                    .unwrap_or(0)
+            }
+            0xC000..=0xFFFF => {
+                // Fixed last 16KB bank
+                let bank_index = self.last_prg_bank();
+                let offset = (addr - 0xC000) as usize;
+                self.prg_rom
+                    .get(bank_index * Self::PRG_BANK_SIZE + offset)
+                    .copied()
+                    .unwrap_or(0)
+            }
+            _ => 0,
+        }
+    }
+
+    fn write_prg(&mut self, addr: u16, value: u8) {
+        // Submapper 5 (LZ93D50): registers at $8000-$800F
+        let reg = addr & 0x000F;
+        match reg {
+            0x00..=0x07 => {
+                // CHR bank select
+                self.chr_banks[reg as usize] = value;
+            }
+            0x08 => {
+                // PRG bank select
+                self.prg_bank = value & 0x0F;
+            }
+            0x09 => {
+                // Mirroring
+                self.mirroring = match value & 0x03 {
+                    0 => MirroringMode::Vertical,
+                    1 => MirroringMode::Horizontal,
+                    2 => MirroringMode::SingleScreenLower,
+                    3 => MirroringMode::SingleScreenUpper,
+                    _ => unreachable!(),
+                };
+            }
+            0x0A => {
+                // IRQ control
+                // Writing acknowledges pending IRQ
+                self.irq_pending = false;
+                // Copy latch to counter (LZ93D50 behavior)
+                self.irq_counter = self.irq_latch;
+                // Enable/disable
+                self.irq_enabled = (value & 0x01) != 0;
+                // If enabled while counter is 0, trigger immediately
+                if self.irq_enabled && self.irq_counter == 0 {
+                    self.irq_pending = true;
+                }
+            }
+            0x0B => {
+                // IRQ latch low byte
+                self.irq_latch = (self.irq_latch & 0xFF00) | (value as u16);
+            }
+            0x0C => {
+                // IRQ latch high byte
+                self.irq_latch = (self.irq_latch & 0x00FF) | ((value as u16) << 8);
+            }
+            0x0D => {
+                // EEPROM control (not implemented yet)
+            }
+            _ => {}
+        }
+    }
+
+    fn read_chr(&self, addr: u16) -> u8 {
+        let slot = (addr >> 10) as usize; // Which 1KB slot (0-7)
+        let offset = (addr & 0x03FF) as usize; // Offset within 1KB
+        let bank = self.chr_banks[slot];
+        self.read_chr_byte(bank, offset)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        let slot = (addr >> 10) as usize;
+        let offset = (addr & 0x03FF) as usize;
+        let bank = self.chr_banks[slot];
+        self.write_chr_byte(bank, offset, value);
+    }
+
+    fn ppu_address_changed(&mut self, _addr: u16) {
+        // Not used for this mapper
+    }
+
+    fn cpu_cycle(&mut self) {
+        // IRQ counter decrements every CPU cycle when enabled
+        if self.irq_enabled && self.irq_counter > 0 {
+            self.irq_counter -= 1;
+            if self.irq_counter == 0 {
+                self.irq_pending = true;
+            }
+        }
+    }
+
+    fn irq_pending(&self) -> bool {
+        self.irq_pending
+    }
+
+    fn get_mirroring(&self) -> MirroringMode {
+        self.mirroring
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cartridge::mapper::create_mapper;
+
+    fn banked_data(bank_size: usize, num_banks: usize) -> Vec<u8> {
+        let mut data = vec![0u8; bank_size * num_banks];
+        for bank in 0..num_banks {
+            for i in 0..bank_size {
+                data[bank * bank_size + i] = bank as u8;
+            }
+        }
+        data
+    }
+
+    #[test]
+    fn test_mapper_16_is_wired_in_factory() {
+        let prg_rom = banked_data(16 * 1024, 2);
+        let chr_rom = banked_data(1024, 8);
+        let mapper = create_mapper(16, prg_rom, chr_rom, MirroringMode::Horizontal);
+        assert!(mapper.is_ok(), "Mapper 16 should be implemented");
+    }
+
+    #[test]
+    fn test_prg_banking_switchable_and_fixed() {
+        let prg_rom = banked_data(16 * 1024, 4); // 4 x 16KB banks
+        let chr_rom = banked_data(1024, 8);
+
+        let mut mapper = BandaiFcgMapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+
+        // Initially bank 0 at $8000, last bank (3) at $C000
+        assert_eq!(mapper.read_prg(0x8000), 0, "Bank 0 at $8000");
+        assert_eq!(mapper.read_prg(0xC000), 3, "Last bank at $C000");
+
+        // Switch to bank 2 at $8000
+        mapper.write_prg(0x8008, 2);
+        assert_eq!(mapper.read_prg(0x8000), 2, "Bank 2 at $8000 after switch");
+        assert_eq!(mapper.read_prg(0xC000), 3, "Last bank still at $C000");
+    }
+
+    #[test]
+    fn test_chr_banking_8x1kb() {
+        let prg_rom = banked_data(16 * 1024, 2);
+        let chr_rom = banked_data(1024, 16); // 16 x 1KB banks
+
+        let mut mapper = BandaiFcgMapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+
+        // Set different banks for each 1KB slot
+        for i in 0..8 {
+            mapper.write_prg(0x8000 + i as u16, i as u8 + 1);
+        }
+
+        // Verify each slot reads from correct bank
+        for i in 0..8 {
+            let addr = (i as u16) * 0x400; // Start of each 1KB slot
+            assert_eq!(
+                mapper.read_chr(addr),
+                (i + 1) as u8,
+                "CHR slot {} should read from bank {}",
+                i,
+                i + 1
+            );
+        }
+    }
+
+    #[test]
+    fn test_mirroring_control() {
+        let prg_rom = banked_data(16 * 1024, 2);
+        let chr_rom = banked_data(1024, 8);
+
+        let mut mapper = BandaiFcgMapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+
+        // Test all mirroring modes
+        mapper.write_prg(0x8009, 0);
+        assert_eq!(mapper.get_mirroring(), MirroringMode::Vertical);
+
+        mapper.write_prg(0x8009, 1);
+        assert_eq!(mapper.get_mirroring(), MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8009, 2);
+        assert_eq!(mapper.get_mirroring(), MirroringMode::SingleScreenLower);
+
+        mapper.write_prg(0x8009, 3);
+        assert_eq!(mapper.get_mirroring(), MirroringMode::SingleScreenUpper);
+    }
+
+    #[test]
+    fn test_irq_counter_triggers_at_zero() {
+        let prg_rom = banked_data(16 * 1024, 2);
+        let chr_rom = banked_data(1024, 8);
+
+        let mut mapper = BandaiFcgMapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+
+        // Set latch to 3
+        mapper.write_prg(0x800B, 3); // Low byte
+        mapper.write_prg(0x800C, 0); // High byte
+
+        // Enable IRQ (copies latch to counter)
+        mapper.write_prg(0x800A, 1);
+        assert!(!mapper.irq_pending(), "IRQ should not be pending yet");
+
+        // Clock 3 cycles - counter goes 3 -> 2 -> 1 -> 0
+        mapper.cpu_cycle();
+        assert!(!mapper.irq_pending());
+        mapper.cpu_cycle();
+        assert!(!mapper.irq_pending());
+        mapper.cpu_cycle();
+        assert!(
+            mapper.irq_pending(),
+            "IRQ should trigger when counter reaches 0"
+        );
+    }
+
+    #[test]
+    fn test_irq_acknowledge_clears_pending() {
+        let prg_rom = banked_data(16 * 1024, 2);
+        let chr_rom = banked_data(1024, 8);
+
+        let mut mapper = BandaiFcgMapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+
+        // Trigger an IRQ
+        mapper.write_prg(0x800B, 1);
+        mapper.write_prg(0x800C, 0);
+        mapper.write_prg(0x800A, 1); // Enable
+        mapper.cpu_cycle(); // Counter 1 -> 0, triggers IRQ
+
+        assert!(mapper.irq_pending());
+
+        // Writing to $800A acknowledges IRQ
+        mapper.write_prg(0x800A, 0);
+        assert!(!mapper.irq_pending(), "IRQ should be acknowledged");
+    }
+
+    #[test]
+    fn test_irq_immediate_if_enabled_with_zero_counter() {
+        let prg_rom = banked_data(16 * 1024, 2);
+        let chr_rom = banked_data(1024, 8);
+
+        let mut mapper = BandaiFcgMapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+
+        // Set latch to 0
+        mapper.write_prg(0x800B, 0);
+        mapper.write_prg(0x800C, 0);
+
+        // Enable IRQ - should trigger immediately since counter will be 0
+        mapper.write_prg(0x800A, 1);
+        assert!(
+            mapper.irq_pending(),
+            "IRQ should trigger immediately when enabled with 0 counter"
+        );
+    }
+}

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -2,6 +2,7 @@ use crate::cartridge::MirroringMode;
 use std::io;
 
 use super::axrom::AxROMMapper;
+use super::bandai_fcg::BandaiFcgMapper;
 use super::cnrom::CNROMMapper;
 use super::colordreams::ColorDreamsMapper;
 use super::gxrom::GxROMMapper;
@@ -133,6 +134,7 @@ pub fn create_mapper(
         11 => Ok(Box::new(ColorDreamsMapper::new(
             prg_rom, chr_rom, mirroring,
         ))),
+        16 => Ok(Box::new(BandaiFcgMapper::new(prg_rom, chr_rom, mirroring))),
         24 => Ok(Box::new(VRC6Mapper::new(24, prg_rom, chr_rom, mirroring))),
         26 => Ok(Box::new(VRC6Mapper::new(26, prg_rom, chr_rom, mirroring))),
         66 => Ok(Box::new(GxROMMapper::new(prg_rom, chr_rom, mirroring))),

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -1,4 +1,5 @@
 mod axrom;
+mod bandai_fcg;
 mod cartridge;
 mod cnrom;
 mod colordreams;


### PR DESCRIPTION
Add core mapper support for Bandai FCG games (Dragon Ball, SD Gundam).

## Features
- PRG banking: 16KB switchable at $8000-$BFFF, fixed last bank at $C000-$FFFF
- CHR banking: 8 × 1KB banks covering full pattern tables
- Mirroring control: V/H/1-screen A/1-screen B
- IRQ: 16-bit CPU cycle counter with latch (LZ93D50/submapper 5 behavior)
- CHR-RAM fallback when no CHR-ROM present

## Implementation Notes
- Implements submapper 5 (LZ93D50) register layout at $8000-$800F
- EEPROM support deferred to Phase 3

## Tests
7 unit tests covering PRG/CHR banking, mirroring, and IRQ behavior.

Closes #242
Related to #241