### PR TITLE
fix(web): prevent >60 FPS emulation in browser loop

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1611,13 +1611,19 @@ function renderNtscPass(frame) {
 function step(timestamp) {
     if (!running || paused) return;
     lastFrameTime = timestamp;
-    const framePlan = planFrame({
+    const { shouldStep, shouldRender } = planFrame({
         shouldRender: frameLimiter.shouldRender(timestamp)
     });
     try {
         if (gamepadEnabled && nes) {
             pollGamepad();
         }
+
+        if (!shouldStep) {
+            requestAnimationFrame(step);
+            return;
+        }
+
         const frame = nes.render_frame_rgba(); // RGBA8888
 
         // Stop when pure autorun playback has consumed all recorded frames
@@ -1629,7 +1635,7 @@ function step(timestamp) {
 
         const filter = filters[currentFilter];
         let rendered = true;
-        if (framePlan.shouldRender) {
+        if (shouldRender) {
             if (filter?.type === "ntsc") {
                 rendered = renderNtscPass(frame);
             } else {

--- a/web/frame_plan.js
+++ b/web/frame_plan.js
@@ -1,6 +1,7 @@
 export function planFrame({ shouldRender }) {
+    const render = Boolean(shouldRender);
     return {
-        shouldStep: true,
-        shouldRender: Boolean(shouldRender)
+        shouldStep: render,
+        shouldRender: render
     };
 }

--- a/web/frame_plan.test.mjs
+++ b/web/frame_plan.test.mjs
@@ -2,13 +2,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { planFrame } from "./frame_plan.js";
 
-test("frame plan always steps", () => {
+test("plans step and render when shouldRender is true", () => {
     assert.deepEqual(planFrame({ shouldRender: true }), {
         shouldStep: true,
         shouldRender: true
     });
+});
+
+test("skips step and render when shouldRender is false", () => {
     assert.deepEqual(planFrame({ shouldRender: false }), {
-        shouldStep: true,
+        shouldStep: false,
         shouldRender: false
     });
 });


### PR DESCRIPTION
## Summary
- ensure throttled frames skip emulation stepping in the web frame loop
- align frame planning so shouldStep and shouldRender are gated together
- update frame plan tests to cover both throttled and non-throttled behavior

Closes #693