### PR TITLE
Enable Arkanoid paddle via ROM CRC

### DIFF
--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -426,7 +426,6 @@ impl Bus {
     }
 
     /// Enable or disable the Arkanoid paddle on controller port 1.
-    #[allow(dead_code)]
     pub fn set_paddle1_enabled(&mut self, enabled: bool) {
         *self.paddle1_enabled.borrow_mut() = enabled;
     }
@@ -446,6 +445,11 @@ impl Bus {
     #[cfg(test)]
     fn open_bus_value_for_test(&self) -> u8 {
         self.open_bus
+    }
+
+    #[cfg(test)]
+    pub fn paddle1_enabled_for_test(&self) -> bool {
+        *self.paddle1_enabled.borrow()
     }
 
     /// Create a snapshot of CPU RAM for save-state (first 2KB is the actual RAM).

--- a/src/cartridge/cartridge.rs
+++ b/src/cartridge/cartridge.rs
@@ -63,6 +63,8 @@ pub struct Cartridge {
     /// Mapper instance that handles banking and memory access
     mapper: Box<dyn Mapper>,
 
+    crc32: u32,
+
     rom_path: Option<PathBuf>,
     save_path: Option<PathBuf>,
     battery_backed_prg_ram: bool,
@@ -132,6 +134,7 @@ impl Cartridge {
         // Extract PRG ROM and CHR ROM
         let prg_rom = data[prg_rom_start..prg_rom_end].to_vec();
         let chr_rom = data[chr_rom_start..chr_rom_end].to_vec();
+        let crc32 = crate::cartridge::calculate_rom_crc32(&prg_rom, &chr_rom);
 
         // Create mapper instance
         let mapper = crate::cartridge::mapper::create_mapper(
@@ -163,6 +166,7 @@ impl Cartridge {
 
         Ok(Self {
             mapper,
+            crc32,
             rom_path: None,
             save_path: None,
             battery_backed_prg_ram,
@@ -257,13 +261,19 @@ impl Cartridge {
         self.mapper.reset();
     }
 
+    pub fn crc32(&self) -> u32 {
+        self.crc32
+    }
+
     /// Create a cartridge directly from components (for testing)
     #[cfg(test)]
     pub fn from_parts(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: MirroringMode) -> Self {
         use crate::cartridge::nrom::NROMMapper;
+        let crc32 = crate::cartridge::calculate_rom_crc32(&prg_rom, &chr_rom);
         let mapper = Box::new(NROMMapper::new(prg_rom, chr_rom, mirroring));
         Self {
             mapper,
+            crc32,
             rom_path: None,
             save_path: None,
             battery_backed_prg_ram: false,
@@ -274,10 +284,16 @@ impl Cartridge {
     pub fn from_mapper_for_test(mapper: Box<dyn Mapper>) -> Self {
         Self {
             mapper,
+            crc32: 0,
             rom_path: None,
             save_path: None,
             battery_backed_prg_ram: false,
         }
+    }
+
+    #[cfg(test)]
+    pub fn set_crc32_for_test(&mut self, crc32: u32) {
+        self.crc32 = crc32;
     }
 }
 

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -34,3 +34,4 @@ pub use common::{BankedRom, ChrMemory, DEFAULT_CHR_RAM_SIZE, DEFAULT_PRG_RAM_SIZ
 pub use mapper::{Mapper, MapperContext};
 #[allow(unused_imports)]
 pub(crate) use rom_db::calculate_rom_crc32;
+pub(crate) use rom_db::requires_arkanoid_paddle;

--- a/src/cartridge/rom_db.rs
+++ b/src/cartridge/rom_db.rs
@@ -41,9 +41,20 @@ const MMC3_ALTERNATE_IRQ_CRCS: &[u32] = &[
     0xA512BDF6, // 6-MMC6.nes
 ];
 
+/// CRC32 values for ROMs that require Arkanoid paddle input on port 1.
+const ARKANOID_PADDLE_CRCS: &[u32] = &[
+    0x32FB0583, // Arkanoid (NES, 1987)
+    0x47F9F410, // PaddleTest3
+];
+
 /// Check if a ROM CRC requires alternate MMC3 IRQ behavior.
 pub fn requires_mmc3_alternate_irq(crc: u32) -> bool {
     MMC3_ALTERNATE_IRQ_CRCS.contains(&crc)
+}
+
+/// Check if a ROM CRC requires Arkanoid paddle input.
+pub fn requires_arkanoid_paddle(crc: u32) -> bool {
+    ARKANOID_PADDLE_CRCS.contains(&crc)
 }
 
 #[cfg(test)]
@@ -77,5 +88,16 @@ mod tests {
     fn test_mmc3_alternate_irq_unknown_crc() {
         // Random CRC should not require alternate IRQ
         assert!(!requires_mmc3_alternate_irq(0x12345678));
+    }
+
+    #[test]
+    fn test_arkanoid_paddle_known_crcs() {
+        assert!(requires_arkanoid_paddle(0x32FB0583));
+        assert!(requires_arkanoid_paddle(0x47F9F410));
+    }
+
+    #[test]
+    fn test_arkanoid_paddle_unknown_crc() {
+        assert!(!requires_arkanoid_paddle(0xDEADBEEF));
     }
 }

--- a/src/console/nes.rs
+++ b/src/console/nes.rs
@@ -91,7 +91,12 @@ impl Nes {
 
     /// Insert a cartridge and map it into memory
     pub fn insert_cartridge(&mut self, cartridge: Cartridge) {
-        self.memory.borrow_mut().map_cartridge(cartridge);
+        let requires_arkanoid_paddle =
+            crate::cartridge::requires_arkanoid_paddle(cartridge.crc32());
+
+        let mut memory = self.memory.borrow_mut();
+        memory.map_cartridge(cartridge);
+        memory.set_paddle1_enabled(requires_arkanoid_paddle);
     }
 
     pub fn state_path(&self) -> Option<PathBuf> {
@@ -1496,5 +1501,29 @@ mod tests {
             end_state2.ppu.timing.scanline
         );
         assert_eq!(end_state1.ppu.timing.pixel, end_state2.ppu.timing.pixel);
+    }
+
+    #[test]
+    fn test_insert_cartridge_enables_paddle_for_known_crc() {
+        let rom_data = create_minimal_nrom_rom();
+        let mut cartridge = crate::cartridge::Cartridge::new(&rom_data).unwrap();
+        cartridge.set_crc32_for_test(0x32FB0583);
+
+        let mut nes = Nes::new(TvSystem::Ntsc);
+        nes.insert_cartridge(cartridge);
+
+        assert!(nes.memory.borrow().paddle1_enabled_for_test());
+    }
+
+    #[test]
+    fn test_insert_cartridge_disables_paddle_for_unknown_crc() {
+        let rom_data = create_minimal_nrom_rom();
+        let mut cartridge = crate::cartridge::Cartridge::new(&rom_data).unwrap();
+        cartridge.set_crc32_for_test(0xDEADBEEF);
+
+        let mut nes = Nes::new(TvSystem::Ntsc);
+        nes.insert_cartridge(cartridge);
+
+        assert!(!nes.memory.borrow().paddle1_enabled_for_test());
     }
 }


### PR DESCRIPTION
## Summary
- store ROM CRC on cartridges and expose for detection
- enable paddle on insert for known Arkanoid CRCs
- add test helpers and CRC DB entries

## Testing
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- cargo test --all-features
- npm test (web)
