### PR TITLE
fix(mapper): CNROM emulates AND-type bus conflicts (#349)

### DIFF
--- a/src/cartridge/cnrom.rs
+++ b/src/cartridge/cnrom.rs
@@ -76,7 +76,7 @@ mod tests {
 
         let mut mapper = CNROMMapper::new(MapperContext::new_for_test(
             3,
-            vec![0; 32 * 1024],
+            vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
             chr_rom,
             NametableLayout::Horizontal,
         ));
@@ -120,7 +120,7 @@ mod tests {
 
         let mut mapper = CNROMMapper::new(MapperContext::new_for_test(
             3,
-            vec![0; 32 * 1024],
+            vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
             chr_rom,
             NametableLayout::Vertical,
         ));
@@ -151,7 +151,7 @@ mod tests {
 
         let mut mapper = CNROMMapper::new(MapperContext::new_for_test(
             3,
-            vec![0; 32 * 1024],
+            vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
             chr_rom.clone(),
             NametableLayout::Horizontal,
         ));
@@ -161,7 +161,7 @@ mod tests {
 
         let mut restored = CNROMMapper::new(MapperContext::new_for_test(
             3,
-            vec![0; 32 * 1024],
+            vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
             chr_rom,
             NametableLayout::Horizontal,
         ));
@@ -223,7 +223,7 @@ mod tests {
 
         let mut mapper = CNROMMapper::new(MapperContext::new_for_test(
             3,
-            vec![0; 32 * 1024],
+            vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
             chr_rom,
             NametableLayout::Horizontal,
         ));
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn test_cnrom_registers_snapshot_bank_wrapping() {
         // Test edge case: bank selection wrapping when bank number exceeds available banks
-        let prg_rom = vec![0; 32 * 1024];
+        let prg_rom = vec![0xFF; 32 * 1024]; // 0xFF ensures bus conflicts don't mask the bank select
         let mut chr_rom = vec![0; 16 * 1024]; // Only 2 banks (16KB)
 
         // Fill CHR ROM with bank-specific data
@@ -414,5 +414,67 @@ mod tests {
             "Explicitly declared PRG-RAM must be readable"
         );
         assert_eq!(mapper.wram_size(), 8 * 1024);
+    }
+
+    #[test]
+    fn test_cnrom_submapper_0_applies_and_type_bus_conflicts() {
+        // Submapper 0 = original CNROM hardware, which has AND-type bus conflicts.
+        // Effective bank = written_value & ROM_value_at_written_address.
+        let mut chr_rom = vec![0; 32 * 1024]; // 4 banks of 8KB
+        for bank in 0..4usize {
+            let start = bank * 8 * 1024;
+            for byte in &mut chr_rom[start..start + 8 * 1024] {
+                *byte = (bank * 10) as u8;
+            }
+        }
+
+        // PRG-ROM: offset 0 (= CPU $8000) contains 0x02
+        let mut prg_rom = vec![0xFF; 32 * 1024];
+        prg_rom[0] = 0x02;
+
+        let mut mapper = CNROMMapper::new(
+            MapperContext::new_for_test(3, prg_rom, chr_rom, NametableLayout::Horizontal)
+                .with_submapper(0)
+                .with_prg_ram_banks(0),
+        );
+
+        // Write 0x01 to $8000. ROM[0] = 0x02. Bus conflict: 0x01 & 0x02 = 0x00 → bank 0
+        mapper.write_prg(0x8000, 0x01);
+        assert_eq!(
+            mapper.read_chr(0x0000),
+            0,
+            "submapper 0: AND-type bus conflict must reduce effective bank to write & ROM"
+        );
+    }
+
+    #[test]
+    fn test_cnrom_submapper_1_disables_bus_conflicts() {
+        // Submapper 1 = no bus conflicts; written value selects bank directly.
+        let mut chr_rom = vec![0; 32 * 1024];
+        for bank in 0..4usize {
+            let start = bank * 8 * 1024;
+            for byte in &mut chr_rom[start..start + 8 * 1024] {
+                *byte = (bank * 10) as u8;
+            }
+        }
+
+        // PRG-ROM offset 0 = 0x02 (would cause conflict if conflicts were active)
+        let mut prg_rom = vec![0xFF; 32 * 1024];
+        prg_rom[0] = 0x02;
+
+        let mut mapper = CNROMMapper::new(
+            MapperContext::new_for_test(3, prg_rom, chr_rom, NametableLayout::Horizontal)
+                .with_submapper(1)
+                .with_prg_ram_banks(0),
+        );
+
+        // Write 0x01 to $8000. ROM[0] = 0x02.
+        // No conflict: written value 0x01 directly → bank 1 (value 10)
+        mapper.write_prg(0x8000, 0x01);
+        assert_eq!(
+            mapper.read_chr(0x0000),
+            10,
+            "submapper 1: no bus conflict, write value selects bank directly"
+        );
     }
 }

--- a/src/cartridge/mapper_templates.rs
+++ b/src/cartridge/mapper_templates.rs
@@ -115,6 +115,7 @@ pub struct SimpleFixedPrgMapper<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> 
     chr_rom: BankedRom,
     mirroring: NametableLayout,
     chr_bank: BankSwitch,
+    bus_conflicts: bool,
 }
 
 impl<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> SimpleFixedPrgMapper<CHR_BANK_KB, MAPPER_NUM> {
@@ -138,6 +139,9 @@ impl<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> SimpleFixedPrgMapper<CHR_BA
         } else {
             None
         };
+        // Submapper 1 = explicitly no bus conflicts; all others (including 0 = original
+        // CNROM hardware) emulate AND-type bus conflicts.
+        let bus_conflicts = ctx.submapper != 1;
 
         Self {
             prg_rom,
@@ -145,6 +149,7 @@ impl<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> SimpleFixedPrgMapper<CHR_BA
             chr_rom: BankedRom::new(chr_rom, chr_bank_size),
             mirroring,
             chr_bank,
+            bus_conflicts,
         }
     }
 }
@@ -187,9 +192,16 @@ impl<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
             return;
         }
 
-        // Any write to $8000-$FFFF sets the CHR bank select
+        // Any write to $8000-$FFFF sets the CHR bank select.
+        // Original CNROM has AND-type bus conflicts: the ROM at the write address
+        // also drives the bus, so the effective value is (write & ROM).
         if (0x8000..=0xFFFF).contains(&addr) {
-            self.chr_bank.set(value);
+            let effective = if self.bus_conflicts {
+                value & self.read_prg(addr)
+            } else {
+                value
+            };
+            self.chr_bank.set(effective);
         }
     }
 
@@ -629,7 +641,7 @@ mod tests {
 
             let mut mapper = TestMapper::new(MapperContext::new_for_test(
                 3,
-                vec![0; 32 * 1024],
+                vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
                 chr_rom,
                 NametableLayout::Horizontal,
             ));
@@ -659,7 +671,7 @@ mod tests {
 
             let mut mapper = TestMapper::new(MapperContext::new_for_test(
                 3,
-                vec![0; 32 * 1024],
+                vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
                 chr_rom,
                 NametableLayout::Vertical,
             ));
@@ -685,7 +697,7 @@ mod tests {
 
             let mut mapper = TestMapper::new(MapperContext::new_for_test(
                 3,
-                vec![0; 32 * 1024],
+                vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
                 chr_rom.clone(),
                 NametableLayout::Horizontal,
             ));
@@ -695,7 +707,7 @@ mod tests {
 
             let mut restored = TestMapper::new(MapperContext::new_for_test(
                 3,
-                vec![0; 32 * 1024],
+                vec![0xFF; 32 * 1024], // 0xFF ensures bus conflicts don't mask the bank select
                 chr_rom,
                 NametableLayout::Horizontal,
             ));


### PR DESCRIPTION
## Summary

Fixes #349 - CNROM bus conflicts not modeled.

## Changes

- Added `bus_conflicts: bool` field to `SimpleFixedPrgMapper`
- Submapper 0 (original CNROM hardware) = bus conflicts enabled
- Submapper 1 = no bus conflicts  
- On writes to $8000–$FFFF: effective bank = `written_value & ROM[addr-$8000]`
- Updated existing tests to use 0xFF PRG-ROM (so `write & 0xFF = write`, conflicts transparent)

## Tests

Added 2 new tests in `cnrom.rs`:
- `test_cnrom_submapper_0_applies_and_type_bus_conflicts`
- `test_cnrom_submapper_1_disables_bus_conflicts`