### PR TITLE
Refactor PPU IO bus access

### DIFF
--- a/src/mem_controller.rs
+++ b/src/mem_controller.rs
@@ -137,16 +137,16 @@ impl MemController {
             0x2000..=0x3FFF => match addr & 0x2007 {
                 // Write-only registers return the PPU I/O bus latch
                 // The PPU I/O bus is separate from the CPU data bus!
-                0x2000 => self.ppu.borrow().registers.io_bus(),
-                0x2001 => self.ppu.borrow().registers.io_bus(),
+                0x2000 => self.ppu.borrow().io_bus(),
+                0x2001 => self.ppu.borrow().io_bus(),
                 0x2002 => {
                     // PPUSTATUS: get_status() already handles updating I/O bus correctly
                     self.ppu.borrow_mut().get_status()
                 }
-                0x2003 => self.ppu.borrow().registers.io_bus(),
+                0x2003 => self.ppu.borrow().io_bus(),
                 0x2004 => self.ppu.borrow_mut().read_oam_data(),
-                0x2005 => self.ppu.borrow().registers.io_bus(),
-                0x2006 => self.ppu.borrow().registers.io_bus(),
+                0x2005 => self.ppu.borrow().io_bus(),
+                0x2006 => self.ppu.borrow().io_bus(),
                 0x2007 => self.ppu.borrow_mut().read_data(),
                 _ => panic!("Should never happen!"),
             },
@@ -324,7 +324,7 @@ impl MemController {
                 }
                 0x2002 => {
                     // PPUSTATUS is read-only, but writes still update the I/O bus!
-                    self.ppu.borrow_mut().registers.set_io_bus(value);
+                    self.ppu.borrow_mut().set_io_bus(value);
                 }
                 0x2003 => self.ppu.borrow_mut().write_oam_address(value),
                 0x2004 => self.ppu.borrow_mut().write_oam_data(value),

--- a/src/ppu/ppu.rs
+++ b/src/ppu/ppu.rs
@@ -21,8 +21,7 @@ pub struct Ppu {
     // subtle boundary timing near VBlank end (blargg ppu_vbl_nmi 07).
     vblank_for_nmi: bool,
     /// Register management (PPUCTRL, PPUMASK, Loopy registers)
-    /// Public to allow MemController to access I/O bus latch
-    pub registers: Registers,
+    registers: Registers,
     /// Memory management (VRAM, palette, CHR ROM)
     memory: Memory,
     /// Background rendering
@@ -107,6 +106,14 @@ impl Ppu {
         self.background.reset();
         self.sprites.reset();
         self.prev_a12 = false;
+    }
+
+    pub fn io_bus(&self) -> u8 {
+        self.registers.io_bus()
+    }
+
+    pub fn set_io_bus(&mut self, value: u8) {
+        self.registers.set_io_bus(value);
     }
 
     /// Run the PPU for a specified number of cycles
@@ -1016,6 +1023,15 @@ mod tests {
         let ppu = Ppu::new(TvSystem::Ntsc);
         assert_eq!(ppu.scanline(), 0);
         assert_eq!(ppu.pixel(), 0);
+    }
+
+    #[test]
+    fn test_ppu_io_bus_round_trip() {
+        let mut ppu = Ppu::new(TvSystem::Ntsc);
+
+        ppu.set_io_bus(0x5A);
+
+        assert_eq!(ppu.io_bus(), 0x5A);
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- add PPU io_bus accessors and make registers private
- update MemController to use accessors
- add io_bus round-trip test

Tests:
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- cargo test --all-features

Closes #281