### PR TITLE
Fix #572: Add web shortcut help overlay with H toggle

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -18,6 +18,12 @@ import { planFrame } from "./frame_plan.js";
 import { createSineScroller } from "./sine_scroller.js";
 import { getKeyboardControllerTarget } from "./input_routing.js";
 import { dispatchWebShortcutAction } from "./shortcut_actions.js";
+import {
+    buildShortcutOverlayText,
+    buildShortcutReferenceText,
+    computeShortcutHelpFontSizePx,
+    toggleShortcutHelpVisibility
+} from "./shortcut_help.js";
 import { createCrosshair } from "./crosshair.js";
 import { createToastContainer, createToastOverlay, drainNesToasts } from "./toast_overlay.js";
 import { createGamepadInitToastNotifier } from "./gamepad_init_toast.js";
@@ -34,6 +40,8 @@ const screenWrap = canvas.closest(".screen-wrap");
 if (!(screenWrap instanceof HTMLElement)) {
     throw new Error("Screen wrapper with class 'screen-wrap' not found");
 }
+const shortcutReference = document.getElementById("shortcut-reference");
+const shortcutHelpOverlay = document.getElementById("shortcut-help-overlay");
 
 // Use WebGL for rendering with filter support
 const gl = canvas.getContext("webgl");
@@ -43,7 +51,7 @@ if (!gl) {
 
 const width = 256;
 const height = 240;
-const SCROLLER_TEXT = "Newest update: Feb 14: Full PAL support! ** Feb 7: Added support for NES Zapper controller. ** Feb 5: Added support for Arkanoid controller!  **";
+const SCROLLER_TEXT = "Updates: Feb 14: Full PAL support! Keyboard shortcuts with 'H'. ** Feb 7: Added support for NES Zapper controller. ** Feb 5: Added support for Arkanoid controller!  **";
 const SCROLLER_SPEED = 2.0;
 const SCROLLER_AMPLITUDE = 40;
 const SCROLLER_FREQUENCY = 0.009;
@@ -1416,8 +1424,13 @@ const webShortcutActions = {
     reset: resetAction,
     saveState: saveStateAction,
     loadState: loadStateAction,
-    toggleFullscreen: toggleScreenFullscreen
+    toggleFullscreen: toggleScreenFullscreen,
+    toggleHelp: toggleShortcutHelp
 };
+
+function toggleShortcutHelp() {
+    toggleShortcutHelpVisibility(shortcutHelpOverlay);
+}
 
 function applyKeyboardMapping(event, mapping, controller, targets, pressed) {
     if (!mapping || !targets.includes(controller)) {
@@ -1428,12 +1441,16 @@ function applyKeyboardMapping(event, mapping, controller, targets, pressed) {
 }
 
 async function handleKeyDown(event) {
-    if (!nes) {
+    if (!nes && event.code !== "KeyH") {
         return;
     }
 
     const handledShortcut = await dispatchWebShortcutAction(event, webShortcutActions);
     if (handledShortcut) {
+        return;
+    }
+
+    if (!nes) {
         return;
     }
 
@@ -1533,6 +1550,8 @@ function updateCanvasSize(newHeight) {
     if (crosshair) {
         crosshair.updateCanvasSize();
     }
+
+    updateShortcutHelpScale();
 }
 
 function updateCanvasSizeForFullscreenViewport() {
@@ -1546,6 +1565,7 @@ function updateCanvasSizeForFullscreenViewport() {
         canvas.style.width = `${viewportHeight * NES_ASPECT_RATIO}px`;
         canvas.width = Math.round(viewportHeight * NES_ASPECT_RATIO * dpr);
         canvas.height = Math.round(viewportHeight * dpr);
+        updateShortcutHelpScale();
         return;
     }
 
@@ -1553,6 +1573,15 @@ function updateCanvasSizeForFullscreenViewport() {
     canvas.style.height = `${viewportWidth / NES_ASPECT_RATIO}px`;
     canvas.width = Math.round(viewportWidth * dpr);
     canvas.height = Math.round((viewportWidth / NES_ASPECT_RATIO) * dpr);
+    updateShortcutHelpScale();
+}
+
+function updateShortcutHelpScale() {
+    if (!shortcutHelpOverlay) {
+        return;
+    }
+    const fontSizePx = computeShortcutHelpFontSizePx(canvas.clientHeight);
+    shortcutHelpOverlay.style.fontSize = `${fontSizePx}px`;
 }
 
 // Update fullscreen button text based on state
@@ -1610,6 +1639,14 @@ updateCanvasSize(INITIAL_HEIGHT);
 updateFullscreenButton();
 filterToggleBtn.textContent = `Filter: ${filters[currentFilter].name}`;
 updateSaveStateButtons();
+const shortcutReferenceText = buildShortcutReferenceText();
+if (shortcutReference) {
+    shortcutReference.textContent = `Shortcuts: ${shortcutReferenceText}`;
+}
+if (shortcutHelpOverlay) {
+    shortcutHelpOverlay.textContent = buildShortcutOverlayText();
+}
+updateShortcutHelpScale();
 startIdleScroller();
 
 screenMinusBtn.addEventListener("click", () => {

--- a/web/index.html
+++ b/web/index.html
@@ -40,6 +40,7 @@
             <div class="col-12 col-lg-9">
               <div class="screen-wrap">
                 <canvas id="screen" width="256" height="240"></canvas>
+                <div id="shortcut-help-overlay" class="shortcut-help-overlay d-none" aria-hidden="true"></div>
               </div>
               <div class="mt-3 d-flex flex-wrap align-items-center gap-2">
                 <span class="badge text-bg-dark">Status</span>
@@ -67,6 +68,7 @@
           <div id="controls">
             <strong>Controls:</strong> W = Up | A = Left | S = Down | D = Right | F = A | G = B | R = Select | T = Start
           </div>
+          <div id="shortcut-reference" class="mt-2"></div>
         </div>
       </div>
     </div>

--- a/web/shortcut_actions.js
+++ b/web/shortcut_actions.js
@@ -9,7 +9,8 @@
  *   reset: Function,
  *   saveState: Function,
  *   loadState: Function,
- *   toggleFullscreen: Function
+ *   toggleFullscreen: Function,
+ *   toggleHelp: Function
  * }} actions
  * @returns {Promise<boolean>}
  */
@@ -33,7 +34,8 @@ const shortcutActionByCode = {
     F1: "reset",
     F6: "saveState",
     F7: "loadState",
-    F12: "toggleFullscreen"
+    F12: "toggleFullscreen",
+    KeyH: "toggleHelp"
 };
 
 function shortcutActionForCode(code, actions) {

--- a/web/shortcut_actions.test.mjs
+++ b/web/shortcut_actions.test.mjs
@@ -26,7 +26,8 @@ function makeActions() {
             reset: () => calls.push("reset"),
             saveState: async () => calls.push("saveState"),
             loadState: async () => calls.push("loadState"),
-            toggleFullscreen: async () => calls.push("toggleFullscreen")
+            toggleFullscreen: async () => calls.push("toggleFullscreen"),
+            toggleHelp: () => calls.push("toggleHelp")
         }
     };
 }
@@ -83,6 +84,17 @@ test("dispatchWebShortcutAction routes F12 to toggleFullscreen", async () => {
 
     assert.equal(handled, true);
     assert.deepEqual(calls, ["toggleFullscreen"]);
+    assert.equal(event.defaultPrevented, true);
+});
+
+test("dispatchWebShortcutAction routes H to toggleHelp", async () => {
+    const event = makeKeyboardEvent("KeyH");
+    const { calls, actions } = makeActions();
+
+    const handled = await dispatchWebShortcutAction(event, actions);
+
+    assert.equal(handled, true);
+    assert.deepEqual(calls, ["toggleHelp"]);
     assert.equal(event.defaultPrevented, true);
 });
 

--- a/web/shortcut_help.js
+++ b/web/shortcut_help.js
@@ -1,0 +1,42 @@
+export const WEB_SHORTCUT_REFERENCE = [
+    { key: "Space", action: "Pause/Resume" },
+    { key: "F1", action: "Reset" },
+    { key: "F6", action: "Save State" },
+    { key: "F7", action: "Load State" },
+    { key: "F12", action: "Fullscreen" },
+    { key: "H", action: "Toggle Help" }
+];
+
+export function buildShortcutReferenceText(shortcuts = WEB_SHORTCUT_REFERENCE) {
+    return shortcuts.map((shortcut) => `${shortcut.key} = ${shortcut.action}`).join(" | ");
+}
+
+export function buildShortcutOverlayText(shortcuts = WEB_SHORTCUT_REFERENCE) {
+    const lines = shortcuts.map((shortcut) => `${shortcut.key}: ${shortcut.action}`);
+    return ["Shortcuts", ...lines].join("\n");
+}
+
+export function computeShortcutHelpFontSizePx(canvasHeightPx) {
+    const baselineHeight = 960;
+    const baselineFontSize = 26;
+    const scaled = Math.round((canvasHeightPx / baselineHeight) * baselineFontSize);
+    return Math.max(12, Math.min(scaled, 38));
+}
+
+export function toggleShortcutHelpVisibility(helpOverlayElement) {
+    if (!helpOverlayElement) {
+        return false;
+    }
+
+    const isHidden = helpOverlayElement.classList.contains("d-none");
+
+    if (isHidden) {
+        helpOverlayElement.classList.remove("d-none");
+        helpOverlayElement.setAttribute("aria-hidden", "false");
+        return true;
+    }
+
+    helpOverlayElement.classList.add("d-none");
+    helpOverlayElement.setAttribute("aria-hidden", "true");
+    return false;
+}

--- a/web/shortcut_help.test.mjs
+++ b/web/shortcut_help.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    WEB_SHORTCUT_REFERENCE,
+    buildShortcutOverlayText,
+    buildShortcutReferenceText,
+    computeShortcutHelpFontSizePx,
+    toggleShortcutHelpVisibility
+} from "./shortcut_help.js";
+
+function createMockHelpOverlay(initiallyHidden = true) {
+    const classes = new Set(initiallyHidden ? ["d-none"] : []);
+    const attributes = new Map();
+
+    return {
+        classList: {
+            contains(name) {
+                return classes.has(name);
+            },
+            add(name) {
+                classes.add(name);
+            },
+            remove(name) {
+                classes.delete(name);
+            }
+        },
+        setAttribute(name, value) {
+            attributes.set(name, value);
+        },
+        getAttribute(name) {
+            return attributes.get(name);
+        }
+    };
+}
+
+test("buildShortcutReferenceText includes H help toggle shortcut", () => {
+    const text = buildShortcutReferenceText();
+    assert.match(text, /H = Toggle Help/);
+    assert.match(text, /F12 = Fullscreen/);
+});
+
+test("buildShortcutOverlayText renders multiline list for overlay", () => {
+    const text = buildShortcutOverlayText();
+
+    assert.match(text, /^Shortcuts/m);
+    assert.match(text, /H: Toggle Help/);
+    assert.match(text, /F12: Fullscreen/);
+    assert.match(text, /\n/);
+});
+
+test("computeShortcutHelpFontSizePx scales from canvas height", () => {
+    assert.equal(computeShortcutHelpFontSizePx(960), 26);
+    assert.equal(computeShortcutHelpFontSizePx(480), 13);
+});
+
+test("computeShortcutHelpFontSizePx clamps to supported range", () => {
+    assert.equal(computeShortcutHelpFontSizePx(120), 12);
+    assert.equal(computeShortcutHelpFontSizePx(2200), 38);
+});
+
+test("WEB_SHORTCUT_REFERENCE includes KeyH mapping", () => {
+    const helpShortcut = WEB_SHORTCUT_REFERENCE.find((shortcut) => shortcut.key === "H");
+    assert.deepEqual(helpShortcut, { key: "H", action: "Toggle Help" });
+});
+
+test("toggleShortcutHelpVisibility shows hidden overlay", () => {
+    const overlay = createMockHelpOverlay(true);
+
+    const visible = toggleShortcutHelpVisibility(overlay);
+
+    assert.equal(visible, true);
+    assert.equal(overlay.classList.contains("d-none"), false);
+    assert.equal(overlay.getAttribute("aria-hidden"), "false");
+});
+
+test("toggleShortcutHelpVisibility hides visible overlay", () => {
+    const overlay = createMockHelpOverlay(false);
+
+    const visible = toggleShortcutHelpVisibility(overlay);
+
+    assert.equal(visible, false);
+    assert.equal(overlay.classList.contains("d-none"), true);
+    assert.equal(overlay.getAttribute("aria-hidden"), "true");
+});

--- a/web/styles.css
+++ b/web/styles.css
@@ -42,6 +42,29 @@ canvas {
     line-height: 1.4;
 }
 
+#shortcut-reference {
+    font-size: 0.85rem;
+    color: #c4c4c4;
+    text-align: center;
+    line-height: 1.4;
+}
+
+.shortcut-help-overlay {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    max-width: min(44%, 460px);
+    padding: 8px 10px;
+    border-radius: 8px;
+    background: rgba(90, 90, 90, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    line-height: 1.25;
+    white-space: pre-line;
+    z-index: 11;
+    pointer-events: none;
+}
+
 .neser-toast-container {
     position: absolute;
     left: 50%;


### PR DESCRIPTION
## Summary
- add web shortcut reference and in-screen help overlay
- map H shortcut to toggle help visibility
- align overlay presentation with SDL-style white text over transparent gray panel
- scale help overlay font size relative to canvas size and keep working in fullscreen
- allow help toggle even when no ROM is loaded

## Testing
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- cargo test --all-features
- wasm-pack test --headless --chrome --features wasm
- /Users/henrikku/repos/neser/.venv/bin/python -m unittest discover -s scripts/scraper -p "test_*.py"
- npm test

Fixes #572
