### PR TITLE
fix(#347): UxROM bus conflicts emulated per submapper

### DIFF
--- a/src/cartridge/mapper_templates.rs
+++ b/src/cartridge/mapper_templates.rs
@@ -291,6 +291,7 @@ pub struct SimpleBankedPrgMapper<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
     mirroring: NametableLayout,
     bank_select: u8,
     bank_select_mask: u8,
+    bus_conflicts: bool,
 }
 
 impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
@@ -316,6 +317,9 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
         };
         let num_banks = (prg_rom.len() / prg_bank_size).max(1);
         let bank_select_mask = (num_banks.next_power_of_two() - 1) as u8;
+        // Submapper 2 = explicitly no bus conflicts; all others (including 0 = original
+        // UxROM hardware) emulate AND-type bus conflicts.
+        let bus_conflicts = ctx.submapper != 2;
 
         Self {
             prg_rom: BankedRom::new(prg_rom, prg_bank_size),
@@ -324,6 +328,7 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
             mirroring,
             bank_select: 0,
             bank_select_mask,
+            bus_conflicts,
         }
     }
 }
@@ -371,9 +376,16 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
             return;
         }
 
-        // Any write to $8000-$FFFF sets the bank register (masked to hardware width)
+        // Any write to $8000-$FFFF sets the bank register (masked to hardware width).
+        // Original UxROM boards have AND-type bus conflicts: the ROM at the write address
+        // also drives the bus, so the effective value is (write & ROM).
         if (0x8000..=0xFFFF).contains(&addr) {
-            self.bank_select = value & self.bank_select_mask;
+            let effective = if self.bus_conflicts {
+                value & self.read_prg(addr)
+            } else {
+                value
+            };
+            self.bank_select = effective & self.bank_select_mask;
         }
     }
 
@@ -773,12 +785,10 @@ mod tests {
                 }
             }
 
-            let mut mapper = TestMapper::new(MapperContext::new_for_test(
-                2,
-                prg_rom,
-                vec![],
-                NametableLayout::Horizontal,
-            ));
+            let mut mapper = TestMapper::new(
+                MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                    .with_submapper(2),
+            );
 
             // Initially bank 0 at $8000-$BFFF
             assert_eq!(mapper.read_prg(0x8000), 0);
@@ -853,24 +863,25 @@ mod tests {
                 }
             }
 
-            let mut mapper = TestMapper::new(MapperContext::new_for_test(
-                2,
-                prg_rom.clone(),
-                vec![],
-                NametableLayout::Horizontal,
-            ));
+            let mut mapper = TestMapper::new(
+                MapperContext::new_for_test(
+                    2,
+                    prg_rom.clone(),
+                    vec![],
+                    NametableLayout::Horizontal,
+                )
+                .with_submapper(2),
+            );
             mapper.write_prg(0x8000, 3);
             mapper.write_chr(0x0000, 0x5A);
 
             let regs = mapper.registers_snapshot();
             let chr = mapper.chr_ram_snapshot();
 
-            let mut restored = TestMapper::new(MapperContext::new_for_test(
-                2,
-                prg_rom,
-                vec![],
-                NametableLayout::Horizontal,
-            ));
+            let mut restored = TestMapper::new(
+                MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                    .with_submapper(2),
+            );
             restored.restore_registers(&regs);
             restored.restore_chr_ram(&chr);
 

--- a/src/cartridge/uxrom.rs
+++ b/src/cartridge/uxrom.rs
@@ -51,12 +51,10 @@ mod tests {
             }
         }
 
-        let mut mapper = UxROMMapper::new(MapperContext::new_for_test(
-            2,
-            prg_rom,
-            vec![],
-            NametableLayout::Horizontal,
-        ));
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_submapper(2),
+        );
 
         // Initially bank 0 should be at $8000-$BFFF
         assert_eq!(mapper.read_prg(0x8000), 0);
@@ -94,12 +92,10 @@ mod tests {
             }
         }
 
-        let mut mapper = UxROMMapper::new(MapperContext::new_for_test(
-            2,
-            prg_rom,
-            vec![],
-            NametableLayout::Vertical,
-        ));
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Vertical)
+                .with_submapper(2),
+        );
 
         // Last bank (15) should be at $C000-$FFFF
         assert_eq!(mapper.read_prg(0xC000), 15);
@@ -166,12 +162,10 @@ mod tests {
             }
         }
 
-        let mut mapper = UxROMMapper::new(MapperContext::new_for_test(
-            2,
-            prg_rom,
-            vec![],
-            NametableLayout::Horizontal,
-        ));
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_submapper(2),
+        );
 
         // Test writing different bit patterns
         mapper.write_prg(0x8000, 0b0000_0000); // Bank 0
@@ -197,12 +191,10 @@ mod tests {
             }
         }
 
-        let mut mapper = UxROMMapper::new(MapperContext::new_for_test(
-            2,
-            prg_rom,
-            vec![],
-            NametableLayout::Horizontal,
-        ));
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_submapper(2),
+        );
 
         // Last bank should always read 115 (bank 15 + 100)
         assert_eq!(mapper.read_prg(0xC000), 115);
@@ -230,12 +222,10 @@ mod tests {
             }
         }
 
-        let mut mapper = UxROMMapper::new(MapperContext::new_for_test(
-            2,
-            prg_rom.clone(),
-            vec![],
-            NametableLayout::Horizontal,
-        ));
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom.clone(), vec![], NametableLayout::Horizontal)
+                .with_submapper(2),
+        );
 
         mapper.write_prg(0x8000, 3);
         mapper.write_chr(0x0000, 0x5A);
@@ -243,12 +233,10 @@ mod tests {
         let regs = mapper.registers_snapshot();
         let chr = mapper.chr_ram_snapshot();
 
-        let mut restored = UxROMMapper::new(MapperContext::new_for_test(
-            2,
-            prg_rom,
-            vec![],
-            NametableLayout::Horizontal,
-        ));
+        let mut restored = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_submapper(2),
+        );
         restored.restore_registers(&regs);
         restored.restore_chr_ram(&chr);
 
@@ -364,6 +352,7 @@ mod tests {
     #[test]
     fn test_uxrom_unrom_bank_select_masked_to_3_bits() {
         // Given: UNROM-style 128KB ROM (8 banks) — hardware supports only 3 bits
+        // Use submapper 2 (no bus conflicts) to test masking in isolation
         let mut mapper = UxROMMapper::new(
             MapperContext::new_for_test(
                 2,
@@ -371,6 +360,7 @@ mod tests {
                 vec![],
                 NametableLayout::Horizontal,
             )
+            .with_submapper(2)
             .with_prg_ram_banks(0),
         );
 
@@ -388,6 +378,7 @@ mod tests {
     #[test]
     fn test_uxrom_uorom_bank_select_masked_to_4_bits() {
         // Given: UOROM-style 256KB ROM (16 banks) — hardware supports 4 bits
+        // Use submapper 2 (no bus conflicts) to test masking in isolation
         let mut mapper = UxROMMapper::new(
             MapperContext::new_for_test(
                 2,
@@ -395,6 +386,7 @@ mod tests {
                 vec![],
                 NametableLayout::Horizontal,
             )
+            .with_submapper(2)
             .with_prg_ram_banks(0),
         );
 
@@ -412,6 +404,7 @@ mod tests {
     #[test]
     fn test_uxrom_bank_select_reads_correct_bank_after_masking() {
         // Given: UOROM 256KB ROM (16 banks), each filled with bank number
+        // Use submapper 2 (no bus conflicts) to test masking in isolation
         let mut prg_rom = vec![0; 256 * 1024];
         for bank in 0..16usize {
             let start = bank * 16 * 1024;
@@ -420,6 +413,7 @@ mod tests {
         }
         let mut mapper = UxROMMapper::new(
             MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_submapper(2)
                 .with_prg_ram_banks(0),
         );
 
@@ -432,5 +426,72 @@ mod tests {
             15,
             "bank_select 0x1F should be masked to bank 15 for UOROM"
         );
+    }
+
+    // --- Issue #347: Bus conflicts ---
+
+    #[test]
+    fn test_uxrom_submapper0_has_bus_conflicts() {
+        // Given: UxROM submapper 0 (original, bus conflicts present)
+        // PRG ROM filled with 0x00 at bank-select write addresses.
+        // With bus conflicts: effective = write_value & 0x00 = 0x00 → always bank 0.
+        let prg_rom = vec![0x00; 128 * 1024]; // all zeros
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_submapper(0)
+                .with_prg_ram_banks(0),
+        );
+
+        // When: trying to write bank 3 (but ROM bytes at write addr are 0x00)
+        mapper.write_prg(0x8000, 3);
+
+        // Then: effective value = 3 & 0x00 = 0 → bank 0 selected (bus conflict)
+        let snapshot = mapper.registers_snapshot();
+        assert_eq!(
+            snapshot[0], 0,
+            "submapper 0: bus conflict should force bank_select to 0 (write & ROM[addr])"
+        );
+    }
+
+    #[test]
+    fn test_uxrom_submapper2_no_bus_conflicts() {
+        // Given: UxROM submapper 2 (explicitly no bus conflicts)
+        // PRG ROM filled with 0x00 at bank-select write addresses.
+        // Without bus conflicts: write_value used directly.
+        let prg_rom = vec![0x00; 128 * 1024]; // all zeros
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_submapper(2)
+                .with_prg_ram_banks(0),
+        );
+
+        // When: writing bank 3
+        mapper.write_prg(0x8000, 3);
+
+        // Then: bank 3 selected (no bus conflict applied)
+        let snapshot = mapper.registers_snapshot();
+        assert_eq!(
+            snapshot[0], 3,
+            "submapper 2: no bus conflict, bank_select should be 3"
+        );
+    }
+
+    #[test]
+    fn test_uxrom_bus_conflict_and_value_selects_correct_bank() {
+        // Given: UxROM submapper 0 (bus conflicts) with ROM filled 0xFF
+        // (0xFF & write_value = write_value, so bank select passes through)
+        let prg_rom = vec![0xFF; 128 * 1024];
+        let mut mapper = UxROMMapper::new(
+            MapperContext::new_for_test(2, prg_rom, vec![], NametableLayout::Horizontal)
+                .with_submapper(0)
+                .with_prg_ram_banks(0),
+        );
+
+        // When: writing bank 5 (0x05 & 0xFF = 0x05 → bank 5)
+        mapper.write_prg(0x8000, 5);
+
+        // Then: bank 5 selected
+        let snapshot = mapper.registers_snapshot();
+        assert_eq!(snapshot[0], 5, "0x05 & 0xFF = 0x05, should select bank 5");
     }
 }


### PR DESCRIPTION
Fixes #347 — adds AND-type bus conflict emulation for UxROM (submapper 0/1). Submapper 2 = no conflicts.