### PR TITLE
fix(#345): UxROM respects PRG-RAM size from cartridge metadata

### DIFF
--- a/src/cartridge/mapper_templates.rs
+++ b/src/cartridge/mapper_templates.rs
@@ -286,7 +286,7 @@ impl<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
 /// ```
 pub struct SimpleBankedPrgMapper<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> {
     prg_rom: BankedRom,
-    prg_ram: PrgRam,
+    prg_ram: Option<PrgRam>,
     chr_memory: ChrMemory,
     mirroring: NametableLayout,
     bank_select: u8,
@@ -306,10 +306,17 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
         let prg_rom = ctx.prg_rom;
         let mirroring = ctx.mirroring;
         let prg_bank_size = PRG_BANK_KB * 1024;
+        let prg_ram = if ctx.prg_ram_size_specified && ctx.prg_ram_banks_8k > 0 {
+            Some(PrgRam::new(
+                ctx.prg_ram_banks_8k as usize * DEFAULT_PRG_RAM_SIZE,
+            ))
+        } else {
+            None
+        };
 
         Self {
             prg_rom: BankedRom::new(prg_rom, prg_bank_size),
-            prg_ram: PrgRam::new(DEFAULT_PRG_RAM_SIZE),
+            prg_ram,
             chr_memory: ChrMemory::new_ram(8192),
             mirroring,
             bank_select: 0,
@@ -321,8 +328,10 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
     for SimpleBankedPrgMapper<PRG_BANK_KB, MAPPER_NUM>
 {
     fn read_prg(&self, addr: u16) -> u8 {
-        // PRG-RAM at $6000-$7FFF
-        if let Some(value) = self.prg_ram.try_read(addr) {
+        // PRG-RAM at $6000-$7FFF (only if present)
+        if let Some(prg_ram) = &self.prg_ram
+            && let Some(value) = prg_ram.try_read(addr)
+        {
             return value;
         }
 
@@ -342,9 +351,19 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
         }
     }
 
+    fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
+        match addr {
+            0x0000..=0x5FFF => open_bus,
+            0x6000..=0x7FFF if self.prg_ram.is_none() => open_bus,
+            _ => self.read_prg(addr),
+        }
+    }
+
     fn write_prg(&mut self, addr: u16, value: u8) {
-        // PRG-RAM at $6000-$7FFF
-        if self.prg_ram.try_write(addr, value) {
+        // PRG-RAM at $6000-$7FFF (only if present)
+        if let Some(prg_ram) = &mut self.prg_ram
+            && prg_ram.try_write(addr, value)
+        {
             return;
         }
 
@@ -371,15 +390,19 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
     }
 
     fn wram_size(&self) -> usize {
-        self.prg_ram.size()
+        self.prg_ram.as_ref().map_or(0, PrgRam::size)
     }
 
     fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.snapshot()
+        self.prg_ram
+            .as_ref()
+            .map_or_else(Vec::new, PrgRam::snapshot)
     }
 
     fn load_wram_snapshot(&mut self, data: &[u8]) {
-        self.prg_ram.load_snapshot(data);
+        if let Some(prg_ram) = &mut self.prg_ram {
+            prg_ram.load_snapshot(data);
+        }
     }
 
     fn chr_ram_snapshot(&self) -> Vec<u8> {
@@ -406,7 +429,7 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
             has_chr_banking: false,
             has_dynamic_mirroring: false,
             has_expansion_audio: false,
-            max_prg_ram_kb: 8,
+            max_prg_ram_kb: self.prg_ram.as_ref().map_or(0, |r| r.size() / 1024),
             prg_bank_size_kb: PRG_BANK_KB,
             chr_bank_size_kb: 8,
             trainer_jsr: false,

--- a/src/cartridge/uxrom.rs
+++ b/src/cartridge/uxrom.rs
@@ -268,4 +268,94 @@ mod tests {
         assert_eq!(mapper.read_prg_open_bus(0x5000, 0xAA), 0xAA);
         assert_eq!(mapper.read_prg_open_bus(0x5FFF, 0xBB), 0xBB);
     }
+
+    // --- Issue #345: PRG-RAM absence via metadata ---
+
+    #[test]
+    fn test_uxrom_no_prg_ram_write_ignored() {
+        // Given: UxROM with no PRG-RAM (prg_ram_banks_8k = 0)
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(
+                2,
+                vec![0; 128 * 1024],
+                vec![],
+                NametableLayout::Horizontal,
+            )
+            .with_prg_ram_banks(0),
+        );
+
+        // When: writing to $6000-$7FFF
+        mapper.write_prg(0x6000, 0xAB);
+        mapper.write_prg(0x7FFF, 0xCD);
+
+        // Then: reads still return 0 (writes ignored, no RAM)
+        assert_eq!(
+            mapper.read_prg(0x6000),
+            0,
+            "no PRG-RAM: write should be ignored"
+        );
+        assert_eq!(
+            mapper.read_prg(0x7FFF),
+            0,
+            "no PRG-RAM: write should be ignored"
+        );
+    }
+
+    #[test]
+    fn test_uxrom_no_prg_ram_open_bus_returns_open_bus() {
+        // Given: UxROM with no PRG-RAM
+        let mapper = UxROMMapper::new(
+            MapperContext::new_for_test(
+                2,
+                vec![0; 128 * 1024],
+                vec![],
+                NametableLayout::Horizontal,
+            )
+            .with_prg_ram_banks(0),
+        );
+        let open_bus = 0x42;
+
+        // When: reading $6000-$7FFF via read_prg_open_bus
+        // Then: return open_bus (no RAM present)
+        assert_eq!(
+            mapper.read_prg_open_bus(0x6000, open_bus),
+            open_bus,
+            "no PRG-RAM: $6000 should return open-bus"
+        );
+        assert_eq!(
+            mapper.read_prg_open_bus(0x7FFF, open_bus),
+            open_bus,
+            "no PRG-RAM: $7FFF should return open-bus"
+        );
+    }
+
+    #[test]
+    fn test_uxrom_with_prg_ram_read_write_works() {
+        // Given: UxROM with 8KB PRG-RAM (prg_ram_banks_8k = 1)
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(
+                2,
+                vec![0; 128 * 1024],
+                vec![],
+                NametableLayout::Horizontal,
+            )
+            .with_prg_ram_banks(1),
+        );
+
+        // When: writing and reading back
+        mapper.write_prg(0x6000, 0x77);
+        mapper.write_prg(0x7FFF, 0x88);
+
+        // Then: values are preserved
+        assert_eq!(
+            mapper.read_prg(0x6000),
+            0x77,
+            "PRG-RAM present: write/read should work"
+        );
+        assert_eq!(
+            mapper.read_prg(0x7FFF),
+            0x88,
+            "PRG-RAM present: write/read should work"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #345 — UxROM mapper (via `SimpleBankedPrgMapper`) was always allocating 8KB PRG-RAM, but standard UxROM boards have none.

## Changes

- `SimpleBankedPrgMapper.prg_ram` changed to `Option<PrgRam>`
- PRG-RAM only allocated when `prg_ram_size_specified=true` AND `prg_ram_banks_8k > 0`
- `read_prg_open_bus` overridden to return open-bus when no PRG-RAM
- All WRAM snapshot/size methods updated for `Option`

## Tests

New: `test_uxrom_no_prg_ram_write_ignored`, `test_uxrom_no_prg_ram_open_bus_returns_open_bus`, `test_uxrom_with_prg_ram_read_write_works`