### PR TITLE
test(web): add lifecycle browser integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ __pycache__/
 *.pyc
 .venv/
 .html_cache/
+
+# Playwright
+playwright-report/
+test-results/

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -10,7 +10,10 @@ export default defineConfig({
     use: {
         baseURL: WEB_APP_URL,
         headless: true,
-        trace: "retain-on-failure"
+        trace: "retain-on-failure",
+        launchOptions: {
+            args: ["--use-angle=swiftshader", "--use-gl=angle"]
+        }
     },
     webServer: {
         command: WEB_APP_SERVER_COMMAND,

--- a/web/integration/helpers/lifecycle.helpers.mjs
+++ b/web/integration/helpers/lifecycle.helpers.mjs
@@ -1,0 +1,83 @@
+import { expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const EXPECT_TIMEOUT_MS = 20_000;
+const STATUS_SELECTOR = "#status";
+const ROM_SELECT_ID = "rom-select";
+const ROM_SELECT_SELECTOR = `#${ROM_SELECT_ID}`;
+const BUNDLED_ROM_NAME = "cpu.nes";
+const IDLE_STATUS_PATTERN = /Load a ROM to begin|Stopped\. You can restart or load a new ROM/;
+
+function readMockRomBytes() {
+    return readFileSync(path.join(process.cwd(), "roms", BUNDLED_ROM_NAME));
+}
+
+async function injectBundledRomOption(page) {
+    const romDataUrl = `data:application/octet-stream;base64,${readMockRomBytes().toString("base64")}`;
+    await page.evaluate(({ value, romSelectId, bundledRomName }) => {
+        const romSelect = document.getElementById(romSelectId);
+        if (!(romSelect instanceof HTMLSelectElement)) {
+            throw new Error("Expected #rom-select to be an HTMLSelectElement");
+        }
+
+        const option = document.createElement("option");
+        option.value = value;
+        option.textContent = bundledRomName;
+        romSelect.appendChild(option);
+    }, {
+        value: romDataUrl,
+        romSelectId: ROM_SELECT_ID,
+        bundledRomName: BUNDLED_ROM_NAME
+    });
+}
+
+export async function openApp(page) {
+    await page.goto("/");
+    await expect(page.locator(STATUS_SELECTOR)).toBeVisible();
+    await expect(page.locator("#shortcut-reference")).toContainText("Shortcuts:", {
+        timeout: EXPECT_TIMEOUT_MS
+    });
+}
+
+export async function waitForRunningState(page) {
+    await expect(page.locator(STATUS_SELECTOR)).toContainText("Running...", {
+        timeout: EXPECT_TIMEOUT_MS
+    });
+}
+
+export async function waitForIdleState(page) {
+    await expect(page.locator(STATUS_SELECTOR)).toHaveText(IDLE_STATUS_PATTERN, {
+        timeout: EXPECT_TIMEOUT_MS
+    });
+}
+
+export async function startFromBundledRom(page) {
+    await openApp(page);
+    await injectBundledRomOption(page);
+
+    const bundledRomOption = page.locator(`${ROM_SELECT_SELECTOR} option`, {
+        hasText: BUNDLED_ROM_NAME
+    });
+    await expect(bundledRomOption).toHaveCount(1, {
+        timeout: EXPECT_TIMEOUT_MS
+    });
+
+    const romValue = await bundledRomOption.getAttribute("value");
+    if (!romValue) {
+        throw new Error("Expected bundled ROM option to have a value");
+    }
+
+    await page.evaluate(({ value, romSelectId }) => {
+        const romSelect = document.getElementById(romSelectId);
+        if (!(romSelect instanceof HTMLSelectElement)) {
+            throw new Error("Expected #rom-select to be an HTMLSelectElement");
+        }
+        romSelect.value = value;
+        romSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    }, {
+        value: romValue,
+        romSelectId: ROM_SELECT_ID
+    });
+    await waitForRunningState(page);
+}

--- a/web/integration/specs/emulation-lifecycle.integration.spec.mjs
+++ b/web/integration/specs/emulation-lifecycle.integration.spec.mjs
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+import {
+    openApp,
+    startFromBundledRom,
+    waitForIdleState,
+    waitForRunningState
+} from "../helpers/lifecycle.helpers.mjs";
+
+const ESSENTIAL_CONTROL_SELECTORS = ["#screen", "#start", "#pause", "#stop", "#reset", "#status"];
+const START_BUTTON_SELECTOR = "#start";
+const STATUS_SELECTOR = "#status";
+const PAUSE_BUTTON_SELECTOR = "#pause";
+const STOP_BUTTON_SELECTOR = "#stop";
+const RESET_BUTTON_SELECTOR = "#reset";
+const SAVE_STATE_BUTTON_SELECTOR = "#save-state";
+const LOAD_STATE_BUTTON_SELECTOR = "#load-state";
+
+test.describe("Phase 1 critical path lifecycle", () => {
+    test("Given app is opened, when shell loads, then essential controls and idle status are visible", async ({ page }) => {
+        await openApp(page);
+
+        for (const selector of ESSENTIAL_CONTROL_SELECTORS) {
+            await expect(page.locator(selector)).toBeVisible();
+        }
+
+        await waitForIdleState(page);
+    });
+
+    test("Given bundled ROM exists, when it is selected from bundled list, then emulator enters running state", async ({ page }) => {
+        await startFromBundledRom(page);
+
+        await waitForRunningState(page);
+        await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
+    });
+
+    test("Given emulator is running, when Pause/Resume is toggled, then paused and running states alternate", async ({ page }) => {
+        await startFromBundledRom(page);
+
+        await page.locator(PAUSE_BUTTON_SELECTOR).click();
+        await expect(page.locator(STATUS_SELECTOR)).toHaveText(/Paused/);
+
+        await page.locator(PAUSE_BUTTON_SELECTOR).click();
+        await waitForRunningState(page);
+    });
+
+    test("Given emulator is running, when Stop is clicked, then app returns to idle-safe state", async ({ page }) => {
+        await startFromBundledRom(page);
+
+        await page.locator(STOP_BUTTON_SELECTOR).click();
+
+        await waitForIdleState(page);
+        await expect(page.locator(START_BUTTON_SELECTOR)).toBeEnabled();
+    });
+
+    test("Given emulator is running, when Reset is clicked, then session resets while emulation remains active", async ({ page }) => {
+        await startFromBundledRom(page);
+
+        await page.locator(RESET_BUTTON_SELECTOR).click();
+
+        await expect(page.locator(STATUS_SELECTOR)).toContainText("Reset");
+        await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
+    });
+
+    test("Given no ROM has been started, when page loads, then save/load state controls are disabled", async ({ page }) => {
+        await openApp(page);
+
+        await expect(page.locator(SAVE_STATE_BUTTON_SELECTOR)).toBeDisabled();
+        await expect(page.locator(LOAD_STATE_BUTTON_SELECTOR)).toBeDisabled();
+    });
+});


### PR DESCRIPTION
Adds Phase 1 web lifecycle integration coverage and deterministic Playwright helpers. Enables headless WebGL for Playwright runs. Closes #705.