### PR TITLE
Expand save-state coverage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,13 +12,13 @@ The application shall ALWAYS be developed in very small, manageable increments t
 
 In the development process, when appropriate, the application should be built using Test-driven Development (TDD) principles. This means that tests are written before the actual code is implemented. This always need be done for all implementation, not just feature additions. The development cycle should always follow the "Red-Green-Refactor" approach:
 
-1. **Red**: Write a failing test that defines a desired improvement or new function.
-2. **Green**: Write the minimum amount of code necessary to make the test pass.
+1. **Red**: Write failing test(s) that defines a desired improvement or new function. Test all relevant aspects of the functionality.
+2. **Green**: Write the minimum amount of code necessary to make the test pass and verify that it passes.
 3. **Refactor**: Clean up the code while ensuring that all tests still pass. This approach helps to ensure that the code is reliable, maintainable, and meets the specified requirements from the outset.
 
 It is VERY VERY important to:
 
-- For more complex things, stop after the red phase and ask the navigator to review the test and approve before moving on to the green phase.
+- For more complex tasks, stop after the red phase and ask the navigator to review the test and approve before moving on to the green phase.
 - ALWAYS stop after the green phase and ask the navigator to review the implementation and approve before moving on to the refactor phase.
 - ALWAYS stop after the refactor phase and ask the navigator to review the refactored code and approve before moving on.
 - ALWAYS use a TDD approach for all kinds of code, feature implementation, bug fixing, feature enhancements.
@@ -55,8 +55,10 @@ When working on an issue, this is important:
 When a PR is merged, the issue should be closed and the branch deleted to keep the repository clean and organized. If the issue is a sub-issue of a larger feature, ensure that the main issue is updated with relevant information about the progress made and that it is closed when all sub-issues are completed.
 
 ### Github CLI
+
 Use the comand line command 'gh' for interacting the github issues. Be careful with quoting when using gh. NEVER use backticks in the text with gh and use real newlines instead of \n.
 When creating issues, always add the appropriate labels to the issue using gh:
+
 - bug - for all bugs
 - enhancement - for any feature development
 - games - for anything that has to do with a specific game or games

--- a/src/apu/apu.rs
+++ b/src/apu/apu.rs
@@ -620,6 +620,31 @@ impl Apu {
         self.pending_samples.clear();
     }
 
+    fn pending_samples_snapshot(&self) -> Vec<f32> {
+        let start = self.pending_samples.read_index();
+        let end = self.pending_samples.write_index();
+        let (first, second) = unsafe { self.pending_samples.unsafe_slices(start, end) };
+        let mut samples = Vec::with_capacity(self.pending_samples.occupied_len());
+        samples.extend(
+            first
+                .iter()
+                .map(|value| unsafe { *value.assume_init_ref() }),
+        );
+        samples.extend(
+            second
+                .iter()
+                .map(|value| unsafe { *value.assume_init_ref() }),
+        );
+        samples
+    }
+
+    fn restore_pending_samples(&mut self, samples: &[f32]) {
+        self.clear_pending_samples();
+        for &sample in samples {
+            self.push_pending_sample(sample);
+        }
+    }
+
     #[cfg(test)]
     fn push_sample_for_test(&mut self, sample: f32) {
         self.push_pending_sample(sample);
@@ -647,7 +672,6 @@ impl Apu {
     }
 
     /// Capture the current APU state for save-state.
-    #[cfg(test)]
     pub fn capture_state(&self) -> crate::savestate::ApuState {
         crate::savestate::ApuState {
             frame_counter: crate::savestate::FrameCounterState {
@@ -655,12 +679,27 @@ impl Apu {
                 mode: self.frame_counter.get_mode(),
                 irq_inhibit: self.frame_counter.get_irq_inhibit(),
                 irq_flag: self.frame_counter.get_irq_flag(),
+                irq_assert_cycles_remaining: self.frame_counter.irq_assert_cycles_remaining(),
+                five_step_extra_cycle: self.frame_counter.five_step_extra_cycle(),
+                pending_write: self.frame_counter.pending_write(),
+                write_delay: self.frame_counter.write_delay(),
+                pending_write_on_odd_cpu_cycle: self.frame_counter.pending_write_on_odd_cpu_cycle(),
+                pending_immediate_quarter: self.frame_counter.pending_immediate_clock().0,
+                pending_immediate_half: self.frame_counter.pending_immediate_clock().1,
             },
             pulse1: self.pulse1.capture_state(),
             pulse2: self.pulse2.capture_state(),
             triangle: self.triangle.capture_state(),
             noise: self.noise.capture_state(),
             dmc: self.dmc.capture_state(),
+            sample_accumulator: self.sample_accumulator,
+            cycles_per_sample: self.cycles_per_sample,
+            pending_samples: self.pending_samples_snapshot(),
+            pulse1_enabled: self.pulse1_enabled,
+            pulse2_enabled: self.pulse2_enabled,
+            triangle_enabled: self.triangle_enabled,
+            noise_enabled: self.noise_enabled,
+            dmc_enabled: self.dmc_enabled,
             apu_cycle: self.apu_cycle,
             cpu_cycle: self.cpu_cycle,
             last_4017_write: self.last_4017_write,
@@ -668,7 +707,6 @@ impl Apu {
     }
 
     /// Restore APU state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(&mut self, state: &crate::savestate::ApuState) {
         // Restore frame counter
         self.frame_counter.restore_state(
@@ -676,6 +714,15 @@ impl Apu {
             state.frame_counter.mode,
             state.frame_counter.irq_inhibit,
             state.frame_counter.irq_flag,
+            state.frame_counter.irq_assert_cycles_remaining,
+            state.frame_counter.five_step_extra_cycle,
+            state.frame_counter.pending_write,
+            state.frame_counter.write_delay,
+            state.frame_counter.pending_write_on_odd_cpu_cycle,
+            (
+                state.frame_counter.pending_immediate_quarter,
+                state.frame_counter.pending_immediate_half,
+            ),
         );
 
         // Restore channels
@@ -690,9 +737,15 @@ impl Apu {
         self.cpu_cycle = state.cpu_cycle;
         self.last_4017_write = state.last_4017_write;
 
-        // Clear sample buffer
-        self.clear_pending_samples();
-        self.sample_accumulator = 0.0;
+        self.sample_accumulator = state.sample_accumulator;
+        self.cycles_per_sample = state.cycles_per_sample;
+        self.restore_pending_samples(&state.pending_samples);
+
+        self.pulse1_enabled = state.pulse1_enabled;
+        self.pulse2_enabled = state.pulse2_enabled;
+        self.triangle_enabled = state.triangle_enabled;
+        self.noise_enabled = state.noise_enabled;
+        self.dmc_enabled = state.dmc_enabled;
     }
 }
 
@@ -722,6 +775,81 @@ mod tests {
 
         let sample = apu.get_sample().expect("expected a sample");
         assert!((sample - 0.1).abs() < 0.0001, "sample was {sample}");
+    }
+
+    #[test]
+    fn test_apu_save_state_roundtrip_includes_internal_state() {
+        let mut apu = Apu::new_for_testing();
+
+        apu.sample_accumulator = 7.25;
+        apu.cycles_per_sample = 123.0;
+        apu.pulse1_enabled = false;
+        apu.pulse2_enabled = true;
+        apu.triangle_enabled = false;
+        apu.noise_enabled = true;
+        apu.dmc_enabled = false;
+
+        apu.apu_cycle = 1234;
+        apu.cpu_cycle = 5678;
+        apu.last_4017_write = 0xC0;
+
+        apu.push_sample_for_test(0.1);
+        apu.push_sample_for_test(0.2);
+
+        apu.frame_counter
+            .queue_delayed_write_with_jitter(0x80, 3, true);
+        apu.frame_counter
+            .debug_set_pending_immediate_clock(true, false);
+        apu.frame_counter.debug_set_irq_assert_cycles_remaining(2);
+        apu.frame_counter.debug_set_five_step_extra_cycle(true);
+
+        apu.dmc.debug_set_dma_pending(true);
+        apu.dmc.debug_set_transfer_start_delay(2);
+
+        let state = apu.capture_state();
+
+        let mut restored = Apu::new_for_testing();
+        restored.restore_state(&state);
+
+        assert!((restored.sample_accumulator - 7.25).abs() < 1e-6);
+        assert!((restored.cycles_per_sample - 123.0).abs() < 1e-6);
+        assert!(!restored.pulse1_enabled);
+        assert!(restored.pulse2_enabled);
+        assert!(!restored.triangle_enabled);
+        assert!(restored.noise_enabled);
+        assert!(!restored.dmc_enabled);
+
+        assert_eq!(restored.apu_cycle, 1234);
+        assert_eq!(restored.cpu_cycle, 5678);
+        assert_eq!(restored.last_4017_write, 0xC0);
+
+        assert_eq!(restored.frame_counter.debug_pending_write(), Some(0x80));
+        assert_eq!(restored.frame_counter.debug_write_delay(), 3);
+        assert!(
+            restored
+                .frame_counter
+                .debug_pending_write_on_odd_cpu_cycle()
+        );
+        assert_eq!(
+            restored.frame_counter.debug_pending_immediate_clock(),
+            (true, false)
+        );
+        assert_eq!(
+            restored.frame_counter.debug_irq_assert_cycles_remaining(),
+            2
+        );
+        assert!(restored.frame_counter.debug_five_step_extra_cycle());
+
+        assert!(restored.dmc.dma_pending());
+        assert_eq!(restored.dmc.debug_transfer_start_delay(), 2);
+
+        let sample1 = restored.get_sample();
+        let sample2 = restored.get_sample();
+        let sample3 = restored.get_sample();
+
+        assert!(matches!(sample1, Some(value) if (value - 0.1).abs() < 1e-6));
+        assert!(matches!(sample2, Some(value) if (value - 0.2).abs() < 1e-6));
+        assert!(sample3.is_none());
     }
 
     #[test]

--- a/src/apu/dmc.rs
+++ b/src/apu/dmc.rs
@@ -87,6 +87,21 @@ impl Dmc {
         self.dma_pending
     }
 
+    #[cfg(test)]
+    pub fn debug_set_dma_pending(&mut self, value: bool) {
+        self.dma_pending = value;
+    }
+
+    #[cfg(test)]
+    pub fn debug_set_transfer_start_delay(&mut self, value: u8) {
+        self.transfer_start_delay = value;
+    }
+
+    #[cfg(test)]
+    pub fn debug_transfer_start_delay(&self) -> u8 {
+        self.transfer_start_delay
+    }
+
     /// If a DMA request is pending, returns the address the DMA should read.
     pub fn dma_address(&self) -> Option<u16> {
         self.dma_pending.then_some(self.current_address)
@@ -331,7 +346,6 @@ impl Dmc {
     }
 
     /// Capture the current DMC channel state for save-state.
-    #[cfg(test)]
     pub fn capture_state(&self) -> crate::savestate::DmcState {
         crate::savestate::DmcState {
             timer: self.timer,
@@ -348,11 +362,12 @@ impl Dmc {
             irq_enabled: self.irq_enabled,
             irq_flag: self.interrupt_flag,
             loop_flag: self.loop_flag,
+            dma_pending: self.dma_pending,
+            transfer_start_delay: self.transfer_start_delay,
         }
     }
 
     /// Restore DMC channel state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(&mut self, state: &crate::savestate::DmcState) {
         self.timer = state.timer;
         self.timer_period = state.timer_period;
@@ -368,8 +383,8 @@ impl Dmc {
         self.irq_enabled = state.irq_enabled;
         self.interrupt_flag = state.irq_flag;
         self.loop_flag = state.loop_flag;
-        self.dma_pending = false;
-        self.transfer_start_delay = 0;
+        self.dma_pending = state.dma_pending;
+        self.transfer_start_delay = state.transfer_start_delay;
     }
 }
 

--- a/src/apu/envelope.rs
+++ b/src/apu/envelope.rs
@@ -114,7 +114,6 @@ impl Envelope {
     }
 
     /// Capture the current envelope state for save-state.
-    #[cfg(test)]
     pub fn capture_state(&self) -> crate::savestate::EnvelopeState {
         crate::savestate::EnvelopeState {
             start_flag: self.start_flag,
@@ -127,7 +126,6 @@ impl Envelope {
     }
 
     /// Restore envelope state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(&mut self, state: &crate::savestate::EnvelopeState) {
         self.start_flag = state.start_flag;
         self.divider = state.divider;

--- a/src/apu/frame_counter.rs
+++ b/src/apu/frame_counter.rs
@@ -83,7 +83,6 @@ impl FrameCounter {
     }
 
     /// Get the current mode
-    #[cfg(test)]
     pub fn get_mode(&self) -> bool {
         self.mode == Mode::FiveStep
     }
@@ -99,36 +98,110 @@ impl FrameCounter {
         self.cycle_counter
     }
 
+    pub(crate) fn pending_write(&self) -> Option<u8> {
+        self.pending_write
+    }
+
+    pub(crate) fn write_delay(&self) -> u8 {
+        self.write_delay
+    }
+
+    pub(crate) fn pending_write_on_odd_cpu_cycle(&self) -> bool {
+        self.pending_write_on_odd_cpu_cycle
+    }
+
+    pub(crate) fn pending_immediate_clock(&self) -> (bool, bool) {
+        self.pending_immediate_clock
+    }
+
+    pub(crate) fn irq_assert_cycles_remaining(&self) -> u8 {
+        self.irq_assert_cycles_remaining
+    }
+
+    pub(crate) fn five_step_extra_cycle(&self) -> bool {
+        self.five_step_extra_cycle
+    }
+
+    #[cfg(test)]
+    pub fn debug_pending_write(&self) -> Option<u8> {
+        self.pending_write
+    }
+
+    #[cfg(test)]
+    pub fn debug_write_delay(&self) -> u8 {
+        self.write_delay
+    }
+
+    #[cfg(test)]
+    pub fn debug_pending_write_on_odd_cpu_cycle(&self) -> bool {
+        self.pending_write_on_odd_cpu_cycle
+    }
+
+    #[cfg(test)]
+    pub fn debug_pending_immediate_clock(&self) -> (bool, bool) {
+        self.pending_immediate_clock
+    }
+
+    #[cfg(test)]
+    pub fn debug_irq_assert_cycles_remaining(&self) -> u8 {
+        self.irq_assert_cycles_remaining
+    }
+
+    #[cfg(test)]
+    pub fn debug_five_step_extra_cycle(&self) -> bool {
+        self.five_step_extra_cycle
+    }
+
+    #[cfg(test)]
+    pub fn debug_set_irq_assert_cycles_remaining(&mut self, value: u8) {
+        self.irq_assert_cycles_remaining = value;
+    }
+
+    #[cfg(test)]
+    pub fn debug_set_five_step_extra_cycle(&mut self, value: bool) {
+        self.five_step_extra_cycle = value;
+    }
+
+    #[cfg(test)]
+    pub fn debug_set_pending_immediate_clock(&mut self, quarter: bool, half: bool) {
+        self.pending_immediate_clock = (quarter, half);
+    }
+
     /// Get the IRQ flag state
     pub fn get_irq_flag(&self) -> bool {
         self.irq_flag
     }
 
     /// Get the IRQ inhibit flag state
-    #[cfg(test)]
     pub fn get_irq_inhibit(&self) -> bool {
         self.irq_inhibit
     }
 
     /// Restore frame counter state from a save-state.
-    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
     pub fn restore_state(
         &mut self,
         cycle_counter: u32,
         mode: bool,
         irq_inhibit: bool,
         irq_flag: bool,
+        irq_assert_cycles_remaining: u8,
+        five_step_extra_cycle: bool,
+        pending_write: Option<u8>,
+        write_delay: u8,
+        pending_write_on_odd_cpu_cycle: bool,
+        pending_immediate_clock: (bool, bool),
     ) {
         self.cycle_counter = cycle_counter;
         self.mode = if mode { Mode::FiveStep } else { Mode::FourStep };
         self.irq_inhibit = irq_inhibit;
         self.irq_flag = irq_flag;
-        self.irq_assert_cycles_remaining = 0;
-        self.five_step_extra_cycle = false;
-        self.pending_write = None;
-        self.write_delay = 0;
-        self.pending_write_on_odd_cpu_cycle = false;
-        self.pending_immediate_clock = (false, false);
+        self.irq_assert_cycles_remaining = irq_assert_cycles_remaining;
+        self.five_step_extra_cycle = five_step_extra_cycle;
+        self.pending_write = pending_write;
+        self.write_delay = write_delay;
+        self.pending_write_on_odd_cpu_cycle = pending_write_on_odd_cpu_cycle;
+        self.pending_immediate_clock = pending_immediate_clock;
     }
 
     /// Clear the IRQ flag

--- a/src/apu/length_counter.rs
+++ b/src/apu/length_counter.rs
@@ -71,19 +71,16 @@ impl LengthCounter {
     }
 
     /// Set the length counter value directly (for save-state restore).
-    #[cfg(test)]
     pub fn set_value(&mut self, value: u8) {
         self.value = value;
     }
 
     /// Enable the length counter (for save-state restore).
-    #[cfg(test)]
     pub fn enable(&mut self) {
         self.enabled = true;
     }
 
     /// Disable the length counter (for save-state restore).
-    #[cfg(test)]
     pub fn disable(&mut self) {
         self.enabled = false;
     }

--- a/src/apu/noise.rs
+++ b/src/apu/noise.rs
@@ -162,7 +162,6 @@ impl Noise {
     }
 
     /// Capture the current noise channel state for save-state.
-    #[cfg(test)]
     pub fn capture_state(&self) -> crate::savestate::NoiseState {
         crate::savestate::NoiseState {
             timer: self.timer,
@@ -176,7 +175,6 @@ impl Noise {
     }
 
     /// Restore noise channel state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(&mut self, state: &crate::savestate::NoiseState) {
         self.timer = state.timer;
         self.timer_period = state.timer_period;

--- a/src/apu/pulse.rs
+++ b/src/apu/pulse.rs
@@ -283,7 +283,6 @@ impl Pulse {
     }
 
     /// Capture the current pulse channel state for save-state.
-    #[cfg(test)]
     pub fn capture_state(&self) -> crate::savestate::PulseState {
         crate::savestate::PulseState {
             timer: self.timer_counter,
@@ -303,7 +302,6 @@ impl Pulse {
     }
 
     /// Restore pulse channel state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(&mut self, state: &crate::savestate::PulseState) {
         self.timer_counter = state.timer;
         self.timer_period = state.timer_period;

--- a/src/apu/triangle.rs
+++ b/src/apu/triangle.rs
@@ -209,7 +209,6 @@ impl Triangle {
     }
 
     /// Capture the current triangle channel state for save-state.
-    #[cfg(test)]
     pub fn capture_state(&self) -> crate::savestate::TriangleState {
         crate::savestate::TriangleState {
             timer: self.timer_counter,
@@ -225,7 +224,6 @@ impl Triangle {
     }
 
     /// Restore triangle channel state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(&mut self, state: &crate::savestate::TriangleState) {
         self.timer_counter = state.timer;
         self.timer_period = state.timer_period;

--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -11,6 +11,7 @@ use crate::ppu;
 use std::cell::RefCell;
 use std::io;
 use std::ops::RangeInclusive;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 pub trait BusDevice {
@@ -115,6 +116,13 @@ impl Bus {
         };
 
         cartridge.borrow().save_ram()
+    }
+
+    pub fn cartridge_state_path(&self) -> Option<PathBuf> {
+        self.cartridge
+            .borrow()
+            .as_ref()
+            .and_then(|cart| cart.borrow().state_path())
     }
 
     /// Read a byte from memory
@@ -356,7 +364,6 @@ impl Bus {
     }
 
     /// Capture mapper state for save-state.
-    #[cfg(test)]
     pub fn capture_mapper_state(&self) -> crate::savestate::MapperState {
         if let Some(ref cartridge_opt) = *self.cartridge.borrow() {
             let cartridge = cartridge_opt.borrow();
@@ -378,7 +385,6 @@ impl Bus {
     }
 
     /// Restore mapper state from a save-state.
-    #[cfg(test)]
     pub fn restore_mapper_state(&mut self, state: &crate::savestate::MapperState) {
         if let Some(ref cartridge_opt) = *self.cartridge.borrow() {
             let mut cartridge = cartridge_opt.borrow_mut();
@@ -386,7 +392,28 @@ impl Bus {
             mapper.restore_prg_ram(&state.prg_ram);
             mapper.restore_chr_ram(&state.chr_ram);
             mapper.restore_registers(&state.registers);
+            let mirroring = mapper.get_mirroring();
+            self.ppu.borrow_mut().set_mirroring(mirroring);
         }
+    }
+
+    /// Capture bus state for save-state.
+    pub fn capture_state(&self) -> crate::savestate::BusState {
+        crate::savestate::BusState {
+            open_bus: self.open_bus,
+            oam_dma_page: *self.oam_dma_page.borrow(),
+            joypad1: self.joypad1.borrow().capture_state(),
+            joypad2: self.joypad2.borrow().capture_state(),
+        }
+    }
+
+    /// Restore bus state from a save-state.
+    pub fn restore_state(&mut self, state: &crate::savestate::BusState) {
+        self.open_bus = state.open_bus;
+        *self.oam_dma_page.borrow_mut() = state.oam_dma_page;
+        self.dma_triggered.replace(false);
+        self.joypad1.borrow_mut().restore_state(&state.joypad1);
+        self.joypad2.borrow_mut().restore_state(&state.joypad2);
     }
 
     // /// Print the current open bus value to stdout (for debugging)
@@ -398,6 +425,8 @@ impl Bus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::nes::TvSystem;
+    use std::rc::Rc;
 
     struct TestBusDevice {
         range: std::ops::RangeInclusive<u16>,
@@ -440,6 +469,86 @@ mod tests {
         fn address_range(&self) -> std::ops::RangeInclusive<u16> {
             self.range.clone()
         }
+    }
+
+    fn create_mmc1_rom() -> Vec<u8> {
+        let prg_rom_banks = 1u8;
+        let chr_rom_banks = 0u8; // CHR RAM
+        let flags6 = 0x10; // mapper 1, horizontal mirroring
+        let flags7 = 0x00;
+
+        let mut rom = vec![
+            b'N',
+            b'E',
+            b'S',
+            0x1A,
+            prg_rom_banks,
+            chr_rom_banks,
+            flags6,
+            flags7,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ];
+
+        let prg_size = prg_rom_banks as usize * 0x4000;
+        rom.extend(std::iter::repeat_n(0, prg_size));
+        rom
+    }
+
+    fn write_mmc1_control(bus: &mut Bus, value: u8) {
+        for i in 0..5 {
+            let bit = (value >> i) & 0x01;
+            bus.write_for_testing(0x8000, bit);
+        }
+    }
+
+    fn assert_vertical_mirroring(ppu: &mut ppu::Ppu) {
+        ppu.write_address(0x20, false);
+        ppu.write_address(0x00, false);
+        ppu.write_data(0x42);
+
+        ppu.write_address(0x28, false);
+        ppu.write_address(0x00, false);
+        let _ = ppu.read_data();
+        assert_eq!(ppu.read_data(), 0x42);
+    }
+
+    fn assert_horizontal_mirroring(ppu: &mut ppu::Ppu) {
+        ppu.write_address(0x20, false);
+        ppu.write_address(0x00, false);
+        ppu.write_data(0x55);
+
+        ppu.write_address(0x24, false);
+        ppu.write_address(0x00, false);
+        let _ = ppu.read_data();
+        assert_eq!(ppu.read_data(), 0x55);
+    }
+
+    #[test]
+    fn test_restore_mapper_state_updates_ppu_mirroring() {
+        let ppu = Rc::new(RefCell::new(ppu::Ppu::new(TvSystem::Ntsc)));
+        let apu = Rc::new(RefCell::new(apu::Apu::new()));
+        let mut bus = Bus::new(ppu.clone(), apu);
+
+        let rom = create_mmc1_rom();
+        let cartridge = Cartridge::new(&rom).expect("Failed to create MMC1 ROM");
+        bus.map_cartridge(cartridge);
+
+        write_mmc1_control(&mut bus, 0x1E); // PRG mode 3, vertical mirroring
+        assert_vertical_mirroring(&mut ppu.borrow_mut());
+        let saved_state = bus.capture_mapper_state();
+
+        write_mmc1_control(&mut bus, 0x1F); // PRG mode 3, horizontal mirroring
+        assert_horizontal_mirroring(&mut ppu.borrow_mut());
+
+        bus.restore_mapper_state(&saved_state);
+        assert_vertical_mirroring(&mut ppu.borrow_mut());
     }
 
     fn create_mmc1_ines_rom_with_vertical_mirroring() -> Vec<u8> {
@@ -596,6 +705,36 @@ mod tests {
         assert!(dma);
         assert!(memory.oam_dma_pending());
         assert_eq!(memory.take_oam_dma_page(), Some(0x22));
+    }
+
+    #[test]
+    fn test_bus_save_state_roundtrip_includes_internal_state() {
+        let mut memory = create_test_memory();
+
+        memory.write(0x0000, 0x3C, false);
+        memory.write(0x4014, 0x22, false);
+
+        memory.set_button(1, crate::input::Button::A, true);
+        memory.set_button(1, crate::input::Button::Right, true);
+        memory.write(0x4016, 0x00, false);
+        memory.read(0x4016);
+        memory.read(0x4016);
+
+        let expected_open_bus = memory.open_bus_value_for_test();
+
+        let saved_state = memory.capture_state();
+
+        let mut restored = create_test_memory();
+        restored.restore_state(&saved_state);
+
+        assert_eq!(restored.open_bus_value_for_test(), expected_open_bus);
+        assert!(restored.oam_dma_pending());
+        assert_eq!(restored.take_oam_dma_page(), Some(0x22));
+
+        let expected_sequence = [0, 0, 0, 0, 0, 1];
+        for expected in expected_sequence {
+            assert_eq!(restored.read(0x4016) & 0x01, expected);
+        }
     }
 
     #[test]

--- a/src/cartridge/axrom.rs
+++ b/src/cartridge/axrom.rs
@@ -115,6 +115,24 @@ impl Mapper for AxROMMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![self.bank_select]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if let Some(&value) = data.first() {
+            self.bank_select = value;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -217,6 +235,38 @@ mod tests {
         // Write with bit 4 = 1 (upper nametable)
         mapper.write_prg(0x8000, 0x10); // Bits: 0001 0000
         assert_eq!(mapper.get_mirroring(), MirroringMode::SingleScreen);
+    }
+
+    #[test]
+    fn test_axrom_registers_and_chr_ram_snapshot_roundtrip() {
+        let mut prg_rom = vec![0; 256 * 1024];
+
+        for bank in 0..8 {
+            let start = bank * 32 * 1024;
+            let end = start + 32 * 1024;
+            for byte in &mut prg_rom[start..end] {
+                *byte = (bank + 1) as u8;
+            }
+        }
+
+        let mut mapper = create_mapper(7, prg_rom.clone(), vec![], MirroringMode::Horizontal)
+            .expect("Failed to create AxROM mapper");
+
+        mapper.write_prg(0x8000, 0x07); // select bank 7
+        mapper.write_chr(0x0000, 0x42);
+        mapper.write_chr(0x1FFF, 0x99);
+
+        let registers = mapper.registers_snapshot();
+        let chr_ram = mapper.chr_ram_snapshot();
+
+        let mut restored = create_mapper(7, prg_rom, vec![], MirroringMode::Horizontal)
+            .expect("Failed to create AxROM mapper");
+        restored.restore_registers(&registers);
+        restored.restore_chr_ram(&chr_ram);
+
+        assert_eq!(restored.read_prg(0x8000), 8);
+        assert_eq!(restored.read_chr(0x0000), 0x42);
+        assert_eq!(restored.read_chr(0x1FFF), 0x99);
     }
 
     #[test]

--- a/src/cartridge/bandai_fcg.rs
+++ b/src/cartridge/bandai_fcg.rs
@@ -351,7 +351,15 @@ impl Mapper for BandaiFcgMapper {
         snapshot.push((self.irq_counter >> 8) as u8);
         snapshot.push((self.irq_latch & 0xFF) as u8);
         snapshot.push((self.irq_latch >> 8) as u8);
-        snapshot.push(self.mirroring as u8);
+        let mirroring = match self.mirroring {
+            MirroringMode::Horizontal => 0,
+            MirroringMode::Vertical => 1,
+            MirroringMode::SingleScreenLower => 2,
+            MirroringMode::SingleScreenUpper => 3,
+            MirroringMode::SingleScreen => 2,
+            MirroringMode::FourScreen => 4,
+        };
+        snapshot.push(mirroring);
         snapshot
     }
 
@@ -367,8 +375,9 @@ impl Mapper for BandaiFcgMapper {
             self.mirroring = match data[14] {
                 0 => MirroringMode::Horizontal,
                 1 => MirroringMode::Vertical,
-                2 => MirroringMode::SingleScreen,
-                3 => MirroringMode::FourScreen,
+                2 => MirroringMode::SingleScreenLower,
+                3 => MirroringMode::SingleScreenUpper,
+                4 => MirroringMode::FourScreen,
                 _ => MirroringMode::Horizontal,
             };
         }
@@ -716,5 +725,35 @@ mod tests {
             mapper.irq_pending(),
             "IRQ should trigger after 3 cycles (latch behavior)"
         );
+    }
+
+    #[test]
+    fn test_bandai_fcg_registers_snapshot_restores_state() {
+        let prg_rom = banked_data(16 * 1024, 4);
+        let chr_rom = vec![]; // CHR-RAM path
+
+        let mut mapper = BandaiFcgMapper::new(prg_rom.clone(), chr_rom, MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8008, 2); // PRG bank
+        mapper.write_prg(0x8000, 3); // CHR bank 0
+        mapper.write_prg(0x8009, 3); // mirroring upper
+
+        mapper.write_chr(0x0000, 0xAB);
+
+        mapper.write_prg(0x800B, 0x34);
+        mapper.write_prg(0x800C, 0x12);
+        mapper.write_prg(0x800A, 1);
+
+        let regs = mapper.registers_snapshot();
+        let chr = mapper.chr_ram_snapshot();
+
+        let mut restored = BandaiFcgMapper::new(prg_rom, vec![], MirroringMode::Vertical);
+        restored.restore_registers(&regs);
+        restored.restore_chr_ram(&chr);
+
+        assert_eq!(restored.read_prg(0x8000), 2);
+        assert_eq!(restored.read_chr(0x0000), 0xAB);
+        assert_eq!(restored.get_mirroring(), MirroringMode::SingleScreenUpper);
+        assert_eq!(restored.irq_pending(), mapper.irq_pending());
     }
 }

--- a/src/cartridge/bnrom_nina.rs
+++ b/src/cartridge/bnrom_nina.rs
@@ -166,6 +166,27 @@ impl Mapper for BnromNinaMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![self.prg_bank_select, self.chr_bank_select]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if let Some(&value) = data.first() {
+            self.prg_bank_select = value;
+        }
+        if let Some(&value) = data.get(1) {
+            self.chr_bank_select = value;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -224,6 +245,35 @@ mod tests {
         assert_eq!(mapper.read_chr(0x0000), 0xAA);
         assert_eq!(mapper.read_chr(0x1000), 0xBB);
         assert_eq!(mapper.read_chr(0x1FFF), 0xCC);
+    }
+
+    #[test]
+    fn test_bnrom_registers_and_chr_ram_snapshot_roundtrip() {
+        let mut prg_rom = vec![0; 128 * 1024];
+
+        for bank in 0..4 {
+            let start = bank * 32 * 1024;
+            let end = start + 32 * 1024;
+            for byte in &mut prg_rom[start..end] {
+                *byte = (bank + 3) as u8;
+            }
+        }
+
+        let mut mapper = BnromNinaMapper::new(prg_rom.clone(), vec![], MirroringMode::Horizontal);
+        mapper.write_prg(0x8000, 2);
+        mapper.write_chr(0x0000, 0x11);
+        mapper.write_chr(0x1FFF, 0x22);
+
+        let registers = mapper.registers_snapshot();
+        let chr_ram = mapper.chr_ram_snapshot();
+
+        let mut restored = BnromNinaMapper::new(prg_rom, vec![], MirroringMode::Horizontal);
+        restored.restore_registers(&registers);
+        restored.restore_chr_ram(&chr_ram);
+
+        assert_eq!(restored.read_prg(0x8000), 5);
+        assert_eq!(restored.read_chr(0x0000), 0x11);
+        assert_eq!(restored.read_chr(0x1FFF), 0x22);
     }
 
     #[test]

--- a/src/cartridge/camerica.rs
+++ b/src/cartridge/camerica.rs
@@ -132,6 +132,27 @@ impl Mapper for CamericaMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        // [0]: bank_select
+        // [1]: one_screen_upper
+        vec![self.bank_select, self.one_screen_upper as u8]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if data.len() >= 2 {
+            self.bank_select = data[0];
+            self.one_screen_upper = data[1] != 0;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -329,5 +350,34 @@ mod tests {
         // Read back
         assert_eq!(mapper.read_prg(0x6000), 0xAA);
         assert_eq!(mapper.read_prg(0x7FFF), 0xBB);
+    }
+
+    #[test]
+    fn test_camerica_registers_snapshot_restores_bank_mirroring_and_chr_ram() {
+        let mut prg_rom = vec![0; 64 * 1024];
+        for bank in 0..4 {
+            let start = bank * 16 * 1024;
+            let end = start + 16 * 1024;
+            for byte in &mut prg_rom[start..end] {
+                *byte = bank as u8;
+            }
+        }
+
+        let mut mapper = CamericaMapper::new(prg_rom.clone(), vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8000, 2);
+        mapper.write_prg(0xC000, 0x10); // one-screen upper
+        mapper.write_chr(0x0000, 0x5A);
+
+        let regs = mapper.registers_snapshot();
+        let chr = mapper.chr_ram_snapshot();
+
+        let mut restored = CamericaMapper::new(prg_rom, vec![], MirroringMode::Horizontal);
+        restored.restore_registers(&regs);
+        restored.restore_chr_ram(&chr);
+
+        assert_eq!(restored.read_prg(0x8000), 2);
+        assert_eq!(restored.get_mirroring(), MirroringMode::SingleScreenUpper);
+        assert_eq!(restored.read_chr(0x0000), 0x5A);
     }
 }

--- a/src/cartridge/cartridge.rs
+++ b/src/cartridge/cartridge.rs
@@ -4,9 +4,10 @@ use std::path::{Path, PathBuf};
 use std::{error, fmt};
 
 use crate::cartridge::Mapper;
+use serde::{Deserialize, Serialize};
 
 // Mirroring types for nametables
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MirroringMode {
     Vertical,
     Horizontal,
@@ -61,6 +62,7 @@ pub struct Cartridge {
     /// Mapper instance that handles banking and memory access
     mapper: Box<dyn Mapper>,
 
+    rom_path: Option<PathBuf>,
     save_path: Option<PathBuf>,
     battery_backed_prg_ram: bool,
 }
@@ -162,6 +164,7 @@ impl Cartridge {
 
         Ok(Self {
             mapper,
+            rom_path: None,
             save_path: None,
             battery_backed_prg_ram,
         })
@@ -173,10 +176,17 @@ impl Cartridge {
         let data = fs::read(&rom_path)?;
         let mut cart = Self::new(&data)?;
 
+        cart.rom_path = Some(rom_path.clone());
         cart.save_path = Some(rom_path.with_extension("sav"));
         cart.load_save_ram_from_disk()?;
 
         Ok(cart)
+    }
+
+    pub fn state_path(&self) -> Option<PathBuf> {
+        self.rom_path
+            .as_ref()
+            .map(|path| path.with_extension("state"))
     }
 
     pub fn save_ram(&self) -> io::Result<()> {
@@ -255,6 +265,7 @@ impl Cartridge {
         let mapper = Box::new(NROMMapper::new(prg_rom, chr_rom, mirroring));
         Self {
             mapper,
+            rom_path: None,
             save_path: None,
             battery_backed_prg_ram: false,
         }
@@ -264,6 +275,7 @@ impl Cartridge {
     pub fn from_mapper_for_test(mapper: Box<dyn Mapper>) -> Self {
         Self {
             mapper,
+            rom_path: None,
             save_path: None,
             battery_backed_prg_ram: false,
         }

--- a/src/cartridge/cnrom.rs
+++ b/src/cartridge/cnrom.rs
@@ -106,6 +106,16 @@ impl Mapper for CNROMMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![self.chr_bank_select]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if let Some(&value) = data.first() {
+            self.chr_bank_select = value;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -196,6 +206,34 @@ mod tests {
         // Writing higher bits should wrap (only 2 banks available)
         mapper.write_prg(0x8000, 0b0000_0011); // Bank 3 wraps to bank 1
         assert_eq!(mapper.read_chr(0x0000), 50);
+    }
+
+    #[test]
+    fn test_cnrom_registers_snapshot_restores_chr_bank() {
+        let mut chr_rom = vec![0; 32 * 1024];
+
+        for bank in 0..4 {
+            let start = bank * 8 * 1024;
+            let end = start + 8 * 1024;
+            for byte in &mut chr_rom[start..end] {
+                *byte = (bank * 7) as u8;
+            }
+        }
+
+        let mut mapper = CNROMMapper::new(
+            vec![0; 32 * 1024],
+            chr_rom.clone(),
+            MirroringMode::Horizontal,
+        );
+        mapper.write_prg(0x8000, 0b0000_0011);
+
+        let registers = mapper.registers_snapshot();
+
+        let mut restored = CNROMMapper::new(vec![0; 32 * 1024], chr_rom, MirroringMode::Horizontal);
+        restored.restore_registers(&registers);
+
+        assert_eq!(restored.read_chr(0x0000), 21);
+        assert_eq!(restored.read_chr(0x1FFF), 21);
     }
 
     #[test]

--- a/src/cartridge/colordreams.rs
+++ b/src/cartridge/colordreams.rs
@@ -116,6 +116,17 @@ impl Mapper for ColorDreamsMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![self.prg_bank_select, self.chr_bank_select]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if data.len() >= 2 {
+            self.prg_bank_select = data[0];
+            self.chr_bank_select = data[1];
+        }
+    }
 }
 
 #[cfg(test)]
@@ -211,5 +222,31 @@ mod tests {
         // Select CHR bank 3, should wrap to bank 1 (3 % 2 = 1)
         mapper.write_prg(0x8000, 0x03); // 0b0000_0011
         assert_eq!(mapper.read_chr(0x0000), 1);
+    }
+
+    #[test]
+    fn test_colordreams_registers_snapshot_restores_banks() {
+        let prg_rom = banked_data(32 * 1024, 4);
+        let chr_rom = banked_data(8 * 1024, 4);
+
+        let mut mapper = create_mapper(
+            11,
+            prg_rom.clone(),
+            chr_rom.clone(),
+            MirroringMode::Horizontal,
+        )
+        .expect("ColorDreams (mapper 11) should be implemented");
+
+        // Select PRG bank 2 and CHR bank 3 (0b0010_0011 = 0x23)
+        mapper.write_prg(0x8000, 0x23);
+
+        let snapshot = mapper.registers_snapshot();
+
+        let mut restored = create_mapper(11, prg_rom, chr_rom, MirroringMode::Horizontal)
+            .expect("ColorDreams (mapper 11) should be implemented");
+        restored.restore_registers(&snapshot);
+
+        assert_eq!(restored.read_prg(0x8000), 2);
+        assert_eq!(restored.read_chr(0x0000), 3);
     }
 }

--- a/src/cartridge/common.rs
+++ b/src/cartridge/common.rs
@@ -174,6 +174,25 @@ impl ChrMemory {
             self.data[index] = value;
         }
     }
+
+    /// Create a snapshot of CHR-RAM for save-state persistence.
+    pub fn snapshot(&self) -> Vec<u8> {
+        if self.is_ram {
+            self.data.clone()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Load a snapshot into CHR-RAM from save-state persistence.
+    pub fn load_snapshot(&mut self, data: &[u8]) {
+        if !self.is_ram {
+            return;
+        }
+
+        let to_copy = data.len().min(self.data.len());
+        self.data[..to_copy].copy_from_slice(&data[..to_copy]);
+    }
 }
 
 #[cfg(test)]

--- a/src/cartridge/cprom.rs
+++ b/src/cartridge/cprom.rs
@@ -318,4 +318,21 @@ mod tests {
         mapper.write_prg(0xFFFF, 3);
         assert_eq!(mapper.read_chr(0x0000), 103);
     }
+
+    #[test]
+    fn test_cprom_registers_snapshot_restores_chr_bank() {
+        let mut mapper = CpromMapper::new(vec![0; 32 * 1024], vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8000, 0b0000_0010); // select bank 2
+        let regs = mapper.registers_snapshot();
+
+        let mut restored = CpromMapper::new(vec![0; 32 * 1024], vec![], MirroringMode::Horizontal);
+        restored.restore_registers(&regs);
+
+        restored.write_chr(0x0000, 0xAA);
+        assert_eq!(restored.read_chr(0x0000), 0xAA);
+
+        restored.write_prg(0x8000, 0b0000_0011); // switch to bank 3
+        assert_ne!(restored.read_chr(0x0000), 0xAA);
+    }
 }

--- a/src/cartridge/gxrom.rs
+++ b/src/cartridge/gxrom.rs
@@ -114,6 +114,19 @@ impl Mapper for GxROMMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![self.prg_bank_select, self.chr_bank_select]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if let Some(&value) = data.first() {
+            self.prg_bank_select = value;
+        }
+        if let Some(&value) = data.get(1) {
+            self.chr_bank_select = value;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -170,5 +183,30 @@ mod tests {
         // Bank select write should not affect mirroring.
         mapper.write_prg(0xFFFF, 0xFF);
         assert_eq!(mapper.get_mirroring(), MirroringMode::Vertical);
+    }
+
+    #[test]
+    fn test_gxrom_registers_snapshot_restores_bank_selects() {
+        let prg_rom = banked_data(32 * 1024, 4);
+        let chr_rom = banked_data(8 * 1024, 4);
+
+        let mut mapper = create_mapper(
+            66,
+            prg_rom.clone(),
+            chr_rom.clone(),
+            MirroringMode::Horizontal,
+        )
+        .expect("GxROM (mapper 66) should be implemented");
+
+        mapper.write_prg(0x8000, 0x21); // PRG bank 2, CHR bank 1
+
+        let registers = mapper.registers_snapshot();
+
+        let mut restored = create_mapper(66, prg_rom, chr_rom, MirroringMode::Horizontal)
+            .expect("GxROM (mapper 66) should be implemented");
+        restored.restore_registers(&registers);
+
+        assert_eq!(restored.read_prg(0x8000), 2);
+        assert_eq!(restored.read_chr(0x0000), 1);
     }
 }

--- a/src/cartridge/mmc1.rs
+++ b/src/cartridge/mmc1.rs
@@ -414,6 +414,8 @@ impl Mapper for MMC1Mapper {
         // [3]: chr_bank_0
         // [4]: chr_bank_1
         // [5]: prg_bank
+        // [6..=13]: cpu_cycle_count (u64 LE)
+        // [14..=21]: last_write_cycle (u64 LE)
         vec![
             self.shift_register,
             self.write_count,
@@ -421,6 +423,22 @@ impl Mapper for MMC1Mapper {
             self.chr_bank_0,
             self.chr_bank_1,
             self.prg_bank,
+            (self.cpu_cycle_count & 0xFF) as u8,
+            ((self.cpu_cycle_count >> 8) & 0xFF) as u8,
+            ((self.cpu_cycle_count >> 16) & 0xFF) as u8,
+            ((self.cpu_cycle_count >> 24) & 0xFF) as u8,
+            ((self.cpu_cycle_count >> 32) & 0xFF) as u8,
+            ((self.cpu_cycle_count >> 40) & 0xFF) as u8,
+            ((self.cpu_cycle_count >> 48) & 0xFF) as u8,
+            ((self.cpu_cycle_count >> 56) & 0xFF) as u8,
+            (self.last_write_cycle & 0xFF) as u8,
+            ((self.last_write_cycle >> 8) & 0xFF) as u8,
+            ((self.last_write_cycle >> 16) & 0xFF) as u8,
+            ((self.last_write_cycle >> 24) & 0xFF) as u8,
+            ((self.last_write_cycle >> 32) & 0xFF) as u8,
+            ((self.last_write_cycle >> 40) & 0xFF) as u8,
+            ((self.last_write_cycle >> 48) & 0xFF) as u8,
+            ((self.last_write_cycle >> 56) & 0xFF) as u8,
         ]
     }
 
@@ -432,6 +450,15 @@ impl Mapper for MMC1Mapper {
             self.chr_bank_0 = data[3];
             self.chr_bank_1 = data[4];
             self.prg_bank = data[5];
+        }
+
+        if data.len() >= 22 {
+            self.cpu_cycle_count = u64::from_le_bytes([
+                data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13],
+            ]);
+            self.last_write_cycle = u64::from_le_bytes([
+                data[14], data[15], data[16], data[17], data[18], data[19], data[20], data[21],
+            ]);
         }
     }
 
@@ -477,6 +504,32 @@ mod tests {
         // Bits 2-3: PRG ROM bank mode = 0b00
         // Bit 4: CHR ROM bank mode = 0
         assert_eq!(mapper.get_mirroring(), MirroringMode::Horizontal);
+    }
+
+    #[test]
+    fn test_mmc1_registers_snapshot_preserves_write_ignore_timing() {
+        let prg_rom = vec![0; PRG_BANK_SIZE * 2];
+        let chr_rom = vec![];
+
+        let mut mapper =
+            MMC1Mapper::new(prg_rom.clone(), chr_rom.clone(), MirroringMode::Horizontal);
+
+        mapper.cpu_cycle();
+        mapper.write_prg(0x8000, 0x01);
+
+        let saved = mapper.registers_snapshot();
+
+        let mut restored = MMC1Mapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+        restored.restore_registers(&saved);
+
+        let before = restored.registers_snapshot();
+        restored.write_prg(0x8000, 0x00);
+        let after = restored.registers_snapshot();
+
+        assert_eq!(
+            after, before,
+            "consecutive write should be ignored when cpu_cycle_count matches last_write_cycle"
+        );
     }
 
     #[test]

--- a/src/cartridge/mmc2.rs
+++ b/src/cartridge/mmc2.rs
@@ -296,8 +296,8 @@ impl Mapper for MMC2Mapper {
             self.latch0_is_fd = (data[5] & 1) != 0;
             self.latch1_is_fd = (data[5] & 2) != 0;
             self.mirroring = match data[6] {
-                0 => MirroringMode::Horizontal,
-                1 => MirroringMode::Vertical,
+                0 => MirroringMode::Vertical,
+                1 => MirroringMode::Horizontal,
                 _ => MirroringMode::Horizontal,
             };
         }
@@ -320,7 +320,7 @@ mod tests {
         let prg_rom = filled_banks(MMC2Mapper::PRG_BANK_SIZE, prg_banks);
         let chr_rom = filled_banks(MMC2Mapper::CHR_BANK_SIZE, 8);
 
-        let mut mapper = MMC2Mapper::new(prg_rom, chr_rom, MirroringMode::Vertical);
+        let mapper = MMC2Mapper::new(prg_rom, chr_rom, MirroringMode::Vertical);
 
         // Power-on: bank 0 at $8000.
         assert_eq!(mapper.read_prg(0x8000), 0);
@@ -329,13 +329,34 @@ mod tests {
         assert_eq!(mapper.read_prg(0xA000), (prg_banks - 3) as u8);
         assert_eq!(mapper.read_prg(0xC000), (prg_banks - 2) as u8);
         assert_eq!(mapper.read_prg(0xE000), (prg_banks - 1) as u8);
+    }
 
-        // Switch $8000 bank via $A000.
-        mapper.write_prg(0xA000, 2);
-        assert_eq!(mapper.read_prg(0x8000), 2);
+    #[test]
+    fn test_mmc2_registers_snapshot_preserves_latches_and_mirroring() {
+        let prg_rom = filled_banks(MMC2Mapper::PRG_BANK_SIZE, 4);
+        let chr_rom = filled_banks(MMC2Mapper::CHR_BANK_SIZE, 8);
 
-        mapper.write_prg(0xA123, 7);
-        assert_eq!(mapper.read_prg(0x8000), 7);
+        let mut mapper = MMC2Mapper::new(prg_rom.clone(), chr_rom.clone(), MirroringMode::Vertical);
+
+        mapper.write_prg(0xA000, 0x03); // PRG bank
+        mapper.write_prg(0xB000, 0x01); // CHR 0 FD
+        mapper.write_prg(0xC000, 0x02); // CHR 0 FE
+        mapper.write_prg(0xD000, 0x03); // CHR 1 FD
+        mapper.write_prg(0xE000, 0x04); // CHR 1 FE
+        mapper.write_prg(0xF000, 0x01); // Mirroring horizontal
+
+        mapper.ppu_address_changed(0x0FD8); // latch0 FD
+        mapper.ppu_address_changed(0x1FE8); // latch1 FE
+
+        let saved = mapper.registers_snapshot();
+
+        let mut restored = MMC2Mapper::new(prg_rom, chr_rom, MirroringMode::Vertical);
+        restored.restore_registers(&saved);
+
+        assert_eq!(restored.get_mirroring(), MirroringMode::Horizontal);
+        assert_eq!(restored.read_prg(0x8000), 3);
+        assert_eq!(restored.read_chr(0x0000), 1);
+        assert_eq!(restored.read_chr(0x1000), 4);
     }
 
     #[test]

--- a/src/cartridge/mmc3.rs
+++ b/src/cartridge/mmc3.rs
@@ -418,6 +418,42 @@ mod tests {
     }
 
     #[test]
+    fn test_mmc3_registers_snapshot_preserves_a12_low_pass_state() {
+        let prg_rom = banked_data(8 * 1024, 8);
+        let chr_rom = banked_data(1024, 16);
+
+        let mut mapper = create_mapper(
+            4,
+            prg_rom.clone(),
+            chr_rom.clone(),
+            MirroringMode::Horizontal,
+        )
+        .expect("MMC3 (mapper 4) should be implemented");
+
+        mapper.write_prg(0xC000, 0); // latch=0
+        mapper.write_prg(0xC001, 0); // reload
+        mapper.write_prg(0xE001, 0); // enable
+
+        // Establish A12 low state and 3 low CPU cycles to satisfy the filter.
+        mapper.ppu_address_changed(0x0FFF);
+        for _ in 0..3 {
+            mapper.cpu_cycle();
+        }
+
+        let saved = mapper.registers_snapshot();
+
+        let mut restored = create_mapper(4, prg_rom, chr_rom, MirroringMode::Horizontal)
+            .expect("MMC3 (mapper 4) should be implemented");
+        restored.restore_registers(&saved);
+
+        restored.ppu_address_changed(0x1000);
+        assert!(
+            restored.irq_pending(),
+            "A12 low-pass state should be preserved across save-state"
+        );
+    }
+
+    #[test]
     fn test_mmc3_irq_reload_clears_counter_immediately() {
         // NesDev: Writing to $C001 (IRQ reload) clears the IRQ counter immediately to 0
         // and sets the reload flag. The counter reloads from latch on the next A12 rising edge.
@@ -990,7 +1026,10 @@ impl Mapper for MMC3Mapper {
         // [10]: irq_counter
         // [11]: flags (irq_reload, irq_enabled, irq_asserted, prg_ram_enabled, prg_ram_write_protected)
         // [12]: mirroring mode
-        let mut snapshot = Vec::with_capacity(13);
+        // [13]: prev_a12
+        // [14]: current_a12
+        // [15]: a12_low_cycles
+        let mut snapshot = Vec::with_capacity(16);
         snapshot.push(self.bank_select);
         snapshot.extend_from_slice(&self.regs);
         snapshot.push(self.irq_latch);
@@ -1002,6 +1041,9 @@ impl Mapper for MMC3Mapper {
             | ((self.prg_ram_write_protected as u8) << 4);
         snapshot.push(flags);
         snapshot.push(self.mirroring as u8);
+        snapshot.push(self.prev_a12 as u8);
+        snapshot.push(self.current_a12 as u8);
+        snapshot.push(self.a12_low_cycles);
         snapshot
     }
 
@@ -1024,6 +1066,12 @@ impl Mapper for MMC3Mapper {
                 3 => MirroringMode::FourScreen,
                 _ => MirroringMode::Horizontal,
             };
+        }
+
+        if data.len() >= 16 {
+            self.prev_a12 = data[13] != 0;
+            self.current_a12 = data[14] != 0;
+            self.a12_low_cycles = data[15];
         }
     }
 }

--- a/src/cartridge/mmc4.rs
+++ b/src/cartridge/mmc4.rs
@@ -265,8 +265,8 @@ impl Mapper for MMC4Mapper {
             self.latch0_is_fd.set((data[5] & 1) != 0);
             self.latch1_is_fd.set((data[5] & 2) != 0);
             self.mirroring = match data[6] {
-                0 => MirroringMode::Horizontal,
-                1 => MirroringMode::Vertical,
+                0 => MirroringMode::Vertical,
+                1 => MirroringMode::Horizontal,
                 _ => MirroringMode::Horizontal,
             };
         }
@@ -334,5 +334,33 @@ mod tests {
         // High region latch: FE
         mapper.ppu_address_changed(0x1FE8);
         assert_eq!(mapper.read_chr(0x1000), 4);
+    }
+
+    #[test]
+    fn test_mmc4_registers_snapshot_preserves_latches_and_mirroring() {
+        let prg_rom = filled_banks(MMC4Mapper::PRG_BANK_SIZE, 4);
+        let chr_rom = filled_banks(MMC4Mapper::CHR_BANK_SIZE, 8);
+
+        let mut mapper = MMC4Mapper::new(prg_rom.clone(), chr_rom.clone(), MirroringMode::Vertical);
+
+        mapper.write_prg(0xA000, 0x03); // PRG bank
+        mapper.write_prg(0xB000, 0x01); // CHR 0 FD
+        mapper.write_prg(0xC000, 0x02); // CHR 0 FE
+        mapper.write_prg(0xD000, 0x03); // CHR 1 FD
+        mapper.write_prg(0xE000, 0x04); // CHR 1 FE
+        mapper.write_prg(0xF000, 0x01); // Mirroring horizontal
+
+        mapper.ppu_address_changed(0x0FD8); // latch0 FD
+        mapper.ppu_address_changed(0x1FE8); // latch1 FE
+
+        let saved = mapper.registers_snapshot();
+
+        let mut restored = MMC4Mapper::new(prg_rom, chr_rom, MirroringMode::Vertical);
+        restored.restore_registers(&saved);
+
+        assert_eq!(restored.get_mirroring(), MirroringMode::Horizontal);
+        assert_eq!(restored.read_prg(0x8000), 3);
+        assert_eq!(restored.read_chr(0x0000), 1);
+        assert_eq!(restored.read_chr(0x1000), 4);
     }
 }

--- a/src/cartridge/mmc5.rs
+++ b/src/cartridge/mmc5.rs
@@ -1023,7 +1023,7 @@ impl Mapper for MMC5Mapper {
         // Hardware detects a scanline when it sees PPU reading from nametable addresses.
         // Reset CPU cycle counter since we just saw a PPU read.
         self.cpu_cycles_since_ppu_read = 0;
-        
+
         // Set in_frame flag when we see PPU reads from nametable
         if !self.in_frame {
             self.in_frame = true;
@@ -1109,7 +1109,7 @@ impl Mapper for MMC5Mapper {
         trace_mapper!(1; "[mmc5] cpu_cycle (audio)");
         self.pulse1.cpu_cycle();
         self.pulse2.cpu_cycle();
-        
+
         // MMC5 hardware in-frame detection:
         // Clear in_frame flag after 3 CPU cycles without PPU reads.
         // This matches the hardware behavior where the in-frame signal
@@ -1149,7 +1149,7 @@ impl Mapper for MMC5Mapper {
         // The in_frame flag is set when rendering is enabled or when PPU reads occur,
         // and cleared after 3 CPU cycles without reads (handled in cpu_cycle).
         // This callback is used to update the scanline counter and check for IRQ.
-        
+
         if !rendering_enabled {
             // When rendering is disabled, clear in_frame immediately
             // (hardware would stop seeing PPU reads)
@@ -1162,7 +1162,7 @@ impl Mapper for MMC5Mapper {
         // Set in_frame when rendering is enabled (hardware would be seeing PPU reads)
         self.in_frame = true;
         self.cpu_cycles_since_ppu_read = 0;
-        
+
         // Update scanline counter - this happens when rendering is enabled
         // and is coordinated with PPU read detection
         self.scanline_counter = scanline;
@@ -1231,6 +1231,353 @@ impl Mapper for MMC5Mapper {
         // MMC5: Write directly to all PRG-RAM banks, bypassing banking and write-protect state.
         let to_copy = data.len().min(self.prg_ram.len());
         self.prg_ram[..to_copy].copy_from_slice(&data[..to_copy]);
+    }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        match &self.chr {
+            Chr::Ram(data) => data.clone(),
+            Chr::Rom(_) => Vec::new(),
+        }
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        let Chr::Ram(chr_ram) = &mut self.chr else {
+            return;
+        };
+
+        let to_copy = data.len().min(chr_ram.len());
+        chr_ram[..to_copy].copy_from_slice(&data[..to_copy]);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        let mut snapshot = Vec::with_capacity(256);
+
+        snapshot.push(self.prg_mode);
+        snapshot.push(self.prg_bank_5113);
+        snapshot.push(self.prg_bank_5114);
+        snapshot.push(self.prg_bank_5115);
+        snapshot.push(self.prg_bank_5116);
+        snapshot.push(self.prg_bank_5117);
+
+        snapshot.push(self.prg_ram_protect_1);
+        snapshot.push(self.prg_ram_protect_2);
+
+        snapshot.push(self.chr_mode);
+        snapshot.extend_from_slice(&self.chr_bank_a);
+        snapshot.extend_from_slice(&self.chr_bank_b);
+        snapshot.push(self.chr_bank_upper);
+        snapshot.push(self.chr_fetch_is_sprite as u8);
+        snapshot.push(self.chr_last_set_written as u8);
+        snapshot.push(self.chr_is_rendering_fetch as u8);
+        snapshot.push(self.sprite_8x16_mode as u8);
+
+        snapshot.push(self.nametable_mapping);
+        snapshot.push(self.fill_tile);
+        snapshot.push(self.fill_attr);
+
+        snapshot.push(self.ex_ram_mode);
+        let ex_len = self.ex_ram.len() as u16;
+        snapshot.extend_from_slice(&ex_len.to_le_bytes());
+        snapshot.extend_from_slice(&self.ex_ram);
+
+        snapshot.extend_from_slice(&(self.last_bg_tile_index as u16).to_le_bytes());
+
+        snapshot.push(self.split_mode);
+        snapshot.push(self.split_scroll);
+        snapshot.push(self.split_bank);
+        snapshot.push(self.split_active as u8);
+
+        snapshot.push(self.irq_scanline_compare);
+        snapshot.push(self.irq_enabled as u8);
+        snapshot.push(self.irq_pending.get() as u8);
+        snapshot.push(self.in_frame as u8);
+        snapshot.extend_from_slice(&self.scanline_counter.to_le_bytes());
+        snapshot.push(self.cpu_cycles_since_ppu_read);
+
+        snapshot.push(self.multiplicand);
+        snapshot.push(self.multiplier);
+
+        snapshot.push(self.pulse1.enabled as u8);
+        snapshot.push(self.pulse1.volume);
+        snapshot.extend_from_slice(&self.pulse1.timer_reload.to_le_bytes());
+        snapshot.extend_from_slice(&self.pulse1.timer.to_le_bytes());
+        snapshot.push(self.pulse1.phase as u8);
+
+        snapshot.push(self.pulse2.enabled as u8);
+        snapshot.push(self.pulse2.volume);
+        snapshot.extend_from_slice(&self.pulse2.timer_reload.to_le_bytes());
+        snapshot.extend_from_slice(&self.pulse2.timer.to_le_bytes());
+        snapshot.push(self.pulse2.phase as u8);
+
+        snapshot.push(self.pcm_enabled as u8);
+        snapshot.push(self.pcm_value);
+
+        snapshot.push(self.mirroring as u8);
+
+        snapshot
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        let mut idx = 0usize;
+        let next_u8 = |data: &[u8], idx: &mut usize| -> Option<u8> {
+            let value = data.get(*idx).copied();
+            *idx += 1;
+            value
+        };
+
+        let next_u16 = |data: &[u8], idx: &mut usize| -> Option<u16> {
+            let lo = data.get(*idx).copied()?;
+            let hi = data.get(*idx + 1).copied()?;
+            *idx += 2;
+            Some(u16::from_le_bytes([lo, hi]))
+        };
+
+        let Some(prg_mode) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(prg_bank_5113) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(prg_bank_5114) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(prg_bank_5115) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(prg_bank_5116) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(prg_bank_5117) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(prg_ram_protect_1) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(prg_ram_protect_2) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(chr_mode) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        if data.len() < idx + 8 + 4 {
+            return;
+        }
+
+        let mut chr_bank_a = [0u8; 8];
+        chr_bank_a.copy_from_slice(&data[idx..idx + 8]);
+        idx += 8;
+
+        let mut chr_bank_b = [0u8; 4];
+        chr_bank_b.copy_from_slice(&data[idx..idx + 4]);
+        idx += 4;
+
+        let Some(chr_bank_upper) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(chr_fetch_is_sprite_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(chr_last_set_written_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(chr_is_rendering_fetch_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(sprite_8x16_mode_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        let chr_fetch_is_sprite = chr_fetch_is_sprite_raw != 0;
+        let chr_last_set_written = chr_last_set_written_raw != 0;
+        let chr_is_rendering_fetch = chr_is_rendering_fetch_raw != 0;
+        let sprite_8x16_mode = sprite_8x16_mode_raw != 0;
+
+        let Some(nametable_mapping) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(fill_tile) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(fill_attr) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        let Some(ex_ram_mode) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(ex_len) = next_u16(data, &mut idx) else {
+            return;
+        };
+        let ex_len = ex_len as usize;
+        if data.len() < idx + ex_len {
+            return;
+        }
+        let ex_ram_slice = &data[idx..idx + ex_len];
+        idx += ex_len;
+
+        let Some(last_bg_tile_index) = next_u16(data, &mut idx) else {
+            return;
+        };
+        let last_bg_tile_index = last_bg_tile_index as usize;
+
+        let Some(split_mode) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(split_scroll) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(split_bank) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(split_active_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let split_active = split_active_raw != 0;
+
+        let Some(irq_scanline_compare) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(irq_enabled_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(irq_pending_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(in_frame_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(scanline_counter) = next_u16(data, &mut idx) else {
+            return;
+        };
+        let Some(cpu_cycles_since_ppu_read) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        let irq_enabled = irq_enabled_raw != 0;
+        let irq_pending = irq_pending_raw != 0;
+        let in_frame = in_frame_raw != 0;
+
+        let Some(multiplicand) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(multiplier) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        let Some(pulse1_enabled_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(pulse1_volume) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(pulse1_timer_reload) = next_u16(data, &mut idx) else {
+            return;
+        };
+        let Some(pulse1_timer) = next_u16(data, &mut idx) else {
+            return;
+        };
+        let Some(pulse1_phase_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        let Some(pulse2_enabled_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(pulse2_volume) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(pulse2_timer_reload) = next_u16(data, &mut idx) else {
+            return;
+        };
+        let Some(pulse2_timer) = next_u16(data, &mut idx) else {
+            return;
+        };
+        let Some(pulse2_phase_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        let Some(pcm_enabled_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+        let Some(pcm_value) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        let Some(mirroring_raw) = next_u8(data, &mut idx) else {
+            return;
+        };
+
+        let pulse1_enabled = pulse1_enabled_raw != 0;
+        let pulse1_phase = pulse1_phase_raw != 0;
+        let pulse2_enabled = pulse2_enabled_raw != 0;
+        let pulse2_phase = pulse2_phase_raw != 0;
+        let pcm_enabled = pcm_enabled_raw != 0;
+
+        let mirroring = match mirroring_raw {
+            0 => MirroringMode::Horizontal,
+            1 => MirroringMode::Vertical,
+            2 => MirroringMode::SingleScreen,
+            3 => MirroringMode::FourScreen,
+            _ => MirroringMode::Horizontal,
+        };
+
+        self.prg_mode = prg_mode;
+        self.prg_bank_5113 = prg_bank_5113;
+        self.prg_bank_5114 = prg_bank_5114;
+        self.prg_bank_5115 = prg_bank_5115;
+        self.prg_bank_5116 = prg_bank_5116;
+        self.prg_bank_5117 = prg_bank_5117;
+        self.prg_ram_protect_1 = prg_ram_protect_1;
+        self.prg_ram_protect_2 = prg_ram_protect_2;
+
+        self.chr_mode = chr_mode;
+        self.chr_bank_a = chr_bank_a;
+        self.chr_bank_b = chr_bank_b;
+        self.chr_bank_upper = chr_bank_upper;
+        self.chr_fetch_is_sprite = chr_fetch_is_sprite;
+        self.chr_last_set_written = chr_last_set_written;
+        self.chr_is_rendering_fetch = chr_is_rendering_fetch;
+        self.sprite_8x16_mode = sprite_8x16_mode;
+
+        self.nametable_mapping = nametable_mapping;
+        self.fill_tile = fill_tile;
+        self.fill_attr = fill_attr;
+        self.ex_ram_mode = ex_ram_mode;
+        let to_copy = ex_ram_slice.len().min(self.ex_ram.len());
+        self.ex_ram[..to_copy].copy_from_slice(&ex_ram_slice[..to_copy]);
+
+        self.last_bg_tile_index = last_bg_tile_index;
+        self.split_mode = split_mode;
+        self.split_scroll = split_scroll;
+        self.split_bank = split_bank;
+        self.split_active = split_active;
+
+        self.irq_scanline_compare = irq_scanline_compare;
+        self.irq_enabled = irq_enabled;
+        self.irq_pending.set(irq_pending);
+        self.in_frame = in_frame;
+        self.scanline_counter = scanline_counter;
+        self.cpu_cycles_since_ppu_read = cpu_cycles_since_ppu_read;
+
+        self.multiplicand = multiplicand;
+        self.multiplier = multiplier;
+
+        self.pulse1.enabled = pulse1_enabled;
+        self.pulse1.volume = pulse1_volume;
+        self.pulse1.timer_reload = pulse1_timer_reload.max(1);
+        self.pulse1.timer = pulse1_timer;
+        self.pulse1.phase = pulse1_phase;
+
+        self.pulse2.enabled = pulse2_enabled;
+        self.pulse2.volume = pulse2_volume;
+        self.pulse2.timer_reload = pulse2_timer_reload.max(1);
+        self.pulse2.timer = pulse2_timer;
+        self.pulse2.phase = pulse2_phase;
+
+        self.pcm_enabled = pcm_enabled;
+        self.pcm_value = pcm_value;
+        self.mirroring = mirroring;
     }
 }
 
@@ -1305,6 +1652,63 @@ mod tests {
         assert!(!mmc5.irq_pending());
         mmc5.ppu_scanline(5, true);
         assert!(mmc5.irq_pending());
+    }
+
+    #[test]
+    fn test_mmc5_registers_snapshot_restores_state() {
+        let prg_rom = banked_data(8 * 1024, 8);
+        let chr_rom = banked_data(1024, 16);
+
+        let mut mapper = MMC5Mapper::new(prg_rom.clone(), chr_rom.clone(), MirroringMode::Vertical);
+
+        mapper.write_prg(0x5100, 3);
+        mapper.write_prg(0x5114, 0x80 | 1);
+        mapper.write_prg(0x5115, 0x80 | 2);
+        mapper.write_prg(0x5116, 0x80 | 3);
+        mapper.write_prg(0x5117, 0x80 | 4);
+
+        mapper.write_prg(0x5101, 3);
+        mapper.write_prg(0x5128, 5); // chr_bank_b[0]
+        mapper.write_prg(0x5120, 1); // chr_bank_a[0]
+        mapper.ppu_write_ctrl(0x20); // 8x16 sprites => use B regs for BG
+        mapper.ppu_set_chr_fetch_is_sprite(false);
+
+        mapper.write_prg(0x5104, 0);
+        mapper.write_prg(0x5105, 0b0000_0010); // $2000 quadrant -> ExRAM
+        assert!(mapper.write_nametable(0x2000, 0x77));
+
+        mapper.write_prg(0xF000, 0x01); // horizontal mirroring
+
+        mapper.write_prg(0x5203, 3);
+        mapper.write_prg(0x5204, 0x80);
+        mapper.ppu_scanline(3, true);
+
+        mapper.write_prg(0x5000, 0x0F);
+        mapper.write_prg(0x5002, 0x01);
+        mapper.write_prg(0x5003, 0x00);
+        mapper.write_prg(0x5015, 0x01);
+        let audio_sample = mapper.expansion_audio_sample();
+
+        let saved = mapper.registers_snapshot();
+
+        let mut restored = MMC5Mapper::new(prg_rom, chr_rom, MirroringMode::Vertical);
+        restored.restore_registers(&saved);
+
+        assert_eq!(restored.read_prg(0x8000), 1);
+        assert_eq!(restored.read_prg(0xA000), 2);
+        assert_eq!(restored.read_prg(0xC000), 3);
+        assert_eq!(restored.read_prg(0xE000), 4);
+
+        assert_eq!(restored.read_chr(0x0000), 5);
+
+        assert_eq!(restored.get_mirroring(), MirroringMode::Horizontal);
+
+        assert_eq!(restored.read_nametable(0x2000), Some(0x77));
+
+        assert!(restored.irq_pending());
+
+        let restored_sample = restored.expansion_audio_sample();
+        assert!((restored_sample - audio_sample).abs() < 1e-6);
     }
 
     #[test]

--- a/src/cartridge/multicart_15.rs
+++ b/src/cartridge/multicart_15.rs
@@ -181,6 +181,45 @@ impl Mapper for Multicart15Mapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        // [0]: bank_select
+        // [1]: sub_bank
+        // [2]: mode
+        // [3]: mirroring
+        let mirroring = match self.mirroring {
+            MirroringMode::Horizontal => 0,
+            MirroringMode::Vertical => 1,
+            MirroringMode::SingleScreen | MirroringMode::SingleScreenLower => 2,
+            MirroringMode::SingleScreenUpper => 3,
+            MirroringMode::FourScreen => 4,
+        };
+        vec![self.bank_select, self.sub_bank, self.mode, mirroring]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if data.len() >= 4 {
+            self.bank_select = data[0];
+            self.sub_bank = data[1];
+            self.mode = data[2];
+            self.mirroring = match data[3] {
+                0 => MirroringMode::Horizontal,
+                1 => MirroringMode::Vertical,
+                2 => MirroringMode::SingleScreen,
+                3 => MirroringMode::SingleScreenUpper,
+                4 => MirroringMode::FourScreen,
+                _ => MirroringMode::Horizontal,
+            };
+        }
+    }
 }
 
 #[cfg(test)]
@@ -376,5 +415,26 @@ mod tests {
 
         mapper.write_prg(0x8000, 20);
         assert_eq!(mapper.read_prg(0x8000), 200);
+    }
+
+    #[test]
+    fn test_multicart15_registers_snapshot_restores_state() {
+        let prg_rom = create_test_prg_rom(8);
+        let mut mapper = Multicart15Mapper::new(prg_rom.clone(), vec![], MirroringMode::Vertical);
+
+        mapper.write_prg(0x8004, 0x80 | 0x12); // mode 2, bank select 0x12, horizontal mirroring
+        mapper.write_chr(0x0000, 0xAB);
+
+        let regs = mapper.registers_snapshot();
+        let chr = mapper.chr_ram_snapshot();
+
+        let mut restored = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Vertical);
+        restored.restore_registers(&regs);
+        restored.restore_chr_ram(&chr);
+
+        assert_eq!(restored.get_mirroring(), MirroringMode::Horizontal);
+        assert_eq!(restored.read_chr(0x0000), 0xAB);
+        assert_eq!(restored.mode, 2);
+        assert_eq!(restored.bank_select, 0x12 & 0x3F);
     }
 }

--- a/src/cartridge/namco118.rs
+++ b/src/cartridge/namco118.rs
@@ -401,4 +401,45 @@ mod tests {
         mapper.load_wram_snapshot(&snap);
         assert_eq!(mapper.read_prg(0x6000), 0xAA);
     }
+
+    #[test]
+    fn namco118_registers_snapshot_restores_bank_mapping() {
+        let prg_rom = banked_data(8 * 1024, 8);
+        let chr_rom = banked_data(1024, 16);
+
+        let mut mapper = create_mapper(
+            206,
+            prg_rom.clone(),
+            chr_rom.clone(),
+            MirroringMode::Horizontal,
+        )
+        .expect("Mapper 206 should be implemented");
+
+        // Set PRG bank registers R6/R7.
+        mapper.write_prg(0x8000, 0b0000_0110);
+        mapper.write_prg(0x8001, 3);
+        mapper.write_prg(0x8000, 0b0000_0111);
+        mapper.write_prg(0x8001, 4);
+
+        // Set CHR registers R0/R1 (2KB) and R2 (1KB).
+        mapper.write_prg(0x8000, 0b0000_0000);
+        mapper.write_prg(0x8001, 6);
+        mapper.write_prg(0x8000, 0b0000_0001);
+        mapper.write_prg(0x8001, 8);
+        mapper.write_prg(0x8000, 0b0000_0010);
+        mapper.write_prg(0x8001, 10);
+
+        let regs = mapper.registers_snapshot();
+
+        let mut restored = create_mapper(206, prg_rom, chr_rom, MirroringMode::Horizontal)
+            .expect("Mapper 206 should be implemented");
+        restored.restore_registers(&regs);
+
+        assert_eq!(restored.read_prg(0x8000), 3);
+        assert_eq!(restored.read_prg(0xA000), 4);
+        assert_eq!(restored.read_chr(0x0000), 6);
+        assert_eq!(restored.read_chr(0x0400), 7);
+        assert_eq!(restored.read_chr(0x0800), 8);
+        assert_eq!(restored.read_chr(0x1000), 10);
+    }
 }

--- a/src/cartridge/namco163.rs
+++ b/src/cartridge/namco163.rs
@@ -452,25 +452,55 @@ impl Mapper for Namco163Mapper {
         // [144]: irq_counter low byte
         // [145]: irq_counter high byte (7 bits) + irq_enabled (1 bit)
         // [146]: flags (irq_pending, audio_disabled)
-        let mut snapshot = Vec::with_capacity(147);
+        // [147]: audio_addr
+        // [148]: audio_autoinc
+        // [149-164]: audio_channel_output[0-7] (i16 LE)
+        // [165]: audio_update_counter
+        // [166]: audio_current_channel
+        // [167-168]: audio_last_output (i16 LE)
+        let mut snapshot = Vec::with_capacity(169);
         snapshot.extend_from_slice(&self.regs);
         snapshot.extend_from_slice(&self.namco_ram);
         snapshot.push((self.irq_counter & 0xFF) as u8);
         snapshot.push(((self.irq_counter >> 8) as u8) | ((self.irq_enabled as u8) << 7));
         let flags = (self.irq_pending as u8) | ((self.audio_disabled as u8) << 1);
         snapshot.push(flags);
+        snapshot.push(self.audio_addr.get());
+        snapshot.push(self.audio_autoinc.get() as u8);
+        for value in self.audio_channel_output {
+            snapshot.extend_from_slice(&value.to_le_bytes());
+        }
+        snapshot.push(self.audio_update_counter);
+        snapshot.push(self.audio_current_channel as u8);
+        snapshot.extend_from_slice(&self.audio_last_output.to_le_bytes());
         snapshot
     }
 
     fn restore_registers(&mut self, data: &[u8]) {
         if data.len() >= 147 {
             self.regs.copy_from_slice(&data[0..16]);
+            self.map_mirroring(self.regs[11]);
             self.namco_ram.copy_from_slice(&data[16..144]);
             self.irq_counter = (data[144] as u16) | (((data[145] & 0x7F) as u16) << 8);
             self.irq_enabled = (data[145] & 0x80) != 0;
             let flags = data[146];
             self.irq_pending = (flags & 1) != 0;
             self.audio_disabled = (flags & 2) != 0;
+        }
+
+        if data.len() >= 169 {
+            self.audio_addr.set(data[147] & 0x7F);
+            self.audio_autoinc.set((data[148] & 1) != 0);
+            let mut offset = 149;
+            for slot in &mut self.audio_channel_output {
+                let lo = data[offset];
+                let hi = data[offset + 1];
+                *slot = i16::from_le_bytes([lo, hi]);
+                offset += 2;
+            }
+            self.audio_update_counter = data[165];
+            self.audio_current_channel = data[166] as i8;
+            self.audio_last_output = i16::from_le_bytes([data[167], data[168]]);
         }
     }
 }
@@ -660,5 +690,61 @@ mod tests {
 
         assert!(mapper.debug_audio_last_output() != 0);
         assert!(mapper.expansion_audio_sample() != 0.0);
+    }
+
+    #[test]
+    fn namco163_registers_snapshot_restores_audio_state_and_mirroring() {
+        let prg_rom = banked_data(8 * 1024, 2);
+        let chr_rom = banked_data(1024, 2);
+
+        let mut mapper =
+            Namco163Mapper::new(prg_rom.clone(), chr_rom.clone(), MirroringMode::Vertical);
+
+        // Configure audio so we have a non-zero last output.
+        mapper.write_prg(0xF800, 0x80); // pointer=0, auto-inc
+        mapper.write_prg(0x4800, 0x0F);
+
+        let base = 0x78u8; // channel 7 base
+        mapper.write_prg(0xF800, 0x80 | base);
+        mapper.write_prg(0x4800, 0x01); // freq low
+        mapper.write_prg(0x4800, 0x00); // phase low
+        mapper.write_prg(0x4800, 0x00); // freq mid
+        mapper.write_prg(0x4800, 0x00); // phase mid
+        mapper.write_prg(0x4800, 0xFC); // freq high + length
+        mapper.write_prg(0x4800, 0x00); // phase high
+        mapper.write_prg(0x4800, 0x00); // wave address
+        mapper.write_prg(0x4800, 0x0F); // volume
+
+        mapper.write_prg(0xF800, 0x7F);
+        mapper.write_prg(0x4800, 0x0F);
+
+        for _ in 0..32 {
+            mapper.cpu_cycle();
+        }
+
+        assert!(mapper.debug_audio_last_output() != 0);
+
+        // Set a known audio pointer/autoinc state.
+        mapper.write_prg(0xF800, 0x80 | 0x05);
+        mapper.write_prg(0x4800, 0xAA);
+        mapper.write_prg(0x4800, 0xBB);
+        mapper.write_prg(0xF800, 0x80 | 0x05);
+
+        // Set mirroring to SingleScreenLower.
+        mapper.write_prg(0x800B, 2);
+        assert_eq!(mapper.get_mirroring(), MirroringMode::SingleScreenLower);
+
+        let snapshot = mapper.registers_snapshot();
+
+        let mut restored = Namco163Mapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+        restored.restore_registers(&snapshot);
+
+        assert_eq!(restored.get_mirroring(), MirroringMode::SingleScreenLower);
+        assert_eq!(restored.read_prg(0x4800), 0xAA);
+        assert_eq!(restored.read_prg(0x4800), 0xBB);
+        assert_eq!(
+            restored.debug_audio_last_output(),
+            mapper.debug_audio_last_output()
+        );
     }
 }

--- a/src/cartridge/nina_tengen.rs
+++ b/src/cartridge/nina_tengen.rs
@@ -145,6 +145,32 @@ impl Mapper for NinaTengenMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        let mirroring = match self.mirroring {
+            MirroringMode::Horizontal => 0,
+            MirroringMode::Vertical => 1,
+            MirroringMode::SingleScreen | MirroringMode::SingleScreenLower => 2,
+            MirroringMode::SingleScreenUpper => 3,
+            MirroringMode::FourScreen => 4,
+        };
+        vec![self.prg_bank_select, self.chr_bank_select, mirroring]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if data.len() >= 3 {
+            self.prg_bank_select = data[0];
+            self.chr_bank_select = data[1];
+            self.mirroring = match data[2] {
+                0 => MirroringMode::Horizontal,
+                1 => MirroringMode::Vertical,
+                2 => MirroringMode::SingleScreen,
+                3 => MirroringMode::SingleScreenUpper,
+                4 => MirroringMode::FourScreen,
+                _ => MirroringMode::Horizontal,
+            };
+        }
+    }
 }
 
 #[cfg(test)]
@@ -380,5 +406,42 @@ mod tests {
 
         // Should still read original ROM value
         assert_eq!(mapper.read_chr(0x0000), 0xAA);
+    }
+
+    #[test]
+    fn test_nina_tengen_registers_snapshot_restores_banks_and_mirroring() {
+        let mut prg_rom = vec![0; 128 * 1024];
+        let mut chr_rom = vec![0; 128 * 1024];
+
+        for bank in 0..8 {
+            let start = bank * 16 * 1024;
+            let end = start + 16 * 1024;
+            for byte in &mut prg_rom[start..end] {
+                *byte = (bank + 10) as u8;
+            }
+        }
+
+        for bank in 0..16 {
+            let start = bank * 8 * 1024;
+            let end = start + 8 * 1024;
+            for byte in &mut chr_rom[start..end] {
+                *byte = (bank + 20) as u8;
+            }
+        }
+
+        let mut mapper =
+            NinaTengenMapper::new(prg_rom.clone(), chr_rom.clone(), MirroringMode::Horizontal);
+
+        // PRG=5, Mirroring=Horizontal, CHR=9
+        mapper.write_prg(0x8000, 0b1001_1101);
+
+        let snapshot = mapper.registers_snapshot();
+
+        let mut restored = NinaTengenMapper::new(prg_rom, chr_rom, MirroringMode::Vertical);
+        restored.restore_registers(&snapshot);
+
+        assert_eq!(restored.read_prg(0x8000), 15);
+        assert_eq!(restored.get_mirroring(), MirroringMode::Horizontal);
+        assert_eq!(restored.read_chr(0x0000), 29);
     }
 }

--- a/src/cartridge/nrom.rs
+++ b/src/cartridge/nrom.rs
@@ -98,6 +98,14 @@ impl Mapper for NROMMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
 }
 
 #[cfg(test)]
@@ -222,5 +230,21 @@ mod tests {
         mapper.ppu_address_changed(0x0000);
         mapper.ppu_address_changed(0x1000);
         mapper.ppu_address_changed(0x1FFF);
+    }
+
+    #[test]
+    fn test_nrom_chr_ram_snapshot_restores_contents() {
+        let mut mapper = NROMMapper::new(vec![0; 0x8000], vec![], MirroringMode::Horizontal);
+
+        mapper.write_chr(0x0000, 0xAA);
+        mapper.write_chr(0x1FFF, 0xBB);
+
+        let chr = mapper.chr_ram_snapshot();
+
+        let mut restored = NROMMapper::new(vec![0; 0x8000], vec![], MirroringMode::Horizontal);
+        restored.restore_chr_ram(&chr);
+
+        assert_eq!(restored.read_chr(0x0000), 0xAA);
+        assert_eq!(restored.read_chr(0x1FFF), 0xBB);
     }
 }

--- a/src/cartridge/sunsoft_fme7.rs
+++ b/src/cartridge/sunsoft_fme7.rs
@@ -359,7 +359,15 @@ impl Mapper for SunsoftFme7Mapper {
         snapshot.push(flags);
         snapshot.push((self.irq_counter & 0xFF) as u8);
         snapshot.push((self.irq_counter >> 8) as u8);
-        snapshot.push(self.mirroring as u8);
+        let mirroring = match self.mirroring {
+            MirroringMode::Horizontal => 0,
+            MirroringMode::Vertical => 1,
+            MirroringMode::SingleScreenLower => 2,
+            MirroringMode::SingleScreenUpper => 3,
+            MirroringMode::SingleScreen => 2,
+            MirroringMode::FourScreen => 4,
+        };
+        snapshot.push(mirroring);
         snapshot
     }
 
@@ -378,8 +386,9 @@ impl Mapper for SunsoftFme7Mapper {
             self.mirroring = match data[16] {
                 0 => MirroringMode::Horizontal,
                 1 => MirroringMode::Vertical,
-                2 => MirroringMode::SingleScreen,
-                3 => MirroringMode::FourScreen,
+                2 => MirroringMode::SingleScreenLower,
+                3 => MirroringMode::SingleScreenUpper,
+                4 => MirroringMode::FourScreen,
                 _ => MirroringMode::Horizontal,
             };
         }
@@ -571,5 +580,32 @@ mod tests {
 
         // $E000-$FFFF should read from last bank (bank 15)
         assert_eq!(mapper.read_prg(0xE000), 15);
+    }
+
+    #[test]
+    fn test_fme7_registers_snapshot_restores_mirroring_and_banks() {
+        let prg_rom = banked_data(8 * 1024, 8);
+        let chr_rom = banked_data(1024, 8);
+        let mut mapper =
+            SunsoftFme7Mapper::new(prg_rom.clone(), chr_rom.clone(), MirroringMode::Horizontal);
+
+        // Set PRG bank 1 and CHR bank 0.
+        mapper.write_prg(0x8000, 0x09);
+        mapper.write_prg(0xA000, 0x03);
+        mapper.write_prg(0x8000, 0x00);
+        mapper.write_prg(0xA000, 0x04);
+
+        // Set mirroring to single screen upper.
+        mapper.write_prg(0x8000, 0x0C);
+        mapper.write_prg(0xA000, 0x03);
+
+        let regs = mapper.registers_snapshot();
+
+        let mut restored = SunsoftFme7Mapper::new(prg_rom, chr_rom, MirroringMode::Vertical);
+        restored.restore_registers(&regs);
+
+        assert_eq!(restored.get_mirroring(), MirroringMode::SingleScreenUpper);
+        assert_eq!(restored.read_prg(0x8000), 3);
+        assert_eq!(restored.read_chr(0x0000), 4);
     }
 }

--- a/src/cartridge/uxrom.rs
+++ b/src/cartridge/uxrom.rs
@@ -111,6 +111,24 @@ impl Mapper for UxROMMapper {
     fn load_wram_snapshot(&mut self, data: &[u8]) {
         self.prg_ram.load_snapshot(data);
     }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![self.bank_select]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if !data.is_empty() {
+            self.bank_select = data[0];
+        }
+    }
 }
 
 #[cfg(test)]
@@ -262,5 +280,32 @@ mod tests {
 
         mapper.write_prg(0x8000, 10);
         assert_eq!(mapper.read_prg(0xC000), 115);
+    }
+
+    #[test]
+    fn test_uxrom_registers_snapshot_restores_bank_and_chr_ram() {
+        let mut prg_rom = vec![0; 128 * 1024];
+        for bank in 0..8 {
+            let start = bank * 16 * 1024;
+            let end = start + 16 * 1024;
+            for byte in &mut prg_rom[start..end] {
+                *byte = bank as u8;
+            }
+        }
+
+        let mut mapper = UxROMMapper::new(prg_rom.clone(), vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8000, 3);
+        mapper.write_chr(0x0000, 0x5A);
+
+        let regs = mapper.registers_snapshot();
+        let chr = mapper.chr_ram_snapshot();
+
+        let mut restored = UxROMMapper::new(prg_rom, vec![], MirroringMode::Horizontal);
+        restored.restore_registers(&regs);
+        restored.restore_chr_ram(&chr);
+
+        assert_eq!(restored.read_prg(0x8000), 3);
+        assert_eq!(restored.read_chr(0x0000), 0x5A);
     }
 }

--- a/src/cartridge/vrc2_vrc4.rs
+++ b/src/cartridge/vrc2_vrc4.rs
@@ -444,7 +444,15 @@ impl Mapper for Vrc2Vrc4Mapper {
         snapshot.push(flags);
         let prescaler_bytes = self.irq_prescaler.to_le_bytes();
         snapshot.extend_from_slice(&prescaler_bytes);
-        snapshot.push(self.mirroring as u8);
+        let mirroring = match self.mirroring {
+            MirroringMode::Horizontal => 0,
+            MirroringMode::Vertical => 1,
+            MirroringMode::SingleScreen => 2,
+            MirroringMode::FourScreen => 3,
+            MirroringMode::SingleScreenLower => 2,
+            MirroringMode::SingleScreenUpper => 2,
+        };
+        snapshot.push(mirroring);
         snapshot
     }
 
@@ -594,5 +602,42 @@ mod tests {
         // Test single screen mirroring
         mapper.write_prg(0x9000, 0x02);
         assert_eq!(mapper.get_mirroring(), MirroringMode::SingleScreen);
+    }
+
+    #[test]
+    fn test_vrc2_vrc4_registers_snapshot_restores_state() {
+        let prg_rom = banked_data(8 * 1024, 8);
+        let chr_rom = banked_data(1024, 8);
+
+        let mut mapper = create_mapper(
+            21,
+            prg_rom.clone(),
+            chr_rom.clone(),
+            MirroringMode::Horizontal,
+        )
+        .expect("Mapper 21 should be implemented");
+
+        mapper.write_prg(0x8000, 0x03); // prg_bank_16k
+        mapper.write_prg(0xA000, 0x05); // prg_bank_8k
+        mapper.write_prg(0xB000, 0x02); // chr bank 0
+        mapper.write_prg(0xC000, 0x04); // chr bank 4
+        mapper.write_prg(0x9000, 0x01); // mirroring horizontal
+
+        mapper.write_prg(0xF000, 0xFE);
+        mapper.write_prg(0xF001, 0b0000_0110);
+        mapper.cpu_cycle();
+
+        let regs = mapper.registers_snapshot();
+
+        let mut restored = create_mapper(21, prg_rom, chr_rom, MirroringMode::Vertical)
+            .expect("Mapper 21 should be implemented");
+        restored.restore_registers(&regs);
+
+        assert_eq!(restored.read_prg(0x8000), 6);
+        assert_eq!(restored.read_prg(0xC000), 5);
+        assert_eq!(restored.read_chr(0x0000), 2);
+        assert_eq!(restored.read_chr(0x1000), 4);
+        assert_eq!(restored.get_mirroring(), MirroringMode::Horizontal);
+        assert_eq!(restored.irq_pending(), mapper.irq_pending());
     }
 }

--- a/src/cartridge/vrc6.rs
+++ b/src/cartridge/vrc6.rs
@@ -8,7 +8,7 @@ enum Vrc6Variant {
     Mapper26,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 struct Vrc6Pulse {
     enabled: bool,
     mode_ignore_duty: bool,
@@ -19,25 +19,11 @@ struct Vrc6Pulse {
     duty_step: u8,
 }
 
-impl Default for Vrc6Pulse {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            mode_ignore_duty: false,
-            duty: 0,
-            volume: 0,
-            period: 0,
-            divider: 0,
-            duty_step: 15,
-        }
-    }
-}
-
 impl Vrc6Pulse {
     fn write_control(&mut self, value: u8) {
-        self.volume = value & 0x0F;
-        self.duty = (value >> 4) & 0x07;
         self.mode_ignore_duty = (value & 0x80) != 0;
+        self.duty = (value >> 4) & 0x07;
+        self.volume = value & 0x0F;
     }
 
     fn write_period_low(&mut self, value: u8) {
@@ -594,8 +580,12 @@ impl Mapper for VRC6Mapper {
         // [13]: flags (irq_enabled, irq_mode_cycle, irq_enable_after_ack, irq_asserted)
         // [14-17]: irq_prescaler (little endian i32)
         // [18]: mirroring
-        // Note: VRC6 audio state not serialized - would need significant additional work
-        let mut snapshot = Vec::with_capacity(19);
+        // [19]: audio.global_halt
+        // [20]: audio.global_shift
+        // [21-27]: pulse1 (enabled, mode_ignore_duty, duty, volume, period LE, divider LE, duty_step)
+        // [28-34]: pulse2 (enabled, mode_ignore_duty, duty, volume, period LE, divider LE, duty_step)
+        // [35-40]: saw (enabled, rate, period LE, divider LE, accumulator, step)
+        let mut snapshot = Vec::with_capacity(41);
         snapshot.push(self.prg_bank_16k);
         snapshot.push(self.prg_bank_8k);
         snapshot.extend_from_slice(&self.chr_banks_1k);
@@ -610,6 +600,31 @@ impl Mapper for VRC6Mapper {
         let prescaler_bytes = self.irq_prescaler.to_le_bytes();
         snapshot.extend_from_slice(&prescaler_bytes);
         snapshot.push(self.mirroring as u8);
+        snapshot.push(self.audio.global_halt as u8);
+        snapshot.push(self.audio.global_shift);
+
+        snapshot.push(self.audio.pulse1.enabled as u8);
+        snapshot.push(self.audio.pulse1.mode_ignore_duty as u8);
+        snapshot.push(self.audio.pulse1.duty);
+        snapshot.push(self.audio.pulse1.volume);
+        snapshot.extend_from_slice(&self.audio.pulse1.period.to_le_bytes());
+        snapshot.extend_from_slice(&self.audio.pulse1.divider.to_le_bytes());
+        snapshot.push(self.audio.pulse1.duty_step);
+
+        snapshot.push(self.audio.pulse2.enabled as u8);
+        snapshot.push(self.audio.pulse2.mode_ignore_duty as u8);
+        snapshot.push(self.audio.pulse2.duty);
+        snapshot.push(self.audio.pulse2.volume);
+        snapshot.extend_from_slice(&self.audio.pulse2.period.to_le_bytes());
+        snapshot.extend_from_slice(&self.audio.pulse2.divider.to_le_bytes());
+        snapshot.push(self.audio.pulse2.duty_step);
+
+        snapshot.push(self.audio.saw.enabled as u8);
+        snapshot.push(self.audio.saw.rate);
+        snapshot.extend_from_slice(&self.audio.saw.period.to_le_bytes());
+        snapshot.extend_from_slice(&self.audio.saw.divider.to_le_bytes());
+        snapshot.push(self.audio.saw.accumulator);
+        snapshot.push(self.audio.saw.step);
         snapshot
     }
 
@@ -634,6 +649,38 @@ impl Mapper for VRC6Mapper {
                 3 => MirroringMode::FourScreen,
                 _ => MirroringMode::Horizontal,
             };
+        }
+
+        if data.len() >= 41 {
+            self.audio.global_halt = data[19] != 0;
+            self.audio.global_shift = data[20];
+
+            self.audio.pulse1.enabled = data[21] != 0;
+            self.audio.pulse1.mode_ignore_duty = data[22] != 0;
+            self.audio.pulse1.duty = data[23];
+            self.audio.pulse1.volume = data[24];
+            self.audio.pulse1.period = u16::from_le_bytes([data[25], data[26]]);
+            self.audio.pulse1.divider = u16::from_le_bytes([data[27], data[28]]);
+            self.audio.pulse1.duty_step = data[29];
+
+            self.audio.pulse2.enabled = data[30] != 0;
+            self.audio.pulse2.mode_ignore_duty = data[31] != 0;
+            self.audio.pulse2.duty = data[32];
+            self.audio.pulse2.volume = data[33];
+            self.audio.pulse2.period = u16::from_le_bytes([data[34], data[35]]);
+            self.audio.pulse2.divider = u16::from_le_bytes([data[36], data[37]]);
+            self.audio.pulse2.duty_step = data[38];
+
+            self.audio.saw.enabled = data[39] != 0;
+            self.audio.saw.rate = data[40];
+            if data.len() >= 46 {
+                self.audio.saw.period = u16::from_le_bytes([data[41], data[42]]);
+                self.audio.saw.divider = u16::from_le_bytes([data[43], data[44]]);
+                self.audio.saw.accumulator = data[45];
+                if data.len() >= 47 {
+                    self.audio.saw.step = data[46];
+                }
+            }
         }
     }
 }
@@ -693,6 +740,54 @@ mod tests {
         }
 
         assert!(mapper.expansion_audio_sample() > 0.0);
+    }
+
+    #[test]
+    fn test_vrc6_registers_snapshot_restores_audio_state() {
+        let prg_rom = banked_data(8 * 1024, 8);
+        let chr_rom = banked_data(1024, 8);
+
+        let mut mapper = create_mapper(
+            24,
+            prg_rom.clone(),
+            chr_rom.clone(),
+            MirroringMode::Horizontal,
+        )
+        .expect("VRC6 (mapper 24) should be implemented");
+
+        mapper.write_prg(0x9000, 0b1000_0111); // pulse1 volume 7, ignore duty
+        mapper.write_prg(0x9001, 0x10);
+        mapper.write_prg(0x9002, 0b1000_0000);
+
+        mapper.write_prg(0xA000, 0b0000_1010); // pulse2 volume 10
+        mapper.write_prg(0xA001, 0x08);
+        mapper.write_prg(0xA002, 0b1000_0000);
+
+        mapper.write_prg(0xB000, 0x20); // saw rate
+        mapper.write_prg(0xB001, 0x02);
+        mapper.write_prg(0xB002, 0b1000_0000);
+
+        for _ in 0..8 {
+            mapper.cpu_cycle();
+        }
+
+        let saved = mapper.registers_snapshot();
+
+        for _ in 0..2 {
+            mapper.cpu_cycle();
+        }
+        let sample = mapper.expansion_audio_sample();
+
+        let mut restored = create_mapper(24, prg_rom, chr_rom, MirroringMode::Horizontal)
+            .expect("VRC6 (mapper 24) should be implemented");
+        restored.restore_registers(&saved);
+
+        for _ in 0..2 {
+            restored.cpu_cycle();
+        }
+
+        let restored_sample = restored.expansion_audio_sample();
+        assert!((restored_sample - sample).abs() < 1e-6);
     }
 
     #[test]

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -76,6 +76,7 @@ pub struct Cpu {
     ///
     /// This is kept separate from `master_clock` because `master_clock` is also
     /// advanced by bus accesses during normal instruction execution.
+    // TODO This must go in the future.
     oob_master_clock: MasterClock,
 
     // DMC DMA state machine
@@ -105,7 +106,7 @@ const NMI_VECTOR: u16 = 0xFFFA;
 const RESET_VECTOR: u16 = 0xFFFC;
 const IRQ_VECTOR: u16 = 0xFFFE;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InterruptKind {
     Nmi,
     Irq,
@@ -257,7 +258,6 @@ impl Cpu {
     }
 
     /// Capture the current CPU state for save-state.
-    #[cfg(test)]
     pub fn capture_state(&self) -> crate::savestate::CpuState {
         crate::savestate::CpuState {
             a: self.a,
@@ -273,11 +273,22 @@ impl Cpu {
             prev_need_nmi: self.prev_need_nmi,
             prev_run_irq: self.prev_run_irq,
             run_irq: self.run_irq,
+            delayed_i_flag: self.delayed_i_flag,
+            forced_irq_pending: self.forced_irq_pending,
+            skip_interrupt_latch_this_cycle: self.skip_interrupt_latch_this_cycle,
+            master_clock: self.master_clock.master_cycles(),
+            master_clock_ppu: self.master_clock.ppu_cycles(),
+            oob_master_clock: self.oob_master_clock.master_cycles(),
+            oob_master_clock_ppu: self.oob_master_clock.ppu_cycles(),
+            dmc_dma_running: self.dmc_dma_running,
+            dmc_dma_need_halt: self.dmc_dma_need_halt,
+            dmc_dma_need_dummy_read: self.dmc_dma_need_dummy_read,
+            interrupt_stack: self.interrupt_stack.clone(),
+            current_tick_info: self.current_tick_info,
         }
     }
 
     /// Restore CPU state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(&mut self, state: &crate::savestate::CpuState) {
         self.a = state.a;
         self.x = state.x;
@@ -292,15 +303,20 @@ impl Cpu {
         self.prev_need_nmi = state.prev_need_nmi;
         self.prev_run_irq = state.prev_run_irq;
         self.run_irq = state.run_irq;
-        // Clear derived state that will be recomputed
-        self.delayed_i_flag = None;
-        self.forced_irq_pending = false;
-        self.skip_interrupt_latch_this_cycle = false;
-        self.dmc_dma_running = false;
-        self.dmc_dma_need_halt = false;
-        self.dmc_dma_need_dummy_read = false;
-        self.interrupt_stack.clear();
-        self.current_tick_info = None;
+        self.delayed_i_flag = state.delayed_i_flag;
+        self.forced_irq_pending = state.forced_irq_pending;
+        self.skip_interrupt_latch_this_cycle = state.skip_interrupt_latch_this_cycle;
+        self.master_clock.set_master_cycles(state.master_clock);
+        self.master_clock.set_ppu_cycles(state.master_clock_ppu);
+        self.oob_master_clock
+            .set_master_cycles(state.oob_master_clock);
+        self.oob_master_clock
+            .set_ppu_cycles(state.oob_master_clock_ppu);
+        self.dmc_dma_running = state.dmc_dma_running;
+        self.dmc_dma_need_halt = state.dmc_dma_need_halt;
+        self.dmc_dma_need_dummy_read = state.dmc_dma_need_dummy_read;
+        self.interrupt_stack = state.interrupt_stack.clone();
+        self.current_tick_info = state.current_tick_info;
     }
 
     fn end_cpu_cycle_latch_interrupt_lines(&mut self) {
@@ -2423,6 +2439,92 @@ mod tests {
         assert_eq!(state.sp, 0x44);
         assert_eq!(state.pc, 0x5566);
         assert_eq!(state.p, 0x77);
+    }
+
+    #[test]
+    fn test_cpu_save_state_roundtrip_includes_internal_flags() {
+        let (ppu, apu, memory) = create_test_memory();
+        let mut cpu = Cpu::new(
+            TvSystem::Ntsc,
+            Rc::clone(&memory),
+            Rc::clone(&ppu),
+            Rc::clone(&apu),
+        );
+
+        cpu.a = 0x11;
+        cpu.x = 0x22;
+        cpu.y = 0x33;
+        cpu.sp = 0x44;
+        cpu.pc = 0x5566;
+        cpu.p = 0x77;
+        cpu.halted = true;
+        cpu.set_total_cycles(1234);
+        cpu.delayed_i_flag = Some(true);
+        cpu.nmi_pending = true;
+        cpu.prev_need_nmi = true;
+        cpu.prev_run_irq = true;
+        cpu.run_irq = true;
+        cpu.irq_pending = true;
+        cpu.forced_irq_pending = true;
+        cpu.skip_interrupt_latch_this_cycle = true;
+        cpu.master_clock.set_master_cycles(111);
+        cpu.master_clock.set_ppu_cycles(222);
+        cpu.oob_master_clock.set_master_cycles(333);
+        cpu.oob_master_clock.set_ppu_cycles(444);
+        cpu.dmc_dma_running = true;
+        cpu.dmc_dma_need_halt = true;
+        cpu.dmc_dma_need_dummy_read = true;
+        cpu.interrupt_stack = vec![InterruptKind::Irq, InterruptKind::Nmi];
+        cpu.current_tick_info = Some((2, 5));
+
+        let state = cpu.capture_state();
+
+        let mut restored = Cpu::new(TvSystem::Ntsc, memory, ppu, apu);
+        restored.restore_state(&state);
+
+        assert_eq!(restored.a, cpu.a);
+        assert_eq!(restored.x, cpu.x);
+        assert_eq!(restored.y, cpu.y);
+        assert_eq!(restored.sp, cpu.sp);
+        assert_eq!(restored.pc, cpu.pc);
+        assert_eq!(restored.p, cpu.p);
+        assert_eq!(restored.halted, cpu.halted);
+        assert_eq!(restored.total_cycles, cpu.total_cycles);
+        assert_eq!(restored.delayed_i_flag, cpu.delayed_i_flag);
+        assert_eq!(restored.nmi_pending, cpu.nmi_pending);
+        assert_eq!(restored.prev_need_nmi, cpu.prev_need_nmi);
+        assert_eq!(restored.prev_run_irq, cpu.prev_run_irq);
+        assert_eq!(restored.run_irq, cpu.run_irq);
+        assert_eq!(restored.irq_pending, cpu.irq_pending);
+        assert_eq!(restored.forced_irq_pending, cpu.forced_irq_pending);
+        assert_eq!(
+            restored.skip_interrupt_latch_this_cycle,
+            cpu.skip_interrupt_latch_this_cycle
+        );
+        assert_eq!(
+            restored.master_clock.master_cycles(),
+            cpu.master_clock.master_cycles()
+        );
+        assert_eq!(
+            restored.master_clock.ppu_cycles(),
+            cpu.master_clock.ppu_cycles()
+        );
+        assert_eq!(
+            restored.oob_master_clock.master_cycles(),
+            cpu.oob_master_clock.master_cycles()
+        );
+        assert_eq!(
+            restored.oob_master_clock.ppu_cycles(),
+            cpu.oob_master_clock.ppu_cycles()
+        );
+        assert_eq!(restored.dmc_dma_running, cpu.dmc_dma_running);
+        assert_eq!(restored.dmc_dma_need_halt, cpu.dmc_dma_need_halt);
+        assert_eq!(
+            restored.dmc_dma_need_dummy_read,
+            cpu.dmc_dma_need_dummy_read
+        );
+        assert_eq!(restored.interrupt_stack, cpu.interrupt_stack);
+        assert_eq!(restored.current_tick_info, cpu.current_tick_info);
     }
 
     #[test]

--- a/src/cpu/master_clock.rs
+++ b/src/cpu/master_clock.rs
@@ -56,6 +56,14 @@ impl MasterClock {
         ppu_cycles
     }
 
+    pub fn ppu_cycles(&self) -> u64 {
+        self.ppu_clock
+    }
+
+    pub fn set_ppu_cycles(&mut self, cycles: u64) {
+        self.ppu_clock = cycles;
+    }
+
     pub fn reset(&mut self) {
         self.master_clock = 0;
         self.ppu_clock = 0;

--- a/src/eventloop.rs
+++ b/src/eventloop.rs
@@ -3,10 +3,12 @@ use crate::rendering::GlBackend;
 use sdl2::event::Event;
 use sdl2::keyboard::Keycode;
 use std::collections::HashMap;
+use std::fs;
 use std::time::{Duration, Instant};
 
 use crate::audio::NesAudio;
 use crate::input::Button;
+use crate::savestate::SaveState;
 use crate::tracing::Tracing;
 
 /// EventLoop manages the SDL2 event loop for the application.
@@ -424,8 +426,8 @@ impl EventLoop {
                             keycode: Some(keycode),
                             ..
                         } => {
-                            // Handle F6 for shader cycling
-                            if keycode == Keycode::F6 {
+                            // Handle F4 for shader cycling
+                            if keycode == Keycode::F4 {
                                 gl_backend.cycle_shader();
                             } else if self.handle_key_down_for_run(nes, keycode)
                                 == KeyDownOutcome::Quit
@@ -884,6 +886,8 @@ impl EventLoop {
     /// - F10: Debugger step-over (JSR runs until RTS)
     /// - F11: Debugger step-into (single CPU tick)
     /// - F2/F3: Volume up/down (when audio is enabled)
+    /// - F6: Save state (when a ROM is loaded)
+    /// - F7: Load state (when a ROM is loaded)
     fn handle_key_down(
         nes: &mut crate::nes::Nes,
         keycode: Keycode,
@@ -934,6 +938,12 @@ impl EventLoop {
                     apply_volume_hotkey(audio, Keycode::F3);
                 }
             }
+            Keycode::F6 => {
+                Self::save_state_to_disk(nes);
+            }
+            Keycode::F7 => {
+                Self::load_state_from_disk(nes);
+            }
             Keycode::W => nes.set_button(1, Button::Up, true),
             Keycode::S => nes.set_button(1, Button::Down, true),
             Keycode::A => nes.set_button(1, Button::Left, true),
@@ -959,6 +969,70 @@ impl EventLoop {
             Keycode::R => nes.set_button(1, Button::Select, false),
             Keycode::T => nes.set_button(1, Button::Start, false),
             _ => {}
+        }
+    }
+
+    fn save_state_to_disk(nes: &mut crate::nes::Nes) {
+        let Some(state_path) = nes.state_path() else {
+            return;
+        };
+
+        let state = nes.save_state();
+        let bytes = match state.to_bytes() {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                eprintln!("Failed to serialize save-state: {err}");
+                return;
+            }
+        };
+
+        if let Some(parent) = state_path.parent()
+            && let Err(err) = fs::create_dir_all(parent)
+        {
+            eprintln!("Failed to create save-state directory: {err}");
+            return;
+        }
+
+        let mut tmp_path = state_path.clone();
+        tmp_path.set_extension(format!("state.tmp.{}", std::process::id()));
+
+        if let Err(err) = fs::write(&tmp_path, bytes) {
+            eprintln!("Failed to write save-state: {err}");
+            return;
+        }
+
+        if let Err(err) = fs::rename(&tmp_path, &state_path) {
+            eprintln!("Failed to finalize save-state: {err}");
+        }
+    }
+
+    fn load_state_from_disk(nes: &mut crate::nes::Nes) {
+        let Some(state_path) = nes.state_path() else {
+            return;
+        };
+
+        if !state_path.exists() {
+            return;
+        }
+
+        let bytes = match fs::read(&state_path) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                eprintln!("Failed to read save-state: {err}");
+                return;
+            }
+        };
+
+        let state = match SaveState::from_bytes(&bytes) {
+            Ok(state) => state,
+            Err(err) => {
+                eprintln!("Failed to deserialize save-state: {err}");
+                return;
+            }
+        };
+
+        if let Err(err) = nes.load_state(&state) {
+            eprintln!("Failed to restore save-state: {err}");
         }
     }
 
@@ -1078,15 +1152,25 @@ fn apply_volume_hotkey(audio: &NesAudio, keycode: Keycode) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cartridge::Cartridge;
     use crate::config::Config;
     use crate::nes::{Nes, TvSystem};
     use serial_test::serial;
     use std::cell::RefCell;
     use std::env;
+    use std::fs;
+    use std::path::PathBuf;
     use std::rc::Rc;
+    use tempfile::TempDir;
 
     fn default_config() -> Config {
         Config::with_defaults()
+    }
+
+    fn copy_test_rom(temp_dir: &TempDir) -> PathBuf {
+        let rom_path = temp_dir.path().join("test.nes");
+        fs::copy("roms/nestest.nes", &rom_path).expect("Failed to copy test ROM");
+        rom_path
     }
 
     fn config_with_video_scale(scale: f32) -> Config {
@@ -1302,6 +1386,63 @@ mod tests {
         assert!((audio.get_volume() - before).abs() < 1e-6);
 
         drop(restore);
+    }
+
+    #[test]
+    fn test_handle_key_down_f6_saves_state_next_to_rom() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let rom_path = copy_test_rom(&temp_dir);
+
+        let cart = Cartridge::load_from_file(&rom_path).expect("Failed to load ROM");
+        let mut nes = Nes::new(TvSystem::Ntsc);
+        nes.insert_cartridge(cart);
+        nes.reset(false);
+
+        let mut paused = false;
+        let mut debugger_open_requested = false;
+        EventLoop::handle_key_down(
+            &mut nes,
+            Keycode::F6,
+            None,
+            &mut paused,
+            &mut debugger_open_requested,
+        );
+
+        let state_path = rom_path.with_extension("state");
+        assert!(state_path.exists(), "Expected state file to be created");
+    }
+
+    #[test]
+    fn test_handle_key_down_f7_loads_state_when_present() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let rom_path = copy_test_rom(&temp_dir);
+
+        let cart = Cartridge::load_from_file(&rom_path).expect("Failed to load ROM");
+        let mut nes = Nes::new(TvSystem::Ntsc);
+        nes.insert_cartridge(cart);
+        nes.reset(false);
+
+        let saved_pc = nes.cpu.pc();
+        let mut paused = false;
+        let mut debugger_open_requested = false;
+        EventLoop::handle_key_down(
+            &mut nes,
+            Keycode::F6,
+            None,
+            &mut paused,
+            &mut debugger_open_requested,
+        );
+
+        nes.cpu.set_pc(saved_pc.wrapping_add(1));
+        EventLoop::handle_key_down(
+            &mut nes,
+            Keycode::F7,
+            None,
+            &mut paused,
+            &mut debugger_open_requested,
+        );
+
+        assert_eq!(nes.cpu.pc(), saved_pc);
     }
 
     #[test]

--- a/src/input/joypad.rs
+++ b/src/input/joypad.rs
@@ -90,6 +90,22 @@ impl Joypad {
             self.button_states &= !(1 << bit);
         }
     }
+
+    /// Capture current joypad state for save-state.
+    pub fn capture_state(&self) -> crate::savestate::JoypadState {
+        crate::savestate::JoypadState {
+            strobe: self.strobe,
+            button_index: self.button_index,
+            button_states: self.button_states,
+        }
+    }
+
+    /// Restore joypad state from a save-state.
+    pub fn restore_state(&mut self, state: &crate::savestate::JoypadState) {
+        self.strobe = state.strobe;
+        self.button_index = state.button_index;
+        self.button_states = state.button_states;
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ mod bus;
 pub use bus::bus::Bus;
 mod nes;
 mod ppu;
-#[cfg(test)]
 mod savestate;
 mod tracing;
 

--- a/src/nes.rs
+++ b/src/nes.rs
@@ -5,6 +5,7 @@ use crate::cpu;
 use crate::ppu;
 use crate::tracing::Tracing;
 use std::cell::RefCell;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -87,6 +88,10 @@ impl Nes {
     /// Insert a cartridge and map it into memory
     pub fn insert_cartridge(&mut self, cartridge: Cartridge) {
         self.memory.borrow_mut().map_cartridge(cartridge);
+    }
+
+    pub fn state_path(&self) -> Option<PathBuf> {
+        self.memory.borrow().cartridge_state_path()
     }
 
     /// Reset the NES system.
@@ -561,12 +566,12 @@ impl Nes {
     ///
     /// This captures the full state of CPU, PPU, APU, RAM, and mapper,
     /// allowing the emulator to be restored to this exact state later.
-    #[cfg(test)]
     pub fn save_state(&self) -> crate::savestate::SaveState {
         crate::savestate::SaveState::new(
             self.cpu.capture_state(),
             self.ppu.borrow().capture_state(),
             self.apu.borrow().capture_state(),
+            self.memory.borrow().capture_state(),
             self.memory.borrow().ram_snapshot(),
             self.memory.borrow().capture_mapper_state(),
         )
@@ -581,7 +586,6 @@ impl Nes {
     ///
     /// Returns an error if the save-state version is incompatible or if
     /// the mapper number doesn't match the currently loaded cartridge.
-    #[cfg(test)]
     pub fn load_state(
         &mut self,
         state: &crate::savestate::SaveState,
@@ -607,6 +611,7 @@ impl Nes {
         self.cpu.restore_state(&state.cpu);
         self.ppu.borrow_mut().restore_state(&state.ppu);
         self.apu.borrow_mut().restore_state(&state.apu);
+        self.memory.borrow_mut().restore_state(&state.bus);
         self.memory.borrow_mut().restore_ram(&state.ram);
         self.memory.borrow_mut().restore_mapper_state(&state.mapper);
 
@@ -618,7 +623,6 @@ impl Nes {
     }
 }
 
-#[cfg(test)]
 mod savestate_error {
     /// Errors that can occur when loading a save-state.
     #[derive(Debug, Clone, PartialEq, Eq)]
@@ -653,7 +657,6 @@ mod savestate_error {
     impl std::error::Error for SaveStateError {}
 }
 
-#[cfg(test)]
 pub use savestate_error::SaveStateError;
 
 #[cfg(test)]

--- a/src/ppu/background.rs
+++ b/src/ppu/background.rs
@@ -211,6 +211,84 @@ impl Background {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundState {
+    pub bg_pattern_shift_lo: u16,
+    pub bg_pattern_shift_hi: u16,
+    pub bg_attribute_shift_lo: u16,
+    pub bg_attribute_shift_hi: u16,
+    pub nametable_latch: u8,
+    pub attribute_latch: u8,
+    pub pattern_lo_latch: u8,
+    pub pattern_hi_latch: u8,
+}
+
+impl Background {
+    pub fn capture_state(&self) -> BackgroundState {
+        BackgroundState {
+            bg_pattern_shift_lo: self.bg_pattern_shift_lo,
+            bg_pattern_shift_hi: self.bg_pattern_shift_hi,
+            bg_attribute_shift_lo: self.bg_attribute_shift_lo,
+            bg_attribute_shift_hi: self.bg_attribute_shift_hi,
+            nametable_latch: self.nametable_latch,
+            attribute_latch: self.attribute_latch,
+            pattern_lo_latch: self.pattern_lo_latch,
+            pattern_hi_latch: self.pattern_hi_latch,
+        }
+    }
+
+    pub fn restore_state(&mut self, state: &BackgroundState) {
+        self.bg_pattern_shift_lo = state.bg_pattern_shift_lo;
+        self.bg_pattern_shift_hi = state.bg_pattern_shift_hi;
+        self.bg_attribute_shift_lo = state.bg_attribute_shift_lo;
+        self.bg_attribute_shift_hi = state.bg_attribute_shift_hi;
+        self.nametable_latch = state.nametable_latch;
+        self.attribute_latch = state.attribute_latch;
+        self.pattern_lo_latch = state.pattern_lo_latch;
+        self.pattern_hi_latch = state.pattern_hi_latch;
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundDebugState {
+    pub bg_pattern_shift_lo: u16,
+    pub bg_pattern_shift_hi: u16,
+    pub bg_attribute_shift_lo: u16,
+    pub bg_attribute_shift_hi: u16,
+    pub nametable_latch: u8,
+    pub attribute_latch: u8,
+    pub pattern_lo_latch: u8,
+    pub pattern_hi_latch: u8,
+}
+
+#[cfg(test)]
+impl Background {
+    pub fn debug_state(&self) -> BackgroundDebugState {
+        BackgroundDebugState {
+            bg_pattern_shift_lo: self.bg_pattern_shift_lo,
+            bg_pattern_shift_hi: self.bg_pattern_shift_hi,
+            bg_attribute_shift_lo: self.bg_attribute_shift_lo,
+            bg_attribute_shift_hi: self.bg_attribute_shift_hi,
+            nametable_latch: self.nametable_latch,
+            attribute_latch: self.attribute_latch,
+            pattern_lo_latch: self.pattern_lo_latch,
+            pattern_hi_latch: self.pattern_hi_latch,
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: BackgroundDebugState) {
+        self.bg_pattern_shift_lo = state.bg_pattern_shift_lo;
+        self.bg_pattern_shift_hi = state.bg_pattern_shift_hi;
+        self.bg_attribute_shift_lo = state.bg_attribute_shift_lo;
+        self.bg_attribute_shift_hi = state.bg_attribute_shift_hi;
+        self.nametable_latch = state.nametable_latch;
+        self.attribute_latch = state.attribute_latch;
+        self.pattern_lo_latch = state.pattern_lo_latch;
+        self.pattern_hi_latch = state.pattern_hi_latch;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ppu/memory.rs
+++ b/src/ppu/memory.rs
@@ -230,30 +230,74 @@ impl Memory {
     }
 
     /// Create a snapshot of VRAM for save-state.
-    #[cfg(test)]
     pub fn vram_snapshot(&self) -> Vec<u8> {
         self.ppu_ram.to_vec()
     }
 
     /// Create a snapshot of palette for save-state.
-    #[cfg(test)]
     pub fn palette_snapshot(&self) -> Vec<u8> {
         self.palette.to_vec()
     }
 
     /// Restore VRAM from a save-state.
-    #[cfg(test)]
     pub fn restore_vram(&mut self, data: &[u8]) {
         let len = data.len().min(self.ppu_ram.len());
         self.ppu_ram[..len].copy_from_slice(&data[..len]);
     }
 
     /// Restore palette from a save-state.
-    #[cfg(test)]
     pub fn restore_palette(&mut self, data: &[u8]) {
         let len = data.len().min(self.palette.len());
         self.palette[..len].copy_from_slice(&data[..len]);
         self.last_palette_index = None; // Invalidate cache
+    }
+
+    pub fn last_palette_index(&self) -> Option<u8> {
+        self.last_palette_index
+    }
+
+    pub fn last_palette_value(&self) -> u8 {
+        self.last_palette_value
+    }
+
+    pub fn mirroring_mode(&self) -> MirroringMode {
+        self.mirroring_mode
+    }
+
+    pub fn set_palette_cache(&mut self, index: Option<u8>, value: u8) {
+        self.last_palette_index = index;
+        self.last_palette_value = value;
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemoryDebugState {
+    pub ppu_ram: [u8; 4096],
+    pub palette: [u8; 32],
+    pub last_palette_index: Option<u8>,
+    pub last_palette_value: u8,
+    pub mirroring_mode: MirroringMode,
+}
+
+#[cfg(test)]
+impl Memory {
+    pub fn debug_state(&self) -> MemoryDebugState {
+        MemoryDebugState {
+            ppu_ram: self.ppu_ram,
+            palette: self.palette,
+            last_palette_index: self.last_palette_index,
+            last_palette_value: self.last_palette_value,
+            mirroring_mode: self.mirroring_mode,
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: MemoryDebugState) {
+        self.ppu_ram = state.ppu_ram;
+        self.palette = state.palette;
+        self.last_palette_index = state.last_palette_index;
+        self.last_palette_value = state.last_palette_value;
+        self.mirroring_mode = state.mirroring_mode;
     }
 }
 

--- a/src/ppu/ppu.rs
+++ b/src/ppu/ppu.rs
@@ -500,14 +500,18 @@ impl Ppu {
     }
 
     /// Capture the current PPU state for save-state.
-    #[cfg(test)]
     pub fn capture_state(&self) -> crate::savestate::PpuState {
+        let (rendering_enabled_d1, rendering_enabled_d2) = self.timing.rendering_enabled_delays();
+        let bg_state = self.background.capture_state();
+        let sprites_state = self.sprites.capture_state();
         crate::savestate::PpuState {
             timing: crate::savestate::PpuTimingState {
                 scanline: self.timing.scanline,
                 pixel: self.timing.pixel,
                 total_cycles: self.timing.total_cycles(),
                 frame_count: self.timing.frame_count(),
+                rendering_enabled_d1,
+                rendering_enabled_d2,
             },
             registers: crate::savestate::PpuRegisterState {
                 control: self.registers.control(),
@@ -518,21 +522,57 @@ impl Ppu {
                 fine_x: self.registers.x(),
                 w: self.registers.w(),
                 io_bus: self.registers.io_bus(),
+                io_bus_refresh_time: self.registers.io_bus_refresh_time(),
+                cycle_count: self.registers.cycle_count(),
             },
             vblank_flag: self.status.is_in_vblank(),
             sprite_zero_hit: self.status.is_sprite_0_hit(),
+            pending_sprite_zero_hit: self.status.pending_sprite_0_hit(),
             sprite_overflow: self.status.is_sprite_overflow(),
             nmi_pending: self.status.is_nmi_enabled(),
+            frame_complete: self.status.frame_complete(),
+            vblank_suppressed_for_frame: self.vblank_suppressed_for_frame,
+            vblank_for_nmi: self.vblank_for_nmi,
+            prev_a12: self.prev_a12,
             vram: self.memory.vram_snapshot(),
             palette: self.memory.palette_snapshot(),
+            last_palette_index: self.memory.last_palette_index(),
+            last_palette_value: self.memory.last_palette_value(),
+            mirroring_mode: self.memory.mirroring_mode(),
             oam: self.sprites.oam_snapshot(),
             secondary_oam: self.sprites.secondary_oam_snapshot(),
+            sprites_found: sprites_state.sprites_found,
+            sprite_count: sprites_state.sprite_count,
+            next_sprite_count: sprites_state.next_sprite_count,
+            sprite_buffers_ready: sprites_state.sprite_buffers_ready,
+            sprite_0_index: sprites_state.sprite_0_index,
+            next_sprite_0_index: sprites_state.next_sprite_0_index,
+            sprite_eval_n: sprites_state.sprite_eval_n,
+            sprite_eval_m: sprites_state.sprite_eval_m,
+            sprite_eval_cycle: sprites_state.sprite_eval_cycle,
+            sprite_eval_in_range: sprites_state.sprite_eval_in_range,
+            sprite_pattern_shift_lo: sprites_state.sprite_pattern_shift_lo,
+            sprite_pattern_shift_hi: sprites_state.sprite_pattern_shift_hi,
+            sprite_x_positions: sprites_state.sprite_x_positions,
+            sprite_attributes: sprites_state.sprite_attributes,
+            next_sprite_pattern_shift_lo: sprites_state.next_sprite_pattern_shift_lo,
+            next_sprite_pattern_shift_hi: sprites_state.next_sprite_pattern_shift_hi,
+            next_sprite_x_positions: sprites_state.next_sprite_x_positions,
+            next_sprite_attributes: sprites_state.next_sprite_attributes,
+            bg_pattern_shift_lo: bg_state.bg_pattern_shift_lo,
+            bg_pattern_shift_hi: bg_state.bg_pattern_shift_hi,
+            bg_attribute_shift_lo: bg_state.bg_attribute_shift_lo,
+            bg_attribute_shift_hi: bg_state.bg_attribute_shift_hi,
+            nametable_latch: bg_state.nametable_latch,
+            attribute_latch: bg_state.attribute_latch,
+            pattern_lo_latch: bg_state.pattern_lo_latch,
+            pattern_hi_latch: bg_state.pattern_hi_latch,
+            screen_buffer: self.rendering.screen_buffer_snapshot(),
             read_buffer: self.registers.data_buffer(),
         }
     }
 
     /// Restore PPU state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(&mut self, state: &crate::savestate::PpuState) {
         // Restore timing
         self.timing.restore_state(
@@ -540,6 +580,10 @@ impl Ppu {
             state.timing.pixel,
             state.timing.total_cycles,
             state.timing.frame_count,
+        );
+        self.timing.set_rendering_enabled_delays(
+            state.timing.rendering_enabled_d1,
+            state.timing.rendering_enabled_d2,
         );
 
         // Restore registers
@@ -554,13 +598,49 @@ impl Ppu {
             state.registers.io_bus,
             state.read_buffer,
         );
+        self.registers
+            .set_io_bus_refresh_time(state.registers.io_bus_refresh_time);
+        self.registers.set_cycle_count(state.registers.cycle_count);
 
         // Restore memory
         self.memory.restore_vram(&state.vram);
         self.memory.restore_palette(&state.palette);
+        self.memory
+            .set_palette_cache(state.last_palette_index, state.last_palette_value);
+        self.memory.set_mirroring(state.mirroring_mode);
 
         // Restore OAM
-        self.sprites.restore_oam(&state.oam, &state.secondary_oam);
+        let mut oam_data = [0xFF; 256];
+        let oam_len = state.oam.len().min(oam_data.len());
+        oam_data[..oam_len].copy_from_slice(&state.oam[..oam_len]);
+
+        let mut secondary_oam = [0xFF; 32];
+        let sec_len = state.secondary_oam.len().min(secondary_oam.len());
+        secondary_oam[..sec_len].copy_from_slice(&state.secondary_oam[..sec_len]);
+
+        self.sprites
+            .restore_state(&crate::ppu::sprites::SpritesState {
+                oam_data,
+                secondary_oam,
+                sprites_found: state.sprites_found,
+                sprite_count: state.sprite_count,
+                next_sprite_count: state.next_sprite_count,
+                sprite_buffers_ready: state.sprite_buffers_ready,
+                sprite_0_index: state.sprite_0_index,
+                next_sprite_0_index: state.next_sprite_0_index,
+                sprite_eval_n: state.sprite_eval_n,
+                sprite_eval_m: state.sprite_eval_m,
+                sprite_eval_cycle: state.sprite_eval_cycle,
+                sprite_eval_in_range: state.sprite_eval_in_range,
+                sprite_pattern_shift_lo: state.sprite_pattern_shift_lo,
+                sprite_pattern_shift_hi: state.sprite_pattern_shift_hi,
+                sprite_x_positions: state.sprite_x_positions,
+                sprite_attributes: state.sprite_attributes,
+                next_sprite_pattern_shift_lo: state.next_sprite_pattern_shift_lo,
+                next_sprite_pattern_shift_hi: state.next_sprite_pattern_shift_hi,
+                next_sprite_x_positions: state.next_sprite_x_positions,
+                next_sprite_attributes: state.next_sprite_attributes,
+            });
 
         // Restore status flags
         self.status.restore_state(
@@ -569,12 +649,83 @@ impl Ppu {
             state.sprite_overflow,
             state.nmi_pending,
         );
+        self.status
+            .set_pending_sprite_0_hit(state.pending_sprite_zero_hit);
+        self.status.set_frame_complete(state.frame_complete);
+
+        self.background
+            .restore_state(&crate::ppu::background::BackgroundState {
+                bg_pattern_shift_lo: state.bg_pattern_shift_lo,
+                bg_pattern_shift_hi: state.bg_pattern_shift_hi,
+                bg_attribute_shift_lo: state.bg_attribute_shift_lo,
+                bg_attribute_shift_hi: state.bg_attribute_shift_hi,
+                nametable_latch: state.nametable_latch,
+                attribute_latch: state.attribute_latch,
+                pattern_lo_latch: state.pattern_lo_latch,
+                pattern_hi_latch: state.pattern_hi_latch,
+            });
+
+        self.rendering.restore_screen_buffer(&state.screen_buffer);
+
+        self.vblank_suppressed_for_frame = state.vblank_suppressed_for_frame;
+        self.vblank_for_nmi = state.vblank_for_nmi;
+        self.prev_a12 = state.prev_a12;
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PpuDebugState {
+    pub timing: super::timing::TimingDebugState,
+    pub status: super::status::StatusDebugState,
+    pub registers: super::registers::RegistersDebugState,
+    pub memory: super::memory::MemoryDebugState,
+    pub background: super::background::BackgroundDebugState,
+    pub sprites: super::sprites::SpritesDebugState,
+    pub rendering: super::rendering::RenderingDebugState,
+    pub vblank_suppressed_for_frame: bool,
+    pub vblank_for_nmi: bool,
+    pub prev_a12: bool,
+}
+
+#[cfg(test)]
+impl Ppu {
+    pub fn debug_state(&self) -> PpuDebugState {
+        PpuDebugState {
+            timing: self.timing.debug_state(),
+            status: self.status.debug_state(),
+            registers: self.registers.debug_state(),
+            memory: self.memory.debug_state(),
+            background: self.background.debug_state(),
+            sprites: self.sprites.debug_state(),
+            rendering: self.rendering.debug_state(),
+            vblank_suppressed_for_frame: self.vblank_suppressed_for_frame,
+            vblank_for_nmi: self.vblank_for_nmi,
+            prev_a12: self.prev_a12,
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: PpuDebugState) {
+        self.timing.set_debug_state(state.timing);
+        self.status.set_debug_state(state.status);
+        self.registers.set_debug_state(state.registers);
+        self.memory.set_debug_state(state.memory);
+        self.background.set_debug_state(state.background);
+        self.sprites.set_debug_state(state.sprites);
+        self.rendering.set_debug_state(state.rendering);
+        self.vblank_suppressed_for_frame = state.vblank_suppressed_for_frame;
+        self.vblank_for_nmi = state.vblank_for_nmi;
+        self.prev_a12 = state.prev_a12;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cartridge::MirroringMode;
+    use crate::ppu::{
+        background, memory, registers, rendering, screen_buffer, sprites, status, timing,
+    };
 
     struct ScanlineSpyMapper {
         calls: Rc<RefCell<Vec<(u16, bool)>>>,
@@ -669,6 +820,148 @@ mod tests {
         let calls = calls.borrow();
         assert!(!calls.is_empty());
         assert_eq!(calls.last().copied(), Some((1, false)));
+    }
+
+    #[test]
+    fn test_ppu_save_state_roundtrip_includes_internal_state() {
+        let mut ppu = Ppu::new(TvSystem::Ntsc);
+
+        let mut ppu_ram = [0u8; 4096];
+        ppu_ram[0] = 0x11;
+        ppu_ram[4095] = 0x22;
+
+        let mut palette = [0u8; 32];
+        palette[0] = 0x3F;
+        palette[31] = 0x2A;
+
+        let mut oam = [0u8; 256];
+        oam[0] = 0x10;
+        oam[1] = 0x20;
+        oam[2] = 0x30;
+        oam[3] = 0x40;
+
+        let mut secondary_oam = [0u8; 32];
+        secondary_oam[0] = 0xAA;
+        secondary_oam[31] = 0xBB;
+
+        let mut io_bus_refresh_time = [0u64; 8];
+        io_bus_refresh_time[0] = 123;
+        io_bus_refresh_time[7] = 456;
+
+        let screen_buffer = screen_buffer::ScreenBufferDebugState {
+            buffer: vec![0x5A; 256 * 240 * 3],
+        };
+
+        let debug_state = PpuDebugState {
+            timing: timing::TimingDebugState {
+                total_cycles: 999,
+                tv_system: TvSystem::Ntsc,
+                scanline: 120,
+                pixel: 200,
+                frame_count: 7,
+                rendering_enabled_d1: true,
+                rendering_enabled_d2: true,
+            },
+            status: status::StatusDebugState {
+                vblank_flag: true,
+                sprite_0_hit: true,
+                pending_sprite_0_hit: true,
+                sprite_overflow: true,
+                nmi_enabled: true,
+                frame_complete: true,
+            },
+            registers: registers::RegistersDebugState {
+                control_register: 0xA5,
+                mask_register: 0x3C,
+                oam_address: 0x7F,
+                data_buffer: 0xEE,
+                io_bus: 0x5A,
+                io_bus_refresh_time,
+                cycle_count: 12345,
+                v: 0x2123,
+                t: 0x3ABC,
+                x: 5,
+                w: true,
+            },
+            memory: memory::MemoryDebugState {
+                ppu_ram,
+                palette,
+                last_palette_index: Some(7),
+                last_palette_value: 0x1C,
+                mirroring_mode: MirroringMode::SingleScreenUpper,
+            },
+            background: background::BackgroundDebugState {
+                bg_pattern_shift_lo: 0x1234,
+                bg_pattern_shift_hi: 0x5678,
+                bg_attribute_shift_lo: 0x9ABC,
+                bg_attribute_shift_hi: 0xDEF0,
+                nametable_latch: 0x12,
+                attribute_latch: 0x34,
+                pattern_lo_latch: 0x56,
+                pattern_hi_latch: 0x78,
+            },
+            sprites: sprites::SpritesDebugState {
+                oam_data: oam,
+                secondary_oam,
+                sprites_found: 5,
+                sprite_count: 4,
+                next_sprite_count: 3,
+                sprite_buffers_ready: true,
+                sprite_0_index: Some(2),
+                next_sprite_0_index: Some(1),
+                sprite_eval_n: 12,
+                sprite_eval_m: 2,
+                sprite_eval_cycle: 6,
+                sprite_eval_in_range: true,
+                sprite_pattern_shift_lo: [0x11; 8],
+                sprite_pattern_shift_hi: [0x22; 8],
+                sprite_x_positions: [0x33; 8],
+                sprite_attributes: [0x44; 8],
+                next_sprite_pattern_shift_lo: [0x55; 8],
+                next_sprite_pattern_shift_hi: [0x66; 8],
+                next_sprite_x_positions: [0x77; 8],
+                next_sprite_attributes: [0x88; 8],
+            },
+            rendering: rendering::RenderingDebugState { screen_buffer },
+            vblank_suppressed_for_frame: true,
+            vblank_for_nmi: true,
+            prev_a12: true,
+        };
+
+        ppu.set_debug_state(debug_state.clone());
+
+        let state = ppu.capture_state();
+        let mut restored = Ppu::new(TvSystem::Ntsc);
+        restored.restore_state(&state);
+
+        let restored_debug = restored.debug_state();
+
+        assert_eq!(
+            restored_debug.vblank_suppressed_for_frame,
+            debug_state.vblank_suppressed_for_frame
+        );
+        assert_eq!(restored_debug.vblank_for_nmi, debug_state.vblank_for_nmi);
+        assert_eq!(restored_debug.prev_a12, debug_state.prev_a12);
+
+        assert_eq!(restored_debug.timing, debug_state.timing);
+        assert_eq!(restored_debug.status, debug_state.status);
+        assert_eq!(restored_debug.registers, debug_state.registers);
+        assert_eq!(restored_debug.memory, debug_state.memory);
+        assert_eq!(restored_debug.background, debug_state.background);
+        assert_eq!(restored_debug.sprites, debug_state.sprites);
+
+        assert_eq!(
+            restored_debug.rendering.screen_buffer.buffer.len(),
+            debug_state.rendering.screen_buffer.buffer.len()
+        );
+        assert_eq!(
+            restored_debug.rendering.screen_buffer.buffer[0],
+            debug_state.rendering.screen_buffer.buffer[0]
+        );
+        assert_eq!(
+            restored_debug.rendering.screen_buffer.buffer[123],
+            debug_state.rendering.screen_buffer.buffer[123]
+        );
     }
 
     struct EndFrameSpyMapper {

--- a/src/ppu/registers.rs
+++ b/src/ppu/registers.rs
@@ -386,7 +386,6 @@ impl Registers {
     }
 
     /// Restore register state from a save-state.
-    #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub fn restore_state(
         &mut self,
@@ -410,6 +409,71 @@ impl Registers {
         self.io_bus = io_bus;
         self.data_buffer = data_buffer;
         // Note: io_bus_refresh_time and cycle_count not restored as they're for decay only
+    }
+
+    pub fn io_bus_refresh_time(&self) -> [u64; 8] {
+        self.io_bus_refresh_time
+    }
+
+    pub fn cycle_count(&self) -> u64 {
+        self.cycle_count
+    }
+
+    pub fn set_io_bus_refresh_time(&mut self, times: [u64; 8]) {
+        self.io_bus_refresh_time = times;
+    }
+
+    pub fn set_cycle_count(&mut self, cycles: u64) {
+        self.cycle_count = cycles;
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistersDebugState {
+    pub control_register: u8,
+    pub mask_register: u8,
+    pub oam_address: u8,
+    pub data_buffer: u8,
+    pub io_bus: u8,
+    pub io_bus_refresh_time: [u64; 8],
+    pub cycle_count: u64,
+    pub v: u16,
+    pub t: u16,
+    pub x: u8,
+    pub w: bool,
+}
+
+#[cfg(test)]
+impl Registers {
+    pub fn debug_state(&self) -> RegistersDebugState {
+        RegistersDebugState {
+            control_register: self.control_register,
+            mask_register: self.mask_register,
+            oam_address: self.oam_address,
+            data_buffer: self.data_buffer,
+            io_bus: self.io_bus,
+            io_bus_refresh_time: self.io_bus_refresh_time,
+            cycle_count: self.cycle_count,
+            v: self.v,
+            t: self.t,
+            x: self.x,
+            w: self.w,
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: RegistersDebugState) {
+        self.control_register = state.control_register;
+        self.mask_register = state.mask_register;
+        self.oam_address = state.oam_address;
+        self.data_buffer = state.data_buffer;
+        self.io_bus = state.io_bus;
+        self.io_bus_refresh_time = state.io_bus_refresh_time;
+        self.cycle_count = state.cycle_count;
+        self.v = state.v;
+        self.t = state.t;
+        self.x = state.x;
+        self.w = state.w;
     }
 }
 

--- a/src/ppu/rendering.rs
+++ b/src/ppu/rendering.rs
@@ -31,6 +31,14 @@ impl Rendering {
         &mut self.screen_buffer
     }
 
+    pub fn screen_buffer_snapshot(&self) -> Vec<u8> {
+        self.screen_buffer.snapshot()
+    }
+
+    pub fn restore_screen_buffer(&mut self, data: &[u8]) {
+        self.screen_buffer.restore_from_snapshot(data);
+    }
+
     /// Compose and render a pixel to the screen buffer
     #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
@@ -65,6 +73,25 @@ impl Rendering {
         self.screen_buffer.set_pixel(screen_x, screen_y, r, g, b);
 
         sprite_0_hit
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderingDebugState {
+    pub screen_buffer: super::screen_buffer::ScreenBufferDebugState,
+}
+
+#[cfg(test)]
+impl Rendering {
+    pub fn debug_state(&self) -> RenderingDebugState {
+        RenderingDebugState {
+            screen_buffer: self.screen_buffer.debug_state(),
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: RenderingDebugState) {
+        self.screen_buffer.set_debug_state(state.screen_buffer);
     }
 }
 

--- a/src/ppu/screen_buffer.rs
+++ b/src/ppu/screen_buffer.rs
@@ -118,6 +118,34 @@ impl ScreenBuffer {
 
         dest[..self.buffer.len()].copy_from_slice(&self.buffer);
     }
+
+    pub fn snapshot(&self) -> Vec<u8> {
+        self.buffer.clone()
+    }
+
+    pub fn restore_from_snapshot(&mut self, data: &[u8]) {
+        let len = data.len().min(self.buffer.len());
+        self.buffer[..len].copy_from_slice(&data[..len]);
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreenBufferDebugState {
+    pub buffer: Vec<u8>,
+}
+
+#[cfg(test)]
+impl ScreenBuffer {
+    pub fn debug_state(&self) -> ScreenBufferDebugState {
+        ScreenBufferDebugState {
+            buffer: self.buffer.clone(),
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: ScreenBufferDebugState) {
+        self.buffer = state.buffer;
+    }
 }
 
 #[cfg(test)]

--- a/src/ppu/sprites.rs
+++ b/src/ppu/sprites.rs
@@ -307,24 +307,8 @@ impl Sprites {
             return;
         }
 
-        // CHR reads happen at specific cycles within each sprite's 8-cycle window:
-        // - fetch_step 4: Pattern low byte read (odd cycle of the 2-cycle fetch)
-        // - fetch_step 6: Pattern high byte read (odd cycle of the 2-cycle fetch)
-        //
-        // Actually, the PPU reads on both cycles of each 2-cycle fetch. The address
-        // appears on cycle N (fetch_step 4 or 6) and the read completes on cycle N+1.
-        // For MMC3 A12 detection, the address change is what matters, which happens
-        // on cycle 4 for the low byte.
-        //
-        // To trigger A12 at the correct time, we do the read at fetch_step 5 and 7
-        // (the second cycle of each 2-cycle access, when data is latched).
-
         let is_pattern_lo_cycle = fetch_step == 5;
         let is_pattern_hi_cycle = fetch_step == 7;
-
-        if !is_pattern_lo_cycle && !is_pattern_hi_cycle {
-            return;
-        }
 
         // On pre-render scanline (261), sprite evaluation doesn't happen, so
         // secondary_oam contains stale data from scanline 239's evaluation.
@@ -552,37 +536,163 @@ impl Sprites {
     }
 
     /// Create a snapshot of OAM for save-state.
-    #[cfg(test)]
     pub fn oam_snapshot(&self) -> Vec<u8> {
         self.oam_data.to_vec()
     }
 
     /// Create a snapshot of secondary OAM for save-state.
-    #[cfg(test)]
     pub fn secondary_oam_snapshot(&self) -> Vec<u8> {
         self.secondary_oam.to_vec()
     }
+}
 
-    /// Restore OAM from a save-state.
-    #[cfg(test)]
-    pub fn restore_oam(&mut self, oam: &[u8], secondary_oam: &[u8]) {
-        let len = oam.len().min(self.oam_data.len());
-        self.oam_data[..len].copy_from_slice(&oam[..len]);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpritesState {
+    pub oam_data: [u8; 256],
+    pub secondary_oam: [u8; 32],
+    pub sprites_found: u8,
+    pub sprite_count: u8,
+    pub next_sprite_count: u8,
+    pub sprite_buffers_ready: bool,
+    pub sprite_0_index: Option<usize>,
+    pub next_sprite_0_index: Option<usize>,
+    pub sprite_eval_n: u8,
+    pub sprite_eval_m: u8,
+    pub sprite_eval_cycle: u8,
+    pub sprite_eval_in_range: bool,
+    pub sprite_pattern_shift_lo: [u8; 8],
+    pub sprite_pattern_shift_hi: [u8; 8],
+    pub sprite_x_positions: [u8; 8],
+    pub sprite_attributes: [u8; 8],
+    pub next_sprite_pattern_shift_lo: [u8; 8],
+    pub next_sprite_pattern_shift_hi: [u8; 8],
+    pub next_sprite_x_positions: [u8; 8],
+    pub next_sprite_attributes: [u8; 8],
+}
 
-        let sec_len = secondary_oam.len().min(self.secondary_oam.len());
-        self.secondary_oam[..sec_len].copy_from_slice(&secondary_oam[..sec_len]);
+impl Sprites {
+    pub fn capture_state(&self) -> SpritesState {
+        SpritesState {
+            oam_data: self.oam_data,
+            secondary_oam: self.secondary_oam,
+            sprites_found: self.sprites_found,
+            sprite_count: self.sprite_count,
+            next_sprite_count: self.next_sprite_count,
+            sprite_buffers_ready: self.sprite_buffers_ready,
+            sprite_0_index: self.sprite_0_index,
+            next_sprite_0_index: self.next_sprite_0_index,
+            sprite_eval_n: self.sprite_eval_n,
+            sprite_eval_m: self.sprite_eval_m,
+            sprite_eval_cycle: self.sprite_eval_cycle,
+            sprite_eval_in_range: self.sprite_eval_in_range,
+            sprite_pattern_shift_lo: self.sprite_pattern_shift_lo,
+            sprite_pattern_shift_hi: self.sprite_pattern_shift_hi,
+            sprite_x_positions: self.sprite_x_positions,
+            sprite_attributes: self.sprite_attributes,
+            next_sprite_pattern_shift_lo: self.next_sprite_pattern_shift_lo,
+            next_sprite_pattern_shift_hi: self.next_sprite_pattern_shift_hi,
+            next_sprite_x_positions: self.next_sprite_x_positions,
+            next_sprite_attributes: self.next_sprite_attributes,
+        }
+    }
 
-        // Reset evaluation state
-        self.sprites_found = 0;
-        self.sprite_count = 0;
-        self.next_sprite_count = 0;
-        self.sprite_buffers_ready = false;
-        self.sprite_0_index = None;
-        self.next_sprite_0_index = None;
-        self.sprite_eval_n = 0;
-        self.sprite_eval_m = 0;
-        self.sprite_eval_cycle = 0;
-        self.sprite_eval_in_range = false;
+    pub fn restore_state(&mut self, state: &SpritesState) {
+        self.oam_data = state.oam_data;
+        self.secondary_oam = state.secondary_oam;
+        self.sprites_found = state.sprites_found;
+        self.sprite_count = state.sprite_count;
+        self.next_sprite_count = state.next_sprite_count;
+        self.sprite_buffers_ready = state.sprite_buffers_ready;
+        self.sprite_0_index = state.sprite_0_index;
+        self.next_sprite_0_index = state.next_sprite_0_index;
+        self.sprite_eval_n = state.sprite_eval_n;
+        self.sprite_eval_m = state.sprite_eval_m;
+        self.sprite_eval_cycle = state.sprite_eval_cycle;
+        self.sprite_eval_in_range = state.sprite_eval_in_range;
+        self.sprite_pattern_shift_lo = state.sprite_pattern_shift_lo;
+        self.sprite_pattern_shift_hi = state.sprite_pattern_shift_hi;
+        self.sprite_x_positions = state.sprite_x_positions;
+        self.sprite_attributes = state.sprite_attributes;
+        self.next_sprite_pattern_shift_lo = state.next_sprite_pattern_shift_lo;
+        self.next_sprite_pattern_shift_hi = state.next_sprite_pattern_shift_hi;
+        self.next_sprite_x_positions = state.next_sprite_x_positions;
+        self.next_sprite_attributes = state.next_sprite_attributes;
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpritesDebugState {
+    pub oam_data: [u8; 256],
+    pub secondary_oam: [u8; 32],
+    pub sprites_found: u8,
+    pub sprite_count: u8,
+    pub next_sprite_count: u8,
+    pub sprite_buffers_ready: bool,
+    pub sprite_0_index: Option<usize>,
+    pub next_sprite_0_index: Option<usize>,
+    pub sprite_eval_n: u8,
+    pub sprite_eval_m: u8,
+    pub sprite_eval_cycle: u8,
+    pub sprite_eval_in_range: bool,
+    pub sprite_pattern_shift_lo: [u8; 8],
+    pub sprite_pattern_shift_hi: [u8; 8],
+    pub sprite_x_positions: [u8; 8],
+    pub sprite_attributes: [u8; 8],
+    pub next_sprite_pattern_shift_lo: [u8; 8],
+    pub next_sprite_pattern_shift_hi: [u8; 8],
+    pub next_sprite_x_positions: [u8; 8],
+    pub next_sprite_attributes: [u8; 8],
+}
+
+#[cfg(test)]
+impl Sprites {
+    pub fn debug_state(&self) -> SpritesDebugState {
+        SpritesDebugState {
+            oam_data: self.oam_data,
+            secondary_oam: self.secondary_oam,
+            sprites_found: self.sprites_found,
+            sprite_count: self.sprite_count,
+            next_sprite_count: self.next_sprite_count,
+            sprite_buffers_ready: self.sprite_buffers_ready,
+            sprite_0_index: self.sprite_0_index,
+            next_sprite_0_index: self.next_sprite_0_index,
+            sprite_eval_n: self.sprite_eval_n,
+            sprite_eval_m: self.sprite_eval_m,
+            sprite_eval_cycle: self.sprite_eval_cycle,
+            sprite_eval_in_range: self.sprite_eval_in_range,
+            sprite_pattern_shift_lo: self.sprite_pattern_shift_lo,
+            sprite_pattern_shift_hi: self.sprite_pattern_shift_hi,
+            sprite_x_positions: self.sprite_x_positions,
+            sprite_attributes: self.sprite_attributes,
+            next_sprite_pattern_shift_lo: self.next_sprite_pattern_shift_lo,
+            next_sprite_pattern_shift_hi: self.next_sprite_pattern_shift_hi,
+            next_sprite_x_positions: self.next_sprite_x_positions,
+            next_sprite_attributes: self.next_sprite_attributes,
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: SpritesDebugState) {
+        self.oam_data = state.oam_data;
+        self.secondary_oam = state.secondary_oam;
+        self.sprites_found = state.sprites_found;
+        self.sprite_count = state.sprite_count;
+        self.next_sprite_count = state.next_sprite_count;
+        self.sprite_buffers_ready = state.sprite_buffers_ready;
+        self.sprite_0_index = state.sprite_0_index;
+        self.next_sprite_0_index = state.next_sprite_0_index;
+        self.sprite_eval_n = state.sprite_eval_n;
+        self.sprite_eval_m = state.sprite_eval_m;
+        self.sprite_eval_cycle = state.sprite_eval_cycle;
+        self.sprite_eval_in_range = state.sprite_eval_in_range;
+        self.sprite_pattern_shift_lo = state.sprite_pattern_shift_lo;
+        self.sprite_pattern_shift_hi = state.sprite_pattern_shift_hi;
+        self.sprite_x_positions = state.sprite_x_positions;
+        self.sprite_attributes = state.sprite_attributes;
+        self.next_sprite_pattern_shift_lo = state.next_sprite_pattern_shift_lo;
+        self.next_sprite_pattern_shift_hi = state.next_sprite_pattern_shift_hi;
+        self.next_sprite_x_positions = state.next_sprite_x_positions;
+        self.next_sprite_attributes = state.next_sprite_attributes;
     }
 }
 

--- a/src/ppu/status.rs
+++ b/src/ppu/status.rs
@@ -140,25 +140,29 @@ impl Status {
     }
 
     /// Check if sprite 0 hit flag is set
-    #[cfg(test)]
     pub fn is_sprite_0_hit(&self) -> bool {
         self.sprite_0_hit
     }
 
     /// Get sprite overflow flag for save-state.
-    #[cfg(test)]
     pub fn is_sprite_overflow(&self) -> bool {
         self.sprite_overflow
     }
 
     /// Get NMI enabled flag for save-state.
-    #[cfg(test)]
     pub fn is_nmi_enabled(&self) -> bool {
         self.nmi_enabled
     }
 
+    pub fn pending_sprite_0_hit(&self) -> bool {
+        self.pending_sprite_0_hit
+    }
+
+    pub fn frame_complete(&self) -> bool {
+        self.frame_complete
+    }
+
     /// Restore status state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(
         &mut self,
         vblank: bool,
@@ -173,6 +177,48 @@ impl Status {
         self.nmi_enabled = nmi_enabled;
         // Note: frame_complete is derived state, will be set during next vblank
         self.frame_complete = false;
+    }
+
+    pub fn set_pending_sprite_0_hit(&mut self, pending: bool) {
+        self.pending_sprite_0_hit = pending;
+    }
+
+    pub fn set_frame_complete(&mut self, complete: bool) {
+        self.frame_complete = complete;
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusDebugState {
+    pub vblank_flag: bool,
+    pub sprite_0_hit: bool,
+    pub pending_sprite_0_hit: bool,
+    pub sprite_overflow: bool,
+    pub nmi_enabled: bool,
+    pub frame_complete: bool,
+}
+
+#[cfg(test)]
+impl Status {
+    pub fn debug_state(&self) -> StatusDebugState {
+        StatusDebugState {
+            vblank_flag: self.vblank_flag,
+            sprite_0_hit: self.sprite_0_hit,
+            pending_sprite_0_hit: self.pending_sprite_0_hit,
+            sprite_overflow: self.sprite_overflow,
+            nmi_enabled: self.nmi_enabled,
+            frame_complete: self.frame_complete,
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: StatusDebugState) {
+        self.vblank_flag = state.vblank_flag;
+        self.sprite_0_hit = state.sprite_0_hit;
+        self.pending_sprite_0_hit = state.pending_sprite_0_hit;
+        self.sprite_overflow = state.sprite_overflow;
+        self.nmi_enabled = state.nmi_enabled;
+        self.frame_complete = state.frame_complete;
     }
 }
 

--- a/src/ppu/timing.rs
+++ b/src/ppu/timing.rs
@@ -117,7 +117,6 @@ impl Timing {
     }
 
     /// Restore timing state from a save-state.
-    #[cfg(test)]
     pub fn restore_state(
         &mut self,
         scanline: u16,
@@ -132,6 +131,15 @@ impl Timing {
         // Note: rendering_enabled delays will be recalculated during emulation
         self.rendering_enabled_d1 = false;
         self.rendering_enabled_d2 = false;
+    }
+
+    pub fn rendering_enabled_delays(&self) -> (bool, bool) {
+        (self.rendering_enabled_d1, self.rendering_enabled_d2)
+    }
+
+    pub fn set_rendering_enabled_delays(&mut self, d1: bool, d2: bool) {
+        self.rendering_enabled_d1 = d1;
+        self.rendering_enabled_d2 = d2;
     }
 
     /// Get the TV system
@@ -163,6 +171,43 @@ impl Timing {
     #[cfg(test)]
     pub fn is_visible_pixel(&self) -> bool {
         self.scanline < 240 && self.pixel >= 1 && self.pixel <= 256
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimingDebugState {
+    pub total_cycles: u64,
+    pub tv_system: TvSystem,
+    pub scanline: u16,
+    pub pixel: u16,
+    pub frame_count: u64,
+    pub rendering_enabled_d1: bool,
+    pub rendering_enabled_d2: bool,
+}
+
+#[cfg(test)]
+impl Timing {
+    pub fn debug_state(&self) -> TimingDebugState {
+        TimingDebugState {
+            total_cycles: self.total_cycles,
+            tv_system: self.tv_system,
+            scanline: self.scanline,
+            pixel: self.pixel,
+            frame_count: self.frame_count,
+            rendering_enabled_d1: self.rendering_enabled_d1,
+            rendering_enabled_d2: self.rendering_enabled_d2,
+        }
+    }
+
+    pub fn set_debug_state(&mut self, state: TimingDebugState) {
+        self.total_cycles = state.total_cycles;
+        self.tv_system = state.tv_system;
+        self.scanline = state.scanline;
+        self.pixel = state.pixel;
+        self.frame_count = state.frame_count;
+        self.rendering_enabled_d1 = state.rendering_enabled_d1;
+        self.rendering_enabled_d2 = state.rendering_enabled_d2;
     }
 }
 

--- a/src/savestate/mod.rs
+++ b/src/savestate/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Current save-state format version.
 /// Increment this when making breaking changes to the state format.
-pub const SAVESTATE_VERSION: u32 = 1;
+pub const SAVESTATE_VERSION: u32 = 5;
 
 /// Complete emulator state snapshot.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -20,6 +20,8 @@ pub struct SaveState {
     pub ppu: PpuState,
     /// APU state
     pub apu: ApuState,
+    /// Bus state
+    pub bus: BusState,
     /// CPU RAM (2KB, mirrored to 8KB)
     pub ram: Vec<u8>,
     /// Mapper state (serialized as opaque bytes)
@@ -42,6 +44,18 @@ pub struct CpuState {
     pub prev_need_nmi: bool,
     pub prev_run_irq: bool,
     pub run_irq: bool,
+    pub delayed_i_flag: Option<bool>,
+    pub forced_irq_pending: bool,
+    pub skip_interrupt_latch_this_cycle: bool,
+    pub master_clock: u64,
+    pub master_clock_ppu: u64,
+    pub oob_master_clock: u64,
+    pub oob_master_clock_ppu: u64,
+    pub dmc_dma_running: bool,
+    pub dmc_dma_need_halt: bool,
+    pub dmc_dma_need_dummy_read: bool,
+    pub interrupt_stack: Vec<crate::cpu::InterruptKind>,
+    pub current_tick_info: Option<(u8, u8)>,
 }
 
 /// PPU timing state.
@@ -51,6 +65,8 @@ pub struct PpuTimingState {
     pub pixel: u16,
     pub total_cycles: u64,
     pub frame_count: u64,
+    pub rendering_enabled_d1: bool,
+    pub rendering_enabled_d2: bool,
 }
 
 /// PPU register state.
@@ -64,6 +80,8 @@ pub struct PpuRegisterState {
     pub fine_x: u8,
     pub w: bool,
     pub io_bus: u8,
+    pub io_bus_refresh_time: [u64; 8],
+    pub cycle_count: u64,
 }
 
 /// PPU complete state.
@@ -73,14 +91,49 @@ pub struct PpuState {
     pub registers: PpuRegisterState,
     pub vblank_flag: bool,
     pub sprite_zero_hit: bool,
+    pub pending_sprite_zero_hit: bool,
     pub sprite_overflow: bool,
     /// Internal edge-detection latch for NMI generation.
     /// This is polled and cleared by the CPU, not the NMI enable control bit.
     pub nmi_pending: bool,
+    pub frame_complete: bool,
+    pub vblank_suppressed_for_frame: bool,
+    pub vblank_for_nmi: bool,
+    pub prev_a12: bool,
     pub vram: Vec<u8>,
     pub palette: Vec<u8>,
+    pub last_palette_index: Option<u8>,
+    pub last_palette_value: u8,
+    pub mirroring_mode: crate::cartridge::MirroringMode,
     pub oam: Vec<u8>,
     pub secondary_oam: Vec<u8>,
+    pub sprites_found: u8,
+    pub sprite_count: u8,
+    pub next_sprite_count: u8,
+    pub sprite_buffers_ready: bool,
+    pub sprite_0_index: Option<usize>,
+    pub next_sprite_0_index: Option<usize>,
+    pub sprite_eval_n: u8,
+    pub sprite_eval_m: u8,
+    pub sprite_eval_cycle: u8,
+    pub sprite_eval_in_range: bool,
+    pub sprite_pattern_shift_lo: [u8; 8],
+    pub sprite_pattern_shift_hi: [u8; 8],
+    pub sprite_x_positions: [u8; 8],
+    pub sprite_attributes: [u8; 8],
+    pub next_sprite_pattern_shift_lo: [u8; 8],
+    pub next_sprite_pattern_shift_hi: [u8; 8],
+    pub next_sprite_x_positions: [u8; 8],
+    pub next_sprite_attributes: [u8; 8],
+    pub bg_pattern_shift_lo: u16,
+    pub bg_pattern_shift_hi: u16,
+    pub bg_attribute_shift_lo: u16,
+    pub bg_attribute_shift_hi: u16,
+    pub nametable_latch: u8,
+    pub attribute_latch: u8,
+    pub pattern_lo_latch: u8,
+    pub pattern_hi_latch: u8,
+    pub screen_buffer: Vec<u8>,
     pub read_buffer: u8,
 }
 
@@ -156,6 +209,8 @@ pub struct DmcState {
     pub irq_enabled: bool,
     pub irq_flag: bool,
     pub loop_flag: bool,
+    pub dma_pending: bool,
+    pub transfer_start_delay: u8,
 }
 
 /// APU frame counter state.
@@ -165,6 +220,30 @@ pub struct FrameCounterState {
     pub mode: bool,
     pub irq_inhibit: bool,
     pub irq_flag: bool,
+    pub irq_assert_cycles_remaining: u8,
+    pub five_step_extra_cycle: bool,
+    pub pending_write: Option<u8>,
+    pub write_delay: u8,
+    pub pending_write_on_odd_cpu_cycle: bool,
+    pub pending_immediate_quarter: bool,
+    pub pending_immediate_half: bool,
+}
+
+/// Bus joypad state.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct JoypadState {
+    pub strobe: bool,
+    pub button_index: u8,
+    pub button_states: u8,
+}
+
+/// Bus state for save-state support.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BusState {
+    pub open_bus: u8,
+    pub oam_dma_page: Option<u8>,
+    pub joypad1: JoypadState,
+    pub joypad2: JoypadState,
 }
 
 /// APU complete state.
@@ -176,6 +255,14 @@ pub struct ApuState {
     pub triangle: TriangleState,
     pub noise: NoiseState,
     pub dmc: DmcState,
+    pub sample_accumulator: f32,
+    pub cycles_per_sample: f32,
+    pub pending_samples: Vec<f32>,
+    pub pulse1_enabled: bool,
+    pub pulse2_enabled: bool,
+    pub triangle_enabled: bool,
+    pub noise_enabled: bool,
+    pub dmc_enabled: bool,
     pub apu_cycle: u32,
     pub cpu_cycle: u64,
     pub last_4017_write: u8,
@@ -196,6 +283,7 @@ impl SaveState {
         cpu: CpuState,
         ppu: PpuState,
         apu: ApuState,
+        bus: BusState,
         ram: Vec<u8>,
         mapper: MapperState,
     ) -> Self {
@@ -204,6 +292,7 @@ impl SaveState {
             cpu,
             ppu,
             apu,
+            bus,
             ram,
             mapper,
         }
@@ -222,13 +311,11 @@ impl SaveState {
     }
 
     /// Serialize the save state to JSON-encoded UTF-8 bytes.
-    #[cfg(test)]
     pub fn to_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
         serde_json::to_vec(self)
     }
 
     /// Deserialize a save state from JSON-encoded UTF-8 bytes.
-    #[cfg(test)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_json::Error> {
         serde_json::from_slice(bytes)
     }
@@ -253,6 +340,18 @@ mod tests {
             prev_need_nmi: false,
             prev_run_irq: false,
             run_irq: false,
+            delayed_i_flag: None,
+            forced_irq_pending: false,
+            skip_interrupt_latch_this_cycle: false,
+            master_clock: 0,
+            master_clock_ppu: 0,
+            oob_master_clock: 0,
+            oob_master_clock_ppu: 0,
+            dmc_dma_running: false,
+            dmc_dma_need_halt: false,
+            dmc_dma_need_dummy_read: false,
+            interrupt_stack: Vec::new(),
+            current_tick_info: None,
         }
     }
 
@@ -263,6 +362,8 @@ mod tests {
                 pixel: 200,
                 total_cycles: 50000,
                 frame_count: 0,
+                rendering_enabled_d1: false,
+                rendering_enabled_d2: false,
             },
             registers: PpuRegisterState {
                 control: 0x80,
@@ -273,15 +374,52 @@ mod tests {
                 fine_x: 0,
                 w: false,
                 io_bus: 0,
+                io_bus_refresh_time: [0; 8],
+                cycle_count: 0,
             },
             vblank_flag: false,
             sprite_zero_hit: false,
+            pending_sprite_zero_hit: false,
             sprite_overflow: false,
             nmi_pending: false,
+            frame_complete: false,
+            vblank_suppressed_for_frame: false,
+            vblank_for_nmi: false,
+            prev_a12: false,
             vram: vec![0; 0x800],
             palette: vec![0; 32],
+            last_palette_index: None,
+            last_palette_value: 0,
+            mirroring_mode: crate::cartridge::MirroringMode::Horizontal,
             oam: vec![0; 256],
             secondary_oam: vec![0; 32],
+            sprites_found: 0,
+            sprite_count: 0,
+            next_sprite_count: 0,
+            sprite_buffers_ready: false,
+            sprite_0_index: None,
+            next_sprite_0_index: None,
+            sprite_eval_n: 0,
+            sprite_eval_m: 0,
+            sprite_eval_cycle: 0,
+            sprite_eval_in_range: false,
+            sprite_pattern_shift_lo: [0; 8],
+            sprite_pattern_shift_hi: [0; 8],
+            sprite_x_positions: [0; 8],
+            sprite_attributes: [0; 8],
+            next_sprite_pattern_shift_lo: [0; 8],
+            next_sprite_pattern_shift_hi: [0; 8],
+            next_sprite_x_positions: [0; 8],
+            next_sprite_attributes: [0; 8],
+            bg_pattern_shift_lo: 0,
+            bg_pattern_shift_hi: 0,
+            bg_attribute_shift_lo: 0,
+            bg_attribute_shift_hi: 0,
+            nametable_latch: 0,
+            attribute_latch: 0,
+            pattern_lo_latch: 0,
+            pattern_hi_latch: 0,
+            screen_buffer: vec![0; 256 * 240 * 3],
             read_buffer: 0,
         }
     }
@@ -293,6 +431,13 @@ mod tests {
                 mode: false,
                 irq_inhibit: false,
                 irq_flag: false,
+                irq_assert_cycles_remaining: 0,
+                five_step_extra_cycle: false,
+                pending_write: None,
+                write_delay: 0,
+                pending_write_on_odd_cpu_cycle: false,
+                pending_immediate_quarter: false,
+                pending_immediate_half: false,
             },
             pulse1: PulseState {
                 timer: 0,
@@ -359,16 +504,43 @@ mod tests {
                 irq_enabled: false,
                 irq_flag: false,
                 loop_flag: false,
+                dma_pending: false,
+                transfer_start_delay: 0,
             },
+            sample_accumulator: 0.0,
+            cycles_per_sample: 0.0,
+            pending_samples: Vec::new(),
+            pulse1_enabled: true,
+            pulse2_enabled: true,
+            triangle_enabled: true,
+            noise_enabled: true,
+            dmc_enabled: true,
             apu_cycle: 0,
             cpu_cycle: 0,
             last_4017_write: 0,
         }
     }
 
+    fn create_test_bus_state() -> BusState {
+        BusState {
+            open_bus: 0xFF,
+            oam_dma_page: None,
+            joypad1: JoypadState {
+                strobe: false,
+                button_index: 0,
+                button_states: 0,
+            },
+            joypad2: JoypadState {
+                strobe: false,
+                button_index: 0,
+                button_states: 0,
+            },
+        }
+    }
+
     #[test]
     fn test_savestate_version() {
-        assert_eq!(SAVESTATE_VERSION, 1);
+        assert_eq!(SAVESTATE_VERSION, 5);
     }
 
     #[test]
@@ -377,6 +549,7 @@ mod tests {
             create_test_cpu_state(),
             create_test_ppu_state(),
             create_test_apu_state(),
+            create_test_bus_state(),
             vec![0; 0x800],
             MapperState {
                 mapper_number: 0,
@@ -401,6 +574,7 @@ mod tests {
             create_test_cpu_state(),
             create_test_ppu_state(),
             create_test_apu_state(),
+            create_test_bus_state(),
             vec![0; 0x800],
             MapperState {
                 mapper_number: 0,


### PR DESCRIPTION
Closes #361.

## Summary
- complete save-state coverage across remaining cartridge mappers and CHR-RAM helpers
- add targeted save/restore tests for mapper state and CHR-RAM snapshots
- fix save-state mirroring serialization and address restore edge cases

## Testing
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- cargo test --all-features