### PR TITLE
fix(web): resolve zoom button no-op and disable-state issues

### DIFF
--- a/src/autorun/mod.rs
+++ b/src/autorun/mod.rs
@@ -1,6 +1,7 @@
 pub use types::{
     AUTORUN_VERSION, AutorunCheckpoint, AutorunFile, AutorunFrame, CHECKPOINT_INTERVAL_FRAMES,
 };
+#[allow(unused_imports)]
 pub use utils::{
     autorun_path_for_rom, backup_autorun_file, crc32, load_autorun_file, save_autorun_file,
     trim_recording,

--- a/src/web_frontend/wasm_tests.rs
+++ b/src/web_frontend/wasm_tests.rs
@@ -384,7 +384,6 @@ fn debugger_step_into_keeps_debugger_open_and_advances_one_instruction() {
     // Advance to a known stable state
     let _ = nes.render_frame_rgba();
 
-    let pc_before = nes.debugger_cpu_pc();
     nes.debugger_open();
     nes.debugger_step_into();
 

--- a/web/app.js
+++ b/web/app.js
@@ -27,6 +27,9 @@ import {
 } from "./shortcut_help.js";
 import { createCrosshair } from "./crosshair.js";
 import { computeFullscreenCanvasSize, computeWindowedCanvasSize } from "./canvas_size.js";
+import {
+    findNextVisibleZoomHeight,
+} from "./zoom_controls.js";
 import { createToastContainer, createToastOverlay, drainNesToasts } from "./toast_overlay.js";
 import { createGamepadInitToastNotifier } from "./gamepad_init_toast.js";
 
@@ -1969,6 +1972,64 @@ function updateShortcutHelpScale() {
     shortcutHelpOverlay.style.fontSize = `${fontSizePx}px`;
 }
 
+function measureDisplayHeightAt(height) {
+    updateCanvasSize(height);
+    return canvas.clientHeight;
+}
+
+function probeNextVisibleZoomHeight(direction) {
+    const startHeight = currentHeight;
+    const nextHeight = findNextVisibleZoomHeight({
+        direction,
+        currentHeight: startHeight,
+        step: SCALE_STEP,
+        measureDisplayHeight: measureDisplayHeightAt,
+    });
+
+    if (nextHeight === null) {
+        updateCanvasSize(startHeight);
+    }
+
+    return nextHeight;
+}
+
+function updateZoomButtonState() {
+    const inScreenFullscreen = document.fullscreenElement === screenWrap;
+    if (inScreenFullscreen) {
+        screenMinusBtn.disabled = true;
+        screenPlusBtn.disabled = true;
+        return;
+    }
+
+    const startHeight = currentHeight;
+    const canZoomOut = probeNextVisibleZoomHeight("out") !== null;
+    updateCanvasSize(startHeight);
+    const canZoomIn = probeNextVisibleZoomHeight("in") !== null;
+    updateCanvasSize(startHeight);
+
+    screenMinusBtn.disabled = !canZoomOut;
+    screenPlusBtn.disabled = !canZoomIn;
+}
+
+function applyZoom(direction) {
+    if (document.fullscreenElement === screenWrap) {
+        updateZoomButtonState();
+        return;
+    }
+
+    const startHeight = currentHeight;
+    const nextHeight = probeNextVisibleZoomHeight(direction);
+    if (nextHeight === null) {
+        updateCanvasSize(startHeight);
+        updateZoomButtonState();
+        return;
+    }
+
+    updateCanvasSize(nextHeight);
+
+    updateZoomButtonState();
+}
+
 // Update fullscreen button text based on state
 function updateFullscreenButton() {
     const inScreenFullscreen = document.fullscreenElement === screenWrap;
@@ -2022,6 +2083,7 @@ function updateSaveStateButtons() {
 // Set initial canvas size and button text
 updateCanvasSize(INITIAL_HEIGHT);
 updateFullscreenButton();
+updateZoomButtonState();
 filterToggleBtn.textContent = `Filter: ${filters[currentFilter].name}`;
 updateSaveStateButtons();
 const shortcutReferenceText = buildShortcutReferenceText();
@@ -2035,11 +2097,11 @@ updateShortcutHelpScale();
 startIdleScroller();
 
 screenMinusBtn.addEventListener("click", () => {
-    updateCanvasSize(currentHeight - SCALE_STEP);
+    applyZoom("out");
 });
 
 screenPlusBtn.addEventListener("click", () => {
-    updateCanvasSize(currentHeight + SCALE_STEP);
+    applyZoom("in");
 });
 
 fullscreenBtn.addEventListener("click", async () => {
@@ -2152,11 +2214,16 @@ document.addEventListener("fullscreenchange", () => {
         // Exited fullscreen - restore previous size
         updateCanvasSize(currentHeight);
     }
+    updateZoomButtonState();
 });
 
 // Re-fit canvas when viewport resizes while in fullscreen (e.g. orientation change)
 window.addEventListener("resize", () => {
     if (document.fullscreenElement === screenWrap) {
         updateCanvasSizeForFullscreenViewport();
+        updateZoomButtonState();
+        return;
     }
+
+    updateZoomButtonState();
 });

--- a/web/zoom_controls.js
+++ b/web/zoom_controls.js
@@ -1,0 +1,96 @@
+export const MIN_CANVAS_HEIGHT = 240;
+export const MAX_CANVAS_HEIGHT = 1440;
+
+export function clampCanvasHeight(height, minHeight = MIN_CANVAS_HEIGHT, maxHeight = MAX_CANVAS_HEIGHT) {
+    return Math.max(minHeight, Math.min(height, maxHeight));
+}
+
+export function findNextVisibleZoomHeight({
+    direction,
+    currentHeight,
+    step,
+    measureDisplayHeight,
+    minHeight = MIN_CANVAS_HEIGHT,
+    maxHeight = MAX_CANVAS_HEIGHT,
+}) {
+    const delta = direction === "in" ? step : -step;
+    const startDisplayHeight = measureDisplayHeight(currentHeight);
+    let probeHeight = currentHeight;
+
+    for (;;) {
+        const trialHeight = clampCanvasHeight(probeHeight + delta, minHeight, maxHeight);
+        if (trialHeight === probeHeight) {
+            return null;
+        }
+
+        const trialDisplayHeight = measureDisplayHeight(trialHeight);
+        const movedInDirection = direction === "in"
+            ? trialDisplayHeight > startDisplayHeight
+            : trialDisplayHeight < startDisplayHeight;
+
+        if (movedInDirection) {
+            return trialHeight;
+        }
+
+        probeHeight = trialHeight;
+    }
+}
+
+function didDisplayMoveInDirection(direction, previousDisplayHeight, nextDisplayHeight) {
+    return direction === "in"
+        ? nextDisplayHeight > previousDisplayHeight
+        : nextDisplayHeight < previousDisplayHeight;
+}
+
+export function advanceZoomState({
+    direction,
+    currentHeight,
+    step,
+    previousDisplayHeight,
+    nextDisplayHeight,
+    minHeight = MIN_CANVAS_HEIGHT,
+    maxHeight = MAX_CANVAS_HEIGHT,
+}) {
+    const delta = direction === "in" ? step : -step;
+    const clampedHeight = clampCanvasHeight(currentHeight + delta, minHeight, maxHeight);
+    const heightChanged = clampedHeight !== currentHeight;
+    const displayMovedInDirection = didDisplayMoveInDirection(direction, previousDisplayHeight, nextDisplayHeight);
+    const canAcceptZoomStep = heightChanged && displayMovedInDirection;
+    const resolvedHeight = canAcceptZoomStep ? clampedHeight : currentHeight;
+    const directionBlocked = !canAcceptZoomStep;
+
+    return {
+        currentHeight: resolvedHeight,
+        plusDisabled: resolvedHeight >= maxHeight || (direction === "in" && directionBlocked),
+        minusDisabled: resolvedHeight <= minHeight || (direction === "out" && directionBlocked),
+    };
+}
+
+export function nextViewportZoomBlocks({
+    direction,
+    accepted,
+    currentHeight,
+    zoomInBlockedByViewport,
+    zoomOutBlockedByViewport,
+    minHeight = MIN_CANVAS_HEIGHT,
+    maxHeight = MAX_CANVAS_HEIGHT,
+}) {
+    if (accepted) {
+        return {
+            zoomInBlockedByViewport: false,
+            zoomOutBlockedByViewport: false,
+        };
+    }
+
+    if (direction === "in") {
+        return {
+            zoomInBlockedByViewport: currentHeight < maxHeight,
+            zoomOutBlockedByViewport,
+        };
+    }
+
+    return {
+        zoomInBlockedByViewport,
+        zoomOutBlockedByViewport: currentHeight > minHeight,
+    };
+}

--- a/web/zoom_controls.test.mjs
+++ b/web/zoom_controls.test.mjs
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+    advanceZoomState,
+    findNextVisibleZoomHeight,
+    nextViewportZoomBlocks,
+} from "./zoom_controls.js";
+
+function createZoomInput(overrides = {}) {
+    return {
+        direction: "in",
+        currentHeight: 720,
+        step: 120,
+        previousDisplayHeight: 700,
+        nextDisplayHeight: 700,
+        ...overrides,
+    };
+}
+
+test("advanceZoomState disables zoom-in when pressing zoom-in does not increase display height", () => {
+    const result = advanceZoomState(createZoomInput());
+
+    assert.equal(result.currentHeight, 720);
+    assert.equal(result.plusDisabled, true);
+});
+
+test("advanceZoomState disables zoom-out when clamped at minimum height", () => {
+    const result = advanceZoomState(createZoomInput({
+        direction: "out",
+        currentHeight: 240,
+        previousDisplayHeight: 240,
+        nextDisplayHeight: 240,
+    }));
+
+    assert.equal(result.currentHeight, 240);
+    assert.equal(result.minusDisabled, true);
+});
+
+test("advanceZoomState disables zoom-out when pressing zoom-out does not decrease display height", () => {
+    const result = advanceZoomState(createZoomInput({
+        direction: "out",
+        currentHeight: 720,
+        previousDisplayHeight: 700,
+        nextDisplayHeight: 700,
+    }));
+
+    assert.equal(result.currentHeight, 720);
+    assert.equal(result.minusDisabled, true);
+    assert.equal(result.plusDisabled, false);
+});
+
+test("advanceZoomState advances height when zoom-in increases display height", () => {
+    const result = advanceZoomState(createZoomInput({
+        nextDisplayHeight: 820,
+    }));
+
+    assert.equal(result.currentHeight, 840);
+    assert.equal(result.plusDisabled, false);
+});
+
+test("nextViewportZoomBlocks keeps opposite direction blocked when current attempt is rejected", () => {
+    const result = nextViewportZoomBlocks({
+        direction: "in",
+        accepted: false,
+        currentHeight: 720,
+        zoomInBlockedByViewport: false,
+        zoomOutBlockedByViewport: true,
+    });
+
+    assert.equal(result.zoomInBlockedByViewport, true);
+    assert.equal(result.zoomOutBlockedByViewport, true);
+});
+
+test("nextViewportZoomBlocks clears both blocks after an accepted zoom step", () => {
+    const result = nextViewportZoomBlocks({
+        direction: "out",
+        accepted: true,
+        currentHeight: 600,
+        zoomInBlockedByViewport: true,
+        zoomOutBlockedByViewport: true,
+    });
+
+    assert.equal(result.zoomInBlockedByViewport, false);
+    assert.equal(result.zoomOutBlockedByViewport, false);
+});
+
+test("findNextVisibleZoomHeight skips no-op zoom-out steps and returns first visible decrease", () => {
+    const displayByHeight = new Map([
+        [720, 400],
+        [600, 400],
+        [480, 400],
+        [360, 320],
+        [240, 240],
+    ]);
+
+    const next = findNextVisibleZoomHeight({
+        direction: "out",
+        currentHeight: 720,
+        step: 120,
+        measureDisplayHeight: (height) => displayByHeight.get(height),
+    });
+
+    assert.equal(next, 360);
+});
+
+test("findNextVisibleZoomHeight returns null when no visible zoom-in step exists", () => {
+    const next = findNextVisibleZoomHeight({
+        direction: "in",
+        currentHeight: 720,
+        step: 120,
+        measureDisplayHeight: () => 400,
+    });
+
+    assert.equal(next, null);
+});


### PR DESCRIPTION
## Summary
- fix web zoom +/- controls to only allow steps that produce visible canvas size changes
- disable each zoom button only when no visible zoom movement exists in that direction
- add targeted web unit tests for zoom plateau/visibility behavior
- clear a wasm test warning and preserve clippy-clean build

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- cargo nextest run --all-features
- wasm-pack test --headless --chrome --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts/scraper -p "test_*.py"
- web test suite (136 tests) via test runner

Closes #698
