### PR TITLE
Add Zapper CRC detection and auto-config

### DIFF
--- a/src/bin/autorunner.rs
+++ b/src/bin/autorunner.rs
@@ -882,10 +882,16 @@ mod tests {
             ControllerStateWrapper::Arkanoid(_) => {
                 panic!("expected joypad on port 1")
             }
+            ControllerStateWrapper::Zapper(_) => {
+                panic!("expected joypad on port 1")
+            }
         };
         let port2_buttons = match &state_after.bus.port2_controller {
             ControllerStateWrapper::Joypad(state) => state.button_states,
             ControllerStateWrapper::Arkanoid(_) => {
+                panic!("expected joypad on port 2")
+            }
+            ControllerStateWrapper::Zapper(_) => {
                 panic!("expected joypad on port 2")
             }
         };

--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -8,7 +8,7 @@ use crate::apu;
 use crate::cartridge::Cartridge;
 use crate::console::{BusState, MapperState};
 use crate::debugging::log_info;
-use crate::input::{Button, Controller, ControllerType, Joypad, Paddle};
+use crate::input::{Button, Controller, ControllerType, Joypad, Paddle, Zapper};
 use crate::ppu;
 use crate::trace_mapper;
 use std::cell::RefCell;
@@ -432,6 +432,7 @@ impl Bus {
         let new_controller: Box<dyn Controller> = match controller_type {
             ControllerType::Joypad => Joypad::new_boxed(),
             ControllerType::Arkanoid => Paddle::new_boxed(),
+            ControllerType::Zapper => Zapper::new_boxed(),
         };
 
         *self.controllers[(port - 1) as usize].borrow_mut() = new_controller;
@@ -524,10 +525,12 @@ impl Bus {
             port1_controller: match port1_state {
                 crate::input::ControllerState::Joypad(s) => ControllerStateWrapper::Joypad(s),
                 crate::input::ControllerState::Paddle(s) => ControllerStateWrapper::Arkanoid(s),
+                crate::input::ControllerState::Zapper(s) => ControllerStateWrapper::Zapper(s),
             },
             port2_controller: match port2_state {
                 crate::input::ControllerState::Joypad(s) => ControllerStateWrapper::Joypad(s),
                 crate::input::ControllerState::Paddle(s) => ControllerStateWrapper::Arkanoid(s),
+                crate::input::ControllerState::Zapper(s) => ControllerStateWrapper::Zapper(s),
             },
         }
     }
@@ -552,6 +555,11 @@ impl Bus {
                 controller.restore_state(&crate::input::ControllerState::Paddle(s.clone()));
                 *self.controllers[0].borrow_mut() = controller;
             }
+            ControllerStateWrapper::Zapper(s) => {
+                let mut controller = Zapper::new_boxed();
+                controller.restore_state(&crate::input::ControllerState::Zapper(s.clone()));
+                *self.controllers[0].borrow_mut() = controller;
+            }
         }
 
         // Restore port 2 controller - replace if type changed
@@ -564,6 +572,11 @@ impl Bus {
             ControllerStateWrapper::Arkanoid(s) => {
                 let mut controller = Paddle::new_boxed();
                 controller.restore_state(&crate::input::ControllerState::Paddle(s.clone()));
+                *self.controllers[1].borrow_mut() = controller;
+            }
+            ControllerStateWrapper::Zapper(s) => {
+                let mut controller = Zapper::new_boxed();
+                controller.restore_state(&crate::input::ControllerState::Zapper(s.clone()));
                 *self.controllers[1].borrow_mut() = controller;
             }
         }

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -35,3 +35,4 @@ pub use mapper::{Mapper, MapperContext};
 #[allow(unused_imports)]
 pub(crate) use rom_db::calculate_rom_crc32;
 pub(crate) use rom_db::default_arkanoid_on_port;
+pub(crate) use rom_db::default_zapper_on_port;

--- a/src/cartridge/rom_db.rs
+++ b/src/cartridge/rom_db.rs
@@ -51,6 +51,11 @@ const ARKANOID_PADDLE_PORT1_CRCS: &[u32] = &[
     0x47F9F410, // PaddleTest3
 ];
 
+/// CRC32 values for ROMs that default to Zapper input on port 2.
+const ZAPPER_PORT2_CRCS: &[u32] = &[
+    0x24598791, // Duck Hunt (World)
+];
+
 /// Check if a ROM CRC requires alternate MMC3 IRQ behavior.
 pub fn requires_mmc3_alternate_irq(crc: u32) -> bool {
     MMC3_ALTERNATE_IRQ_CRCS.contains(&crc)
@@ -63,6 +68,17 @@ pub fn default_arkanoid_on_port(crc: u32) -> u8 {
     if ARKANOID_PADDLE_PORT1_CRCS.contains(&crc) {
         1
     } else if ARKANOID_PADDLE_PORT2_CRCS.contains(&crc) {
+        2
+    } else {
+        0
+    }
+}
+
+/// Return the default Zapper controller port for a ROM CRC.
+///
+/// Returns 0 for none, 2 for port 2.
+pub fn default_zapper_on_port(crc: u32) -> u8 {
+    if ZAPPER_PORT2_CRCS.contains(&crc) {
         2
     } else {
         0
@@ -111,5 +127,15 @@ mod tests {
     #[test]
     fn test_arkanoid_paddle_unknown_crc() {
         assert_eq!(default_arkanoid_on_port(0xDEADBEEF), 0);
+    }
+
+    #[test]
+    fn test_zapper_known_crc() {
+        assert_eq!(default_zapper_on_port(0x24598791), 2);
+    }
+
+    #[test]
+    fn test_zapper_unknown_crc() {
+        assert_eq!(default_zapper_on_port(0xDEADBEEF), 0);
     }
 }

--- a/src/console/config.rs
+++ b/src/console/config.rs
@@ -1116,7 +1116,12 @@ impl Config {
     fn validate_controller_ports(&self) -> Result<(), String> {
         let mouse_emulated_controller_count = [self.controller_port1, self.controller_port2]
             .iter()
-            .filter(|controller| **controller == ControllerType::Arkanoid)
+            .filter(|controller| {
+                matches!(
+                    **controller,
+                    ControllerType::Arkanoid | ControllerType::Zapper
+                )
+            })
             .count();
 
         if mouse_emulated_controller_count > 1 {

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -11,4 +11,5 @@ pub use savestate::{
     ApuState, ArkanoidState, BusState, ControllerStateWrapper, CpuState, DmcState, EnvelopeState,
     FrameCounterState, JoypadState, MapperState, NoiseState, PpuRegisterState, PpuState,
     PpuTimingState, PulseState, SAVESTATE_VERSION, SaveState, SpritesState, TriangleState,
+    ZapperState,
 };

--- a/src/console/nes.rs
+++ b/src/console/nes.rs
@@ -5,7 +5,7 @@ use crate::console::{Config, SAVESTATE_VERSION, SaveState};
 use crate::cpu::Cpu;
 use crate::cpu::lookup;
 use crate::debugging::{Tracing, log_info};
-use crate::input::ControllerType;
+use crate::input::{ControllerInput, ControllerType, controller_input_type};
 use crate::ppu::Ppu;
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -94,8 +94,9 @@ impl Nes {
     }
 
     /// Insert a cartridge and map it into memory.
-    /// Auto-configures Arkanoid controllers for known ROMs if that specific port hasn't been explicitly configured.
+    /// Auto-configures Arkanoid or Zapper controllers for known ROMs if that specific port hasn't been explicitly configured.
     pub fn insert_cartridge(&mut self, cartridge: Cartridge) {
+        let zapper_port = crate::cartridge::default_zapper_on_port(cartridge.crc32());
         let arkanoid_port = crate::cartridge::default_arkanoid_on_port(cartridge.crc32());
 
         let mut bus = self.bus.borrow_mut();
@@ -107,54 +108,72 @@ impl Nes {
         let port1_explicit = self.config.controller_port1_explicit;
         let port2_explicit = self.config.controller_port2_explicit;
 
-        // Auto-configure Arkanoid controller when detected, but only if the specific port
+        let auto_controller = if zapper_port != 0 {
+            Some((zapper_port, ControllerType::Zapper))
+        } else if arkanoid_port != 0 {
+            Some((arkanoid_port, ControllerType::Arkanoid))
+        } else {
+            None
+        };
+
+        // Auto-configure mouse-emulated controller when detected, but only if the specific port
         // hasn't been explicitly configured by the user, and we wouldn't create a second
-        // Arkanoid controller alongside another mouse-emulated controller.
-        if arkanoid_port != 0 {
-            let port_explicitly_configured = match arkanoid_port {
+        // mouse-emulated controller alongside another mouse-emulated controller.
+        if let Some((auto_port, auto_type)) = auto_controller {
+            let port_explicitly_configured = match auto_port {
                 1 => port1_explicit,
                 2 => port2_explicit,
                 _ => false,
             };
 
-            let other_port_type = if arkanoid_port == 1 {
+            let other_port_type = if auto_port == 1 {
                 port2_type
             } else {
                 port1_type
             };
-            let other_port_explicit = if arkanoid_port == 1 {
+            let other_port_explicit = if auto_port == 1 {
                 port2_explicit
             } else {
                 port1_explicit
             };
 
-            let other_port_is_explicit_paddle =
-                other_port_explicit && matches!(other_port_type, ControllerType::Arkanoid);
+            let other_port_is_explicit_mouse = other_port_explicit
+                && controller_input_type(other_port_type) == ControllerInput::Mouse;
 
-            if !port_explicitly_configured && !other_port_is_explicit_paddle {
+            if !port_explicitly_configured && !other_port_is_explicit_mouse {
+                let auto_label = match auto_type {
+                    ControllerType::Arkanoid => "Arkanoid",
+                    ControllerType::Zapper => "Zapper",
+                    ControllerType::Joypad => "Joypad",
+                };
                 log_info(format!(
-                    "Enabling Arkanoid controller on port {} for inserted cartridge. If you don't want this behavior, explicitly configure that port or configure another mouse-emulated controller on the other port to prevent auto-detection. Note that some games expect the Arkanoid controller on a specific port, so be sure to configure the correct one if you have issues with input not working in certain games.",
-                    arkanoid_port
+                    "Enabling {} controller on port {} for inserted cartridge. If you don't want this behavior, explicitly configure that port or configure another mouse-emulated controller on the other port to prevent auto-detection. Note that some games expect the controller on a specific port, so be sure to configure the correct one if you have issues with input not working in certain games.",
+                    auto_label, auto_port
                 ));
-                bus.set_controller_type(arkanoid_port, ControllerType::Arkanoid);
+                bus.set_controller_type(auto_port, auto_type);
 
                 // Apply the other port's configuration
-                let other_port = if arkanoid_port == 1 { 2 } else { 1 };
+                let other_port = if auto_port == 1 { 2 } else { 1 };
                 bus.set_controller_type(other_port, other_port_type);
             } else {
+                let auto_label = match auto_type {
+                    ControllerType::Arkanoid => "Arkanoid",
+                    ControllerType::Zapper => "Zapper",
+                    ControllerType::Joypad => "Joypad",
+                };
                 log_info(format!(
-                    "ROM detected as supporting an Arkanoid controller on port {}, but user has explicitly configured that port \
+                    "ROM detected as supporting a {} controller on port {}, but user has explicitly configured that port \
                     or configured another mouse-emulated controller on another port. \
-                    Keeping user configuration. Note that this may cause issues if the game expects an Arkanoid controller on \
+                    Keeping user configuration. Note that this may cause issues if the game expects a {} controller on \
                     port {}.",
-                    arkanoid_port, arkanoid_port
+                    auto_label, auto_port, auto_label, auto_port
                 ));
                 // Apply user's explicit configuration
                 bus.set_controller_type(1, port1_type);
                 bus.set_controller_type(2, port2_type);
             }
         } else {
-            // No Arkanoid controller detected, just apply user config
+            // No mouse-emulated controller detected, just apply user config
             bus.set_controller_type(1, port1_type);
             bus.set_controller_type(2, port2_type);
         }
@@ -1654,6 +1673,50 @@ mod tests {
             bus_state.port1_controller,
             crate::console::ControllerStateWrapper::Arkanoid(_)
         ));
+        assert!(matches!(
+            bus_state.port2_controller,
+            crate::console::ControllerStateWrapper::Joypad(_)
+        ));
+    }
+
+    #[test]
+    fn test_insert_cartridge_enables_zapper_for_known_crc() {
+        let rom_data = create_minimal_nrom_rom();
+        let mut cartridge = crate::cartridge::Cartridge::new(&rom_data).unwrap();
+        cartridge.set_crc32_for_test(0x24598791);
+
+        let mut nes = Nes::new(Config::default());
+        nes.insert_cartridge(cartridge);
+
+        let bus_state = nes.bus.borrow().capture_state();
+        assert!(matches!(
+            bus_state.port1_controller,
+            crate::console::ControllerStateWrapper::Joypad(_)
+        ));
+        assert!(matches!(
+            bus_state.port2_controller,
+            crate::console::ControllerStateWrapper::Zapper(_)
+        ));
+    }
+
+    #[test]
+    fn test_insert_cartridge_keeps_explicit_port2_when_zapper_detected() {
+        let rom_data = create_minimal_nrom_rom();
+        let mut cartridge = crate::cartridge::Cartridge::new(&rom_data).unwrap();
+        cartridge.set_crc32_for_test(0x24598791);
+
+        let config = Config {
+            controller_port1: crate::input::ControllerType::Joypad,
+            controller_port1_explicit: false,
+            controller_port2: crate::input::ControllerType::Joypad,
+            controller_port2_explicit: true,
+            ..Default::default()
+        };
+
+        let mut nes = Nes::new(config);
+        nes.insert_cartridge(cartridge);
+
+        let bus_state = nes.bus.borrow().capture_state();
         assert!(matches!(
             bus_state.port2_controller,
             crate::console::ControllerStateWrapper::Joypad(_)

--- a/src/console/savestate.rs
+++ b/src/console/savestate.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Current save-state format version.
 /// Increment this when making breaking changes to the state format.
-pub const SAVESTATE_VERSION: u32 = 6;
+pub const SAVESTATE_VERSION: u32 = 7;
 
 /// Complete emulator state snapshot.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -286,6 +286,15 @@ pub struct ArkanoidState {
     pub enabled: bool,
 }
 
+/// Bus Zapper controller state.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ZapperState {
+    pub x: u8,
+    pub y: u8,
+    pub trigger: bool,
+    pub light: bool,
+}
+
 /// Bus state for save-state support.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BusState {
@@ -300,6 +309,7 @@ pub struct BusState {
 pub enum ControllerStateWrapper {
     Joypad(JoypadState),
     Arkanoid(ArkanoidState),
+    Zapper(ZapperState),
 }
 
 /// APU complete state.
@@ -613,7 +623,7 @@ mod tests {
 
     #[test]
     fn test_savestate_version() {
-        assert_eq!(SAVESTATE_VERSION, 6);
+        assert_eq!(SAVESTATE_VERSION, 7);
     }
 
     #[test]

--- a/src/input/controller.rs
+++ b/src/input/controller.rs
@@ -1,4 +1,4 @@
-use crate::console::{ArkanoidState, JoypadState};
+use crate::console::{ArkanoidState, JoypadState, ZapperState};
 use crate::input::Button;
 
 /// Unified controller state for save-state support.
@@ -6,6 +6,7 @@ use crate::input::Button;
 pub enum ControllerState {
     Joypad(JoypadState),
     Paddle(ArkanoidState),
+    Zapper(ZapperState),
 }
 
 /// Controller type for a port.
@@ -13,6 +14,7 @@ pub enum ControllerState {
 pub enum ControllerType {
     Joypad,
     Arkanoid,
+    Zapper,
 }
 
 // TODO remove the "paddle" variant
@@ -22,6 +24,7 @@ impl ControllerType {
         match value.to_lowercase().as_str() {
             "joypad" => Some(Self::Joypad),
             "arkanoid" | "paddle" => Some(Self::Arkanoid),
+            "zapper" => Some(Self::Zapper),
             _ => None,
         }
     }
@@ -42,6 +45,7 @@ pub fn controller_input_type(controller_type: ControllerType) -> ControllerInput
     match controller_type {
         ControllerType::Joypad => ControllerInput::Gamepad,
         ControllerType::Arkanoid => ControllerInput::Mouse,
+        ControllerType::Zapper => ControllerInput::Mouse,
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,9 +1,11 @@
 mod controller;
 mod joypad;
 mod paddle;
+mod zapper;
 
 pub use controller::{
     Controller, ControllerInput, ControllerState, ControllerType, controller_input_type,
 };
 pub use joypad::{Button, Joypad};
 pub use paddle::Paddle;
+pub use zapper::Zapper;

--- a/src/input/zapper.rs
+++ b/src/input/zapper.rs
@@ -1,0 +1,97 @@
+use super::ControllerInput;
+use crate::console::ZapperState;
+use crate::input::Button;
+
+/// NES Zapper controller.
+///
+/// Minimal implementation for save-state support and mouse-driven trigger.
+pub struct Zapper {
+    x: u8,
+    y: u8,
+    trigger: bool,
+    light: bool,
+}
+
+impl Default for Zapper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Zapper {
+    pub fn new() -> Self {
+        Self {
+            x: 0,
+            y: 0,
+            trigger: false,
+            light: false,
+        }
+    }
+
+    pub fn new_boxed() -> Box<dyn crate::input::Controller> {
+        Box::new(Self::new())
+    }
+
+    pub fn capture_state(&self) -> ZapperState {
+        ZapperState {
+            x: self.x,
+            y: self.y,
+            trigger: self.trigger,
+            light: self.light,
+        }
+    }
+
+    pub fn restore_state(&mut self, state: &ZapperState) {
+        self.x = state.x;
+        self.y = state.y;
+        self.trigger = state.trigger;
+        self.light = state.light;
+    }
+}
+
+impl crate::input::Controller for Zapper {
+    fn write_strobe(&mut self, _value: u8) {}
+
+    fn read(&mut self) -> u8 {
+        0
+    }
+
+    fn read_no_clock(&self) -> u8 {
+        0
+    }
+
+    fn capture_state(&self) -> crate::input::ControllerState {
+        crate::input::ControllerState::Zapper(self.capture_state())
+    }
+
+    fn restore_state(&mut self, state: &crate::input::ControllerState) {
+        if let crate::input::ControllerState::Zapper(zapper_state) = state {
+            self.restore_state(zapper_state);
+        }
+    }
+
+    fn new_boxed() -> Box<dyn crate::input::Controller>
+    where
+        Self: Sized,
+    {
+        Self::new_boxed()
+    }
+
+    fn set_button(&mut self, _button: Button, _pressed: bool) -> bool {
+        false
+    }
+
+    fn set_mouse_x_position(&mut self, position: u8) -> bool {
+        self.x = position;
+        true
+    }
+
+    fn set_mouse_left_button(&mut self, pressed: bool) -> bool {
+        self.trigger = pressed;
+        true
+    }
+
+    fn input_type(&self) -> ControllerInput {
+        crate::input::controller_input_type(crate::input::ControllerType::Zapper)
+    }
+}

--- a/src/web_frontend/wasm_tests.rs
+++ b/src/web_frontend/wasm_tests.rs
@@ -23,6 +23,7 @@ fn port1_arkanoid_state(state: &SaveState) -> ArkanoidState {
     match &state.bus.port1_controller {
         ControllerStateWrapper::Arkanoid(arkanoid) => arkanoid.clone(),
         ControllerStateWrapper::Joypad(_) => panic!("expected Arkanoid controller on port 1"),
+        ControllerStateWrapper::Zapper(_) => panic!("expected Arkanoid controller on port 1"),
     }
 }
 


### PR DESCRIPTION
## Summary\n- add Zapper CRC lookup and default port detection\n- auto-configure Zapper controller on port 2 when supported ROMs are inserted\n- introduce Zapper controller type/state wiring for save-state compatibility\n\n## Testing\n- cargo check --all-targets --all-features\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo fmt\n- cargo test --all-features\n- wasm-pack test --headless --chrome --features wasm\n- npm test (web)\n\nRefs #466\nPart of #438