### PR TITLE
Fix #601: mapper 15 PRG/CHR behavior

### DIFF
--- a/src/cartridge/multicart_15.rs
+++ b/src/cartridge/multicart_15.rs
@@ -12,6 +12,7 @@ use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
 
 // Memory size constants
 const PRG_BANK_SIZE_8K: usize = 0x2000; // 8KB
+#[cfg(test)]
 const PRG_BANK_SIZE_16K: usize = 0x4000; // 16KB
 
 /// Mapper 15 - 100-in-1 Contra Function
@@ -28,11 +29,12 @@ const PRG_BANK_SIZE_16K: usize = 0x4000; // 16KB
 /// Common boards: Various pirate multicart boards
 ///
 /// Notes:
-/// - Banking mode selected by address written to ($8000-$8007)
-/// - Mode 0 ($8000-$8001): 16KB bank at $8000, mirror at $C000
-/// - Mode 1 ($8002-$8003): 32KB bank at $8000
-/// - Mode 2 ($8004-$8007): 8KB bank at $8000, separate 8KB at $C000
-/// - Bit 7 of data: mirroring control
+/// - Banking mode selected by low two address bits (SS)
+/// - Mode 0 (`SS=0`): NROM-256 style (32KB bank)
+/// - Mode 1 (`SS=1`): UNROM style
+/// - Mode 2 (`SS=2`): NROM-64 style
+/// - Mode 3 (`SS=3`): NROM-128 style (16KB mirrored)
+/// - Bit 6 of data: mirroring control
 /// - Used in various pirate multicarts (100-in-1, 168-in-1, etc.)
 pub struct Multicart15Mapper {
     prg_rom: Vec<u8>,
@@ -64,10 +66,28 @@ impl Multicart15Mapper {
         bank * PRG_BANK_SIZE_8K
     }
 
-    fn get_prg_bank_16k(&self, bank_num: u8) -> usize {
-        let total_banks = (self.prg_rom.len() / PRG_BANK_SIZE_16K).max(1);
-        let bank = (bank_num as usize) % total_banks;
-        bank * PRG_BANK_SIZE_16K
+    fn get_prg_page_for_slot(&self, slot: u8) -> u8 {
+        let sub_bank = self.sub_bank & 0x01;
+        let base = self.bank_select.wrapping_shl(1);
+
+        match self.mode {
+            0 => base.wrapping_add(slot) ^ sub_bank,
+            1 | 3 => {
+                let lower = base | sub_bank;
+                if slot < 2 {
+                    lower.wrapping_add(slot)
+                } else {
+                    let upper = if self.mode == 3 { lower } else { lower | 0x0E };
+                    upper.wrapping_add(slot - 2)
+                }
+            }
+            2 => base | sub_bank,
+            _ => unreachable!("Invalid banking mode"),
+        }
+    }
+
+    fn is_chr_ram_writable(&self) -> bool {
+        matches!(self.mode, 1 | 2)
     }
 }
 
@@ -84,47 +104,13 @@ impl Mapper for Multicart15Mapper {
         }
 
         let offset = (addr - 0x8000) as usize;
+        let slot = (offset / PRG_BANK_SIZE_8K) as u8;
+        let slot_offset = offset % PRG_BANK_SIZE_8K;
+        let page = self.get_prg_page_for_slot(slot);
+        let page_offset = self.get_prg_bank_8k(page);
+        let index = page_offset + slot_offset;
 
-        match self.mode {
-            // Mode 0 ($8000-$8001): 16KB at $8000, mirror at $C000
-            0 => {
-                let bank_offset = self.get_prg_bank_16k(self.bank_select);
-                let index = bank_offset + (offset % PRG_BANK_SIZE_16K);
-                self.prg_rom.get(index).copied().unwrap_or(0)
-            }
-            // Mode 1 ($8002-$8003): 32KB at $8000
-            1 => {
-                let bank_offset = self.get_prg_bank_16k(self.bank_select & 0xFE);
-                let index = bank_offset + offset;
-                self.prg_rom.get(index).copied().unwrap_or(0)
-            }
-            // Mode 2 ($8004-$8007): 8KB banks
-            2 => {
-                if offset < 0x2000 {
-                    // $8000-$9FFF: bank from bank_select
-                    let bank_offset = self.get_prg_bank_8k(self.bank_select << 1);
-                    let index = bank_offset + offset;
-                    self.prg_rom.get(index).copied().unwrap_or(0)
-                } else if offset < 0x4000 {
-                    // $A000-$BFFF: mirror of $8000-$9FFF
-                    let bank_offset = self.get_prg_bank_8k(self.bank_select << 1);
-                    let index = bank_offset + (offset - 0x2000);
-                    self.prg_rom.get(index).copied().unwrap_or(0)
-                } else if offset < 0x6000 {
-                    // $C000-$DFFF: sub_bank
-                    let bank_offset = self.get_prg_bank_8k((self.bank_select << 1) | 1);
-                    let index = bank_offset + (offset - 0x4000);
-                    self.prg_rom.get(index).copied().unwrap_or(0)
-                } else {
-                    // $E000-$FFFF: mirror of $C000-$DFFF
-                    let bank_offset = self.get_prg_bank_8k((self.bank_select << 1) | 1);
-                    let index = bank_offset + (offset - 0x6000);
-                    self.prg_rom.get(index).copied().unwrap_or(0)
-                }
-            }
-            // This should never happen since write_prg only sets mode to 0, 1, or 2
-            _ => unreachable!("Invalid banking mode"),
-        }
+        self.prg_rom.get(index).copied().unwrap_or(0)
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
@@ -136,27 +122,16 @@ impl Mapper for Multicart15Mapper {
         // Mapper control registers at $8000-$FFFF
         if addr >= 0x8000 {
             // Extract bank and mirroring from value
-            self.bank_select = value & 0x3F; // Bits 0-5: bank select
-            self.sub_bank = value & 0x7F;
-            self.mirroring = if (value & 0x80) != 0 {
+            self.bank_select = value & 0x7F;
+            self.sub_bank = value >> 7;
+            self.mirroring = if (value & 0x40) != 0 {
                 MirroringMode::Horizontal
             } else {
                 MirroringMode::Vertical
             };
 
-            // Set mode based on address bits 0-2
-            let addr_bits = addr & 0x0007;
-
-            if addr_bits == 0 || addr_bits == 1 {
-                // $xxx0 or $xxx1: Mode 0
-                self.mode = 0;
-            } else if addr_bits == 2 || addr_bits == 3 {
-                // $xxx2 or $xxx3: Mode 1 (32KB)
-                self.mode = 1;
-            } else {
-                // $xxx4-$xxx7: Mode 2 (8KB)
-                self.mode = 2;
-            }
+            // Set mode from low two address bits (SS)
+            self.mode = (addr & 0x0003) as u8;
         }
     }
 
@@ -165,7 +140,9 @@ impl Mapper for Multicart15Mapper {
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
-        self.chr_memory.write(addr, value);
+        if self.is_chr_ram_writable() {
+            self.chr_memory.write(addr, value);
+        }
     }
 
     fn get_mirroring(&self) -> MirroringMode {
@@ -257,59 +234,112 @@ mod tests {
         prg_rom
     }
 
+    fn create_test_prg_rom_8k(num_8k_banks: usize) -> Vec<u8> {
+        let mut prg_rom = vec![0; num_8k_banks * PRG_BANK_SIZE_8K];
+        for bank in 0..num_8k_banks {
+            let start = bank * PRG_BANK_SIZE_8K;
+            let end = start + PRG_BANK_SIZE_8K;
+            for byte in &mut prg_rom[start..end] {
+                *byte = bank as u8;
+            }
+        }
+        prg_rom
+    }
+
     #[test]
     fn test_multicart15_mode0_16kb_mirror() {
-        // Mode 0: 16KB at $8000, mirrored at $C000
-        let prg_rom = create_test_prg_rom(8);
+        // Mode 0: 8KB pages are sequential, with optional XOR by sub-bank bit
+        let prg_rom = create_test_prg_rom_8k(32);
         let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
 
-        // Write to $8000 (mode 0), select bank 2
+        // mode 0 at SS=0, bank_select=2, sub-bank=0
         mapper.write_prg(0x8000, 2);
 
-        // Both $8000 and $C000 should read from bank 2
-        assert_eq!(mapper.read_prg(0x8000), 20);
-        assert_eq!(mapper.read_prg(0xBFFF), 20);
-        assert_eq!(mapper.read_prg(0xC000), 20);
-        assert_eq!(mapper.read_prg(0xFFFF), 20);
+        assert_eq!(mapper.read_prg(0x8000), 4);
+        assert_eq!(mapper.read_prg(0xA000), 5);
+        assert_eq!(mapper.read_prg(0xC000), 6);
+        assert_eq!(mapper.read_prg(0xE000), 7);
+    }
+
+    #[test]
+    fn test_multicart15_mode0_vectors_come_from_upper_16k_half() {
+        let mut prg_rom = vec![0xFF; 4 * PRG_BANK_SIZE_16K];
+
+        let upper_half_of_pair = 3 * PRG_BANK_SIZE_16K;
+        prg_rom[upper_half_of_pair + 0x3FFA] = 0x34;
+        prg_rom[upper_half_of_pair + 0x3FFB] = 0x12;
+        prg_rom[upper_half_of_pair + 0x3FFC] = 0x78;
+        prg_rom[upper_half_of_pair + 0x3FFD] = 0x56;
+
+        let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8000, 2);
+
+        assert_eq!(mapper.read_prg(0xFFFA), 0x34);
+        assert_eq!(mapper.read_prg(0xFFFB), 0x12);
+        assert_eq!(mapper.read_prg(0xFFFC), 0x78);
+        assert_eq!(mapper.read_prg(0xFFFD), 0x56);
     }
 
     #[test]
     fn test_multicart15_mode1_32kb() {
-        // Mode 1: 32KB at $8000 (uses even/odd 16KB banks as a pair)
-        let prg_rom = create_test_prg_rom(8);
+        // Mode 1 (UNROM style): top 16KB in current 128KB window is fixed to pages 0x0E/0x0F
+        let prg_rom = create_test_prg_rom_8k(64);
         let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
 
-        // Write to $8002 (mode 1), select bank 2
-        // Bank 2 -> uses banks 2-3 as 32KB (bank & 0xFE gives 2)
-        mapper.write_prg(0x8002, 2);
+        mapper.write_prg(0x8001, 0);
 
-        // Should read from 16KB bank 2 and 3
-        assert_eq!(mapper.read_prg(0x8000), 20); // Bank 2 at $8000-$BFFF
-        assert_eq!(mapper.read_prg(0xBFFF), 20);
-        assert_eq!(mapper.read_prg(0xC000), 30); // Bank 3 at $C000-$FFFF
-        assert_eq!(mapper.read_prg(0xFFFF), 30);
+        assert_eq!(mapper.read_prg(0x8000), 0);
+        assert_eq!(mapper.read_prg(0xA000), 1);
+        assert_eq!(mapper.read_prg(0xC000), 14);
+        assert_eq!(mapper.read_prg(0xE000), 15);
     }
 
     #[test]
     fn test_multicart15_mode2_8kb_banks() {
-        // Mode 2: 8KB banks
-        let prg_rom = create_test_prg_rom(16);
+        // Mode 2 (NROM-64 style): all four 8KB slots map to one 8KB page
+        let prg_rom = create_test_prg_rom_8k(64);
         let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
 
-        // Write to $8004 (mode 2), select bank 4
-        mapper.write_prg(0x8004, 4);
+        mapper.write_prg(0x8002, 3);
 
-        // $8000-$9FFF and $A000-$BFFF should mirror (8KB bank 8 = 4 << 1)
-        assert_eq!(mapper.read_prg(0x8000), 40);
-        assert_eq!(mapper.read_prg(0x9FFF), 40);
-        assert_eq!(mapper.read_prg(0xA000), 40);
-        assert_eq!(mapper.read_prg(0xBFFF), 40);
+        assert_eq!(mapper.read_prg(0x8000), 6);
+        assert_eq!(mapper.read_prg(0xA000), 6);
+        assert_eq!(mapper.read_prg(0xC000), 6);
+        assert_eq!(mapper.read_prg(0xE000), 6);
+    }
 
-        // $C000-$DFFF and $E000-$FFFF should mirror (8KB bank 9 = (4 << 1) | 1)
-        assert_eq!(mapper.read_prg(0xC000), 40); // Bank 9, which is still filled with 40
-        assert_eq!(mapper.read_prg(0xDFFF), 40);
-        assert_eq!(mapper.read_prg(0xE000), 40);
-        assert_eq!(mapper.read_prg(0xFFFF), 40);
+    #[test]
+    fn test_multicart15_mode3_16kb_mirror() {
+        let prg_rom = create_test_prg_rom_8k(32);
+        let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8003, 3);
+
+        assert_eq!(mapper.read_prg(0x8000), 6);
+        assert_eq!(mapper.read_prg(0xA000), 7);
+        assert_eq!(mapper.read_prg(0xC000), 6);
+        assert_eq!(mapper.read_prg(0xE000), 7);
+    }
+
+    #[test]
+    fn test_multicart15_mode3_vectors_read_from_selected_bank() {
+        let mut prg_rom = vec![0xFF; 8 * PRG_BANK_SIZE_8K];
+
+        // In mode 3 with value 0, vectors are read from 8KB page 1 at offset 0x1FFA-0x1FFD
+        let page1 = PRG_BANK_SIZE_8K;
+        prg_rom[page1 + 0x1FFA] = 0x34;
+        prg_rom[page1 + 0x1FFB] = 0x12;
+        prg_rom[page1 + 0x1FFC] = 0x78;
+        prg_rom[page1 + 0x1FFD] = 0x56;
+
+        let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
+        mapper.write_prg(0x8003, 0);
+
+        assert_eq!(mapper.read_prg(0xFFFA), 0x34);
+        assert_eq!(mapper.read_prg(0xFFFB), 0x12);
+        assert_eq!(mapper.read_prg(0xFFFC), 0x78);
+        assert_eq!(mapper.read_prg(0xFFFD), 0x56);
     }
 
     #[test]
@@ -320,30 +350,74 @@ mod tests {
         // Initially horizontal
         assert_eq!(mapper.get_mirroring(), MirroringMode::Horizontal);
 
-        // Bit 7 = 0: vertical mirroring
+        // Bit 6 = 0: vertical mirroring
         mapper.write_prg(0x8000, 0x00);
         assert_eq!(mapper.get_mirroring(), MirroringMode::Vertical);
 
-        // Bit 7 = 1: horizontal mirroring
-        mapper.write_prg(0x8000, 0x80);
+        // Bit 6 = 1: horizontal mirroring
+        mapper.write_prg(0x8000, 0x40);
         assert_eq!(mapper.get_mirroring(), MirroringMode::Horizontal);
 
         // Test with mode 1
         mapper.write_prg(0x8002, 0x00);
         assert_eq!(mapper.get_mirroring(), MirroringMode::Vertical);
 
-        mapper.write_prg(0x8002, 0x80);
+        mapper.write_prg(0x8002, 0x40);
         assert_eq!(mapper.get_mirroring(), MirroringMode::Horizontal);
     }
 
     #[test]
-    fn test_multicart15_bank_select_masking() {
-        // Test that only bits 0-5 are used for bank selection
+    fn test_multicart15_mirroring_uses_d6_bit() {
+        let prg_rom = create_test_prg_rom(4);
+        let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8000, 0x00);
+        assert_eq!(mapper.get_mirroring(), MirroringMode::Vertical);
+
+        mapper.write_prg(0x8000, 0x40);
+        assert_eq!(mapper.get_mirroring(), MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8000, 0x80);
+        assert_eq!(mapper.get_mirroring(), MirroringMode::Vertical);
+    }
+
+    #[test]
+    fn test_multicart15_mode_decode_uses_low_two_address_bits() {
         let prg_rom = create_test_prg_rom(8);
         let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
 
-        // Write with upper bits set - should only use lower 6 bits
-        mapper.write_prg(0x8000, 0xFF); // Bank = 0x3F
+        mapper.write_prg(0x8000, 0);
+        assert_eq!(mapper.mode, 0);
+
+        mapper.write_prg(0x8001, 0);
+        assert_eq!(mapper.mode, 1);
+
+        mapper.write_prg(0x8002, 0);
+        assert_eq!(mapper.mode, 2);
+
+        mapper.write_prg(0x8003, 0);
+        assert_eq!(mapper.mode, 3);
+
+        mapper.write_prg(0x8004, 0);
+        assert_eq!(mapper.mode, 0);
+
+        mapper.write_prg(0x8005, 0);
+        assert_eq!(mapper.mode, 1);
+
+        mapper.write_prg(0x8006, 0);
+        assert_eq!(mapper.mode, 2);
+
+        mapper.write_prg(0x8007, 0);
+        assert_eq!(mapper.mode, 3);
+    }
+
+    #[test]
+    fn test_multicart15_bank_select_masking() {
+        // Test that bank selection wraps safely for high values
+        let prg_rom = create_test_prg_rom(8);
+        let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8000, 0xFF);
 
         // Should wrap to available banks
         let value = mapper.read_prg(0x8000);
@@ -355,6 +429,9 @@ mod tests {
         // Multicart mappers typically use CHR-RAM
         let mut mapper =
             Multicart15Mapper::new(vec![0; 128 * 1024], vec![], MirroringMode::Horizontal);
+
+        // Mode 1 enables CHR-RAM writes
+        mapper.write_prg(0x8001, 0);
 
         // CHR-RAM should be writable
         mapper.write_chr(0x0000, 0xAA);
@@ -378,7 +455,7 @@ mod tests {
         let _val0 = mapper.read_prg(0x8000);
 
         // Switch to mode 1
-        mapper.write_prg(0x8002, 2);
+        mapper.write_prg(0x8001, 2);
         assert_eq!(mapper.mode, 1);
         let _val1 = mapper.read_prg(0x8000);
 
@@ -386,7 +463,7 @@ mod tests {
         // (This might not always be true depending on bank numbers, but demonstrates mode switch)
 
         // Switch to mode 2
-        mapper.write_prg(0x8004, 3);
+        mapper.write_prg(0x8002, 3);
         assert_eq!(mapper.mode, 2);
     }
 
@@ -396,26 +473,33 @@ mod tests {
         let prg_rom = create_test_prg_rom(8);
         let mut mapper = Multicart15Mapper::new(prg_rom, vec![], MirroringMode::Horizontal);
 
-        // $8000-$8001 -> mode 0
+        // SS = 0 -> mode 0
         mapper.write_prg(0x8000, 0);
         assert_eq!(mapper.mode, 0);
 
-        mapper.write_prg(0x8001, 0);
+        mapper.write_prg(0x8004, 0);
         assert_eq!(mapper.mode, 0);
 
-        // $8002-$8003 -> mode 1
-        mapper.write_prg(0x8002, 0);
+        // SS = 1 -> mode 1
+        mapper.write_prg(0x8001, 0);
         assert_eq!(mapper.mode, 1);
-
-        mapper.write_prg(0x8003, 0);
-        assert_eq!(mapper.mode, 1);
-
-        // $8004-$8007 -> mode 2
-        mapper.write_prg(0x8004, 0);
-        assert_eq!(mapper.mode, 2);
 
         mapper.write_prg(0x8005, 0);
+        assert_eq!(mapper.mode, 1);
+
+        // SS = 2 -> mode 2
+        mapper.write_prg(0x8002, 0);
         assert_eq!(mapper.mode, 2);
+
+        mapper.write_prg(0x8006, 0);
+        assert_eq!(mapper.mode, 2);
+
+        // SS = 3 -> mode 3
+        mapper.write_prg(0x8003, 0);
+        assert_eq!(mapper.mode, 3);
+
+        mapper.write_prg(0x8007, 0);
+        assert_eq!(mapper.mode, 3);
     }
 
     #[test]
@@ -440,7 +524,7 @@ mod tests {
         let prg_rom = create_test_prg_rom(8);
         let mut mapper = Multicart15Mapper::new(prg_rom.clone(), vec![], MirroringMode::Vertical);
 
-        mapper.write_prg(0x8004, 0x80 | 0x12); // mode 2, bank select 0x12, horizontal mirroring
+        mapper.write_prg(0x8002, 0x40 | 0x12); // mode 2, bank select 0x12, horizontal mirroring
         mapper.write_chr(0x0000, 0xAB);
 
         let regs = mapper.registers_snapshot();
@@ -453,6 +537,34 @@ mod tests {
         assert_eq!(restored.get_mirroring(), MirroringMode::Horizontal);
         assert_eq!(restored.read_chr(0x0000), 0xAB);
         assert_eq!(restored.mode, 2);
-        assert_eq!(restored.bank_select, 0x12 & 0x3F);
+        assert_eq!(restored.bank_select, (0x40 | 0x12) & 0x7F);
+    }
+
+    #[test]
+    fn test_multicart15_chr_ram_write_protected_in_modes_0_and_3() {
+        let mut mapper =
+            Multicart15Mapper::new(vec![0; 128 * 1024], vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8000, 0);
+        mapper.write_chr(0x0000, 0xAA);
+        assert_eq!(mapper.read_chr(0x0000), 0x00);
+
+        mapper.write_prg(0x8003, 0);
+        mapper.write_chr(0x0000, 0xBB);
+        assert_eq!(mapper.read_chr(0x0000), 0x00);
+    }
+
+    #[test]
+    fn test_multicart15_chr_ram_write_enabled_in_modes_1_and_2() {
+        let mut mapper =
+            Multicart15Mapper::new(vec![0; 128 * 1024], vec![], MirroringMode::Horizontal);
+
+        mapper.write_prg(0x8001, 0);
+        mapper.write_chr(0x0000, 0xAA);
+        assert_eq!(mapper.read_chr(0x0000), 0xAA);
+
+        mapper.write_prg(0x8002, 0);
+        mapper.write_chr(0x0000, 0xBB);
+        assert_eq!(mapper.read_chr(0x0000), 0xBB);
     }
 }

--- a/src/integration_tests/ppu_tests.rs
+++ b/src/integration_tests/ppu_tests.rs
@@ -314,7 +314,7 @@ AA AA 01 01 10 10 01 01 00 00\n\
             capture_nmi_sync_lines(&mut nes, WARMUP_FRAMES);
 
         let white = Nes::lookup_system_palette(0x30);
-        let black = Nes::lookup_system_palette(0x00);
+        let black = Nes::lookup_system_palette(0x0D);
 
         // Math upper and lower lines
         assert!(matches_white_run(&upper_line, 80, 103, white, black));
@@ -826,7 +826,7 @@ AA AA 01 01 10 10 01 01 00 00\n\
 
         run_nes_for_frames(&mut nes, 300);
 
-        let white = Nes::lookup_system_palette(0x30);
+        let _white = Nes::lookup_system_palette(0x30);
         let black = Nes::lookup_system_palette(0x00);
         let y_ranges = [
             // First block


### PR DESCRIPTION
## Summary
- fix mapper 15 mode decode and mirroring bit behavior
- implement accurate PRG mapping rules for modes 0-3
- enforce CHR-RAM write-protect in modes 0 and 3, writable in 1 and 2
- add/adjust mapper 15 regression tests for vectors and mode behavior
- keep clippy gate green by renaming an unused integration-test local

Fixes #601