### PR TITLE
Fix #538: Document known mapper limitations across all mappers

### DIFF
--- a/src/cartridge/axrom.rs
+++ b/src/cartridge/axrom.rs
@@ -1,3 +1,10 @@
+//! Mapper 7 - AxROM
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing/board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::MirroringMode;

--- a/src/cartridge/bandai_fcg.rs
+++ b/src/cartridge/bandai_fcg.rs
@@ -20,7 +20,7 @@
 //! - CPU-cycle driven IRQ counter (counts down from 16-bit value)
 //! - Used in Dragon Ball series, SD Gundam series
 //!
-//! Limitations:
+//! Known Limitations:
 //! - **EEPROM not implemented**: 24C02 EEPROM (register $800D) used for save data
 //!   in some games (Dragon Ball Z II/III, SD Gundam Gaiden) is not supported
 //! - Games requiring EEPROM cannot save progress

--- a/src/cartridge/bnrom_nina.rs
+++ b/src/cartridge/bnrom_nina.rs
@@ -1,3 +1,10 @@
+//! Mapper 34 - BNROM / NINA-001
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::MirroringMode;

--- a/src/cartridge/camerica.rs
+++ b/src/cartridge/camerica.rs
@@ -1,3 +1,10 @@
+//! Mapper 71 - Camerica / BF909x
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::MirroringMode;

--- a/src/cartridge/cnrom.rs
+++ b/src/cartridge/cnrom.rs
@@ -1,3 +1,10 @@
+//! Mapper 3 - CNROM
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::mapper_templates::SimpleFixedPrgMapper;
 
 /// Mapper 3 - CNROM

--- a/src/cartridge/colordreams.rs
+++ b/src/cartridge/colordreams.rs
@@ -1,3 +1,10 @@
+//! Mapper 11 - Color Dreams
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::mapper_templates::DualBank32Mapper;
 
 /// Mapper 11 - Color Dreams

--- a/src/cartridge/cprom.rs
+++ b/src/cartridge/cprom.rs
@@ -1,3 +1,10 @@
+//! Mapper 13 - CPROM
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::MirroringMode;

--- a/src/cartridge/gxrom.rs
+++ b/src/cartridge/gxrom.rs
@@ -1,3 +1,10 @@
+//! Mapper 66 - GxROM / GNROM
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::mapper_templates::DualBank32Mapper;
 
 /// Mapper 66 - GxROM / GNROM

--- a/src/cartridge/mmc1.rs
+++ b/src/cartridge/mmc1.rs
@@ -1,3 +1,10 @@
+//! Mapper 1 - MMC1 (SxROM)
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::MirroringMode;

--- a/src/cartridge/mmc2.rs
+++ b/src/cartridge/mmc2.rs
@@ -1,3 +1,10 @@
+//! Mapper 9 - MMC2
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
 use crate::cartridge::{Mapper, MapperCapabilities, MirroringMode};
 

--- a/src/cartridge/mmc3.rs
+++ b/src/cartridge/mmc3.rs
@@ -42,6 +42,11 @@ use crate::trace_mapper;
 /// - This implementation focuses on PRG/CHR banking + mirroring control
 /// - Includes MMC3 scanline IRQ counter with both Sharp and NEC behaviors
 /// - A12 edge detection with debounce (3 PPU cycles low required)
+///
+/// Known Limitations:
+/// - IRQ timing is not fully PPU-cycle accurate in all edge cases.
+/// - IRQ behavior selection is currently derived from ROM metadata/CRC heuristics.
+/// - Some board-specific clone quirks are intentionally not modeled yet.
 pub struct MMC3Mapper {
     prg_rom: Vec<u8>,
     chr_memory: ChrMemory,

--- a/src/cartridge/mmc4.rs
+++ b/src/cartridge/mmc4.rs
@@ -1,3 +1,10 @@
+//! Mapper 10 - MMC4
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use std::cell::Cell;
 
 use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};

--- a/src/cartridge/multicart_15.rs
+++ b/src/cartridge/multicart_15.rs
@@ -1,3 +1,10 @@
+//! Mapper 15 - Multicart 100-in-1
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::MirroringMode;

--- a/src/cartridge/namco118.rs
+++ b/src/cartridge/namco118.rs
@@ -1,3 +1,10 @@
+//! Mapper 206 - Namco 118 / Namco 108
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::common::ChrMemory;
 use crate::cartridge::{Mapper, MapperCapabilities, MirroringMode};
 

--- a/src/cartridge/namco163.rs
+++ b/src/cartridge/namco163.rs
@@ -1,3 +1,10 @@
+//! Mapper 19 - Namco 163
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use std::cell::Cell;
 
 use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};

--- a/src/cartridge/nina_tengen.rs
+++ b/src/cartridge/nina_tengen.rs
@@ -1,3 +1,10 @@
+//! Mappers 34/64 variants - NINA / Tengen support
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::MirroringMode;

--- a/src/cartridge/nrom.rs
+++ b/src/cartridge/nrom.rs
@@ -1,3 +1,10 @@
+//! Mapper 0 - NROM
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::MirroringMode;

--- a/src/cartridge/sunsoft_4.rs
+++ b/src/cartridge/sunsoft_4.rs
@@ -20,6 +20,11 @@
 //! - Register $800B-$800C: 1KB nametable banks (when CHR-ROM nametable mode)
 //! - Register $800D: PRG-RAM enable/write-protect
 //! - Used in After Burner II, Nantettatte!! Baseball
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
 use crate::cartridge::common::{BankedRom, ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
 use crate::cartridge::{Mapper, MapperCapabilities, MirroringMode};

--- a/src/cartridge/sunsoft_fme7.rs
+++ b/src/cartridge/sunsoft_fme7.rs
@@ -36,7 +36,7 @@
 //! - Used in Gimmick! (with 5B audio), Batman: Return of the Joker, Hebereke
 //! - 5B variant adds YM2149F-compatible expansion audio (3 square waves)
 //!
-//! Limitations:
+//! Known Limitations:
 //! - **Expansion audio not implemented** (5B audio chip)
 
 use crate::cartridge::common::ChrMemory;

--- a/src/cartridge/uxrom.rs
+++ b/src/cartridge/uxrom.rs
@@ -1,3 +1,10 @@
+//! Mapper 2 - UxROM
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::mapper_templates::SimpleBankedPrgMapper;
 
 /// Mapper 2 - UxROM (UNROM, UOROM boards)

--- a/src/cartridge/vrc2_vrc4.rs
+++ b/src/cartridge/vrc2_vrc4.rs
@@ -1,3 +1,10 @@
+//! Mappers 21/22/23/25 - Konami VRC2/VRC4
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
 use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
 use crate::cartridge::{Mapper, MapperCapabilities, MirroringMode};
 use crate::trace_mapper;

--- a/src/cartridge/vrc6.rs
+++ b/src/cartridge/vrc6.rs
@@ -1,3 +1,14 @@
+//! Mapper 24/26 - Konami VRC6
+//!
+//! Specifications:
+//! - Main: <https://www.nesdev.org/wiki/VRC6>
+//! - Audio: <https://www.nesdev.org/wiki/VRC6_audio>
+//!
+//! Known Limitations:
+//! - No known gameplay-blocking functional limitations are currently documented.
+//! - Cycle-accuracy edge cases and less-common board wiring variants are not yet
+//!   comprehensively validated by dedicated ROM test suites.
+
 use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
 use crate::cartridge::{Mapper, MapperCapabilities, MirroringMode};
 use crate::trace_mapper;

--- a/src/integration_tests/mapper_tests.rs
+++ b/src/integration_tests/mapper_tests.rs
@@ -67,6 +67,48 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_complex_mapper_files_document_limitations() {
+        let mapper_registry = fs::read_to_string("src/cartridge/mapper.rs")
+            .expect("mapper registry source should be readable");
+
+        let mut mapper_files: Vec<String> = mapper_registry
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                if !trimmed.starts_with("use super::") || !trimmed.ends_with("Mapper;") {
+                    return None;
+                }
+
+                let module_path = trimmed.strip_prefix("use super::")?;
+                let module = module_path.split("::").next()?;
+                Some(format!("src/cartridge/{}.rs", module))
+            })
+            .collect();
+
+        mapper_files.sort();
+        mapper_files.dedup();
+
+        assert!(
+            !mapper_files.is_empty(),
+            "expected mapper module list to be non-empty"
+        );
+
+        for mapper_file in mapper_files {
+            let source = fs::read_to_string(&mapper_file)
+                .unwrap_or_else(|error| panic!("failed to read {}: {}", mapper_file, error));
+
+            let has_limitations_docs =
+                source.contains("Known Limitations") || source.contains("Known Issues");
+
+            assert!(
+                has_limitations_docs,
+                "{} is missing a searchable limitations section",
+                mapper_file
+            );
+        }
+    }
     // TODO mmc5test_v2
 
     // TODO Submappers


### PR DESCRIPTION
## Summary
- add standardized searchable `Known Limitations` sections to all mapper modules registered in `src/cartridge/mapper.rs`
- normalize existing headings (e.g. `Limitations` -> `Known Limitations`) for consistency
- expand integration coverage in `src/integration_tests/mapper_tests.rs` to dynamically verify every factory-registered mapper has a limitations section

## Validation
- cargo check --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check (after formatting)
- cargo test --all-features
- wasm-pack test --headless --chrome --features wasm
- /Users/henrikku/repos/neser/.venv/bin/python -m unittest discover -s scripts/scraper -p "test_*.py"
- npm test

Fixes #538
