### PR TITLE
feat(web): autorun recording and playback for web frontend

### DIFF
--- a/src/autorun/mod.rs
+++ b/src/autorun/mod.rs
@@ -2,7 +2,8 @@ pub use types::{
     AUTORUN_VERSION, AutorunCheckpoint, AutorunFile, AutorunFrame, CHECKPOINT_INTERVAL_FRAMES,
 };
 pub use utils::{
-    autorun_path_for_rom, backup_autorun_file, load_autorun_file, save_autorun_file, trim_recording,
+    autorun_path_for_rom, backup_autorun_file, crc32, load_autorun_file, save_autorun_file,
+    trim_recording,
 };
 pub mod headless_playback;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod ppu;
 #[cfg(feature = "wasm")]
 #[path = "web_frontend/wasm.rs"]
 pub mod wasm;
+#[path = "web_frontend/wasm_autorun_state.rs"]
+pub mod wasm_autorun;
 #[cfg(all(test, feature = "wasm", target_arch = "wasm32"))]
 #[path = "web_frontend/wasm_tests.rs"]
 mod wasm_tests;

--- a/src/web_frontend/wasm.rs
+++ b/src/web_frontend/wasm.rs
@@ -1,4 +1,5 @@
 use crate::app_context::{AppContext, SharedAppContext};
+use crate::autorun::crc32;
 use crate::cartridge::Cartridge;
 use crate::console::{Config, Nes, SaveState, log_rom_timing_mode_selection};
 use crate::frontend_toasts::{
@@ -6,6 +7,7 @@ use crate::frontend_toasts::{
     gamepad_init_toast_message as shared_gamepad_init_toast_message,
 };
 use crate::input::{Button, ControllerType};
+use crate::wasm_autorun::WasmAutorunState;
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
@@ -18,6 +20,12 @@ pub struct WasmNes {
     rom_loaded: bool,
     pending_toasts: Vec<String>,
     app_context: SharedAppContext,
+    /// Current autorun recording or playback state.
+    autorun_state: Option<WasmAutorunState>,
+    /// Bitmask of currently pressed buttons on controller 1 (for autorun recording).
+    controller1_buttons: u8,
+    /// Bitmask of currently pressed buttons on controller 2 (for autorun recording).
+    controller2_buttons: u8,
 }
 
 impl Default for WasmNes {
@@ -80,6 +88,9 @@ impl WasmNes {
             rom_loaded: false,
             pending_toasts: Vec::new(),
             app_context,
+            autorun_state: None,
+            controller1_buttons: 0,
+            controller2_buttons: 0,
         }
     }
 
@@ -157,9 +168,191 @@ impl WasmNes {
             return Self::opaque_black_rgba_frame(pixel_count);
         }
         let (h, v) = self.overscan();
+
+        // ── Autorun pre-frame: extract pre-recorded input (borrow dropped before injection) ──
+        if let Some(ref mut state) = self.autorun_state {
+            state.begin_frame();
+        }
+        let prerecorded = if let Some(ref mut state) = self.autorun_state {
+            if state.is_extending_playback() || state.is_playback() {
+                state.next_playback_frame()
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        if let Some(frame) = prerecorded {
+            // Borrow is released now; we can call self methods freely.
+            self.inject_autorun_buttons(frame.player1, frame.player2);
+        }
+
         self.run_until_frame_ready();
         let rgb = self.nes.get_screen_buffer().cropped_snapshot(h, v);
+
+        // ── Autorun post-frame: record or verify ─────────────────────────────────────────────
+        let screen_crc = if self.autorun_state.is_some() {
+            crc32(&rgb)
+        } else {
+            0
+        };
+
+        // Phase 1: record the frame or check the CRC; capture whether a checkpoint is needed.
+        let needs_checkpoint = if let Some(ref mut state) = self.autorun_state {
+            if state.is_recording() && !state.is_extending_playback() {
+                let p1 = self.controller1_buttons;
+                let p2 = self.controller2_buttons;
+                // record_frame only borrows state here (not self.nes)
+                // We shadow p1/p2 to avoid re-borrowing self after borrow of autorun_state.
+                state.record_frame(p1, p2)
+            } else {
+                state.check_playback_checkpoint(screen_crc);
+                false
+            }
+        } else {
+            false
+        };
+
+        // Phase 2: if a checkpoint is needed, gather NES state and store it.
+        // The borrow of autorun_state from Phase 1 is fully released here.
+        if needs_checkpoint {
+            let state_bytes = self.nes.save_state().to_bytes().unwrap_or_default();
+            if let Some(ref mut state) = self.autorun_state {
+                state.record_checkpoint(screen_crc, state_bytes);
+            }
+        }
+
         Self::rgb_to_rgba(&rgb)
+    }
+
+    /// Inject controller buttons directly into the NES without affecting tracking bitmasks.
+    fn inject_autorun_buttons(&mut self, controller1: u8, controller2: u8) {
+        for bit in 0..8u8 {
+            let btn = match bit {
+                0 => Button::A,
+                1 => Button::B,
+                2 => Button::Select,
+                3 => Button::Start,
+                4 => Button::Up,
+                5 => Button::Down,
+                6 => Button::Left,
+                _ => Button::Right,
+            };
+            self.nes.set_button(1, btn, controller1 & (1 << bit) != 0);
+            self.nes.set_button(2, btn, controller2 & (1 << bit) != 0);
+        }
+    }
+
+    /// Start autorun recording mode.
+    ///
+    /// Call before `load_rom`.  Every subsequent frame rendered by `render_frame_rgba`
+    /// will be recorded.  Retrieve the recording with `stop_autorun`.
+    #[wasm_bindgen]
+    pub fn start_autorun_recording(&mut self) {
+        self.autorun_state = Some(WasmAutorunState::new_recording());
+    }
+
+    /// Load an autorun file for playback (or extend-recording).
+    ///
+    /// # Arguments
+    /// * `bytes`          – JSON-serialized AutorunFile bytes.
+    /// * `checkpoint_idx` – 0-based checkpoint to seek to, or -1 for "from beginning".
+    /// * `extend`         – `true` to play back and then continue recording.
+    ///
+    /// Returns the save-state bytes that the caller must restore before running the
+    /// first frame.  Returns an empty slice when no restore is needed.
+    #[wasm_bindgen]
+    pub fn load_autorun_playback(
+        &mut self,
+        bytes: &[u8],
+        checkpoint_idx: i32,
+        extend: bool,
+    ) -> Result<Vec<u8>, JsValue> {
+        let cp_idx = if checkpoint_idx < 0 {
+            None
+        } else {
+            Some(checkpoint_idx as u32)
+        };
+        let (state, pending) = WasmAutorunState::new_playback(bytes, cp_idx, extend)
+            .map_err(|e| JsValue::from_str(&e))?;
+        self.autorun_state = Some(state);
+        Ok(pending.unwrap_or_default())
+    }
+
+    /// Finalize autorun recording and return the serialized file bytes.
+    ///
+    /// Appends a final checkpoint with the current screen CRC and emulator state,
+    /// then clears the autorun state.  The returned bytes can be offered to the user
+    /// as a browser download.
+    ///
+    /// Returns an empty `Vec` if no recording is active.
+    #[wasm_bindgen]
+    pub fn stop_autorun(&mut self) -> Vec<u8> {
+        if self
+            .autorun_state
+            .as_ref()
+            .map(|s| !s.is_recording())
+            .unwrap_or(true)
+        {
+            self.autorun_state = None;
+            return Vec::new();
+        }
+        // Compute screen CRC and save state before borrowing autorun_state mutably.
+        let screen_crc = {
+            let (h, v) = self.overscan();
+            let rgb = self.nes.get_screen_buffer().cropped_snapshot(h, v);
+            crc32(&rgb)
+        };
+        let save_state_bytes = self.nes.save_state().to_bytes().unwrap_or_default();
+        let bytes = if let Some(ref mut state) = self.autorun_state {
+            state.finalize_recording(screen_crc, save_state_bytes)
+        } else {
+            Vec::new()
+        };
+        self.autorun_state = None;
+        bytes
+    }
+
+    /// Clear any active autorun state without finalizing a recording.
+    #[wasm_bindgen]
+    pub fn clear_autorun(&mut self) {
+        self.autorun_state = None;
+    }
+
+    /// Returns `true` if an autorun (recording or playback) is currently active.
+    #[wasm_bindgen]
+    pub fn is_autorun_active(&self) -> bool {
+        self.autorun_state.is_some()
+    }
+
+    /// Returns `true` if the emulator is currently recording an autorun.
+    #[wasm_bindgen]
+    pub fn autorun_is_recording(&self) -> bool {
+        self.autorun_state
+            .as_ref()
+            .map(|s| s.is_recording())
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the emulator is currently playing back an autorun.
+    #[wasm_bindgen]
+    pub fn autorun_is_playback(&self) -> bool {
+        self.autorun_state
+            .as_ref()
+            .map(|s| s.is_playback())
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` when pure playback has exhausted all recorded frames.
+    ///
+    /// The JavaScript layer should call this after each `render_frame_rgba` and
+    /// stop emulation when it returns `true`.
+    #[wasm_bindgen]
+    pub fn autorun_playback_finished(&self) -> bool {
+        self.autorun_state
+            .as_ref()
+            .map(|s| s.is_playback_finished())
+            .unwrap_or(false)
     }
 
     /// Returns the display width in pixels after overscan removal.
@@ -196,6 +389,18 @@ impl WasmNes {
             _ => return, // Invalid button, ignore
         };
         self.nes.set_button(controller, nes_button, pressed);
+
+        // Track button state bitmask for autorun recording
+        let bitmask = match controller {
+            1 => &mut self.controller1_buttons,
+            2 => &mut self.controller2_buttons,
+            _ => return,
+        };
+        if pressed {
+            *bitmask |= 1 << button;
+        } else {
+            *bitmask &= !(1 << button);
+        }
     }
 
     /// Set the controller type for a port.

--- a/src/web_frontend/wasm_autorun_state.rs
+++ b/src/web_frontend/wasm_autorun_state.rs
@@ -1,0 +1,545 @@
+use crate::autorun::{
+    AUTORUN_VERSION, AutorunCheckpoint, AutorunFile, AutorunFrame, CHECKPOINT_INTERVAL_FRAMES,
+};
+use crate::console::AutorunMode;
+
+/// In-memory autorun state for the WASM frontend.
+///
+/// Unlike [`crate::sdl_frontend::autorun_state::AutorunState`] this variant never
+/// touches the file system – recordings are created in memory and returned as raw
+/// bytes that the JavaScript layer can trigger the browser to download.
+pub struct WasmAutorunState {
+    autorun: AutorunFile,
+    frame_index: usize,
+    extending_playback: bool,
+    mode: AutorunMode,
+    playback_checkpoint_idx: usize,
+    crc_mismatches: usize,
+    total_checkpoints_verified: usize,
+    current_frame_prerecorded: bool,
+}
+
+impl WasmAutorunState {
+    /// Create a fresh recording state with no frames.
+    pub fn new_recording() -> Self {
+        WasmAutorunState {
+            autorun: AutorunFile {
+                version: AUTORUN_VERSION,
+                frames: Vec::new(),
+                checkpoints: Vec::new(),
+            },
+            frame_index: 0,
+            extending_playback: false,
+            mode: AutorunMode::Record,
+            playback_checkpoint_idx: 0,
+            crc_mismatches: 0,
+            total_checkpoints_verified: 0,
+            current_frame_prerecorded: false,
+        }
+    }
+
+    /// Create a playback state from serialized [`AutorunFile`] bytes.
+    ///
+    /// Returns `(state, pending_restore)` where `pending_restore` is `Some(state_bytes)` when
+    /// the caller must restore the NES state before starting emulation (checkpoint seek or
+    /// extend mode).
+    ///
+    /// # Parameters
+    /// * `bytes` – JSON-serialized [`AutorunFile`].
+    /// * `checkpoint_idx` – If `Some(idx)`, start playback from that checkpoint (0-based).
+    /// * `extend` – If `true`, play back and then continue recording (extend mode).
+    pub fn new_playback(
+        bytes: &[u8],
+        checkpoint_idx: Option<u32>,
+        extend: bool,
+    ) -> Result<(Self, Option<Vec<u8>>), String> {
+        let autorun = parse_autorun_bytes(bytes)?;
+
+        if extend {
+            return Ok(Self::new_extend(autorun));
+        }
+
+        // Pure playback
+        let (frame_index, playback_checkpoint_idx, pending) = if let Some(cp_idx) = checkpoint_idx {
+            let cp_idx = cp_idx as usize;
+            let cp = autorun.checkpoints.get(cp_idx).ok_or_else(|| {
+                format!(
+                    "Checkpoint index {cp_idx} out of range (recording has {} checkpoints)",
+                    autorun.checkpoints.len()
+                )
+            })?;
+            let pending = cp.state_bytes.clone();
+            (cp.frame_index as usize + 1, cp_idx + 1, Some(pending))
+        } else {
+            (0, 0, None)
+        };
+
+        Ok((
+            WasmAutorunState {
+                autorun,
+                frame_index,
+                extending_playback: false,
+                mode: AutorunMode::Playback,
+                playback_checkpoint_idx,
+                crc_mismatches: 0,
+                total_checkpoints_verified: 0,
+                current_frame_prerecorded: false,
+            },
+            pending,
+        ))
+    }
+
+    /// Build extend state: restore from a checkpoint and optionally replay.
+    ///
+    /// - n ≥ 2 checkpoints: restore from second-to-last, replay toward last.
+    /// - n = 1 checkpoint:  restore from the single checkpoint, record immediately.
+    /// - n = 0 checkpoints: start from frame 0 with nothing to restore.
+    fn new_extend(autorun: AutorunFile) -> (Self, Option<Vec<u8>>) {
+        let n = autorun.checkpoints.len();
+        let (frame_index, playback_checkpoint_idx, pending, extending_playback) = if n >= 2 {
+            let second_to_last = &autorun.checkpoints[n - 2];
+            let pending = second_to_last.state_bytes.clone();
+            (
+                second_to_last.frame_index as usize + 1,
+                n - 1,
+                Some(pending),
+                true,
+            )
+        } else if n == 1 {
+            let cp = &autorun.checkpoints[0];
+            let pending = cp.state_bytes.clone();
+            (cp.frame_index as usize + 1, 1, Some(pending), false)
+        } else {
+            (0, 0, None, false)
+        };
+
+        (
+            WasmAutorunState {
+                autorun,
+                frame_index,
+                extending_playback,
+                mode: AutorunMode::Record,
+                playback_checkpoint_idx,
+                crc_mismatches: 0,
+                total_checkpoints_verified: 0,
+                current_frame_prerecorded: false,
+            },
+            pending,
+        )
+    }
+
+    /// Signal the start of a new frame cycle.  Must be called before [`next_playback_frame`].
+    pub fn begin_frame(&mut self) {
+        self.current_frame_prerecorded = false;
+    }
+
+    /// Returns true if the current frame's inputs came from a pre-recorded source.
+    pub fn current_frame_was_prerecorded(&self) -> bool {
+        self.current_frame_prerecorded
+    }
+
+    /// Get the next pre-recorded frame.  Returns `None` when playback is exhausted.
+    pub fn next_playback_frame(&mut self) -> Option<AutorunFrame> {
+        if self.frame_index < self.autorun.frames.len() {
+            let frame = self.autorun.frames[self.frame_index].clone();
+            self.frame_index += 1;
+            self.current_frame_prerecorded = true;
+            Some(frame)
+        } else {
+            None
+        }
+    }
+
+    /// Record one frame.  Returns `true` when a checkpoint should be captured.
+    pub fn record_frame(&mut self, player1: u8, player2: u8) -> bool {
+        self.autorun.frames.push(AutorunFrame { player1, player2 });
+        self.frame_index += 1;
+        (self.frame_index as u32).is_multiple_of(CHECKPOINT_INTERVAL_FRAMES)
+    }
+
+    /// Persist a checkpoint.  Call immediately after `record_frame` returns `true`.
+    pub fn record_checkpoint(&mut self, screen_crc: u32, state_bytes: Vec<u8>) {
+        self.autorun.checkpoints.push(AutorunCheckpoint {
+            frame_index: (self.frame_index - 1) as u32,
+            screen_crc,
+            state_bytes,
+        });
+    }
+
+    /// Append a final checkpoint and return the recording as serialized JSON bytes.
+    pub fn finalize_recording(&mut self, screen_crc: u32, state_bytes: Vec<u8>) -> Vec<u8> {
+        self.autorun.checkpoints.push(AutorunCheckpoint {
+            frame_index: self.frame_index.saturating_sub(1) as u32,
+            screen_crc,
+            state_bytes,
+        });
+        serde_json::to_vec_pretty(&self.autorun).unwrap_or_default()
+    }
+
+    /// Check whether the just-completed frame has a playback checkpoint, verify CRC.
+    ///
+    /// Returns `Some(true)` on CRC match, `Some(false)` on mismatch, `None` if no checkpoint.
+    pub fn check_playback_checkpoint(&mut self, screen_crc: u32) -> Option<bool> {
+        let current = (self.frame_index - 1) as u32;
+        let mut matched = None;
+        while self.playback_checkpoint_idx < self.autorun.checkpoints.len()
+            && self.autorun.checkpoints[self.playback_checkpoint_idx].frame_index == current
+        {
+            let expected = self.autorun.checkpoints[self.playback_checkpoint_idx].screen_crc;
+            let ok = screen_crc == expected;
+            if !ok {
+                self.crc_mismatches += 1;
+            }
+            self.total_checkpoints_verified += 1;
+            self.playback_checkpoint_idx += 1;
+            matched = Some(ok);
+        }
+        matched
+    }
+
+    /// True while in extend mode and still replaying the existing recording.
+    pub fn is_extending_playback(&self) -> bool {
+        self.extending_playback && self.frame_index < self.autorun.frames.len()
+    }
+
+    /// True when the state is in recording mode (original or extend).
+    pub fn is_recording(&self) -> bool {
+        self.mode == AutorunMode::Record
+    }
+
+    /// True when the state is in playback mode (not recording).
+    pub fn is_playback(&self) -> bool {
+        self.mode == AutorunMode::Playback
+    }
+
+    /// Returns `true` when pure playback (non-extend mode) has consumed all recorded frames.
+    ///
+    /// This is the signal for the frontend to stop emulation at the end of a run.
+    /// Returns `false` for recording mode and extend mode.
+    pub fn is_playback_finished(&self) -> bool {
+        self.mode == AutorunMode::Playback && self.frame_index >= self.autorun.frames.len()
+    }
+
+    /// Number of CRC mismatches detected during playback.
+    pub fn crc_mismatches(&self) -> usize {
+        self.crc_mismatches
+    }
+
+    /// Total number of checkpoints verified during playback.
+    pub fn total_checkpoints_verified(&self) -> usize {
+        self.total_checkpoints_verified
+    }
+
+    /// Current frame index.
+    pub fn current_frame_index(&self) -> usize {
+        self.frame_index
+    }
+
+    /// Total number of frames in the recording.
+    pub fn total_frames(&self) -> usize {
+        self.autorun.frames.len()
+    }
+}
+
+fn parse_autorun_bytes(bytes: &[u8]) -> Result<AutorunFile, String> {
+    let file: AutorunFile =
+        serde_json::from_slice(bytes).map_err(|e| format!("Failed to parse autorun file: {e}"))?;
+    if file.version != AUTORUN_VERSION {
+        return Err(format!("Unsupported autorun version: {}", file.version));
+    }
+    Ok(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_autorun_bytes(num_frames: usize, num_checkpoints: usize) -> Vec<u8> {
+        let checkpoints: Vec<AutorunCheckpoint> = (0..num_checkpoints)
+            .map(|i| {
+                let frame = if num_checkpoints > 0 {
+                    ((i + 1) * num_frames / num_checkpoints).saturating_sub(1) as u32
+                } else {
+                    0
+                };
+                AutorunCheckpoint {
+                    frame_index: frame,
+                    screen_crc: (i as u32 + 1) * 0x1111,
+                    state_bytes: format!("state{i}").into_bytes(),
+                }
+            })
+            .collect();
+        let file = AutorunFile {
+            version: AUTORUN_VERSION,
+            frames: (0..num_frames)
+                .map(|i| AutorunFrame {
+                    player1: (i % 256) as u8,
+                    player2: 0,
+                })
+                .collect(),
+            checkpoints,
+        };
+        serde_json::to_vec(&file).expect("serialize")
+    }
+
+    // ── new_recording ────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_recording_starts_with_no_frames() {
+        let state = WasmAutorunState::new_recording();
+        assert_eq!(state.total_frames(), 0);
+    }
+
+    #[test]
+    fn new_recording_is_in_record_mode() {
+        let state = WasmAutorunState::new_recording();
+        assert!(state.is_recording());
+        assert!(!state.is_playback());
+    }
+
+    #[test]
+    fn new_recording_frame_index_is_zero() {
+        let state = WasmAutorunState::new_recording();
+        assert_eq!(state.current_frame_index(), 0);
+    }
+
+    // ── record_frame ────────────────────────────────────────────────────────
+
+    #[test]
+    fn record_frame_returns_true_at_checkpoint_interval() {
+        let mut state = WasmAutorunState::new_recording();
+        for _ in 0..299 {
+            assert!(!state.record_frame(0, 0));
+        }
+        assert!(
+            state.record_frame(0, 0),
+            "frame 300 should trigger checkpoint"
+        );
+    }
+
+    #[test]
+    fn record_frame_increments_frame_index() {
+        let mut state = WasmAutorunState::new_recording();
+        state.record_frame(1, 2);
+        assert_eq!(state.current_frame_index(), 1);
+    }
+
+    // ── record_checkpoint + finalize_recording ───────────────────────────────
+
+    #[test]
+    fn finalize_recording_returns_valid_bytes() {
+        let mut state = WasmAutorunState::new_recording();
+        state.record_frame(1, 0);
+        let bytes = state.finalize_recording(0xDEAD, b"end".to_vec());
+        let file: AutorunFile = serde_json::from_slice(&bytes).expect("bytes must be valid JSON");
+        assert_eq!(file.version, AUTORUN_VERSION);
+        assert_eq!(file.frames.len(), 1);
+        assert_eq!(file.checkpoints.last().unwrap().screen_crc, 0xDEAD);
+    }
+
+    #[test]
+    fn record_checkpoint_stores_crc_and_state() {
+        let mut state = WasmAutorunState::new_recording();
+        for _ in 0..300 {
+            state.record_frame(0, 0);
+        }
+        state.record_checkpoint(0xCAFE, b"s".to_vec());
+        assert_eq!(state.autorun.checkpoints.len(), 1);
+        assert_eq!(state.autorun.checkpoints[0].screen_crc, 0xCAFE);
+    }
+
+    // ── new_playback – basic ────────────────────────────────────────────────
+
+    #[test]
+    fn new_playback_from_start_has_no_pending_restore() {
+        let bytes = make_autorun_bytes(300, 1);
+        let (state, pending) =
+            WasmAutorunState::new_playback(&bytes, None, false).expect("create playback");
+        assert!(pending.is_none());
+        assert_eq!(state.current_frame_index(), 0);
+    }
+
+    #[test]
+    fn new_playback_is_in_playback_mode() {
+        let bytes = make_autorun_bytes(300, 1);
+        let (state, _) =
+            WasmAutorunState::new_playback(&bytes, None, false).expect("create playback");
+        assert!(state.is_playback());
+        assert!(!state.is_recording());
+    }
+
+    #[test]
+    fn new_playback_from_checkpoint_returns_pending_restore() {
+        let bytes = make_autorun_bytes(600, 2);
+        let (state, pending) = WasmAutorunState::new_playback(&bytes, Some(0), false).expect("ok");
+        assert!(pending.is_some());
+        // Frame index should be checkpoint[0].frame_index + 1
+        let file: AutorunFile = serde_json::from_slice(&bytes).unwrap();
+        let expected_idx = file.checkpoints[0].frame_index as usize + 1;
+        assert_eq!(state.current_frame_index(), expected_idx);
+    }
+
+    #[test]
+    fn new_playback_invalid_bytes_returns_error() {
+        let result = WasmAutorunState::new_playback(b"not json", None, false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn new_playback_checkpoint_out_of_range_returns_error() {
+        let bytes = make_autorun_bytes(300, 1);
+        let result = WasmAutorunState::new_playback(&bytes, Some(99), false);
+        assert!(result.is_err());
+    }
+
+    // ── next_playback_frame ─────────────────────────────────────────────────
+
+    #[test]
+    fn next_playback_frame_returns_recorded_input() {
+        let file = AutorunFile {
+            version: AUTORUN_VERSION,
+            frames: vec![AutorunFrame {
+                player1: 42,
+                player2: 7,
+            }],
+            checkpoints: vec![AutorunCheckpoint {
+                frame_index: 0,
+                screen_crc: 0,
+                state_bytes: vec![],
+            }],
+        };
+        let bytes = serde_json::to_vec(&file).unwrap();
+        let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
+        state.begin_frame();
+        let frame = state.next_playback_frame();
+        assert!(frame.is_some());
+        let f = frame.unwrap();
+        assert_eq!(f.player1, 42);
+        assert_eq!(f.player2, 7);
+    }
+
+    #[test]
+    fn next_playback_frame_returns_none_when_exhausted() {
+        let bytes = make_autorun_bytes(1, 1);
+        let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
+        state.begin_frame();
+        state.next_playback_frame(); // consume
+        state.begin_frame();
+        assert!(state.next_playback_frame().is_none());
+    }
+
+    // ── extend mode ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn extend_mode_is_extending_playback_initially() {
+        let bytes = make_autorun_bytes(600, 2);
+        let (state, _) = WasmAutorunState::new_playback(&bytes, None, true).unwrap();
+        assert!(state.is_extending_playback());
+        assert!(state.is_recording()); // extend = record mode
+    }
+
+    #[test]
+    fn extend_mode_with_no_checkpoints_starts_fresh() {
+        let bytes = make_autorun_bytes(0, 0);
+        let (state, pending) = WasmAutorunState::new_playback(&bytes, None, true).unwrap();
+        assert!(pending.is_none());
+        assert!(!state.is_extending_playback());
+        assert_eq!(state.current_frame_index(), 0);
+    }
+
+    // ── CRC check ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn check_playback_checkpoint_detects_mismatch() {
+        let file = AutorunFile {
+            version: AUTORUN_VERSION,
+            frames: vec![AutorunFrame {
+                player1: 0,
+                player2: 0,
+            }],
+            checkpoints: vec![AutorunCheckpoint {
+                frame_index: 0,
+                screen_crc: 0x1234,
+                state_bytes: vec![],
+            }],
+        };
+        let bytes = serde_json::to_vec(&file).unwrap();
+        let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
+        state.begin_frame();
+        state.next_playback_frame();
+        let result = state.check_playback_checkpoint(0xBAD0);
+        assert_eq!(result, Some(false));
+        assert_eq!(state.crc_mismatches(), 1);
+    }
+
+    #[test]
+    fn check_playback_checkpoint_matching_crc_no_mismatch() {
+        let file = AutorunFile {
+            version: AUTORUN_VERSION,
+            frames: vec![AutorunFrame {
+                player1: 0,
+                player2: 0,
+            }],
+            checkpoints: vec![AutorunCheckpoint {
+                frame_index: 0,
+                screen_crc: 0x5678,
+                state_bytes: vec![],
+            }],
+        };
+        let bytes = serde_json::to_vec(&file).unwrap();
+        let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
+        state.begin_frame();
+        state.next_playback_frame();
+        let result = state.check_playback_checkpoint(0x5678);
+        assert_eq!(result, Some(true));
+        assert_eq!(state.crc_mismatches(), 0);
+        assert_eq!(state.total_checkpoints_verified(), 1);
+    }
+
+    // ── is_playback_finished ─────────────────────────────────────────────────
+
+    #[test]
+    fn playback_not_finished_before_frames_exhausted() {
+        let bytes = make_autorun_bytes(3, 0);
+        let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
+        assert!(!state.is_playback_finished());
+        state.begin_frame();
+        state.next_playback_frame();
+        assert!(!state.is_playback_finished());
+    }
+
+    #[test]
+    fn playback_finished_when_all_frames_consumed() {
+        let bytes = make_autorun_bytes(2, 0);
+        let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
+        state.begin_frame();
+        state.next_playback_frame();
+        state.begin_frame();
+        state.next_playback_frame();
+        assert!(state.is_playback_finished());
+    }
+
+    #[test]
+    fn playback_finished_is_false_for_recording_mode() {
+        let mut state = WasmAutorunState::new_recording();
+        // Drive frame_index well past 0 by recording frames
+        state.begin_frame();
+        state.record_frame(0, 0);
+        state.begin_frame();
+        state.record_frame(0, 0);
+        assert!(!state.is_playback_finished());
+    }
+
+    #[test]
+    fn playback_finished_is_false_for_extend_mode() {
+        // Extend mode uses Record mode internally; playback_finished must stay false
+        let bytes = make_autorun_bytes(2, 1);
+        let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, true).unwrap();
+        // Drain the pre-recorded frames
+        state.begin_frame();
+        state.next_playback_frame();
+        state.begin_frame();
+        state.next_playback_frame();
+        assert!(!state.is_playback_finished());
+    }
+}

--- a/web/app.js
+++ b/web/app.js
@@ -12,6 +12,7 @@ import { applyJoypadButtonIfAllowed, applyMouseMotion, applyMouseButton, isZappe
 import { createSaveStateContext } from "./save_state_context.js";
 import { fetchRomList } from "./rom_list.js";
 import { handleRomSelection } from "./rom_selection.js";
+import { createAutorunContext, parseAutorunFile } from "./autorun_context.js";
 import { createFrameLimiter } from "./frame_limiter.js";
 import { computePlaybackRate } from "./audio_resampler.js";
 import { planFrame } from "./frame_plan.js";
@@ -798,6 +799,141 @@ let saveStateAvailable = false;
 let running = false;
 let paused = false;
 
+// ── Autorun context + DOM elements ───────────────────────────────────────────
+const autorunCtx = createAutorunContext();
+const autorunCreateCheckbox = document.getElementById("autorun-create");
+const autorunLoadBtn = document.getElementById("autorun-load");
+const autorunStatusEl = document.getElementById("autorun-status");
+const autorunFileInput = document.getElementById("autorun-file-input");
+const autorunFileInfo = document.getElementById("autorun-file-info");
+const autorunFileSummary = document.getElementById("autorun-file-summary");
+const autorunCheckpointSelect = document.getElementById("autorun-checkpoint-select");
+const autorunExtendCheck = document.getElementById("autorun-extend-check");
+const autorunUseBtn = document.getElementById("autorun-use-btn");
+const autorunCancelBtn = document.getElementById("autorun-cancel");
+
+/** Update the small autorun status text and cancel button in the header. */
+function updateAutorunStatus() {
+    if (!autorunStatusEl) return;
+    const config = autorunCtx.getActiveConfig();
+    if (!config) {
+        autorunStatusEl.textContent = "";
+        autorunCancelBtn?.classList.add("d-none");
+    } else if (config.mode === "record") {
+        autorunStatusEl.textContent = "Will record autorun";
+        autorunCancelBtn?.classList.remove("d-none");
+    } else {
+        const info = autorunCtx.getLoadedFile();
+        const cpText = config.checkpointIdx != null
+            ? `from checkpoint ${config.checkpointIdx + 1}`
+            : "from beginning";
+        const extText = config.extend ? ", extending" : "";
+        const expectedRom = autorunCtx.getExpectedRomName();
+        const romHint = expectedRom ? ` · Load ${expectedRom}` : "";
+        autorunStatusEl.textContent =
+            `Autorun loaded (${info?.frameCount ?? "?"} frames, ${cpText}${extText})${romHint}`;
+        autorunCancelBtn?.classList.remove("d-none");
+    }
+}
+
+if (autorunCreateCheckbox) {
+    autorunCreateCheckbox.addEventListener("change", () => {
+        autorunCtx.setCreateRecording(autorunCreateCheckbox.checked);
+        if (autorunCreateCheckbox.checked) {
+            // Clear loaded file when switching to create-recording mode
+            autorunCtx.clearLoadedFile();
+        }
+        updateAutorunStatus();
+    });
+}
+
+if (autorunCancelBtn) {
+    autorunCancelBtn.addEventListener("click", () => {
+        autorunCtx.clearLoadedFile();
+        autorunCtx.setCreateRecording(false);
+        if (autorunCreateCheckbox) autorunCreateCheckbox.checked = false;
+        updateAutorunStatus();
+    });
+}
+
+// Open modal on "Load autorun" button click
+if (autorunLoadBtn) {
+    autorunLoadBtn.addEventListener("click", () => {
+        // Reset modal state
+        if (autorunFileInput) autorunFileInput.value = "";
+        if (autorunFileInfo) autorunFileInfo.classList.add("d-none");
+        if (autorunUseBtn) autorunUseBtn.disabled = true;
+        if (autorunExtendCheck) autorunExtendCheck.checked = false;
+        if (autorunCheckpointSelect) {
+            while (autorunCheckpointSelect.options.length > 1) {
+                autorunCheckpointSelect.remove(1);
+            }
+        }
+        const modal = new window.bootstrap.Modal(document.getElementById("autorun-modal"));
+        modal.show();
+    });
+}
+
+// Handle autorun file selection inside modal
+if (autorunFileInput) {
+    autorunFileInput.addEventListener("change", async (e) => {
+        const file = e.target.files?.[0];
+        if (!file || !autorunFileInfo || !autorunFileSummary || !autorunCheckpointSelect || !autorunUseBtn) return;
+        try {
+            const bytes = new Uint8Array(await file.arrayBuffer());
+            const info = parseAutorunFile(bytes);
+            const expectedRom = file.name.replace(/\.autorun$/i, ".nes");
+            autorunFileSummary.textContent =
+                `${file.name} (${info.frameCount} frames, ${info.checkpointCount} checkpoints) · ROM: ${expectedRom}`;
+            // Populate checkpoint selector
+            while (autorunCheckpointSelect.options.length > 1) {
+                autorunCheckpointSelect.remove(1);
+            }
+            for (let i = 0; i < info.checkpointCount; i++) {
+                const opt = document.createElement("option");
+                opt.value = String(i);
+                opt.textContent = `Checkpoint ${i + 1} (frame ${Math.round((i + 1) * info.frameCount / info.checkpointCount)})`;
+                autorunCheckpointSelect.appendChild(opt);
+            }
+            autorunFileInfo.classList.remove("d-none");
+            autorunUseBtn.disabled = false;
+            // Store raw bytes and filename on the input element for the Use button
+            autorunFileInput._bytes = bytes;
+            autorunFileInput._fileName = file.name;
+        } catch (err) {
+            autorunFileSummary.textContent = `Error: ${err.message}`;
+            autorunFileInfo.classList.remove("d-none");
+            autorunUseBtn.disabled = true;
+            autorunFileInput._bytes = null;
+            autorunFileInput._fileName = null;
+        }
+    });
+}
+
+// Handle "Use Autorun" button click
+if (autorunUseBtn) {
+    autorunUseBtn.addEventListener("click", () => {
+        const bytes = autorunFileInput?._bytes;
+        if (!bytes) return;
+        try {
+            autorunCtx.setLoadedFile(bytes, autorunFileInput?._fileName ?? null);
+            // Uncheck "Create autorun" since playback takes over
+            if (autorunCreateCheckbox) autorunCreateCheckbox.checked = false;
+            autorunCtx.setCreateRecording(false);
+            const cpVal = autorunCheckpointSelect?.value;
+            autorunCtx.setSelectedCheckpoint(cpVal != null && cpVal !== "-1" ? parseInt(cpVal, 10) : null);
+            autorunCtx.setExtend(autorunExtendCheck?.checked ?? false);
+            updateAutorunStatus();
+            // Close modal
+            const modalEl = document.getElementById("autorun-modal");
+            const modal = window.bootstrap.Modal.getInstance(modalEl);
+            modal?.hide();
+        } catch (err) {
+            console.error("Failed to configure autorun:", err);
+        }
+    });
+}
+
 /**
  * Update NES display dimensions from the WASM instance and reallocate the GL texture.
  * Must be called after `nes` is created so overscan is reflected.
@@ -907,6 +1043,10 @@ async function refreshSaveStateController() {
 romInput.addEventListener("change", async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    const expectedRom = autorunCtx.getExpectedRomName();
+    if (expectedRom && file.name.toLowerCase() !== expectedRom.toLowerCase()) {
+        toastOverlay.show(`⚠ Autorun expects "${expectedRom}" but "${file.name}" was loaded — playback may not work correctly`);
+    }
     await handleRomSelection({
         bytes: new Uint8Array(await file.arrayBuffer()),
         name: file.name,
@@ -1028,8 +1168,36 @@ async function start() {
             updateNesDisplayDimensions();
         }
         const romName = romMetadata?.name || "selected-rom.nes";
+
+        // ── Autorun setup: configure before loading ROM ─────────────────────
+        const autorunConfig = autorunCtx.getActiveConfig();
+        if (autorunConfig?.mode === "record") {
+            nes.start_autorun_recording();
+        } else {
+            nes.clear_autorun();
+        }
+
         nes.load_rom(romBytes, romName);
         drainNesToasts(nes, toastOverlay);
+
+        // ── Autorun setup: playback / extend – after ROM is loaded ───────────
+        if (autorunConfig?.mode === "playback") {
+            try {
+                const pendingRestore = nes.load_autorun_playback(
+                    autorunConfig.bytes,
+                    autorunConfig.checkpointIdx ?? -1,
+                    autorunConfig.extend
+                );
+                if (pendingRestore && pendingRestore.length > 0) {
+                    nes.load_state_bytes(pendingRestore);
+                }
+            } catch (autorunErr) {
+                console.error("Failed to load autorun for playback:", autorunErr);
+                toastOverlay.show(`Autorun load failed: ${autorunErr}`);
+                nes.clear_autorun();
+            }
+        }
+
         frameLimiter.setTargetFps(nes.frame_rate_hz());
         // Initialize audio context on user interaction (browser requirement)
         initAudioContext();
@@ -1071,6 +1239,16 @@ function pauseResume() {
 }
 
 function stop() {
+    // ── Autorun teardown: download recording if active ────────────────────
+    if (nes && nes.autorun_is_recording()) {
+        const recordingBytes = nes.stop_autorun();
+        if (recordingBytes && recordingBytes.length > 0) {
+            triggerAutorunDownload(recordingBytes, romMetadata?.name);
+        }
+    } else if (nes) {
+        nes.clear_autorun();
+    }
+
     running = false;
     paused = false;
     startBtn.disabled = false;
@@ -1078,6 +1256,26 @@ function stop() {
     lastFrameTime = 0;
     frameLimiter.reset();
     setStatus("Stopped. You can restart or load a new ROM");
+}
+
+/**
+ * Trigger a browser download of an autorun recording.
+ * @param {Uint8Array} bytes - The serialized AutorunFile JSON bytes.
+ * @param {string|undefined} romName - ROM file name (used to derive the download file name).
+ */
+function triggerAutorunDownload(bytes, romName) {
+    const baseName = romName ? romName.replace(/\.nes$/i, "") : "recording";
+    const fileName = `${baseName}.autorun`;
+    const blob = new Blob([bytes], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = fileName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+    toastOverlay.show(`Autorun saved: ${fileName}`);
 }
 
 function startIdleScroller() {
@@ -1269,6 +1467,14 @@ function step(timestamp) {
             pollGamepad();
         }
         const frame = nes.render_frame_rgba(); // RGBA8888
+
+        // Stop when pure autorun playback has consumed all recorded frames
+        if (nes.autorun_playback_finished()) {
+            stop();
+            setStatus("Autorun playback complete.");
+            return;
+        }
+
         const filter = filters[currentFilter];
         let rendered = true;
         if (framePlan.shouldRender) {

--- a/web/autorun_context.js
+++ b/web/autorun_context.js
@@ -1,0 +1,165 @@
+const SUPPORTED_AUTORUN_VERSION = 2;
+
+/**
+ * Parse an autorun file's bytes and return metadata about the recording.
+ *
+ * @param {Uint8Array} bytes - Raw bytes of a JSON-serialized AutorunFile.
+ * @returns {{ version: number, frameCount: number, checkpointCount: number }}
+ * @throws {Error} If the bytes are not valid JSON or the version is unsupported.
+ */
+export function parseAutorunFile(bytes) {
+    let obj;
+    try {
+        const text = new TextDecoder().decode(bytes);
+        obj = JSON.parse(text);
+    } catch (e) {
+        throw new Error(`Failed to parse autorun file: ${e.message}`);
+    }
+    if (obj.version !== SUPPORTED_AUTORUN_VERSION) {
+        throw new Error(
+            `Unsupported autorun version: ${obj.version} (expected ${SUPPORTED_AUTORUN_VERSION})`
+        );
+    }
+    return {
+        version: obj.version,
+        frameCount: Array.isArray(obj.frames) ? obj.frames.length : 0,
+        checkpointCount: Array.isArray(obj.checkpoints) ? obj.checkpoints.length : 0
+    };
+}
+
+/**
+ * Create an autorun context that manages the web frontend's autorun UI state.
+ *
+ * Two mutually-exclusive modes:
+ *  - **Create recording**: when `createRecording` is `true`, every ROM run is
+ *    recorded and the recording is offered for download when the ROM is stopped.
+ *  - **Playback/Extend**: when an autorun file is loaded via `setLoadedFile`, the
+ *    recording is played back (optionally from a specific checkpoint, optionally
+ *    extended after playback ends).
+ *
+ * `getActiveConfig()` is the single query point used when starting a ROM:
+ *  - Returns `{ mode: 'record' }` when create-recording is on.
+ *  - Returns `{ mode: 'playback', bytes, checkpointIdx, extend }` when a file is loaded.
+ *  - Returns `null` when neither mode is active.
+ *
+ * Create-recording takes precedence over a loaded file when both are set.
+ */
+export function createAutorunContext() {
+    let createRecording = false;
+    let loadedFile = null; // null | { bytes: Uint8Array, checkpointCount: number, frameCount: number }
+    let selectedCheckpoint = null;
+    let extend = false;
+
+    return {
+        // ── create-recording mode ─────────────────────────────────────────
+
+        /** @returns {boolean} */
+        isCreateRecording() {
+            return createRecording;
+        },
+
+        /** @param {boolean} flag */
+        setCreateRecording(flag) {
+            createRecording = Boolean(flag);
+        },
+
+        // ── loaded file ───────────────────────────────────────────────────
+
+        /**
+         * @returns {{ bytes: Uint8Array, checkpointCount: number, frameCount: number } | null}
+         */
+        getLoadedFile() {
+            return loadedFile;
+        },
+
+        /**
+         * Parse and store an autorun file.
+         * @param {Uint8Array} bytes
+         * @param {string|null} [fileName] - Original filename (e.g. "mario.autorun"), used to derive expected ROM name.
+         * @throws {Error} If the bytes are invalid.
+         */
+        setLoadedFile(bytes, fileName = null) {
+            const info = parseAutorunFile(bytes);
+            loadedFile = {
+                bytes,
+                checkpointCount: info.checkpointCount,
+                frameCount: info.frameCount,
+                fileName
+            };
+        },
+
+        /** Clear the loaded autorun file. */
+        clearLoadedFile() {
+            loadedFile = null;
+            selectedCheckpoint = null;
+            extend = false;
+        },
+
+        /**
+         * Returns the expected .nes ROM filename derived from the loaded autorun filename.
+         * E.g. "mario.autorun" → "mario.nes". Returns null if no file is loaded or filename is unknown.
+         * @returns {string|null}
+         */
+        getExpectedRomName() {
+            if (!loadedFile?.fileName) return null;
+            return loadedFile.fileName.replace(/\.autorun$/i, ".nes");
+        },
+
+        // ── checkpoint & extend ───────────────────────────────────────────
+
+        /** @returns {number | null} 0-based checkpoint index, or null for "from beginning". */
+        getSelectedCheckpoint() {
+            return selectedCheckpoint;
+        },
+
+        /** @param {number | null} idx */
+        setSelectedCheckpoint(idx) {
+            selectedCheckpoint = idx ?? null;
+        },
+
+        /** @returns {boolean} */
+        isExtend() {
+            return extend;
+        },
+
+        /** @param {boolean} flag */
+        setExtend(flag) {
+            extend = Boolean(flag);
+        },
+
+        // ── combined queries ──────────────────────────────────────────────
+
+        /**
+         * Returns true when any autorun mode is active (recording or playback).
+         * @returns {boolean}
+         */
+        isActive() {
+            return createRecording || loadedFile !== null;
+        },
+
+        /**
+         * Returns the active autorun configuration for the next ROM run,
+         * or `null` if no autorun is configured.
+         *
+         * Create-recording takes precedence over a loaded file.
+         *
+         * @returns {{ mode: 'record' } |
+         *           { mode: 'playback', bytes: Uint8Array, checkpointIdx: number | null, extend: boolean } |
+         *           null}
+         */
+        getActiveConfig() {
+            if (createRecording) {
+                return { mode: "record" };
+            }
+            if (loadedFile !== null) {
+                return {
+                    mode: "playback",
+                    bytes: loadedFile.bytes,
+                    checkpointIdx: selectedCheckpoint,
+                    extend
+                };
+            }
+            return null;
+        }
+    };
+}

--- a/web/autorun_context.test.mjs
+++ b/web/autorun_context.test.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    parseAutorunFile,
+    createAutorunContext
+} from "./autorun_context.js";
+
+// ── parseAutorunFile ──────────────────────────────────────────────────────────
+
+test("parseAutorunFile returns checkpointCount and frameCount for valid file", () => {
+    const file = {
+        version: 2,
+        frames: [{ player1: 0, player2: 0 }, { player1: 1, player2: 0 }],
+        checkpoints: [
+            { frame_index: 0, screen_crc: 0, state_bytes: [] },
+            { frame_index: 1, screen_crc: 0, state_bytes: [] }
+        ]
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const info = parseAutorunFile(bytes);
+    assert.equal(info.checkpointCount, 2);
+    assert.equal(info.frameCount, 2);
+    assert.equal(info.version, 2);
+});
+
+test("parseAutorunFile throws for invalid JSON", () => {
+    const bytes = new TextEncoder().encode("not json");
+    assert.throws(() => parseAutorunFile(bytes), /parse|invalid|JSON/i);
+});
+
+test("parseAutorunFile throws for unsupported version", () => {
+    const file = { version: 99, frames: [], checkpoints: [] };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    assert.throws(() => parseAutorunFile(bytes), /version/i);
+});
+
+// ── createAutorunContext – create-recording mode ──────────────────────────────
+
+test("createAutorunContext initial state: recording off, no loaded file", () => {
+    const ctx = createAutorunContext();
+    assert.equal(ctx.isCreateRecording(), false);
+    assert.equal(ctx.getLoadedFile(), null);
+    assert.equal(ctx.isExtend(), false);
+    assert.equal(ctx.getSelectedCheckpoint(), null);
+    assert.equal(ctx.isActive(), false);
+});
+
+test("createAutorunContext setCreateRecording enables create-recording mode", () => {
+    const ctx = createAutorunContext();
+    ctx.setCreateRecording(true);
+    assert.equal(ctx.isCreateRecording(), true);
+    assert.equal(ctx.isActive(), true);
+});
+
+test("createAutorunContext setCreateRecording false deactivates", () => {
+    const ctx = createAutorunContext();
+    ctx.setCreateRecording(true);
+    ctx.setCreateRecording(false);
+    assert.equal(ctx.isCreateRecording(), false);
+    assert.equal(ctx.isActive(), false);
+});
+
+test("getActiveConfig returns record config when create-recording is enabled", () => {
+    const ctx = createAutorunContext();
+    ctx.setCreateRecording(true);
+    const config = ctx.getActiveConfig();
+    assert.equal(config?.mode, "record");
+});
+
+// ── createAutorunContext – load file ─────────────────────────────────────────
+
+test("createAutorunContext setLoadedFile stores file info", () => {
+    const file = {
+        version: 2,
+        frames: new Array(600).fill({ player1: 0, player2: 0 }),
+        checkpoints: [
+            { frame_index: 299, screen_crc: 1, state_bytes: [] },
+            { frame_index: 599, screen_crc: 2, state_bytes: [] }
+        ]
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const ctx = createAutorunContext();
+    ctx.setLoadedFile(bytes);
+    const loaded = ctx.getLoadedFile();
+    assert.ok(loaded !== null);
+    assert.equal(loaded.checkpointCount, 2);
+    assert.equal(loaded.frameCount, 600);
+    assert.deepEqual(loaded.bytes, bytes);
+});
+
+test("createAutorunContext isActive returns true when file is loaded", () => {
+    const file = { version: 2, frames: [], checkpoints: [] };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const ctx = createAutorunContext();
+    ctx.setLoadedFile(bytes);
+    assert.equal(ctx.isActive(), true);
+});
+
+test("createAutorunContext setLoadedFile throws for invalid file", () => {
+    const ctx = createAutorunContext();
+    assert.throws(
+        () => ctx.setLoadedFile(new TextEncoder().encode("bad")),
+        /parse|invalid|JSON/i
+    );
+});
+
+test("createAutorunContext clearLoadedFile removes file and deactivates (if no recording)", () => {
+    const file = { version: 2, frames: [], checkpoints: [] };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const ctx = createAutorunContext();
+    ctx.setLoadedFile(bytes);
+    ctx.clearLoadedFile();
+    assert.equal(ctx.getLoadedFile(), null);
+    assert.equal(ctx.isActive(), false);
+});
+
+// ── createAutorunContext – checkpoint & extend ────────────────────────────────
+
+test("createAutorunContext setSelectedCheckpoint stores index", () => {
+    const ctx = createAutorunContext();
+    ctx.setSelectedCheckpoint(3);
+    assert.equal(ctx.getSelectedCheckpoint(), 3);
+});
+
+test("createAutorunContext setSelectedCheckpoint null means 'from beginning'", () => {
+    const ctx = createAutorunContext();
+    ctx.setSelectedCheckpoint(2);
+    ctx.setSelectedCheckpoint(null);
+    assert.equal(ctx.getSelectedCheckpoint(), null);
+});
+
+test("createAutorunContext setExtend true enables extend mode", () => {
+    const ctx = createAutorunContext();
+    ctx.setExtend(true);
+    assert.equal(ctx.isExtend(), true);
+});
+
+// ── createAutorunContext – getActiveConfig for playback ───────────────────────
+
+test("getActiveConfig returns playback config when file is loaded", () => {
+    const file = {
+        version: 2,
+        frames: [{ player1: 0, player2: 0 }],
+        checkpoints: [{ frame_index: 0, screen_crc: 0, state_bytes: [] }]
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const ctx = createAutorunContext();
+    ctx.setLoadedFile(bytes);
+    const config = ctx.getActiveConfig();
+    assert.equal(config?.mode, "playback");
+    assert.deepEqual(config?.bytes, bytes);
+    assert.equal(config?.checkpointIdx, null);
+    assert.equal(config?.extend, false);
+});
+
+test("getActiveConfig includes checkpointIdx and extend when set", () => {
+    const file = {
+        version: 2,
+        frames: new Array(300).fill({ player1: 0, player2: 0 }),
+        checkpoints: [{ frame_index: 299, screen_crc: 0, state_bytes: [] }]
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const ctx = createAutorunContext();
+    ctx.setLoadedFile(bytes);
+    ctx.setSelectedCheckpoint(0);
+    ctx.setExtend(true);
+    const config = ctx.getActiveConfig();
+    assert.equal(config?.mode, "playback");
+    assert.equal(config?.checkpointIdx, 0);
+    assert.equal(config?.extend, true);
+});
+
+test("getActiveConfig returns null when neither recording nor file is loaded", () => {
+    const ctx = createAutorunContext();
+    assert.equal(ctx.getActiveConfig(), null);
+});
+
+// ── createAutorunContext – record takes precedence over loaded file ─────────
+
+test("getActiveConfig returns record mode when both recording and file are set", () => {
+    const file = { version: 2, frames: [], checkpoints: [] };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const ctx = createAutorunContext();
+    ctx.setLoadedFile(bytes);
+    ctx.setCreateRecording(true);
+    const config = ctx.getActiveConfig();
+    assert.equal(config?.mode, "record");
+});

--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,15 @@
             <button id="pause" class="btn btn-outline-secondary btn-sm" aria-label="Pause or resume emulation">Pause/Resume</button>
             <button id="stop" class="btn btn-outline-danger btn-sm" aria-label="Stop emulation">Stop</button>
           </div>
+          <div class="d-flex flex-nowrap align-items-center gap-3 mt-1">
+            <div class="form-check mb-0">
+              <input class="form-check-input" type="checkbox" id="autorun-create" />
+              <label class="form-check-label" for="autorun-create">Create autorun</label>
+            </div>
+            <button id="autorun-load" class="btn btn-outline-info btn-sm">Load autorun</button>
+            <span id="autorun-status" class="small"></span>
+            <button id="autorun-cancel" class="btn btn-outline-danger btn-sm d-none" aria-label="Cancel autorun">✕ Cancel</button>
+          </div>
         </div>
       </div>
 
@@ -72,6 +81,45 @@
         </div>
       </div>
     </div>
+
+    <!-- Autorun modal dialog -->
+    <div class="modal fade" id="autorun-modal" tabindex="-1" aria-labelledby="autorun-modal-label" aria-hidden="true">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="autorun-modal-label">Configure Autorun</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="autorun-file-input" class="form-label">Autorun file (.autorun)</label>
+              <input type="file" id="autorun-file-input" accept=".autorun" class="form-control form-control-sm" />
+            </div>
+            <div id="autorun-file-info" class="d-none mb-3">
+              <div class="alert alert-info py-2 small mb-2" id="autorun-file-summary"></div>
+              <div class="mb-3">
+                <label for="autorun-checkpoint-select" class="form-label">Start from checkpoint</label>
+                <select id="autorun-checkpoint-select" class="form-select form-select-sm">
+                  <option value="-1">From the beginning</option>
+                </select>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" id="autorun-extend-check" />
+                <label class="form-check-label" for="autorun-extend-check">Extend autorun (record after playback ends)</label>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="btn btn-primary" id="autorun-use-btn" disabled>Use Autorun</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+      crossorigin="anonymous"></script>
     <script type="module" src="./app.js"></script>
   </body>
 </html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -39,6 +39,10 @@ canvas {
     color: #8fe28f;
 }
 
+#autorun-status {
+    color: #9bc2ff;
+}
+
 #controls {
     font-size: 0.9rem;
     color: #c4c4c4;
@@ -91,4 +95,68 @@ canvas {
     color: #e6e6e6;
     font-size: 0.9rem;
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+}
+
+/* ── Dark theme overrides for Bootstrap modal ───────────────────────────── */
+.modal-content {
+    background: rgba(18, 19, 23, 0.98);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #e6e6e6;
+}
+
+.modal-header {
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.modal-footer {
+    border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+.modal-header .btn-close {
+    filter: invert(1) grayscale(100%) brightness(200%);
+}
+
+.modal .form-label {
+    color: #c4c4c4;
+}
+
+.modal .form-control,
+.modal .form-select {
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #e6e6e6;
+}
+
+.modal .form-control:focus,
+.modal .form-select:focus {
+    background-color: rgba(255, 255, 255, 0.08);
+    border-color: rgba(86, 156, 214, 0.6);
+    color: #e6e6e6;
+    box-shadow: 0 0 0 0.2rem rgba(86, 156, 214, 0.15);
+}
+
+.modal .form-control::file-selector-button {
+    background-color: rgba(255, 255, 255, 0.08);
+    color: #e6e6e6;
+    border-color: rgba(255, 255, 255, 0.15);
+}
+
+.modal .form-check-input {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.25);
+}
+
+.modal .form-check-label {
+    color: #c4c4c4;
+}
+
+.modal .alert-info {
+    background-color: rgba(13, 110, 253, 0.12);
+    border-color: rgba(13, 110, 253, 0.3);
+    color: #9bc2ff;
+}
+
+.modal .form-select option {
+    background-color: #1e1f24;
+    color: #e6e6e6;
 }


### PR DESCRIPTION
Closes #687

## Summary

Implements autorun recording and playback for the web frontend, mirroring the SDL frontend's `--create-recording` and autorun playback parameters.

## Changes

### Rust / WASM
- **`src/web_frontend/wasm_autorun_state.rs`** (new): `WasmAutorunState` manages record/playback/extend modes fully in-memory (no file system). Recordings are finalized as JSON bytes returned to the JavaScript layer for browser download.
- **`src/web_frontend/wasm.rs`**: Added autorun fields and WASM bindings:
  - `start_autorun_recording()` – begin a new recording
  - `load_autorun_playback(bytes, checkpoint_idx, extend)` – start playback from serialized file
  - `stop_autorun()` → bytes – finalize and download recording
  - `clear_autorun()` – deactivate
  - `is_autorun_active()`, `autorun_is_recording()`, `autorun_is_playback()`, `autorun_playback_finished()`
- **`src/autorun/mod.rs`**: Re-exported `crc32` for use in WASM module.
- **`src/lib.rs`**: Exposed `wasm_autorun` module for unit testing.

### JavaScript
- **`web/autorun_context.js`** (new): Manages UI autorun state (create-recording flag, loaded file, checkpoint selection, extend flag). Exports `createAutorunContext` and `parseAutorunFile`.
- **`web/autorun_context.test.mjs`** (new): 18 unit tests covering all state transitions.
- **`web/app.js`**: Wired all UI interactions — recording setup before ROM load, playback restore, browser download on stop, automatic stop when playback finishes, ROM filename mismatch warning.

### UI
- **`web/index.html`**: Added "Create autorun" checkbox, "Load autorun" button, status indicator, cancel button, and Bootstrap modal (file picker, checkpoint selector, extend checkbox).
- **`web/styles.css`**: Dark theme overrides for Bootstrap modal; `#autorun-status` colour.

## Test coverage

| Suite | Tests | Result |
|---|---|---|
| `cargo nextest --all-features` | 5532 | ✅ all pass |
| `wasm-pack test --headless --chrome --features wasm` | 22 | ✅ all pass |
| `npm test` | 124 | ✅ all pass |
| Python scraper | 22 | ✅ all pass |

## User-facing behaviour

- **Create autorun**: check the checkbox before starting a ROM → recording begins automatically; when you stop, the `.autorun` file is offered as a browser download.
- **Load autorun**: click the button → modal to select `.autorun` file, choose start checkpoint, optionally enable extend mode → click "Use Autorun" → start ROM normally.
- **Status bar**: shows active mode with frame count, checkpoint, ROM hint, and a ✕ Cancel button.
- **Auto-stop**: playback ends the emulation automatically when all frames are consumed.
- **ROM name hint**: derived from the `.autorun` filename; warns if a different `.nes` is loaded.
