### PR TITLE
Auto-detect ROM TV system

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,7 +76,7 @@ Before merging or committing to main, the following checkpoint shall pass:
 - Run `cargo test --all-features` and fix all warnings and ensure all tests pass
 - Run `wasm-pack test --headless --chrome --features wasm` and fix all warnings and ensure all tests pass
 - Run `npm test` in the `web/` directory and ensure all tests pass (if any tests exist)
-- Run `python -m unittest discover -s scripts/scraper -p "test_*.py"` and ensure all tests pass
+- Run `source .venv/bin/activate && python -m unittest discover -s scripts/scraper -p "test_*.py"` and ensure all tests pass
 
 ### Fixing Bugs
 

--- a/src/bin/autorunner.rs
+++ b/src/bin/autorunner.rs
@@ -1,5 +1,5 @@
 use neser::cartridge::Cartridge;
-use neser::console::{Config, Nes, ParseResult};
+use neser::console::{Config, Nes, ParseResult, log_rom_tv_system_selection};
 use neser::input::Button;
 use neser::integration_tests::autorun::{
     AUTORUN_VERSION, AutorunFile, AutorunFrame, autorun_path_for_rom, crc32, load_autorun_file,
@@ -87,13 +87,18 @@ enum ExitReason {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
-    let Some((mode, rom_path, config, headless, overwrite_recording, extend)) = parse_args(&args)?
+    let Some((mode, rom_path, mut config, headless, overwrite_recording, extend)) =
+        parse_args(&args)?
     else {
         return Ok(());
     };
 
-    let mut nes = Nes::new(config.clone());
     let cart = Cartridge::load_from_file(&rom_path)?;
+    let rom_tv_system = cart.rom_tv_system();
+    let applied = config.apply_rom_tv_system(rom_tv_system);
+    log_rom_tv_system_selection(&config, rom_tv_system, applied);
+
+    let mut nes = Nes::new(config.clone());
     nes.insert_cartridge(cart);
     nes.reset(false);
 

--- a/src/cartridge/cartridge.rs
+++ b/src/cartridge/cartridge.rs
@@ -26,6 +26,23 @@ pub enum CartridgeError {
     Io(io::Error),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RomTvSystem {
+    Ntsc,
+    Pal,
+    Unknown,
+}
+
+impl RomTvSystem {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RomTvSystem::Ntsc => "ntsc",
+            RomTvSystem::Pal => "pal",
+            RomTvSystem::Unknown => "unknown",
+        }
+    }
+}
+
 impl fmt::Display for CartridgeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -65,6 +82,8 @@ pub struct Cartridge {
 
     crc32: u32,
 
+    rom_tv_system: RomTvSystem,
+
     rom_path: Option<PathBuf>,
     save_path: Option<PathBuf>,
     battery_backed_prg_ram: bool,
@@ -93,6 +112,16 @@ impl Cartridge {
         // iNES v1 header byte 8 encodes PRG-RAM size in 8KB units.
         // A value of 0 commonly means 8KB.
         let prg_ram_banks_8k = data[8].max(1);
+
+        let flags9 = data[9];
+
+        let rom_tv_system = if (flags7 & 0x0C) == 0x08 {
+            RomTvSystem::Unknown
+        } else if (flags9 & 0x01) != 0 {
+            RomTvSystem::Pal
+        } else {
+            RomTvSystem::Ntsc
+        };
 
         // Battery-backed PRG-RAM present (iNES v1): bit 1 of flags6.
         let battery_backed_prg_ram = (flags6 & 0x02) != 0;
@@ -153,6 +182,7 @@ impl Cartridge {
         Ok(Self {
             mapper,
             crc32,
+            rom_tv_system,
             rom_path: None,
             save_path: None,
             battery_backed_prg_ram,
@@ -251,6 +281,10 @@ impl Cartridge {
         self.crc32
     }
 
+    pub fn rom_tv_system(&self) -> RomTvSystem {
+        self.rom_tv_system
+    }
+
     /// Create a cartridge directly from components (for testing)
     #[cfg(test)]
     pub fn from_parts(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: MirroringMode) -> Self {
@@ -260,6 +294,7 @@ impl Cartridge {
         Self {
             mapper,
             crc32,
+            rom_tv_system: RomTvSystem::Ntsc,
             rom_path: None,
             save_path: None,
             battery_backed_prg_ram: false,
@@ -271,6 +306,7 @@ impl Cartridge {
         Self {
             mapper,
             crc32: 0,
+            rom_tv_system: RomTvSystem::Ntsc,
             rom_path: None,
             save_path: None,
             battery_backed_prg_ram: false,
@@ -323,6 +359,46 @@ mod tests {
         rom.extend(vec![0xAA; prg_size]);
 
         // Add CHR ROM data
+        let chr_size = chr_rom_banks as usize * 8192;
+        rom.extend(vec![0xBB; chr_size]);
+
+        rom
+    }
+
+    fn create_test_rom_with_flags9(
+        prg_rom_banks: u8,
+        chr_rom_banks: u8,
+        flags6: u8,
+        flags7: u8,
+        flags9: u8,
+        include_trainer: bool,
+    ) -> Vec<u8> {
+        let mut rom = vec![
+            b'N',
+            b'E',
+            b'S',
+            0x1A,          // iNES header
+            prg_rom_banks, // PRG ROM size (16KB units)
+            chr_rom_banks, // CHR ROM size (8KB units)
+            flags6,        // Flags 6
+            flags7,        // Flags 7
+            0,             // Flags 8 (PRG RAM size)
+            flags9,        // Flags 9 (TV system)
+            0,             // Flags 10
+            0,
+            0,
+            0,
+            0,
+            0, // Reserved (unused)
+        ];
+
+        if include_trainer {
+            rom.extend(vec![0x00; 512]);
+        }
+
+        let prg_size = prg_rom_banks as usize * 16384;
+        rom.extend(vec![0xAA; prg_size]);
+
         let chr_size = chr_rom_banks as usize * 8192;
         rom.extend(vec![0xBB; chr_size]);
 
@@ -479,6 +555,27 @@ mod tests {
         // Verify CHR ROM can be read (only first 8KB used by NROM)
         assert_eq!(cartridge.mapper().read_chr(0x0000), 0xBB);
         assert_eq!(cartridge.mapper().read_chr(0x1FFF), 0xBB);
+    }
+
+    #[test]
+    fn test_rom_tv_system_defaults_to_ntsc() {
+        let rom_data = create_test_rom_with_flags9(1, 1, 0, 0, 0, false);
+        let cartridge = Cartridge::new(&rom_data).unwrap();
+        assert_eq!(cartridge.rom_tv_system(), RomTvSystem::Ntsc);
+    }
+
+    #[test]
+    fn test_rom_tv_system_parses_pal_flag() {
+        let rom_data = create_test_rom_with_flags9(1, 1, 0, 0, 0x01, false);
+        let cartridge = Cartridge::new(&rom_data).unwrap();
+        assert_eq!(cartridge.rom_tv_system(), RomTvSystem::Pal);
+    }
+
+    #[test]
+    fn test_rom_tv_system_unknown_for_nes2_header() {
+        let rom_data = create_test_rom_with_flags9(1, 1, 0, 0x08, 0x01, false);
+        let cartridge = Cartridge::new(&rom_data).unwrap();
+        assert_eq!(cartridge.rom_tv_system(), RomTvSystem::Unknown);
     }
 
     #[test]

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -27,7 +27,7 @@ mod uxrom;
 mod vrc2_vrc4;
 mod vrc6;
 
-pub use cartridge::{Cartridge, MirroringMode};
+pub use cartridge::{Cartridge, MirroringMode, RomTvSystem};
 #[allow(unused_imports)]
 pub use common::{BankedRom, ChrMemory, DEFAULT_CHR_RAM_SIZE, DEFAULT_PRG_RAM_SIZE, PrgRam};
 #[allow(unused_imports)]

--- a/src/console/config.rs
+++ b/src/console/config.rs
@@ -291,6 +291,8 @@ pub enum ParseResult {
 pub struct Config {
     /// TV system (NTSC or PAL).
     pub tv_system: TvSystem,
+    /// Whether the TV system was explicitly configured.
+    pub tv_system_explicit: bool,
     /// Whether audio is enabled.
     pub audio_enabled: bool,
     /// Whether VSync is enabled.
@@ -356,6 +358,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             tv_system: TvSystem::Ntsc,
+            tv_system_explicit: false,
             audio_enabled: true,
             vsync_enabled: true,
             gamepads_enabled: true,
@@ -450,8 +453,10 @@ impl Config {
         if let Some(tv_system) = Self::parse_string_arg(args, "--tv-system") {
             if tv_system.eq_ignore_ascii_case("pal") {
                 self.tv_system = TvSystem::Pal;
+                self.tv_system_explicit = true;
             } else if tv_system.eq_ignore_ascii_case("ntsc") {
                 self.tv_system = TvSystem::Ntsc;
+                self.tv_system_explicit = true;
             } else {
                 return Err(format!(
                     "Invalid --tv-system value: '{}'. Valid options are: ntsc, pal",
@@ -894,8 +899,10 @@ impl Config {
             "tv_system" => {
                 if value.eq_ignore_ascii_case("pal") {
                     self.tv_system = TvSystem::Pal;
+                    self.tv_system_explicit = true;
                 } else if value.eq_ignore_ascii_case("ntsc") {
                     self.tv_system = TvSystem::Ntsc;
+                    self.tv_system_explicit = true;
                 }
             }
             "audio" => {
@@ -1078,6 +1085,24 @@ impl Config {
             _ => {} // Unknown keys are silently ignored
         }
         Ok(())
+    }
+
+    pub fn apply_rom_tv_system(&mut self, rom_tv_system: crate::cartridge::RomTvSystem) -> bool {
+        if self.tv_system_explicit {
+            return false;
+        }
+
+        match rom_tv_system {
+            crate::cartridge::RomTvSystem::Ntsc => {
+                self.tv_system = TvSystem::Ntsc;
+                true
+            }
+            crate::cartridge::RomTvSystem::Pal => {
+                self.tv_system = TvSystem::Pal;
+                true
+            }
+            crate::cartridge::RomTvSystem::Unknown => false,
+        }
     }
 
     /// Parse a boolean value from config file.
@@ -1265,6 +1290,35 @@ mod tests {
         ];
         let config = parse_config(args);
         assert_eq!(config.tv_system, TvSystem::Pal);
+        assert!(config.tv_system_explicit);
+    }
+
+    #[test]
+    fn test_config_apply_rom_tv_system_when_not_explicit() {
+        let mut config = Config::default();
+        let applied = config.apply_rom_tv_system(crate::cartridge::RomTvSystem::Pal);
+        assert!(applied);
+        assert_eq!(config.tv_system, TvSystem::Pal);
+    }
+
+    #[test]
+    fn test_config_apply_rom_tv_system_does_not_override_explicit() {
+        let mut config = Config {
+            tv_system: TvSystem::Pal,
+            tv_system_explicit: true,
+            ..Default::default()
+        };
+        let applied = config.apply_rom_tv_system(crate::cartridge::RomTvSystem::Ntsc);
+        assert!(!applied);
+        assert_eq!(config.tv_system, TvSystem::Pal);
+    }
+
+    #[test]
+    fn test_config_apply_rom_tv_system_unknown_keeps_default() {
+        let mut config = Config::default();
+        let applied = config.apply_rom_tv_system(crate::cartridge::RomTvSystem::Unknown);
+        assert!(!applied);
+        assert_eq!(config.tv_system, TvSystem::Ntsc);
     }
 
     #[test]
@@ -1663,6 +1717,7 @@ mod tests {
         let mut config = Config::default();
         config.apply_config_value("tv_system", "pal").unwrap();
         assert_eq!(config.tv_system, TvSystem::Pal);
+        assert!(config.tv_system_explicit);
     }
 
     #[test]
@@ -1673,6 +1728,7 @@ mod tests {
         };
         config.apply_config_value("tv_system", "ntsc").unwrap();
         assert_eq!(config.tv_system, TvSystem::Ntsc);
+        assert!(config.tv_system_explicit);
     }
 
     #[test]

--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -2,6 +2,9 @@ mod config;
 mod nes;
 mod savestate;
 
+use crate::cartridge::RomTvSystem;
+use crate::debugging::log_info;
+
 pub use config::ApuChannels;
 pub use config::Config;
 pub use config::ParseResult;
@@ -13,3 +16,17 @@ pub use savestate::{
     PpuTimingState, PulseState, SAVESTATE_VERSION, SaveState, SpritesState, TriangleState,
     ZapperState,
 };
+
+pub fn log_rom_tv_system_selection(config: &Config, rom_tv_system: RomTvSystem, applied: bool) {
+    if !config.tv_system_explicit && rom_tv_system == RomTvSystem::Unknown {
+        log_info(format!(
+            "ROM TV system unknown; using configured {}",
+            config.tv_system.as_str()
+        ));
+    } else if applied {
+        log_info(format!(
+            "ROM TV system detected as {}; applying timing",
+            rom_tv_system.as_str()
+        ));
+    }
+}

--- a/src/console/nes.rs
+++ b/src/console/nes.rs
@@ -57,6 +57,13 @@ impl TvSystem {
     pub fn screen_height(&self) -> u32 {
         240
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TvSystem::Ntsc => "ntsc",
+            TvSystem::Pal => "pal",
+        }
+    }
 }
 
 pub struct Nes {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod ppu;
 mod rendering;
 mod sdl_frontend;
 
-use console::{ApuChannels, Config, Nes, ParseResult, SaveState};
+use console::{ApuChannels, Config, Nes, ParseResult, SaveState, log_rom_tv_system_selection};
 use debugging::log_info;
 use sdl_frontend::{SdlEventLoop, SdlNesAudio};
 use std::fs;
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse command-line arguments
     let args: Vec<String> = std::env::args().collect();
 
-    let config = match Config::new(&args)? {
+    let mut config = match Config::new(&args)? {
         ParseResult::Help => {
             Config::print_help();
             return Ok(());
@@ -31,29 +31,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize SDL2
     let sdl_context = sdl2::init()?;
-    let mut nes_instance = Nes::new(config.clone());
 
     // Create audio output (request 44.1 kHz) unless disabled.
     // SDL may open the device at a different rate; always sync the APU to the actual rate
     // to avoid steady underruns.
+    let mut audio_sample_rate = None;
     let audio = if !config.audio_enabled {
         None
     } else {
         let audio = SdlNesAudio::new(&sdl_context, 44100)?;
-        let actual_rate = audio.actual_sample_rate() as f32;
-        nes_instance.apu.borrow_mut().set_sample_rate(actual_rate);
+        audio_sample_rate = Some(audio.actual_sample_rate() as f32);
         Some(audio)
     };
-
-    let mut event_loop = SdlEventLoop::new(false, audio, &config)?;
-
-    // Request debugger open if enabled via CLI
-    if config.debugger_enabled {
-        event_loop.request_debugger_open();
-    }
-
-    // Temporary hard-coded breakpoint for debugger development.
-    // event_loop.add_breakpoint(0xE486);
 
     // Palette display requiring only scanline-based palette changes,
     // intended to demonstrate the full palette even on less advanced emulators
@@ -87,7 +76,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let rom_path = config.rom_path.as_deref().unwrap_or(default_rom_path);
     let cart = cartridge::Cartridge::load_from_file(rom_path)?;
+
+    let rom_tv_system = cart.rom_tv_system();
+    let applied = config.apply_rom_tv_system(rom_tv_system);
+    log_rom_tv_system_selection(&config, rom_tv_system, applied);
+
+    let mut nes_instance = Nes::new(config.clone());
     nes_instance.insert_cartridge(cart);
+
+    if let Some(actual_rate) = audio_sample_rate {
+        nes_instance.apu.borrow_mut().set_sample_rate(actual_rate);
+    }
+
+    let mut event_loop = SdlEventLoop::new(false, audio, &config)?;
+
+    // Request debugger open if enabled via CLI
+    if config.debugger_enabled {
+        event_loop.request_debugger_open();
+    }
+
+    // Temporary hard-coded breakpoint for debugger development.
+    // event_loop.add_breakpoint(0xE486);
 
     if config.load_state {
         let state_path = nes_instance

--- a/src/web_frontend/wasm.rs
+++ b/src/web_frontend/wasm.rs
@@ -1,5 +1,5 @@
 use crate::cartridge::Cartridge;
-use crate::console::{Config, Nes, SaveState};
+use crate::console::{Config, Nes, SaveState, log_rom_tv_system_selection};
 use crate::input::{Button, ControllerType};
 use wasm_bindgen::prelude::*;
 
@@ -38,9 +38,14 @@ impl WasmNes {
     /// Load a ROM from raw bytes.
     #[wasm_bindgen]
     pub fn load_rom(&mut self, rom: &[u8]) -> Result<(), JsValue> {
-        self.nes = Nes::new(Config::default());
+        let mut config = Config::default();
         self.rom_loaded = false;
         let cart = Cartridge::new(rom).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let rom_tv_system = cart.rom_tv_system();
+        let applied = config.apply_rom_tv_system(rom_tv_system);
+        log_rom_tv_system_selection(&config, rom_tv_system, applied);
+
+        self.nes = Nes::new(config);
         self.nes.insert_cartridge(cart);
         self.nes.reset(false);
         self.rom_loaded = true;


### PR DESCRIPTION
## Summary
- parse ROM TV system metadata from iNES headers and expose it on Cartridge
- apply ROM TV system to config when not explicitly set, with shared logging
- wire ROM TV system selection into SDL, autorunner, and WASM flows

## Testing
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- cargo test --all-features
- wasm-pack test --headless --chrome --features wasm
- (cd web && npm test)
- source .venv/bin/activate && python -m unittest discover -s scripts/scraper -p test_*.py
