### PR TITLE
Fix MMC5 fill-mode attributes in extended attribute mode

### DIFF
--- a/src/cartridge/mmc5.rs
+++ b/src/cartridge/mmc5.rs
@@ -2397,6 +2397,8 @@ mod tests {
         // Palette 2 in upper bits => replicated attribute byte 0xAA.
         mapper.write_prg(0x5C00, 0x80);
 
+        // Enable rendering so that tile/attribute fetch behavior matches PPU operation.
+        mapper.ppu_write_mask(0x18);
         let _ = mapper.read_nametable(0x2000);
         let attr = mapper
             .read_nametable(0x23C0)


### PR DESCRIPTION
## Summary
- use ExRAM palette bits for fill-mode attribute fetches when  is set to %01
- keep  handling for fill mode when extended attributes are disabled
- add coverage for fill-mode extended attribute behavior

## Testing
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- cargo test --all-features