### PR TITLE
Implement Mapper 243 (Sachen 74LS374N)

### DIFF
--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -30,6 +30,7 @@ use super::mapper64::Mapper64;
 use super::mapper65::Mapper65;
 use super::mapper241::Mapper241;
 use super::mapper242::Mapper242;
+use super::mapper243::Mapper243;
 use super::mapper244::Mapper244;
 use super::mapper246::Mapper246;
 use super::mmc1::MMC1Mapper;
@@ -748,6 +749,7 @@ mapper_registry! {
     206 => Namco118Mapper::new,
     241 => Mapper241::new,
     242 => Mapper242::new,
+    243 => Mapper243::new,
     244 => Mapper244::new,
     246 => Mapper246::new,
 }
@@ -757,7 +759,7 @@ const SUPPORTED_MAPPERS: &[u8] = &[
     4, // MMC3 is constructed with CRC-specific behavior.
     0, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 13, 15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 32, 33, 34, 40,
     42, 44, 45, 46, 47, 49, 50, 51, 52, 53, 56, 57, 58, 60, 61, 62, 64, 65, 66, 68, 69, 71, 78,
-    206, 241, 242, 244, 246,
+    206, 241, 242, 243, 244, 246,
 ];
 
 /// List of supported iNES mapper IDs handled by the factory.

--- a/src/cartridge/mapper243.rs
+++ b/src/cartridge/mapper243.rs
@@ -1,0 +1,348 @@
+//! Mapper 243 - Sachen 74LS374N (SA-020A)
+//!
+//! Specifications:
+//! - Main: <https://www.nesdev.org/wiki/INES_Mapper_243>
+//!
+//! Known Limitations:
+//! - No known gameplay-blocking functional limitations are currently documented.
+
+use crate::cartridge::NametableLayout;
+use crate::cartridge::common::{BankedRom, ChrMemory};
+use crate::cartridge::mapper::{Mapper, MapperCapabilities};
+
+/// Mapper 243 - Sachen 74LS374N (SA-020A)
+///
+/// Hardware: Sachen latch-based register select/data write interface.
+///
+/// Specifications:
+/// - Main: <https://www.nesdev.org/wiki/INES_Mapper_243>
+/// - PRG-ROM: Up to 64KB (32KB banks, selected by bit 0)
+/// - CHR-ROM: Up to 64KB (8KB banks, selected by 3 bits from registers)
+/// - Mirroring: Software-controlled (Horizontal/Vertical)
+///
+/// Address decoding:
+/// - Write to $4100 (A0=0): Set command register (bits 0-2)
+/// - Write to $4101 (A0=1): Write data to selected register
+///
+/// Register effects (when data written to $4101):
+/// - Reg 2: bit 1 → mirroring flag, bit 3 → CHR bit 0
+/// - Reg 4: bit 1 → CHR bit 1
+/// - Reg 5: bit 0 → PRG bank (32KB)
+/// - Reg 6: bit 1 → CHR bit 2
+/// - Reg 7: Triggers mirroring update from stored flag
+///
+/// CHR bank = chr_bit0 | (chr_bit1 << 1) | (chr_bit2 << 2)
+/// Mirroring: flag 0 = Vertical, flag 1 = Horizontal
+pub struct Mapper243 {
+    prg_rom: BankedRom,
+    chr_memory: ChrMemory,
+    command: u8,
+    prg_bank: u8,
+    chr_bits: [u8; 3], // chr_bit0, chr_bit1, chr_bit2
+    mirror_flag: u8,
+    mirroring: NametableLayout,
+}
+
+impl Mapper243 {
+    const MAPPER_NUMBER: u8 = 243;
+    const PRG_BANK_SIZE: usize = 32 * 1024;
+
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: NametableLayout) -> Self {
+        Self {
+            prg_rom: BankedRom::new(prg_rom, Self::PRG_BANK_SIZE),
+            chr_memory: ChrMemory::new(chr_rom),
+            command: 0,
+            prg_bank: 0,
+            chr_bits: [0; 3],
+            mirror_flag: 0,
+            mirroring,
+        }
+    }
+
+    fn chr_bank(&self) -> usize {
+        let bank = self.chr_bits[0] as usize
+            | ((self.chr_bits[1] as usize) << 1)
+            | ((self.chr_bits[2] as usize) << 2);
+        let num_banks = self.chr_memory.size() / (8 * 1024);
+        if num_banks == 0 { 0 } else { bank % num_banks }
+    }
+
+    fn update_mirroring(&mut self) {
+        self.mirroring = if self.mirror_flag == 0 {
+            NametableLayout::Vertical
+        } else {
+            NametableLayout::Horizontal
+        };
+    }
+}
+
+impl Mapper for Mapper243 {
+    fn read_prg(&self, addr: u16) -> u8 {
+        match addr {
+            0x8000..=0xFFFF => {
+                let bank = (self.prg_bank as usize) % self.prg_rom.num_banks().max(1);
+                let offset = (addr - 0x8000) as usize;
+                self.prg_rom.read(bank, offset)
+            }
+            _ => 0,
+        }
+    }
+
+    fn write_prg(&mut self, addr: u16, value: u8) {
+        // Address decoding: bit 0 selects command vs data
+        if addr & 0x4101 == 0x4100 {
+            // $4100: Set command register
+            self.command = value & 0x07;
+        } else if addr & 0x4101 == 0x4101 {
+            // $4101: Write data to selected register
+            match self.command {
+                2 => {
+                    self.mirror_flag = (value >> 1) & 1;
+                    self.chr_bits[0] = (value >> 3) & 1;
+                    self.update_mirroring();
+                }
+                4 => {
+                    self.chr_bits[1] = (value >> 1) & 1;
+                }
+                5 => {
+                    self.prg_bank = value & 1;
+                }
+                6 => {
+                    self.chr_bits[2] = (value >> 1) & 1;
+                }
+                7 => {
+                    self.update_mirroring();
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn read_chr(&self, addr: u16) -> u8 {
+        let bank = self.chr_bank();
+        let offset = addr as usize & 0x1FFF;
+        let index = bank * 8 * 1024 + offset;
+        self.chr_memory.read_at_index(index)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.chr_memory.write(addr, value);
+    }
+
+    fn get_mirroring(&self) -> NametableLayout {
+        self.mirroring
+    }
+
+    fn mapper_number(&self) -> u8 {
+        Self::MAPPER_NUMBER
+    }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![
+            self.command,
+            self.prg_bank,
+            self.chr_bits[0],
+            self.chr_bits[1],
+            self.chr_bits[2],
+            self.mirror_flag,
+        ]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if data.len() >= 6 {
+            self.command = data[0];
+            self.prg_bank = data[1];
+            self.chr_bits[0] = data[2];
+            self.chr_bits[1] = data[3];
+            self.chr_bits[2] = data[4];
+            self.mirror_flag = data[5];
+            self.update_mirroring();
+        }
+    }
+
+    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
+        self.chr_memory.initialize(mode);
+    }
+
+    fn capabilities(&self) -> MapperCapabilities {
+        MapperCapabilities {
+            has_chr_banking: true,
+            prg_bank_size_kb: 32,
+            chr_bank_size_kb: 8,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cartridge::mapper::{MapperContext, create_mapper};
+    use crate::cartridge::test_helpers::banked_data;
+
+    fn create_mapper243(
+        prg_rom: Vec<u8>,
+        chr_rom: Vec<u8>,
+        mirroring: NametableLayout,
+    ) -> std::io::Result<Box<dyn Mapper>> {
+        create_mapper(MapperContext::new(243, prg_rom, chr_rom, mirroring))
+    }
+
+    #[test]
+    fn test_factory_creates_mapper_243() {
+        let prg_rom = banked_data(32 * 1024, 2);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mapper = create_mapper243(prg_rom, chr_rom, NametableLayout::Vertical);
+        assert!(mapper.is_ok());
+    }
+
+    #[test]
+    fn test_prg_bank_switching() {
+        let prg_rom = banked_data(32 * 1024, 2);
+        let chr_rom = banked_data(8 * 1024, 4);
+        let mut mapper = create_mapper243(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        // Default bank 0
+        assert_eq!(mapper.read_prg(0x8000), 0);
+
+        // Select register 5 (PRG bank)
+        mapper.write_prg(0x4100, 5);
+        // Write value with bit 0 = 1 → PRG bank 1
+        mapper.write_prg(0x4101, 1);
+        assert_eq!(mapper.read_prg(0x8000), 1);
+
+        // Write value with bit 0 = 0 → PRG bank 0
+        mapper.write_prg(0x4101, 0);
+        assert_eq!(mapper.read_prg(0x8000), 0);
+    }
+
+    #[test]
+    fn test_chr_bank_switching_via_register_2() {
+        let prg_rom = banked_data(32 * 1024, 1);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mut mapper = create_mapper243(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        // Default CHR bank should be 0
+        assert_eq!(mapper.read_chr(0x0000), 0);
+
+        // Register 2, bit 3 → CHR bit 0
+        mapper.write_prg(0x4100, 2);
+        mapper.write_prg(0x4101, 0x08); // bit 3 set → chr_bit0 = 1
+
+        // CHR bank = 1
+        assert_eq!(mapper.read_chr(0x0000), 1);
+    }
+
+    #[test]
+    fn test_chr_bank_all_bits() {
+        let prg_rom = banked_data(32 * 1024, 1);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mut mapper = create_mapper243(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        // Set CHR bit 0 via register 2
+        mapper.write_prg(0x4100, 2);
+        mapper.write_prg(0x4101, 0x08); // bit 3 → chr_bit0 = 1
+
+        // Set CHR bit 1 via register 4
+        mapper.write_prg(0x4100, 4);
+        mapper.write_prg(0x4101, 0x02); // bit 1 → chr_bit1 = 1
+
+        // Set CHR bit 2 via register 6
+        mapper.write_prg(0x4100, 6);
+        mapper.write_prg(0x4101, 0x02); // bit 1 → chr_bit2 = 1
+
+        // CHR bank = 1 | (1<<1) | (1<<2) = 7
+        assert_eq!(mapper.read_chr(0x0000), 7);
+    }
+
+    #[test]
+    fn test_mirroring_via_register_2() {
+        let prg_rom = banked_data(32 * 1024, 1);
+        let chr_rom = banked_data(8 * 1024, 4);
+        let mut mapper = create_mapper243(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Vertical);
+
+        // Register 2, bit 1 → mirror_flag
+        mapper.write_prg(0x4100, 2);
+        mapper.write_prg(0x4101, 0x02); // bit 1 set → mirror_flag = 1 → Horizontal
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Horizontal);
+
+        // Clear mirror flag
+        mapper.write_prg(0x4101, 0x00); // bit 1 clear → mirror_flag = 0 → Vertical
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Vertical);
+    }
+
+    #[test]
+    fn test_mirroring_via_register_7() {
+        let prg_rom = banked_data(32 * 1024, 1);
+        let chr_rom = banked_data(8 * 1024, 4);
+        let mut mapper = create_mapper243(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        // Set mirror flag via register 2
+        mapper.write_prg(0x4100, 2);
+        mapper.write_prg(0x4101, 0x02); // mirror_flag = 1 → Horizontal
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Horizontal);
+
+        // Reset mirror flag but don't trigger register 7 yet
+        mapper.write_prg(0x4101, 0x00); // mirror_flag = 0 → Vertical
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Vertical);
+
+        // Set mirror flag again
+        mapper.write_prg(0x4101, 0x02);
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Horizontal);
+
+        // Register 7 also applies mirroring from stored flag
+        mapper.write_prg(0x4100, 7);
+        mapper.write_prg(0x4101, 0x00); // value doesn't matter, uses stored flag
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Horizontal);
+    }
+
+    #[test]
+    fn test_command_register_only_uses_low_3_bits() {
+        let prg_rom = banked_data(32 * 1024, 2);
+        let chr_rom = banked_data(8 * 1024, 4);
+        let mut mapper = create_mapper243(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+
+        // Write 0xFF to command register - only bits 0-2 should be used (= 7)
+        mapper.write_prg(0x4100, 0xFF);
+        // This is register 7 (mirroring), write should not crash
+        mapper.write_prg(0x4101, 0x00);
+    }
+
+    #[test]
+    fn test_registers_snapshot_and_restore() {
+        let prg_rom = banked_data(32 * 1024, 2);
+        let chr_rom = banked_data(8 * 1024, 8);
+        let mut mapper =
+            create_mapper243(prg_rom.clone(), chr_rom.clone(), NametableLayout::Vertical).unwrap();
+
+        // Set up registers
+        mapper.write_prg(0x4100, 5);
+        mapper.write_prg(0x4101, 1); // PRG bank 1
+        mapper.write_prg(0x4100, 2);
+        mapper.write_prg(0x4101, 0x0A); // mirror_flag=1, chr_bit0=1
+        mapper.write_prg(0x4100, 4);
+        mapper.write_prg(0x4101, 0x02); // chr_bit1=1
+        mapper.write_prg(0x4100, 6);
+        mapper.write_prg(0x4101, 0x02); // chr_bit2=1
+
+        let regs = mapper.registers_snapshot();
+
+        let mut restored = create_mapper243(prg_rom, chr_rom, NametableLayout::Vertical).unwrap();
+        restored.restore_registers(&regs);
+
+        // Should have CHR bank 7 (all bits set)
+        assert_eq!(restored.read_chr(0x0000), 7);
+        assert_eq!(restored.read_prg(0x8000), 1);
+        assert_eq!(restored.get_mirroring(), NametableLayout::Horizontal);
+    }
+}

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -14,6 +14,7 @@ mod irem_g101;
 mod mapper;
 mod mapper241;
 mod mapper242;
+mod mapper243;
 mod mapper244;
 mod mapper246;
 mod mapper42;


### PR DESCRIPTION
Implements Mapper 243 (Sachen 74LS374N / SA-020A) with:
- Register select at $4100, data write at $4101
- 32KB PRG switching via register 5 (bit 0)
- 8KB CHR switching via 3 bits from registers 2, 4, 6
- Software-controlled H/V mirroring via registers 2, 7
- Save/restore state support
- 8 unit tests

Closes #712