### PR TITLE
feat(web): support F4 filter cycling shortcut

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1811,6 +1811,7 @@ ensureWasmInitialized()
 const webShortcutActions = {
     togglePause: pauseResume,
     reset: resetAction,
+    toggleFilter: toggleFilterAction,
     saveState: saveStateAction,
     loadState: loadStateAction,
     toggleFullscreen: toggleScreenFullscreen,
@@ -1829,6 +1830,15 @@ function updateShortcutHelpOverlayText() {
 function toggleShortcutHelp() {
     updateShortcutHelpOverlayText();
     toggleShortcutHelpVisibility(shortcutHelpOverlay);
+}
+
+function updateFilterToggleButtonLabel() {
+    filterToggleBtn.textContent = `Filter: ${filters[currentFilter].name}`;
+}
+
+function toggleFilterAction() {
+    cycleFilter();
+    updateFilterToggleButtonLabel();
 }
 
 function applyKeyboardMapping(event, mapping, controller, targets, pressed) {
@@ -2084,7 +2094,7 @@ function updateSaveStateButtons() {
 updateCanvasSize(INITIAL_HEIGHT);
 updateFullscreenButton();
 updateZoomButtonState();
-filterToggleBtn.textContent = `Filter: ${filters[currentFilter].name}`;
+updateFilterToggleButtonLabel();
 updateSaveStateButtons();
 const shortcutReferenceText = buildShortcutReferenceText();
 if (shortcutReference) {
@@ -2108,10 +2118,7 @@ fullscreenBtn.addEventListener("click", async () => {
     await toggleScreenFullscreen();
 });
 
-filterToggleBtn.addEventListener("click", () => {
-    cycleFilter();
-    filterToggleBtn.textContent = `Filter: ${filters[currentFilter].name}`;
-});
+filterToggleBtn.addEventListener("click", toggleFilterAction);
 
 saveStateBtn?.addEventListener("click", async () => {
     await saveStateAction();

--- a/web/shortcut_actions.js
+++ b/web/shortcut_actions.js
@@ -7,6 +7,7 @@
  * @param {{
  *   togglePause: Function,
  *   reset: Function,
+ *   toggleFilter: Function,
  *   saveState: Function,
  *   loadState: Function,
  *   toggleFullscreen: Function,
@@ -35,6 +36,7 @@ export async function dispatchWebShortcutAction(event, actions) {
 const shortcutActionByCode = {
     Space: "togglePause",
     F1: "reset",
+    F4: "toggleFilter",
     F5: "debuggerToggle",
     F6: "saveState",
     F7: "loadState",

--- a/web/shortcut_actions.test.mjs
+++ b/web/shortcut_actions.test.mjs
@@ -24,6 +24,7 @@ function makeActions() {
         actions: {
             togglePause: () => calls.push("togglePause"),
             reset: () => calls.push("reset"),
+            toggleFilter: () => calls.push("toggleFilter"),
             saveState: async () => calls.push("saveState"),
             loadState: async () => calls.push("loadState"),
             toggleFullscreen: async () => calls.push("toggleFullscreen"),
@@ -54,6 +55,17 @@ test("dispatchWebShortcutAction routes F1 to reset", async () => {
 
     assert.equal(handled, true);
     assert.deepEqual(calls, ["reset"]);
+    assert.equal(event.defaultPrevented, true);
+});
+
+test("dispatchWebShortcutAction routes F4 to toggleFilter", async () => {
+    const event = makeKeyboardEvent("F4");
+    const { calls, actions } = makeActions();
+
+    const handled = await dispatchWebShortcutAction(event, actions);
+
+    assert.equal(handled, true);
+    assert.deepEqual(calls, ["toggleFilter"]);
     assert.equal(event.defaultPrevented, true);
 });
 

--- a/web/shortcut_help.js
+++ b/web/shortcut_help.js
@@ -1,6 +1,7 @@
 export const WEB_SHORTCUT_REFERENCE = [
     { key: "Space", action: "Pause/Resume" },
     { key: "F1", action: "Reset" },
+    { key: "F4", action: "Cycle Filter" },
     { key: "F5", action: "Debugger Toggle" },
     { key: "F6", action: "Save State" },
     { key: "F7", action: "Load State" },

--- a/web/shortcut_help.test.mjs
+++ b/web/shortcut_help.test.mjs
@@ -39,6 +39,7 @@ test("buildShortcutReferenceText includes H help toggle shortcut", () => {
     const text = buildShortcutReferenceText();
     assert.match(text, /H = Toggle Help/);
     assert.match(text, /F12 = Fullscreen/);
+    assert.match(text, /F4 = Cycle Filter/);
 });
 
 test("buildShortcutOverlayText renders multiline list for overlay", () => {
@@ -47,6 +48,7 @@ test("buildShortcutOverlayText renders multiline list for overlay", () => {
     assert.match(text, /^Shortcuts/m);
     assert.match(text, /H: Toggle Help/);
     assert.match(text, /F12: Fullscreen/);
+    assert.match(text, /F4: Cycle Filter/);
     assert.match(text, /\n/);
 });
 


### PR DESCRIPTION
## Summary
- Add `F4` mapping in web shortcut dispatcher to cycle filter (matching SDL behavior)
- Reuse existing filter cycling path in web app shortcut actions
- Add/adjust web tests for shortcut routing and shortcut help text

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt -- --check
- cargo nextest run --all-features
- wasm-pack test --headless --chrome --features wasm
- /Users/henrikku/repos/neser/.venv/bin/python -m unittest discover -s scripts/scraper -p "test_*.py"
- cd web && npm test
