### PR TITLE
Add web paddle mouse input

### DIFF
--- a/src/web_frontend/wasm.rs
+++ b/src/web_frontend/wasm.rs
@@ -110,6 +110,24 @@ impl WasmNes {
         self.nes.set_button(controller, nes_button, pressed);
     }
 
+    /// Returns `true` if paddle 1 is enabled.
+    #[wasm_bindgen]
+    pub fn paddle1_enabled(&self) -> bool {
+        self.nes.paddle1_enabled()
+    }
+
+    /// Set the current position of paddle 1 (0..=255).
+    #[wasm_bindgen]
+    pub fn set_paddle1_position(&mut self, position: u8) {
+        self.nes.set_paddle1_position(position);
+    }
+
+    /// Set the trigger button state for paddle 1.
+    #[wasm_bindgen]
+    pub fn set_paddle1_trigger(&mut self, pressed: bool) {
+        self.nes.set_paddle1_trigger(pressed);
+    }
+
     /// Get all available audio samples from the emulator.
     ///
     /// Returns a Float32Array containing all pending audio samples.

--- a/src/web_frontend/wasm_tests.rs
+++ b/src/web_frontend/wasm_tests.rs
@@ -1,5 +1,6 @@
 #![cfg(all(test, feature = "wasm", target_arch = "wasm32"))]
 
+use crate::console::SaveState;
 use crate::wasm::WasmNes;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
@@ -13,6 +14,10 @@ fn minimal_nrom() -> Vec<u8> {
     data[4] = 1; // 1 * 16KB PRG
     data[5] = 1; // 1 * 8KB CHR
     data
+}
+
+fn read_save_state(nes: &WasmNes) -> SaveState {
+    SaveState::from_bytes(&nes.save_state_bytes()).expect("save state should decode")
 }
 
 #[wasm_bindgen_test]
@@ -180,4 +185,33 @@ fn reset_restores_initial_state() {
     let after_reset = nes.save_state_bytes();
 
     assert_eq!(initial, after_reset);
+}
+
+#[wasm_bindgen_test]
+fn paddle1_enabled_matches_save_state() {
+    let nes = WasmNes::new();
+    let state = read_save_state(&nes);
+    assert_eq!(nes.paddle1_enabled(), state.bus.paddle1.enabled);
+}
+
+#[wasm_bindgen_test]
+fn set_paddle1_position_updates_save_state() {
+    let mut nes = WasmNes::new();
+    nes.set_paddle1_position(0x5A);
+
+    let state = read_save_state(&nes);
+    assert_eq!(state.bus.paddle1.position, 0x5A);
+}
+
+#[wasm_bindgen_test]
+fn set_paddle1_trigger_updates_save_state() {
+    let mut nes = WasmNes::new();
+    nes.set_paddle1_trigger(true);
+
+    let state = read_save_state(&nes);
+    assert!(state.bus.paddle1.trigger);
+
+    nes.set_paddle1_trigger(false);
+    let state = read_save_state(&nes);
+    assert!(!state.bus.paddle1.trigger);
 }

--- a/web/app.js
+++ b/web/app.js
@@ -15,6 +15,11 @@ import { createFrameLimiter } from "./frame_limiter.js";
 import { computePlaybackRate } from "./audio_resampler.js";
 import { planFrame } from "./frame_plan.js";
 import { createSineScroller } from "./sine_scroller.js";
+import {
+    applyJoypadButtonIfAllowed,
+    applyPaddleMouseButton,
+    applyPaddleMouseMotion
+} from "./paddle_input.js";
 
 const statusEl = document.getElementById("status");
 const startBtn = document.getElementById("start");
@@ -1333,7 +1338,7 @@ document.addEventListener('keydown', (e) => {
     const mapping = keyToButton[key];
     if (mapping) {
         e.preventDefault(); // Prevent default browser behavior
-        nes.set_button(1, mapping.button, true);
+        applyJoypadButtonIfAllowed(nes, 1, mapping.button, true);
     }
 });
 
@@ -1343,9 +1348,28 @@ document.addEventListener('keyup', (e) => {
     const mapping = keyToButton[key];
     if (mapping) {
         e.preventDefault();
-        nes.set_button(1, mapping.button, false);
+        applyJoypadButtonIfAllowed(nes, 1, mapping.button, false);
     }
 });
+
+function handlePaddleMouseMotion(event) {
+    if (!nes) return;
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 1) {
+        return;
+    }
+    const x = event.clientX - rect.left;
+    applyPaddleMouseMotion(nes, x, rect.width);
+}
+
+function handlePaddleMouseButton(event, pressed) {
+    if (!nes) return;
+    applyPaddleMouseButton(nes, event.button, pressed);
+}
+
+canvas.addEventListener("mousemove", handlePaddleMouseMotion);
+canvas.addEventListener("mousedown", (event) => handlePaddleMouseButton(event, true));
+window.addEventListener("mouseup", (event) => handlePaddleMouseButton(event, false));
 
 // Screen size controls
 const screenMinusBtn = document.getElementById("screen-minus");
@@ -1447,28 +1471,28 @@ function pollGamepad() {
 function applyGamepadState(state) {
     if (!nes) return;
     if (state.a !== lastGamepadState.a) {
-        nes.set_button(1, 0, state.a);
+        applyJoypadButtonIfAllowed(nes, 1, 0, state.a);
     }
     if (state.b !== lastGamepadState.b) {
-        nes.set_button(1, 1, state.b);
+        applyJoypadButtonIfAllowed(nes, 1, 1, state.b);
     }
     if (state.select !== lastGamepadState.select) {
-        nes.set_button(1, 2, state.select);
+        applyJoypadButtonIfAllowed(nes, 1, 2, state.select);
     }
     if (state.start !== lastGamepadState.start) {
-        nes.set_button(1, 3, state.start);
+        applyJoypadButtonIfAllowed(nes, 1, 3, state.start);
     }
     if (state.up !== lastGamepadState.up) {
-        nes.set_button(1, 4, state.up);
+        applyJoypadButtonIfAllowed(nes, 1, 4, state.up);
     }
     if (state.down !== lastGamepadState.down) {
-        nes.set_button(1, 5, state.down);
+        applyJoypadButtonIfAllowed(nes, 1, 5, state.down);
     }
     if (state.left !== lastGamepadState.left) {
-        nes.set_button(1, 6, state.left);
+        applyJoypadButtonIfAllowed(nes, 1, 6, state.left);
     }
     if (state.right !== lastGamepadState.right) {
-        nes.set_button(1, 7, state.right);
+        applyJoypadButtonIfAllowed(nes, 1, 7, state.right);
     }
     lastGamepadState = state;
 }

--- a/web/paddle_input.js
+++ b/web/paddle_input.js
@@ -1,0 +1,40 @@
+export function mapMouseXToPaddlePosition(x, windowWidth) {
+    if (windowWidth <= 1) {
+        return 0;
+    }
+
+    const maxX = windowWidth - 1;
+    const clampedX = Math.min(Math.max(x, 0), maxX);
+    const normalized = (clampedX / maxX) * 2 - 1;
+    const curved = Math.sign(normalized) * Math.pow(Math.abs(normalized), 1.5);
+    const scaled = (curved + 1) * 0.5 * 255;
+
+    return Math.min(255, Math.max(0, Math.round(scaled)));
+}
+
+export function applyPaddleMouseMotion(nes, x, windowWidth) {
+    if (!nes.paddle1_enabled()) {
+        return;
+    }
+
+    const position = mapMouseXToPaddlePosition(x, windowWidth);
+    nes.set_paddle1_position(position);
+}
+
+export function applyPaddleMouseButton(nes, button, pressed) {
+    if (!nes.paddle1_enabled()) {
+        return;
+    }
+
+    if (button === 0) {
+        nes.set_paddle1_trigger(pressed);
+    }
+}
+
+export function applyJoypadButtonIfAllowed(nes, controller, button, pressed) {
+    if (controller === 1 && nes.paddle1_enabled()) {
+        return;
+    }
+
+    nes.set_button(controller, button, pressed);
+}

--- a/web/paddle_input.test.mjs
+++ b/web/paddle_input.test.mjs
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+    applyJoypadButtonIfAllowed,
+    applyPaddleMouseButton,
+    applyPaddleMouseMotion,
+    mapMouseXToPaddlePosition
+} from "./paddle_input.js";
+
+function makeNesStub({ paddleEnabled = false } = {}) {
+    const calls = {
+        setButton: [],
+        setPaddlePosition: [],
+        setPaddleTrigger: []
+    };
+
+    const nes = {
+        paddle1_enabled: () => paddleEnabled,
+        set_button: (controller, button, pressed) => {
+            calls.setButton.push({ controller, button, pressed });
+        },
+        set_paddle1_position: (position) => {
+            calls.setPaddlePosition.push(position);
+        },
+        set_paddle1_trigger: (pressed) => {
+            calls.setPaddleTrigger.push(pressed);
+        }
+    };
+
+    return { nes, calls, setPaddleEnabled: (enabled) => { paddleEnabled = enabled; } };
+}
+
+test("mapMouseXToPaddlePosition maps edges and center", () => {
+    const width = 300;
+
+    const left = mapMouseXToPaddlePosition(0, width);
+    const right = mapMouseXToPaddlePosition(width - 1, width);
+    const centerX = Math.floor((width - 1) / 2);
+    const center = mapMouseXToPaddlePosition(centerX, width);
+
+    assert.equal(left, 0);
+    assert.equal(right, 255);
+    assert.ok(center >= 120 && center <= 135);
+});
+
+test("mapMouseXToPaddlePosition uses non-linear curve", () => {
+    const width = 400;
+    const centerA = 200;
+    const centerB = 220;
+    const edgeA = 360;
+    const edgeB = 380;
+
+    const centerDelta =
+        mapMouseXToPaddlePosition(centerB, width) -
+        mapMouseXToPaddlePosition(centerA, width);
+    const edgeDelta =
+        mapMouseXToPaddlePosition(edgeB, width) -
+        mapMouseXToPaddlePosition(edgeA, width);
+
+    assert.ok(edgeDelta > centerDelta);
+});
+
+test("applyPaddleMouseMotion updates position when enabled", () => {
+    const { nes, calls } = makeNesStub({ paddleEnabled: true });
+    const width = 320;
+    const x = 240;
+
+    const expected = mapMouseXToPaddlePosition(x, width);
+    applyPaddleMouseMotion(nes, x, width);
+
+    assert.deepEqual(calls.setPaddlePosition, [expected]);
+});
+
+test("applyPaddleMouseMotion ignored when disabled", () => {
+    const { nes, calls } = makeNesStub({ paddleEnabled: false });
+    applyPaddleMouseMotion(nes, 240, 320);
+
+    assert.deepEqual(calls.setPaddlePosition, []);
+});
+
+test("applyPaddleMouseButton maps left button to trigger", () => {
+    const { nes, calls } = makeNesStub({ paddleEnabled: true });
+
+    applyPaddleMouseButton(nes, 0, true);
+    applyPaddleMouseButton(nes, 0, false);
+
+    assert.deepEqual(calls.setPaddleTrigger, [true, false]);
+});
+
+test("applyPaddleMouseButton ignores non-left buttons", () => {
+    const { nes, calls } = makeNesStub({ paddleEnabled: true });
+
+    applyPaddleMouseButton(nes, 1, true);
+
+    assert.deepEqual(calls.setPaddleTrigger, []);
+});
+
+test("applyPaddleMouseButton ignored when disabled", () => {
+    const { nes, calls } = makeNesStub({ paddleEnabled: false });
+
+    applyPaddleMouseButton(nes, 0, true);
+
+    assert.deepEqual(calls.setPaddleTrigger, []);
+});
+
+test("applyJoypadButtonIfAllowed suppresses controller 1 in paddle mode", () => {
+    const { nes, calls } = makeNesStub({ paddleEnabled: true });
+
+    applyJoypadButtonIfAllowed(nes, 1, 0, true);
+
+    assert.deepEqual(calls.setButton, []);
+});
+
+test("applyJoypadButtonIfAllowed allows controller 2 in paddle mode", () => {
+    const { nes, calls } = makeNesStub({ paddleEnabled: true });
+
+    applyJoypadButtonIfAllowed(nes, 2, 1, true);
+
+    assert.deepEqual(calls.setButton, [
+        { controller: 2, button: 1, pressed: true }
+    ]);
+});
+
+test("applyJoypadButtonIfAllowed allows controller 1 when paddle disabled", () => {
+    const { nes, calls } = makeNesStub({ paddleEnabled: false });
+
+    applyJoypadButtonIfAllowed(nes, 1, 7, false);
+
+    assert.deepEqual(calls.setButton, [
+        { controller: 1, button: 7, pressed: false }
+    ]);
+});


### PR DESCRIPTION
## Summary
- add web paddle mouse mapping helpers and tests
- wire mouse + input suppression in the web frontend
- expose paddle bindings in the WASM bridge and add WASM tests

## Testing
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- cargo test --all-features
- npm test

## Notes
- wasm-pack test --headless --chrome --features wasm (not run; reports no tests)
