### PR TITLE
Fix CPU memory map ranges

### DIFF
--- a/src/bus/apu_device.rs
+++ b/src/bus/apu_device.rs
@@ -95,6 +95,6 @@ impl BusDevice for ApuDevice {
     }
 
     fn address_range(&self) -> RangeInclusive<u16> {
-        0x4000..=0x40FF
+        0x4000..=0x401F
     }
 }

--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -586,6 +586,36 @@ mod tests {
         rom
     }
 
+    fn create_nrom_rom() -> Vec<u8> {
+        let prg_rom_banks = 1u8;
+        let chr_rom_banks = 1u8;
+        let flags6 = 0x00;
+        let flags7 = 0x00;
+
+        let mut rom = vec![
+            b'N',
+            b'E',
+            b'S',
+            0x1A,
+            prg_rom_banks,
+            chr_rom_banks,
+            flags6,
+            flags7,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ];
+
+        rom.extend(vec![0u8; prg_rom_banks as usize * 16 * 1024]);
+        rom.extend(vec![0u8; chr_rom_banks as usize * 8 * 1024]);
+        rom
+    }
+
     fn create_test_memory() -> Bus {
         let ppu = Rc::new(RefCell::new(ppu::Ppu::new(crate::nes::TvSystem::Ntsc)));
         let apu = Rc::new(RefCell::new(apu::Apu::new()));
@@ -597,11 +627,14 @@ mod tests {
         let mut memory = create_test_memory();
         let last_write = Rc::new(RefCell::new(None));
 
-        memory.register_device(Box::new(TestBusDevice::new(
-            0x4100..=0x4101,
-            0xAB,
-            last_write.clone(),
-        )));
+        memory.devices.insert(
+            0,
+            Box::new(TestBusDevice::new(
+                0x4100..=0x4101,
+                0xAB,
+                last_write.clone(),
+            )),
+        );
 
         assert_eq!(memory.read(0x4100), 0xAB);
 
@@ -690,11 +723,15 @@ mod tests {
     }
 
     #[test]
-    fn test_unallocated_io_space_is_registered() {
+    fn test_cpu_memory_map_io_and_mapper_ranges() {
         let memory = create_test_memory();
 
+        // $4018-$401F is normally disabled/test mode but is claimed by the APU device.
         assert!(memory.has_device_for_address(0x4018));
-        assert!(memory.has_device_for_address(0x40FF));
+        assert!(memory.has_device_for_address(0x401F));
+
+        // Cartridge space begins at $4020.
+        assert!(memory.has_device_for_address(0x4020));
     }
 
     #[test]
@@ -705,6 +742,45 @@ mod tests {
         assert!(dma);
         assert!(memory.oam_dma_pending());
         assert_eq!(memory.take_oam_dma_page(), Some(0x22));
+    }
+
+    #[test]
+    fn test_unmapped_cartridge_space_returns_open_bus() {
+        let mut memory = create_test_memory();
+
+        memory.write(0x0000, 0x3C, false);
+        let open_bus = memory.read(0x0000);
+
+        assert_eq!(open_bus, 0x3C);
+        assert_eq!(memory.read(0x4020), open_bus);
+    }
+
+    #[test]
+    fn test_unmapped_cartridge_space_returns_open_bus_with_mapper() {
+        let mut memory = create_test_memory();
+        let rom = create_mmc1_rom();
+        let cartridge = crate::cartridge::Cartridge::new(&rom).expect("valid cartridge");
+        memory.map_cartridge(cartridge);
+
+        memory.write(0x0000, 0x5A, false);
+        let open_bus = memory.read(0x0000);
+
+        assert_eq!(open_bus, 0x5A);
+        assert_eq!(memory.read(0x4020), open_bus);
+    }
+
+    #[test]
+    fn test_unmapped_cartridge_space_returns_open_bus_with_nrom() {
+        let mut memory = create_test_memory();
+        let rom = create_nrom_rom();
+        let cartridge = crate::cartridge::Cartridge::new(&rom).expect("valid cartridge");
+        memory.map_cartridge(cartridge);
+
+        memory.write(0x0000, 0xA5, false);
+        let open_bus = memory.read(0x0000);
+
+        assert_eq!(open_bus, 0xA5);
+        assert_eq!(memory.read(0x4020), open_bus);
     }
 
     #[test]

--- a/src/bus/mapper_device.rs
+++ b/src/bus/mapper_device.rs
@@ -27,7 +27,7 @@ impl BusDevice for MapperDevice {
 
         let Some(cartridge) = self.cartridge.borrow().as_ref().cloned() else {
             return match addr {
-                0x5000..=0x5FFF => Some(open_bus),
+                0x4020..=0x5FFF => Some(open_bus),
                 0x6000..=0x7FFF => {
                     eprintln!(
                         "Warning: Read from PRG-RAM {:04X} without cartridge, returning 0",
@@ -55,7 +55,7 @@ impl BusDevice for MapperDevice {
 
         let Some(cartridge) = self.cartridge.borrow().as_ref().cloned() else {
             match addr {
-                0x5000..=0x5FFF => eprintln!(
+                0x4020..=0x5FFF => eprintln!(
                     "Warning: Write to mapper expansion area {:04X} without cartridge, ignored",
                     addr
                 ),
@@ -83,6 +83,6 @@ impl BusDevice for MapperDevice {
     }
 
     fn address_range(&self) -> RangeInclusive<u16> {
-        0x5000..=0xFFFF
+        0x4020..=0xFFFF
     }
 }

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -27,6 +27,7 @@ use super::vrc6::VRC6Mapper;
 /// Metadata for constructing a mapper, containing cartridge header details and
 /// derived values (e.g., CRC32) used by the factory.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct MapperContext {
     /// iNES/NES 2.0 mapper number. Submapper is kept separately.
     pub mapper: u16,
@@ -46,6 +47,7 @@ pub struct MapperContext {
     pub crc32: u32,
 }
 
+#[allow(dead_code)]
 impl MapperContext {
     /// Create mapper metadata with default submapper 0, 1×8KB PRG-RAM (not battery-backed),
     /// and CRC32 computed from PRG+CHR data.
@@ -108,7 +110,11 @@ pub trait Mapper {
     /// Mappers that return open bus for disabled regions can override this method
     /// to return `open_bus` when appropriate. Default falls back to `read_prg`.
     fn read_prg_open_bus(&self, addr: u16, _open_bus: u8) -> u8 {
-        self.read_prg(addr)
+        if addr < 0x6000 {
+            _open_bus
+        } else {
+            self.read_prg(addr)
+        }
     }
 
     /// Write a byte to PRG address space (CPU $6000-$FFFF)

--- a/src/cartridge/mmc1.rs
+++ b/src/cartridge/mmc1.rs
@@ -311,7 +311,13 @@ impl Mapper for MMC1Mapper {
                 }
                 self.read_prg(addr)
             }
-            _ => self.read_prg(addr),
+            _ => {
+                if addr < 0x6000 {
+                    open_bus
+                } else {
+                    self.read_prg(addr)
+                }
+            }
         }
     }
 

--- a/src/cartridge/mmc3.rs
+++ b/src/cartridge/mmc3.rs
@@ -868,7 +868,13 @@ impl Mapper for MMC3Mapper {
                 }
                 self.read_prg(addr)
             }
-            _ => self.read_prg(addr),
+            _ => {
+                if addr < 0x6000 {
+                    open_bus
+                } else {
+                    self.read_prg(addr)
+                }
+            }
         }
     }
 

--- a/src/cartridge/mmc5.rs
+++ b/src/cartridge/mmc5.rs
@@ -220,6 +220,7 @@ impl MMC5Mapper {
     const PRG_RAM_BANK_COUNT_MAX: usize = 8;
     const PRG_ROM_BANK_SIZE: usize = 8 * 1024;
 
+    #[allow(dead_code)]
     pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: MirroringMode) -> Self {
         Self::new_with_prg_ram_size(
             prg_rom,
@@ -777,6 +778,14 @@ impl Mapper for MMC5Mapper {
             }
 
             _ => 0,
+        }
+    }
+
+    fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
+        if addr < 0x5000 {
+            open_bus
+        } else {
+            self.read_prg(addr)
         }
     }
 
@@ -1749,6 +1758,20 @@ mod tests {
         // Reading $5204 should clear the pending flag.
         let _ = mmc5.read_prg(0x5204);
         assert!(!mmc5.irq_pending());
+    }
+
+    #[test]
+    fn test_mmc5_read_prg_open_bus_allows_expansion_registers() {
+        let prg_rom = banked_data(8 * 1024, 2);
+        let chr_rom = banked_data(1024, 1);
+        let mut mmc5 = MMC5Mapper::new(prg_rom, chr_rom, MirroringMode::Horizontal);
+
+        mmc5.write_prg(0x5205, 3);
+        mmc5.write_prg(0x5206, 4);
+
+        let open_bus = 0xA5;
+        assert_eq!(mmc5.read_prg_open_bus(0x5205, open_bus), 12);
+        assert_eq!(mmc5.read_prg_open_bus(0x5206, open_bus), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- align APU and mapper bus ranges with NES CPU memory map
- enforce open bus behavior for unmapped cartridge space and mapper overrides
- add tests for unclaimed IO space and open bus reads (including MMC5 expansion registers)

## Testing
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- cargo test --all-features

Closes #365