### PR TITLE
fix(#346): UxROM bank select masked to hardware bit-width

### DIFF
--- a/src/cartridge/mapper_templates.rs
+++ b/src/cartridge/mapper_templates.rs
@@ -290,6 +290,7 @@ pub struct SimpleBankedPrgMapper<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
     chr_memory: ChrMemory,
     mirroring: NametableLayout,
     bank_select: u8,
+    bank_select_mask: u8,
 }
 
 impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
@@ -313,6 +314,8 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
         } else {
             None
         };
+        let num_banks = (prg_rom.len() / prg_bank_size).max(1);
+        let bank_select_mask = (num_banks.next_power_of_two() - 1) as u8;
 
         Self {
             prg_rom: BankedRom::new(prg_rom, prg_bank_size),
@@ -320,6 +323,7 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
             chr_memory: ChrMemory::new_ram(8192),
             mirroring,
             bank_select: 0,
+            bank_select_mask,
         }
     }
 }
@@ -367,9 +371,9 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
             return;
         }
 
-        // Any write to $8000-$FFFF sets the bank register
+        // Any write to $8000-$FFFF sets the bank register (masked to hardware width)
         if (0x8000..=0xFFFF).contains(&addr) {
-            self.bank_select = value;
+            self.bank_select = value & self.bank_select_mask;
         }
     }
 

--- a/src/cartridge/uxrom.rs
+++ b/src/cartridge/uxrom.rs
@@ -358,4 +358,79 @@ mod tests {
             "PRG-RAM present: write/read should work"
         );
     }
+
+    // --- Issue #346: Bank select masking ---
+
+    #[test]
+    fn test_uxrom_unrom_bank_select_masked_to_3_bits() {
+        // Given: UNROM-style 128KB ROM (8 banks) — hardware supports only 3 bits
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(
+                2,
+                vec![0; 128 * 1024],
+                vec![],
+                NametableLayout::Horizontal,
+            )
+            .with_prg_ram_banks(0),
+        );
+
+        // When: writing a value with upper bits set (0xFF = 8 bits set)
+        mapper.write_prg(0x8000, 0xFF);
+
+        // Then: bank_select stored in snapshot should have upper bits cleared (3-bit mask)
+        let snapshot = mapper.registers_snapshot();
+        assert_eq!(
+            snapshot[0], 0x07,
+            "UNROM bank_select should be masked to 3 bits (0x07)"
+        );
+    }
+
+    #[test]
+    fn test_uxrom_uorom_bank_select_masked_to_4_bits() {
+        // Given: UOROM-style 256KB ROM (16 banks) — hardware supports 4 bits
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(
+                2,
+                vec![0; 256 * 1024],
+                vec![],
+                NametableLayout::Horizontal,
+            )
+            .with_prg_ram_banks(0),
+        );
+
+        // When: writing a value with upper bits set (0xFF)
+        mapper.write_prg(0x8000, 0xFF);
+
+        // Then: bank_select stored in snapshot should have upper bits cleared (4-bit mask)
+        let snapshot = mapper.registers_snapshot();
+        assert_eq!(
+            snapshot[0], 0x0F,
+            "UOROM bank_select should be masked to 4 bits (0x0F)"
+        );
+    }
+
+    #[test]
+    fn test_uxrom_bank_select_reads_correct_bank_after_masking() {
+        // Given: UOROM 256KB ROM (16 banks), each filled with bank number
+        let mut prg_rom = vec![0; 256 * 1024];
+        for bank in 0..16usize {
+            let start = bank * 16 * 1024;
+            let end = start + 16 * 1024;
+            prg_rom[start..end].fill(bank as u8);
+        }
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_prg_ram_banks(0),
+        );
+
+        // When: writing 0x1F (upper bit beyond 4-bit mask), expect mask to 0x0F = 15
+        mapper.write_prg(0x8000, 0x1F);
+
+        // Then: reads bank 15 (0x1F & 0x0F = 0x0F = 15)
+        assert_eq!(
+            mapper.read_prg(0x8000),
+            15,
+            "bank_select 0x1F should be masked to bank 15 for UOROM"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #346 — bank select register now masked to 3 bits for UNROM (128KB) and 4 bits for UOROM (256KB), based on ROM size.