### PR TITLE
feat: Overscan removal for CRT simulation (#617)

### DIFF
--- a/neser.conf.example
+++ b/neser.conf.example
@@ -209,3 +209,18 @@ ram_init_mode=zero
 # Valid values: true, false
 #
 oam_dram_decay=false
+
+# -----------------------------------------------------------------------------
+# Overscan Removal
+# -----------------------------------------------------------------------------
+# Simulate a CRT television by removing overscan pixels before displaying.
+# Pixels are removed symmetrically from both edges.
+#
+# horizontal_overscan: pixels removed from each of left and right edges.
+#   Valid range: 0..=8. Default: 8.
+#
+# vertical_overscan: pixels removed from each of top and bottom edges.
+#   Valid range: 0..=16. Default: 8.
+#
+horizontal_overscan=8
+vertical_overscan=8

--- a/src/console/config.rs
+++ b/src/console/config.rs
@@ -325,6 +325,20 @@ const CLI_FLAGS: &[CliFlag] = &[
         help: Some("Add a frame breakpoint on startup (break at first instruction of frame N)"),
         has_value: true,
     },
+    CliFlag {
+        flag: "--horizontal-overscan",
+        help: Some(
+            "Horizontal overscan removal in pixels (0..=8, default: 8; removed from left and right)",
+        ),
+        has_value: true,
+    },
+    CliFlag {
+        flag: "--vertical-overscan",
+        help: Some(
+            "Vertical overscan removal in pixels (0..=16, default: 8; removed from top and bottom)",
+        ),
+        has_value: true,
+    },
 ];
 
 /// Boolean flags that accept optional values (shared by validate_args and parse_rom_arg).
@@ -462,6 +476,14 @@ pub struct Config {
     pub oam_dram_decay_enabled: bool,
     /// Breakpoints to set on startup (from --breakpoint / --frame CLI flags).
     pub breakpoints: Vec<BreakpointKind>,
+    /// Horizontal overscan removal in pixels (removed from both left and right edges).
+    ///
+    /// Valid range: `0..=8`. Default: `8`.
+    pub horizontal_overscan: u8,
+    /// Vertical overscan removal in pixels (removed from both top and bottom edges).
+    ///
+    /// Valid range: `0..=16`. Default: `8`.
+    pub vertical_overscan: u8,
 }
 
 /// Autorun operating mode.
@@ -573,6 +595,8 @@ impl Default for Config {
             ram_init_mode: RamInitMode::Random,
             oam_dram_decay_enabled: false,
             breakpoints: Vec::new(),
+            horizontal_overscan: 8,
+            vertical_overscan: 8,
         }
     }
 }
@@ -809,6 +833,14 @@ impl Config {
         // RAM initialization mode
         if let Some(value) = Self::parse_string_arg(args, "--ram-init-mode") {
             self.apply_config_value("ram_init_mode", &value)?;
+        }
+
+        // Overscan
+        if let Some(v) = Self::parse_u32_arg(args, "--horizontal-overscan")? {
+            self.horizontal_overscan = (v as u8).min(8);
+        }
+        if let Some(v) = Self::parse_u32_arg(args, "--vertical-overscan")? {
+            self.vertical_overscan = (v as u8).min(16);
         }
 
         // Autorun mode flags
@@ -1404,6 +1436,16 @@ impl Config {
                          Valid values: true/false/yes/no/1/0",
                         value
                     );
+                }
+            }
+            "horizontal_overscan" => {
+                if let Ok(v) = value.parse::<u8>() {
+                    self.horizontal_overscan = v.min(8);
+                }
+            }
+            "vertical_overscan" => {
+                if let Ok(v) = value.parse::<u8>() {
+                    self.vertical_overscan = v.min(16);
                 }
             }
             _ => {} // Unknown keys are silently ignored
@@ -2069,6 +2111,105 @@ mod tests {
         ];
         let result = config_new(args);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_default_horizontal_overscan_is_8() {
+        let config = Config::default();
+        assert_eq!(config.horizontal_overscan, 8);
+    }
+
+    #[test]
+    fn test_config_default_vertical_overscan_is_8() {
+        let config = Config::default();
+        assert_eq!(config.vertical_overscan, 8);
+    }
+
+    #[test]
+    fn test_config_file_horizontal_overscan() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("horizontal_overscan", "4")
+            .unwrap();
+        assert_eq!(config.horizontal_overscan, 4);
+    }
+
+    #[test]
+    fn test_config_file_vertical_overscan() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("vertical_overscan", "12")
+            .unwrap();
+        assert_eq!(config.vertical_overscan, 12);
+    }
+
+    #[test]
+    fn test_config_file_overscan_zero() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("horizontal_overscan", "0")
+            .unwrap();
+        config.apply_config_value("vertical_overscan", "0").unwrap();
+        assert_eq!(config.horizontal_overscan, 0);
+        assert_eq!(config.vertical_overscan, 0);
+    }
+
+    #[test]
+    fn test_config_file_horizontal_overscan_max_is_8() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("horizontal_overscan", "8")
+            .unwrap();
+        assert_eq!(config.horizontal_overscan, 8);
+    }
+
+    #[test]
+    fn test_config_file_vertical_overscan_max_is_16() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("vertical_overscan", "16")
+            .unwrap();
+        assert_eq!(config.vertical_overscan, 16);
+    }
+
+    #[test]
+    fn test_config_file_horizontal_overscan_above_max_is_clamped_to_8() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("horizontal_overscan", "9")
+            .unwrap();
+        assert_eq!(config.horizontal_overscan, 8);
+    }
+
+    #[test]
+    fn test_config_file_vertical_overscan_above_max_is_clamped_to_16() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("vertical_overscan", "17")
+            .unwrap();
+        assert_eq!(config.vertical_overscan, 16);
+    }
+
+    #[test]
+    fn test_config_cli_horizontal_overscan() {
+        let args = vec![
+            "neser".to_string(),
+            "--horizontal-overscan".to_string(),
+            "4".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(config.horizontal_overscan, 4);
+    }
+
+    #[test]
+    fn test_config_cli_vertical_overscan() {
+        let args = vec![
+            "neser".to_string(),
+            "--vertical-overscan".to_string(),
+            "0".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(config.vertical_overscan, 0);
     }
 
     #[test]

--- a/src/ppu/screen_buffer.rs
+++ b/src/ppu/screen_buffer.rs
@@ -106,24 +106,29 @@ impl ScreenBuffer {
             dest.len()
         );
 
-        // let len = self.buffer.len();
-        // dest[..len].copy_from_slice(&self.buffer);
-
         dest[..self.buffer.len()].copy_from_slice(&self.buffer);
-
-        // // Display debug pixels to help count and pinpoint positions
-        // for x in 189usize..=190 {
-        //     for y in 192usize..=198 {
-        //         let offset = ((y * Self::WIDTH as usize) + x) * Self::BYTES_PER_PIXEL;
-        //         dest[offset] = if x.is_multiple_of(2) { 0xFF } else { 0x00 };
-        //         dest[offset + 1] = 0xFF;
-        //         dest[offset + 2] = if x.is_multiple_of(2) { 0x00 } else { 0xFF };
-        //     }
-        // }
     }
 
     pub fn snapshot(&self) -> Vec<u8> {
         self.buffer.clone()
+    }
+
+    /// Returns a cropped snapshot with the given overscan removed from all edges.
+    ///
+    /// `h_overscan` pixels are removed from the left and right edges.
+    /// `v_overscan` pixels are removed from the top and bottom edges.
+    /// The returned buffer has dimensions `(256 - 2*h_overscan) × (240 - 2*v_overscan)` in RGB888.
+    pub fn cropped_snapshot(&self, h_overscan: u32, v_overscan: u32) -> Vec<u8> {
+        let src_w = Self::WIDTH;
+        let dst_w = src_w - 2 * h_overscan;
+        let dst_h = Self::HEIGHT - 2 * v_overscan;
+        let mut out = Vec::with_capacity((dst_w * dst_h) as usize * Self::BYTES_PER_PIXEL);
+        for row in v_overscan..v_overscan + dst_h {
+            let row_start = (row * src_w + h_overscan) as usize * Self::BYTES_PER_PIXEL;
+            let row_end = row_start + dst_w as usize * Self::BYTES_PER_PIXEL;
+            out.extend_from_slice(&self.buffer[row_start..row_end]);
+        }
+        out
     }
 
     pub fn crc32(&self) -> u32 {
@@ -334,5 +339,82 @@ mod tests {
         let luminance = screen_buffer.get_luminance(50, 50);
         // 0.2126 * 128 + 0.7152 * 200 + 0.0722 * 64 = 27.2128 + 143.04 + 4.6208 = 174.8736
         assert!((luminance - 174.8736).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_cropped_snapshot_no_overscan_returns_full_frame() {
+        let mut buf = ScreenBuffer::new();
+        buf.set_pixel(0, 0, 10, 20, 30);
+        buf.set_pixel(255, 239, 40, 50, 60);
+        let cropped = buf.cropped_snapshot(0, 0);
+        assert_eq!(cropped.len(), 256 * 240 * 3);
+        assert_eq!(&cropped[0..3], &[10, 20, 30]);
+    }
+
+    #[test]
+    fn test_cropped_snapshot_default_overscan_produces_240x224_frame() {
+        let buf = ScreenBuffer::new();
+        let h: u32 = 8;
+        let v: u32 = 8;
+        let cropped = buf.cropped_snapshot(h, v);
+        let expected_w = 256 - 2 * h; // 240
+        let expected_h = 240 - 2 * v; // 224
+        assert_eq!(cropped.len() as u32, expected_w * expected_h * 3);
+    }
+
+    #[test]
+    fn test_cropped_snapshot_first_visible_pixel_is_at_overscan_offset() {
+        let mut buf = ScreenBuffer::new();
+        // Mark the first pixel inside the overscan boundary
+        buf.set_pixel(8, 8, 1, 2, 3);
+        // Mark a pixel inside the left overscan (should not appear in cropped output)
+        buf.set_pixel(0, 8, 255, 0, 0);
+        let cropped = buf.cropped_snapshot(8, 8);
+        assert_eq!(&cropped[0..3], &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_cropped_snapshot_last_visible_pixel_is_before_overscan_boundary() {
+        let mut buf = ScreenBuffer::new();
+        let h: u32 = 8;
+        let v: u32 = 8;
+        // Last visible pixel: (255 - h, 239 - v) = (247, 231)
+        buf.set_pixel(247, 231, 7, 8, 9);
+        let cropped = buf.cropped_snapshot(h, v);
+        let expected_w = (256 - 2 * h) as usize;
+        let expected_h = (240 - 2 * v) as usize;
+        let last_offset = (expected_h - 1) * expected_w * 3 + (expected_w - 1) * 3;
+        assert_eq!(&cropped[last_offset..last_offset + 3], &[7, 8, 9]);
+    }
+
+    #[test]
+    fn test_cropped_snapshot_right_overscan_pixel_excluded() {
+        let mut buf = ScreenBuffer::new();
+        // Pixel at x=248 is in the right overscan region (h=8 → right starts at 256-8=248)
+        buf.set_pixel(248, 8, 99, 0, 0);
+        let cropped = buf.cropped_snapshot(8, 8);
+        let expected_w = (256 - 2 * 8) as usize; // 240
+        // Row 0 of cropped (row 8 of original) has 240 pixels; none should be 99
+        for x in 0..expected_w {
+            assert_ne!(
+                cropped[x * 3],
+                99,
+                "overscan pixel should not appear at x={x}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cropped_snapshot_max_horizontal_overscan() {
+        let buf = ScreenBuffer::new();
+        let cropped = buf.cropped_snapshot(8, 0);
+        assert_eq!(cropped.len(), (256 - 16) * 240 * 3); // 240 * 240 * 3
+    }
+
+    #[test]
+    fn test_cropped_snapshot_max_vertical_overscan() {
+        let buf = ScreenBuffer::new();
+        let cropped = buf.cropped_snapshot(0, 16);
+        assert_eq!(cropped.len(), 256 * (240 - 32) * 3); // 256 * 208 * 3
     }
 }

--- a/src/rendering/gl_backend.rs
+++ b/src/rendering/gl_backend.rs
@@ -64,6 +64,10 @@ pub struct GlBackend {
     bp_add_state: BreakpointAddUiState,
     hexdump_ui_state: HexdumpUiState,
     shader_manager: ShaderManager,
+    /// Horizontal overscan in pixels (removed from left and right).
+    h_overscan: u32,
+    /// Vertical overscan in pixels (removed from top and bottom).
+    v_overscan: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -223,7 +227,19 @@ impl GlBackend {
 
     /// Returns the aspect ratio used for rendering the NES output.
     fn target_aspect(&self) -> f32 {
-        Self::NTSC_ASPECT
+        // NES pixel aspect ratio (8:7 NTSC) applied to the cropped pixel dimensions.
+        let w = self.cropped_width() as f32;
+        let h = self.cropped_height() as f32;
+        // pixel_ar = 8/7; display_ar = (w / h) * pixel_ar
+        (w / h) * (8.0 / 7.0)
+    }
+
+    fn cropped_width(&self) -> u32 {
+        256 - 2 * self.h_overscan
+    }
+
+    fn cropped_height(&self) -> u32 {
+        240 - 2 * self.v_overscan
     }
 
     /// Returns the logical window size in pixels reported by the render target.
@@ -264,6 +280,14 @@ impl GlBackend {
         shader_path: Option<&str>,
         app_context: SharedAppContext,
     ) -> Result<Self, String> {
+        let (h_overscan, v_overscan) = {
+            let ctx = app_context.borrow();
+            let cfg = ctx.config();
+            (cfg.horizontal_overscan as u32, cfg.vertical_overscan as u32)
+        };
+        let tex_w = 256 - 2 * h_overscan;
+        let tex_h = 240 - 2 * v_overscan;
+
         unsafe {
             gl::Disable(gl::DEPTH_TEST);
             gl::Disable(gl::CULL_FACE);
@@ -298,13 +322,13 @@ impl GlBackend {
             gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_WRAP_T, gl::CLAMP_TO_EDGE as i32);
             gl::PixelStorei(gl::UNPACK_ALIGNMENT, 1);
 
-            // Allocate texture storage.
+            // Allocate texture storage with cropped (overscan-removed) dimensions.
             gl::TexImage2D(
                 gl::TEXTURE_2D,
                 0,
                 gl::RGB8 as i32,
-                256,
-                240,
+                tex_w as i32,
+                tex_h as i32,
                 0,
                 gl::RGB,
                 gl::UNSIGNED_BYTE,
@@ -360,7 +384,7 @@ impl GlBackend {
             overlay_font,
             overlay_text_color: OverlayTextColor::White,
             app_context,
-            framebuffer: vec![0u8; 256 * 240 * 3],
+            framebuffer: vec![0u8; (tex_w * tex_h * 3) as usize],
             last_frame: Instant::now(),
             debugger_view_state: DebuggerViewState::default(),
             debugger_alpha: 1.0,
@@ -368,6 +392,8 @@ impl GlBackend {
             bp_add_state: BreakpointAddUiState::default(),
             hexdump_ui_state: HexdumpUiState::default(),
             shader_manager,
+            h_overscan,
+            v_overscan,
         })
     }
 
@@ -439,8 +465,12 @@ impl GlBackend {
         // Update NES texture (keep the PPU borrow short-lived so we can snapshot later).
         {
             let screen_buffer = nes.get_screen_buffer();
-            screen_buffer.copy_buffer(&mut self.framebuffer);
+            let cropped = screen_buffer.cropped_snapshot(self.h_overscan, self.v_overscan);
+            self.framebuffer.copy_from_slice(&cropped);
         }
+
+        let tex_w = self.cropped_width() as i32;
+        let tex_h = self.cropped_height() as i32;
 
         unsafe {
             gl::BindTexture(gl::TEXTURE_2D, self.nes_texture);
@@ -450,8 +480,8 @@ impl GlBackend {
                 0,
                 0,
                 0,
-                256,
-                240,
+                tex_w,
+                tex_h,
                 gl::RGB,
                 gl::UNSIGNED_BYTE,
                 self.framebuffer.as_ptr() as *const _,

--- a/src/web_frontend/wasm.rs
+++ b/src/web_frontend/wasm.rs
@@ -39,13 +39,21 @@ impl WasmNes {
         self.nes.clear_ready_to_render();
     }
 
-    fn opaque_black_rgba_frame() -> Vec<u8> {
-        let pixel_count = 256 * 240;
+    fn opaque_black_rgba_frame(pixel_count: usize) -> Vec<u8> {
         let mut rgba = vec![0u8; pixel_count * 4];
         for alpha in rgba.iter_mut().skip(3).step_by(4) {
             *alpha = 0xFF;
         }
         rgba
+    }
+
+    fn overscan(&self) -> (u32, u32) {
+        let cfg = self.app_context.borrow();
+        let config = cfg.config();
+        (
+            config.horizontal_overscan as u32,
+            config.vertical_overscan as u32,
+        )
     }
 
     fn rgb_to_rgba(rgb: &[u8]) -> Vec<u8> {
@@ -125,30 +133,47 @@ impl WasmNes {
 
     /// Step the emulator until a full frame is ready and return the pixel buffer (RGB888).
     ///
-    /// Returns a Uint8Array with length 256*240*3.
+    /// Returns a Uint8Array with the cropped frame after overscan removal.
+    /// Width = 256 - 2*horizontal_overscan, Height = 240 - 2*vertical_overscan.
     #[wasm_bindgen]
     pub fn render_frame(&mut self) -> Vec<u8> {
         if !self.rom_loaded {
-            return vec![0u8; 256 * 240 * 3];
+            let pixel_count = self.screen_width() as usize * self.screen_height() as usize;
+            return vec![0u8; pixel_count * 3];
         }
-        // For browser responsiveness, this could be broken into smaller chunks via
-        // async/yield in a future enhancement. See web/README.md for notes about
-        // potential main-thread blocking with heavy frames.
+        let (h, v) = self.overscan();
         self.run_until_frame_ready();
-        self.nes.get_screen_buffer().snapshot()
+        self.nes.get_screen_buffer().cropped_snapshot(h, v)
     }
 
     /// Step the emulator until a full frame is ready and return the pixel buffer (RGBA8888).
     ///
-    /// Returns a Uint8Array with length 256*240*4 (alpha set to 0xFF).
+    /// Returns a Uint8Array with the cropped frame after overscan removal.
+    /// Width = 256 - 2*horizontal_overscan, Height = 240 - 2*vertical_overscan.
     #[wasm_bindgen]
     pub fn render_frame_rgba(&mut self) -> Vec<u8> {
+        let pixel_count = self.screen_width() as usize * self.screen_height() as usize;
         if !self.rom_loaded {
-            return Self::opaque_black_rgba_frame();
+            return Self::opaque_black_rgba_frame(pixel_count);
         }
+        let (h, v) = self.overscan();
         self.run_until_frame_ready();
-        let rgb = self.nes.get_screen_buffer().snapshot();
+        let rgb = self.nes.get_screen_buffer().cropped_snapshot(h, v);
         Self::rgb_to_rgba(&rgb)
+    }
+
+    /// Returns the display width in pixels after overscan removal.
+    #[wasm_bindgen]
+    pub fn screen_width(&self) -> u32 {
+        let (h, _) = self.overscan();
+        256 - 2 * h
+    }
+
+    /// Returns the display height in pixels after overscan removal.
+    #[wasm_bindgen]
+    pub fn screen_height(&self) -> u32 {
+        let (_, v) = self.overscan();
+        240 - 2 * v
     }
 
     /// Set button state for a controller.

--- a/web/app.js
+++ b/web/app.js
@@ -49,8 +49,9 @@ if (!gl) {
     throw new Error("WebGL rendering context not available for canvas 'screen'");
 }
 
-const width = 256;
-const height = 240;
+// NES display dimensions after overscan removal (updated after NES instance is created).
+let width = 256 - 2 * 8; // default: horizontal_overscan=8 → 240
+let height = 240 - 2 * 8; // default: vertical_overscan=8  → 224
 const SCROLLER_TEXT = "Updates: Feb 14: Full PAL support! Keyboard shortcuts with 'H'. ** Feb 7: Added support for NES Zapper controller. ** Feb 5: Added support for Arkanoid controller!  **";
 const SCROLLER_SPEED = 2.0;
 const SCROLLER_AMPLITUDE = 40;
@@ -795,6 +796,22 @@ let saveStateController = null;
 let saveStateAvailable = false;
 let running = false;
 let paused = false;
+
+/**
+ * Update NES display dimensions from the WASM instance and reallocate the GL texture.
+ * Must be called after `nes` is created so overscan is reflected.
+ */
+function updateNesDisplayDimensions() {
+    if (!nes) return;
+    width = nes.screen_width();
+    height = nes.screen_height();
+    NES_ASPECT_RATIO = width / height;
+    // Reallocate the NES texture with the correct (cropped) dimensions.
+    if (nesTexture) {
+        gl.bindTexture(gl.TEXTURE_2D, nesTexture);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    }
+}
 let lastFrameTime = 0;
 const fpsLogIntervalMs = 1000;
 let fpsLastTime = 0;
@@ -1007,6 +1024,7 @@ async function start() {
             }
 
             nes = new WasmNes();
+            updateNesDisplayDimensions();
         }
         const romName = romMetadata?.name || "selected-rom.nes";
         nes.load_rom(romBytes, romName);
@@ -1531,8 +1549,8 @@ const filterToggleBtn = document.getElementById("filter-toggle");
 const saveStateBtn = document.getElementById("save-state");
 const loadStateBtn = document.getElementById("load-state");
 
-// NES native resolution is 256x240 pixels
-const NES_ASPECT_RATIO = 256 / 240;
+// NES native resolution is 256x240 pixels; aspect ratio updated after NES init.
+let NES_ASPECT_RATIO = width / height;
 const SCALE_STEP = 120; // Change height by 120px each step
 const INITIAL_HEIGHT = 720; // Initial display height in pixels
 let currentHeight = INITIAL_HEIGHT;


### PR DESCRIPTION
## Summary

Implements overscan removal to simulate the result on an old CRT television by removing overscan pixels from the edges of the NES frame before displaying.

## Changes

- **Config**: Added `horizontal_overscan` (range `0..=8`, default `8`) and `vertical_overscan` (range `0..=16`, default `8`) config fields. Both the config file and CLI flags (`--horizontal-overscan` / `--vertical-overscan`) are supported.
- **ScreenBuffer**: Added `cropped_snapshot(h, v)` method that returns a cropped RGB888 buffer with overscan removed from all edges.
- **SDL/GL backend**: NES texture is allocated with cropped dimensions; aspect ratio is computed from the visible (cropped) pixel area.
- **Web (WASM)**: `render_frame()` and `render_frame_rgba()` return the cropped frame; `screen_width()` and `screen_height()` expose the display dimensions to JavaScript.
- **app.js**: Uses `nes.screen_width()` / `nes.screen_height()` for texture allocation, rendering, and aspect ratio.
- **neser.conf.example**: Documents the new config keys.

## Default behaviour

With defaults (`horizontal_overscan=8`, `vertical_overscan=8`), 8 pixels are removed from each edge, resulting in a 240×224 displayed frame (instead of the full 256×240).

## Testing

- Unit tests for `ScreenBuffer::cropped_snapshot` covering all edge cases
- Config tests for default values, parsing, clamping, and CLI args
- All 2302 existing tests continue to pass

Closes #617