### PR TITLE
Sub-issue (709): Implement Mapper 244 (Decathlon)

### DIFF
--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -30,6 +30,7 @@ use super::mapper64::Mapper64;
 use super::mapper65::Mapper65;
 use super::mapper241::Mapper241;
 use super::mapper242::Mapper242;
+use super::mapper244::Mapper244;
 use super::mmc1::MMC1Mapper;
 use super::mmc2::MMC2Mapper;
 use super::mmc3::MMC3Mapper;
@@ -746,6 +747,7 @@ mapper_registry! {
     206 => Namco118Mapper::new,
     241 => Mapper241::new,
     242 => Mapper242::new,
+    244 => Mapper244::new,
 }
 
 #[cfg(test)]
@@ -753,7 +755,7 @@ const SUPPORTED_MAPPERS: &[u8] = &[
     4, // MMC3 is constructed with CRC-specific behavior.
     0, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 13, 15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 32, 33, 34, 40,
     42, 44, 45, 46, 47, 49, 50, 51, 52, 53, 56, 57, 58, 60, 61, 62, 64, 65, 66, 68, 69, 71, 78,
-    206, 241, 242,
+    206, 241, 242, 244,
 ];
 
 /// List of supported iNES mapper IDs handled by the factory.

--- a/src/cartridge/mapper244.rs
+++ b/src/cartridge/mapper244.rs
@@ -1,0 +1,271 @@
+//! Mapper 244 - Decathlon (C-N22M)
+//!
+//! Specifications:
+//! - Main: <https://www.nesdev.org/wiki/INES_Mapper_244>
+//!
+//! Known Limitations:
+//! - No known gameplay-blocking functional limitations are currently documented.
+
+use crate::cartridge::NametableLayout;
+use crate::cartridge::common::{BankSwitch, BankedRom, DEFAULT_PRG_RAM_SIZE, PrgRam};
+use crate::cartridge::mapper::{Mapper, MapperCapabilities};
+
+/// Mapper 244 - Decathlon (C-N22M)
+///
+/// Hardware: Simple PRG+CHR bank switching with lookup tables.
+///
+/// Specifications:
+/// - Main: <https://www.nesdev.org/wiki/INES_Mapper_244>
+/// - PRG-ROM: Up to 128KB (4 x 32KB banks)
+/// - CHR-ROM: Up to 64KB (8 x 8KB banks)
+/// - Mirroring: Fixed from header
+///
+/// Write to $8000-$FFFF:
+/// - If bit 3 == 0: bits 0-1 select PRG bank (through lookup table)
+/// - If bit 3 == 1: bits 0-2 select CHR bank (through lookup table)
+///
+/// The lookup tables implement a simple copy-protection scramble:
+/// - PRG: Identity mapping [0, 1, 2, 3]
+/// - CHR: Swapped pairs [0, 2, 1, 3, 4, 6, 5, 7]
+pub struct Mapper244 {
+    prg_rom: BankedRom,
+    prg_ram: PrgRam,
+    chr_rom: BankedRom,
+    mirroring: NametableLayout,
+    prg_bank: BankSwitch,
+    chr_bank: BankSwitch,
+}
+
+impl Mapper244 {
+    const MAPPER_NUMBER: u8 = 244;
+    const PRG_BANK_SIZE: usize = 32 * 1024;
+    const CHR_BANK_SIZE: usize = 8 * 1024;
+
+    /// PRG bank lookup table (identity)
+    const PRG_LUT: [u8; 4] = [0, 1, 2, 3];
+    /// CHR bank lookup table (pairs 1/2 and 5/6 swapped)
+    const CHR_LUT: [u8; 8] = [0, 2, 1, 3, 4, 6, 5, 7];
+
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: NametableLayout) -> Self {
+        let prg_bank = BankSwitch::from_rom(&prg_rom, Self::PRG_BANK_SIZE);
+        let chr_bank = BankSwitch::from_rom(&chr_rom, Self::CHR_BANK_SIZE);
+        Self {
+            prg_rom: BankedRom::new(prg_rom, Self::PRG_BANK_SIZE),
+            prg_ram: PrgRam::new(DEFAULT_PRG_RAM_SIZE),
+            chr_rom: BankedRom::new(chr_rom, Self::CHR_BANK_SIZE),
+            mirroring,
+            prg_bank,
+            chr_bank,
+        }
+    }
+}
+
+impl Mapper for Mapper244 {
+    fn read_prg(&self, addr: u16) -> u8 {
+        if let Some(value) = self.prg_ram.try_read(addr) {
+            return value;
+        }
+        match addr {
+            0x8000..=0xFFFF => self
+                .prg_rom
+                .read_with_base(self.prg_bank.current(), 0x8000, addr),
+            _ => 0,
+        }
+    }
+
+    fn write_prg(&mut self, addr: u16, value: u8) {
+        if self.prg_ram.try_write(addr, value) {
+            return;
+        }
+        if (0x8000..=0xFFFF).contains(&addr) {
+            if value & 0x08 == 0 {
+                // PRG bank select
+                let index = (value & 0x03) as usize;
+                self.prg_bank.set(Self::PRG_LUT[index]);
+            } else {
+                // CHR bank select
+                let index = (value & 0x07) as usize;
+                self.chr_bank.set(Self::CHR_LUT[index]);
+            }
+        }
+    }
+
+    fn read_chr(&self, addr: u16) -> u8 {
+        let offset = (addr & 0x1FFF) as usize;
+        self.chr_rom.read(self.chr_bank.current(), offset)
+    }
+
+    fn write_chr(&mut self, _addr: u16, _value: u8) {
+        // CHR-ROM is read-only
+    }
+
+    fn get_mirroring(&self) -> NametableLayout {
+        self.mirroring
+    }
+
+    fn mapper_number(&self) -> u8 {
+        Self::MAPPER_NUMBER
+    }
+
+    fn wram_size(&self) -> usize {
+        self.prg_ram.size()
+    }
+
+    fn wram_snapshot(&self) -> Vec<u8> {
+        self.prg_ram.snapshot()
+    }
+
+    fn load_wram_snapshot(&mut self, data: &[u8]) {
+        self.prg_ram.load_snapshot(data);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![self.prg_bank.raw(), self.chr_bank.raw()]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if let Some(&value) = data.first() {
+            self.prg_bank.set(value);
+        }
+        if let Some(&value) = data.get(1) {
+            self.chr_bank.set(value);
+        }
+    }
+
+    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
+        self.prg_ram.initialize(mode);
+    }
+
+    fn capabilities(&self) -> MapperCapabilities {
+        MapperCapabilities {
+            has_chr_banking: true,
+            max_prg_ram_kb: 8,
+            prg_bank_size_kb: 32,
+            chr_bank_size_kb: 8,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cartridge::mapper::{MapperContext, create_mapper};
+    use crate::cartridge::test_helpers::banked_data;
+
+    fn create_mapper244(
+        prg_rom: Vec<u8>,
+        chr_rom: Vec<u8>,
+        mirroring: NametableLayout,
+    ) -> std::io::Result<Box<dyn Mapper>> {
+        create_mapper(MapperContext::new(244, prg_rom, chr_rom, mirroring))
+    }
+
+    #[test]
+    fn test_factory_creates_mapper_244() {
+        let prg_rom = banked_data(32 * 1024, 4);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mapper = create_mapper244(prg_rom, chr_rom, NametableLayout::Vertical);
+        assert!(mapper.is_ok(), "Mapper 244 should be creatable via factory");
+    }
+
+    #[test]
+    fn test_prg_bank_select_via_lut() {
+        let prg_rom = banked_data(32 * 1024, 4);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mut mapper = create_mapper244(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        // PRG LUT is identity: [0, 1, 2, 3]
+        // value bit 3 == 0, so bits 0-1 select PRG bank via LUT
+        mapper.write_prg(0x8000, 0); // index 0 -> bank 0
+        assert_eq!(mapper.read_prg(0x8000), 0);
+
+        mapper.write_prg(0x8000, 1); // index 1 -> bank 1
+        assert_eq!(mapper.read_prg(0x8000), 1);
+
+        mapper.write_prg(0x8000, 2); // index 2 -> bank 2
+        assert_eq!(mapper.read_prg(0x8000), 2);
+
+        mapper.write_prg(0x8000, 3); // index 3 -> bank 3
+        assert_eq!(mapper.read_prg(0x8000), 3);
+    }
+
+    #[test]
+    fn test_chr_bank_select_via_scrambled_lut() {
+        let prg_rom = banked_data(32 * 1024, 4);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mut mapper = create_mapper244(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        // CHR LUT: [0, 2, 1, 3, 4, 6, 5, 7]
+        // value bit 3 == 1, so bits 0-2 select CHR bank via LUT
+        mapper.write_prg(0x8000, 0x08); // index 0 -> bank 0
+        assert_eq!(mapper.read_chr(0x0000), 0);
+
+        mapper.write_prg(0x8000, 0x09); // index 1 -> bank 2 (scrambled!)
+        assert_eq!(mapper.read_chr(0x0000), 2);
+
+        mapper.write_prg(0x8000, 0x0A); // index 2 -> bank 1 (scrambled!)
+        assert_eq!(mapper.read_chr(0x0000), 1);
+
+        mapper.write_prg(0x8000, 0x0B); // index 3 -> bank 3
+        assert_eq!(mapper.read_chr(0x0000), 3);
+
+        mapper.write_prg(0x8000, 0x0C); // index 4 -> bank 4
+        assert_eq!(mapper.read_chr(0x0000), 4);
+
+        mapper.write_prg(0x8000, 0x0D); // index 5 -> bank 6 (scrambled!)
+        assert_eq!(mapper.read_chr(0x0000), 6);
+
+        mapper.write_prg(0x8000, 0x0E); // index 6 -> bank 5 (scrambled!)
+        assert_eq!(mapper.read_chr(0x0000), 5);
+
+        mapper.write_prg(0x8000, 0x0F); // index 7 -> bank 7
+        assert_eq!(mapper.read_chr(0x0000), 7);
+    }
+
+    #[test]
+    fn test_mirroring_is_fixed() {
+        let prg_rom = banked_data(32 * 1024, 4);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mut mapper = create_mapper244(prg_rom, chr_rom, NametableLayout::Horizontal).unwrap();
+
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Horizontal);
+        mapper.write_prg(0x8000, 0xFF);
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Horizontal);
+    }
+
+    #[test]
+    fn test_prg_and_chr_banks_are_independent() {
+        let prg_rom = banked_data(32 * 1024, 4);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mut mapper = create_mapper244(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        // Set PRG bank 2
+        mapper.write_prg(0x8000, 2);
+        assert_eq!(mapper.read_prg(0x8000), 2);
+        assert_eq!(mapper.read_chr(0x0000), 0); // CHR unchanged
+
+        // Set CHR bank (index 1 -> bank 2)
+        mapper.write_prg(0x8000, 0x09);
+        assert_eq!(mapper.read_prg(0x8000), 2); // PRG unchanged
+        assert_eq!(mapper.read_chr(0x0000), 2);
+    }
+
+    #[test]
+    fn test_registers_snapshot_and_restore() {
+        let prg_rom = banked_data(32 * 1024, 4);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mut mapper =
+            create_mapper244(prg_rom.clone(), chr_rom.clone(), NametableLayout::Vertical).unwrap();
+
+        mapper.write_prg(0x8000, 2); // PRG bank 2
+        mapper.write_prg(0x8000, 0x0D); // CHR bank 6 (LUT index 5)
+
+        let regs = mapper.registers_snapshot();
+
+        let mut restored = create_mapper244(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+        restored.restore_registers(&regs);
+        assert_eq!(restored.read_prg(0x8000), 2);
+        assert_eq!(restored.read_chr(0x0000), 6);
+    }
+}

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -14,6 +14,7 @@ mod irem_g101;
 mod mapper;
 mod mapper241;
 mod mapper242;
+mod mapper244;
 mod mapper42;
 mod mapper44;
 mod mapper45;


### PR DESCRIPTION
Implement iNES Mapper 244 with PRG/CHR bank selection via lookup tables (copy-protection scramble). 6 unit tests. All tests pass. Fixes #713