### PR TITLE
feat(mapper): implement Mapper 040 (NTDEC 2722 / SMB2J)

### DIFF
--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -20,6 +20,7 @@ use super::namco118::Namco118Mapper;
 use super::namco163::Namco163Mapper;
 use super::nina_tengen::NinaTengenMapper;
 use super::nrom::NROMMapper;
+use super::ntdec_2722::Ntdec2722Mapper;
 use super::rom_db;
 use super::sunsoft_4::Sunsoft4Mapper;
 use super::sunsoft_fme7::SunsoftFme7Mapper;
@@ -701,6 +702,7 @@ mapper_registry! {
     32 => IremG101Mapper::new,
     33 => TaitoTc0190Mapper::new,
     34 => BnromNinaMapper::new,
+    40 => Ntdec2722Mapper::new,
     66 => GxROMMapper::new,
     69 => SunsoftFme7Mapper::new,
     71 => CamericaMapper::new,

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -23,6 +23,7 @@ mod namco118;
 mod namco163;
 mod nina_tengen;
 mod nrom;
+mod ntdec_2722;
 mod rom_db;
 mod sunsoft_4;
 mod sunsoft_fme7;

--- a/src/cartridge/ntdec_2722.rs
+++ b/src/cartridge/ntdec_2722.rs
@@ -1,0 +1,457 @@
+//! Mapper 040 - NTDEC 2722 (Super Mario Bros. 2 Japanese)
+//!
+//! Known Limitations:
+//! - Submapper 1 (NTDEC 2752 multicart outer bank register) not implemented.
+//!
+//! Specification: <https://www.nesdev.org/wiki/INES_Mapper_040>
+
+use crate::cartridge::common::ChrMemory;
+use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
+
+/// Mapper 040 - NTDEC 2722
+///
+/// Hardware: NTDEC 2722 PCB, used in Super Mario Bros. 2 (Japanese) conversions.
+///
+/// Specifications:
+/// - Main: <https://www.nesdev.org/wiki/INES_Mapper_040>
+/// - PRG-ROM: 64KB (8 × 8KB banks, with specific fixed and switchable windows)
+/// - CHR: 8KB fixed CHR-ROM (no banking)
+/// - Mirroring: Fixed from ROM header
+///
+/// PRG window map (8KB each):
+/// - $6000-$7FFF: Fixed bank 6
+/// - $8000-$9FFF: Fixed bank 4
+/// - $A000-$BFFF: Fixed bank 5
+/// - $C000-$DFFF: Switchable (via $E000 write)
+/// - $E000-$FFFF: Fixed bank 7
+///
+/// Register map (range $8000-$FFFF, mask $E000):
+/// - $8000: Disable and acknowledge IRQ
+/// - $A000: Enable IRQ (counter resets to 0, starts counting)
+/// - $E000: Select 8KB PRG bank for $C000 window (bits 2:0)
+///
+/// IRQ: CD4020 CPU-cycle counter; fires after 4096 cycles, self-acks at 8192.
+///
+/// Known games: Super Mario Bros. 2 (Japanese, aka The Lost Levels)
+pub struct Ntdec2722Mapper {
+    prg_rom: Vec<u8>,
+    chr_memory: ChrMemory,
+    mirroring: NametableLayout,
+    /// Switchable bank index for the $C000-$DFFF window.
+    prg_bank: u8,
+    irq_enabled: bool,
+    irq_counter: u16,
+    irq_pending: bool,
+}
+
+impl Ntdec2722Mapper {
+    const MAPPER_NUMBER: u8 = 40;
+    const PRG_BANK_SIZE: usize = 0x2000; // 8KB
+    const PRG_BANK_MASK: usize = Self::PRG_BANK_SIZE - 1;
+
+    // Fixed PRG window bank assignments (hardwired per spec)
+    const BANK_AT_6000: usize = 6;
+    const BANK_AT_8000: usize = 4;
+    const BANK_AT_A000: usize = 5;
+    const BANK_AT_E000: usize = 7;
+
+    // IRQ counter thresholds (CD4020 bits Q12 and Q13)
+    const IRQ_FIRE_COUNT: u16 = 4096;
+    const IRQ_SELF_ACK_COUNT: u16 = 8192;
+
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: NametableLayout) -> Self {
+        Self {
+            prg_rom,
+            chr_memory: ChrMemory::new(chr_rom),
+            mirroring,
+            prg_bank: 0,
+            irq_enabled: false,
+            irq_counter: 0,
+            irq_pending: false,
+        }
+    }
+
+    fn prg_bank_count(&self) -> usize {
+        self.prg_rom.len() / Self::PRG_BANK_SIZE
+    }
+
+    fn wrapped_bank(index: usize, bank_count: usize) -> usize {
+        if bank_count == 0 {
+            0
+        } else {
+            index % bank_count
+        }
+    }
+}
+
+impl Mapper for Ntdec2722Mapper {
+    fn read_prg(&self, addr: u16) -> u8 {
+        let bank_count = self.prg_bank_count();
+        let bank_offset = (addr as usize) & Self::PRG_BANK_MASK;
+        let bank_index = match addr {
+            0x6000..=0x7FFF => Self::wrapped_bank(Self::BANK_AT_6000, bank_count),
+            0x8000..=0x9FFF => Self::wrapped_bank(Self::BANK_AT_8000, bank_count),
+            0xA000..=0xBFFF => Self::wrapped_bank(Self::BANK_AT_A000, bank_count),
+            0xC000..=0xDFFF => Self::wrapped_bank(self.prg_bank as usize, bank_count),
+            0xE000..=0xFFFF => Self::wrapped_bank(Self::BANK_AT_E000, bank_count),
+            _ => return 0,
+        };
+        let mapped = bank_index * Self::PRG_BANK_SIZE + bank_offset;
+        self.prg_rom.get(mapped).copied().unwrap_or(0)
+    }
+
+    fn write_prg(&mut self, addr: u16, value: u8) {
+        match addr & 0xE000 {
+            0x8000 => {
+                // Disable and acknowledge IRQ
+                self.irq_enabled = false;
+                self.irq_pending = false;
+                self.irq_counter = 0;
+            }
+            0xA000 => {
+                // Enable IRQ, reset counter
+                self.irq_enabled = true;
+                self.irq_counter = 0;
+            }
+            0xE000 => {
+                // Select 8KB PRG bank for $C000 window
+                self.prg_bank = value;
+            }
+            _ => {}
+        }
+    }
+
+    fn read_chr(&self, addr: u16) -> u8 {
+        self.chr_memory.read_at_index((addr & 0x1FFF) as usize)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.chr_memory
+            .write_at_index((addr & 0x1FFF) as usize, value);
+    }
+
+    fn get_mirroring(&self) -> NametableLayout {
+        self.mirroring
+    }
+
+    fn mapper_number(&self) -> u8 {
+        Self::MAPPER_NUMBER
+    }
+
+    fn wram_size(&self) -> usize {
+        // No WRAM: $6000-$7FFF is mapped to PRG ROM bank 6, not RAM.
+        0
+    }
+
+    fn cpu_cycle(&mut self) {
+        if !self.irq_enabled {
+            return;
+        }
+        self.irq_counter += 1;
+        if self.irq_counter == Self::IRQ_FIRE_COUNT {
+            self.irq_pending = true;
+        } else if self.irq_counter == Self::IRQ_SELF_ACK_COUNT {
+            self.irq_pending = false;
+        }
+    }
+
+    fn irq_pending(&self) -> bool {
+        self.irq_pending
+    }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
+        self.chr_memory.initialize(mode);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        // Layout: [0] prg_bank, [1] flags (irq_enabled | irq_pending<<1),
+        //         [2-3] irq_counter (little-endian)
+        let flags = (self.irq_enabled as u8) | ((self.irq_pending as u8) << 1);
+        vec![
+            self.prg_bank,
+            flags,
+            (self.irq_counter & 0xFF) as u8,
+            (self.irq_counter >> 8) as u8,
+        ]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if data.len() >= 4 {
+            self.prg_bank = data[0];
+            self.irq_enabled = (data[1] & 1) != 0;
+            self.irq_pending = (data[1] & 2) != 0;
+            self.irq_counter = (data[2] as u16) | ((data[3] as u16) << 8);
+        }
+    }
+
+    fn capabilities(&self) -> MapperCapabilities {
+        MapperCapabilities {
+            has_irq: true,
+            has_chr_banking: false,
+            has_dynamic_mirroring: false,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 0,
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 8,
+            trainer_jsr: false,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Ntdec2722Mapper;
+    use crate::cartridge::NametableLayout;
+    use crate::cartridge::mapper::{Mapper, MapperContext, create_mapper};
+    use crate::cartridge::test_helpers::banked_data;
+
+    // 11 banks × 8KB = non-power-of-two to prevent false-pass wrapping.
+    const PRG_BANKS: usize = 11;
+    const CHR_BANKS: usize = 1; // 8KB fixed
+
+    fn make_mapper() -> Box<dyn Mapper> {
+        let prg_rom = banked_data(8 * 1024, PRG_BANKS);
+        let chr_rom = banked_data(8 * 1024, CHR_BANKS);
+        create_mapper(MapperContext::new(
+            40,
+            prg_rom,
+            chr_rom,
+            NametableLayout::Vertical,
+        ))
+        .expect("Mapper 40 should be implemented")
+    }
+
+    fn make_mapper_direct() -> Ntdec2722Mapper {
+        let prg_rom = banked_data(8 * 1024, PRG_BANKS);
+        let chr_rom = banked_data(8 * 1024, CHR_BANKS);
+        Ntdec2722Mapper::new(prg_rom, chr_rom, NametableLayout::Vertical)
+    }
+
+    // --- Factory ---
+
+    #[test]
+    fn mapper_40_is_registered_in_factory() {
+        // create_mapper should return Some for mapper id 40
+        let prg_rom = banked_data(8 * 1024, PRG_BANKS);
+        let chr_rom = banked_data(8 * 1024, CHR_BANKS);
+        let result = create_mapper(MapperContext::new(
+            40,
+            prg_rom,
+            chr_rom,
+            NametableLayout::Vertical,
+        ));
+        assert!(
+            result.is_ok(),
+            "Mapper 40 must be registered in the factory"
+        );
+    }
+
+    // --- PRG banking ---
+
+    #[test]
+    fn prg_bank4_is_fixed_at_8000() {
+        // With 11-bank ROM, bank 4 is filled with 0x04.
+        let mapper = make_mapper();
+        assert_eq!(
+            mapper.read_prg(0x8000),
+            4,
+            "$8000 window must be hardwired to PRG bank 4"
+        );
+    }
+
+    #[test]
+    fn prg_bank5_is_fixed_at_a000() {
+        let mapper = make_mapper();
+        assert_eq!(
+            mapper.read_prg(0xA000),
+            5,
+            "$A000 window must be hardwired to PRG bank 5"
+        );
+    }
+
+    #[test]
+    fn prg_bank6_is_fixed_at_6000() {
+        let mapper = make_mapper();
+        assert_eq!(
+            mapper.read_prg(0x6000),
+            6,
+            "$6000 window must be hardwired to PRG bank 6"
+        );
+    }
+
+    #[test]
+    fn prg_bank7_is_fixed_at_e000() {
+        let mapper = make_mapper();
+        assert_eq!(
+            mapper.read_prg(0xE000),
+            7,
+            "$E000 window must be hardwired to PRG bank 7"
+        );
+    }
+
+    #[test]
+    fn prg_c000_is_switchable_via_e000_register() {
+        let mut mapper = make_mapper();
+        // Select bank 3 for the $C000 window
+        mapper.write_prg(0xE000, 3);
+        assert_eq!(
+            mapper.read_prg(0xC000),
+            3,
+            "$C000 window must map to the bank selected by $E000 register"
+        );
+    }
+
+    #[test]
+    fn prg_c000_bank_selection_wraps() {
+        // With 11 banks, bank 11 wraps to bank 0.
+        let mut mapper = make_mapper();
+        mapper.write_prg(0xE000, 11);
+        assert_eq!(
+            mapper.read_prg(0xC000),
+            0,
+            "$C000 bank register must wrap around total bank count (11 % 11 = 0)"
+        );
+    }
+
+    #[test]
+    fn prg_read_offset_within_bank_is_correct() {
+        // Bank 4 is all 0x04; the last byte of the window should also be 0x04.
+        let mapper = make_mapper();
+        assert_eq!(
+            mapper.read_prg(0x9FFF),
+            4,
+            "last byte of $8000 window must still be bank 4"
+        );
+    }
+
+    // --- Mirroring ---
+
+    #[test]
+    fn mirroring_is_preserved_from_header() {
+        let prg_rom = banked_data(8 * 1024, PRG_BANKS);
+        let chr_rom = banked_data(8 * 1024, CHR_BANKS);
+        let mapper = Ntdec2722Mapper::new(prg_rom, chr_rom, NametableLayout::Horizontal);
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Horizontal);
+    }
+
+    // --- IRQ ---
+
+    #[test]
+    fn irq_not_pending_initially() {
+        let mapper = make_mapper_direct();
+        assert!(!mapper.irq_pending(), "IRQ must not be pending on power-on");
+    }
+
+    #[test]
+    fn irq_fires_after_4096_cpu_cycles() {
+        let mut mapper = make_mapper_direct();
+        mapper.write_prg(0xA000, 0); // enable IRQ
+        for _ in 0..4096 {
+            mapper.cpu_cycle();
+        }
+        assert!(mapper.irq_pending(), "IRQ must fire after 4096 CPU cycles");
+    }
+
+    #[test]
+    fn irq_does_not_fire_before_4096_cycles() {
+        let mut mapper = make_mapper_direct();
+        mapper.write_prg(0xA000, 0); // enable IRQ
+        for _ in 0..4095 {
+            mapper.cpu_cycle();
+        }
+        assert!(
+            !mapper.irq_pending(),
+            "IRQ must NOT fire before 4096 CPU cycles have elapsed"
+        );
+    }
+
+    #[test]
+    fn irq_acknowledged_and_disabled_by_8000_write() {
+        let mut mapper = make_mapper_direct();
+        mapper.write_prg(0xA000, 0); // enable IRQ
+        for _ in 0..4096 {
+            mapper.cpu_cycle();
+        }
+        assert!(mapper.irq_pending(), "IRQ should be pending before ack");
+        mapper.write_prg(0x8000, 0); // disable + ack
+        assert!(
+            !mapper.irq_pending(),
+            "IRQ must be cleared after $8000 write"
+        );
+    }
+
+    #[test]
+    fn irq_counter_resets_when_re_enabled() {
+        // After ack, re-enabling should restart the 4096-cycle count from zero.
+        let mut mapper = make_mapper_direct();
+        mapper.write_prg(0xA000, 0); // enable
+        for _ in 0..4096 {
+            mapper.cpu_cycle();
+        }
+        mapper.write_prg(0x8000, 0); // ack
+        mapper.write_prg(0xA000, 0); // re-enable
+        // 4095 more cycles should NOT fire
+        for _ in 0..4095 {
+            mapper.cpu_cycle();
+        }
+        assert!(
+            !mapper.irq_pending(),
+            "IRQ must not fire until 4096 cycles after re-enable"
+        );
+    }
+
+    #[test]
+    fn irq_self_acknowledges_at_8192_cycles() {
+        // The CD4020 counter bit 13 fires at 8192 and clears the IRQ line.
+        let mut mapper = make_mapper_direct();
+        mapper.write_prg(0xA000, 0); // enable
+        for _ in 0..8192 {
+            mapper.cpu_cycle();
+        }
+        assert!(
+            !mapper.irq_pending(),
+            "IRQ must self-acknowledge after 8192 CPU cycles (CD4020 bit 13)"
+        );
+    }
+
+    // --- Registers snapshot ---
+
+    #[test]
+    fn registers_snapshot_and_restore() {
+        let prg_rom = banked_data(8 * 1024, PRG_BANKS);
+        let chr_rom = banked_data(8 * 1024, CHR_BANKS);
+        let mut mapper =
+            Ntdec2722Mapper::new(prg_rom.clone(), chr_rom.clone(), NametableLayout::Vertical);
+
+        // Set up state
+        mapper.write_prg(0xE000, 2); // $C000 bank = 2
+        mapper.write_prg(0xA000, 0); // enable IRQ
+        for _ in 0..100 {
+            mapper.cpu_cycle();
+        }
+
+        let snap = mapper.registers_snapshot();
+
+        let mut restored = Ntdec2722Mapper::new(prg_rom, chr_rom, NametableLayout::Vertical);
+        restored.restore_registers(&snap);
+
+        assert_eq!(
+            restored.read_prg(0xC000),
+            2,
+            "Restored $C000 bank must match snapshotted value"
+        );
+        assert!(
+            restored.irq_pending() == mapper.irq_pending(),
+            "Restored IRQ pending state must match"
+        );
+    }
+}

--- a/src/cartridge/vrc6.rs
+++ b/src/cartridge/vrc6.rs
@@ -420,10 +420,10 @@ impl VRC6Mapper {
 impl Mapper for VRC6Mapper {
     fn read_prg(&self, addr: u16) -> u8 {
         // PRG-RAM at $6000-$7FFF, enabled by $B003 bit 7 (W)
-        if self.prg_ram_enabled {
-            if let Some(value) = self.prg_ram.try_read(addr) {
-                return value;
-            }
+        if self.prg_ram_enabled
+            && let Some(value) = self.prg_ram.try_read(addr)
+        {
+            return value;
         }
 
         match addr {

--- a/src/console/nes.rs
+++ b/src/console/nes.rs
@@ -367,6 +367,7 @@ impl Nes {
     /// registers, and PPU state. Useful for debugging and comparing against reference logs.
     ///
     /// Format: `PC  OPCODE  INSTRUCTION                 A:XX X:XX Y:XX P:XX SP:XX PPU:SSS,PPP CYC:C`
+    #[allow(dead_code)]
     pub fn trace(&mut self, tracing: &Tracing) -> String {
         let nestest = tracing.nestest;
         let cpu_state = self.cpu.state();

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -107,6 +107,7 @@ pub enum InterruptKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
 pub struct CpuRegisters {
     pub a: u8,
     pub x: u8,
@@ -121,6 +122,7 @@ impl Cpu {
         self.interrupt_stack.last().copied()
     }
 
+    #[allow(dead_code)]
     pub fn state(&self) -> CpuRegisters {
         CpuRegisters {
             a: self.a,

--- a/src/debugging/ui.rs
+++ b/src/debugging/ui.rs
@@ -643,11 +643,10 @@ mod tests {
         assert!(lines.iter().any(|l| l.contains("P:  A5")));
         // N(7)=1, V(6)=0, U(5)=1, B(4)=0, D(3)=0, I(2)=1, Z(1)=0, C(0)=1
         assert!(lines.iter().any(|l| l.contains("N-U--I-C")));
-        assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("VEC:") && l.contains("NMI") && l.contains("RST") && l.contains("IRQ"))
-        );
+        assert!(lines.iter().any(|l| l.contains("VEC:")
+            && l.contains("NMI")
+            && l.contains("RST")
+            && l.contains("IRQ")));
         // PPU info integrated after separator
         assert!(lines.iter().any(|l| l == "---"));
         assert!(


### PR DESCRIPTION
## Summary

Implements full Mapper 40 (NTDEC 2722) support per the [NesDev specification](https://www.nesdev.org/wiki/INES_Mapper_040).

Used in Super Mario Bros. 2 (Japanese, aka "The Lost Levels") cartridge conversions.

## Changes

### New: `src/cartridge/ntdec_2722.rs`

`Ntdec2722Mapper` — 16 tests covering:

**PRG banking**
- `$6000-$7FFF` → fixed bank 6 (ROM, not WRAM)
- `$8000-$9FFF` → fixed bank 4
- `$A000-$BFFF` → fixed bank 5
- `$C000-$DFFF` → switchable via `$E000` register (with bank wrapping)
- `$E000-$FFFF` → fixed bank 7

**IRQ (CD4020 CPU-cycle counter)**
- `$A000` write: enable IRQ, reset counter to 0
- `$8000` write: disable and acknowledge IRQ
- Fires after 4096 CPU cycles (bit Q12)
- Self-acknowledges after 8192 cycles (bit Q13)

**Other**
- Fixed 8KB CHR-ROM, no banking
- Mirroring fixed from ROM header
- `wram_size` returns 0 (no WRAM; `$6000` maps to PRG ROM)
- Full `registers_snapshot` / `restore_registers` support

### Pre-existing clippy fixes
- `src/cartridge/vrc6.rs`: collapse nested `if`/`if let` (clippy `collapsible_if`)
- `src/cpu/cpu.rs`: `#[allow(dead_code)]` on `CpuRegisters` and `Cpu::state` (used in integration tests)
- `src/console/nes.rs`: `#[allow(dead_code)]` on `Nes::trace` (used in integration tests)

## Known limitations

- Submapper 1 (NTDEC 2752 multicart outer bank register) not yet implemented

Closes #659
