### PR TITLE
feat(mapper72): Jaleco JF-17 mapper

### DIFF
--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -29,6 +29,7 @@ use super::mapper61::Mapper61;
 use super::mapper62::Mapper62;
 use super::mapper64::Mapper64;
 use super::mapper65::Mapper65;
+use super::mapper72::Mapper72;
 use super::mapper185::Mapper185;
 use super::mapper241::Mapper241;
 use super::mapper242::Mapper242;
@@ -528,6 +529,7 @@ mapper_registry! {
     68 => Sunsoft4Mapper::new,
     69 => SunsoftFme7Mapper::new,
     71 => CamericaMapper::new,
+    72 => Mapper72::new,
     78 => NinaTengenMapper::new,
     185 => Mapper185::new,
     206 => Namco118Mapper::new,
@@ -545,8 +547,8 @@ mapper_registry! {
 #[cfg(test)]
 const SUPPORTED_MAPPERS: &[u8] = &[
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 32, 33, 34,
-    40, 42, 44, 45, 46, 47, 49, 50, 51, 52, 53, 56, 57, 58, 60, 61, 62, 64, 65, 66, 68, 69, 71, 78,
-    185, 206, 241, 242, 243, 244, 245, 246, 251, 254, 255,
+    40, 42, 44, 45, 46, 47, 49, 50, 51, 52, 53, 56, 57, 58, 60, 61, 62, 64, 65, 66, 68, 69, 71, 72,
+    78, 185, 206, 241, 242, 243, 244, 245, 246, 251, 254, 255,
 ];
 
 /// List of supported iNES mapper IDs handled by the factory.

--- a/src/cartridge/mapper72.rs
+++ b/src/cartridge/mapper72.rs
@@ -1,0 +1,379 @@
+//! Mapper 072 - Jaleco JF-17
+//!
+//! Specifications:
+//! - Main: <https://www.nesdev.org/wiki/INES_Mapper_072>
+//!
+//! Known Limitations:
+//! - No known gameplay-blocking functional limitations are currently documented.
+
+use crate::cartridge::NametableLayout;
+use crate::cartridge::common::ChrMemory;
+use crate::cartridge::mapper::{Mapper, MapperCapabilities};
+
+/// Mapper 072 - Jaleco JF-17
+///
+/// Hardware: Jaleco JF-17 board
+///
+/// Specifications:
+/// - Main: <https://www.nesdev.org/wiki/INES_Mapper_072>
+/// - PRG-ROM: 128 KiB (16 KiB switchable at $8000-$BFFF, last 16 KiB fixed at $C000-$FFFF)
+/// - PRG-RAM: None
+/// - CHR: 128 KiB ROM (single 8 KiB switchable bank)
+/// - Mirroring: Fixed from header (not programmable)
+/// - Bus conflicts: YES (written value ANDed with ROM byte at address)
+///
+/// Register ($8000-$FFFF):
+/// - Bit 7 (P): 0→1 transition loads PRG bank from D[2:0]
+/// - Bit 6 (C): 0→1 transition loads CHR bank from D[3:0]
+/// - Bits [3:0] (D): bank number
+///
+/// Power-on state: PRG bank 0 at $8000, CHR bank 0, latch = 0.
+pub struct Mapper72 {
+    prg_rom: Vec<u8>,
+    chr_memory: ChrMemory,
+    mirroring: NametableLayout,
+    prg_bank: u8,
+    chr_bank: u8,
+    latch: u8,
+}
+
+impl Mapper72 {
+    const MAPPER_NUMBER: u8 = 72;
+    const PRG_BANK_SIZE: usize = 0x4000; // 16 KiB
+    const PRG_BANK_MASK: usize = Self::PRG_BANK_SIZE - 1;
+    const CHR_BANK_SIZE: usize = 0x2000; // 8 KiB
+    const CHR_BANK_MASK: usize = Self::CHR_BANK_SIZE - 1;
+
+    pub fn new(ctx: super::mapper::MapperContext) -> Self {
+        let prg_rom = ctx.prg_rom;
+        let chr_rom = ctx.chr_rom;
+        let mirroring = ctx.mirroring;
+        Self {
+            prg_rom,
+            chr_memory: ChrMemory::new(chr_rom),
+            mirroring,
+            prg_bank: 0,
+            chr_bank: 0,
+            latch: 0,
+        }
+    }
+
+    fn prg_bank_count(&self) -> usize {
+        self.prg_rom.len() / Self::PRG_BANK_SIZE
+    }
+
+    fn read_prg_bank(&self, bank: usize, offset: usize) -> u8 {
+        let count = self.prg_bank_count();
+        if count == 0 {
+            return 0;
+        }
+        let b = bank % count;
+        self.prg_rom
+            .get(b * Self::PRG_BANK_SIZE + offset)
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+impl Mapper for Mapper72 {
+    fn read_prg(&self, addr: u16) -> u8 {
+        let offset = (addr as usize) & Self::PRG_BANK_MASK;
+        match addr {
+            0x8000..=0xBFFF => self.read_prg_bank(self.prg_bank as usize, offset),
+            0xC000..=0xFFFF => {
+                let last = self.prg_bank_count().saturating_sub(1);
+                self.read_prg_bank(last, offset)
+            }
+            _ => 0,
+        }
+    }
+
+    fn write_prg(&mut self, addr: u16, value: u8) {
+        if !(0x8000..=0xFFFF).contains(&addr) {
+            return;
+        }
+        // Bus conflict: AND written value with ROM byte at address
+        let rom_byte = self.read_prg(addr);
+        let effective = value & rom_byte;
+
+        let p_rising = (self.latch & 0x80) == 0 && (effective & 0x80) != 0;
+        let c_rising = (self.latch & 0x40) == 0 && (effective & 0x40) != 0;
+
+        if p_rising {
+            self.prg_bank = effective & 0x07;
+        }
+        if c_rising {
+            self.chr_bank = effective & 0x0F;
+        }
+        self.latch = effective;
+    }
+
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        let offset = (addr as usize) & Self::CHR_BANK_MASK;
+        let chr_count = self.chr_memory.size() / Self::CHR_BANK_SIZE;
+        if chr_count == 0 {
+            return self.chr_memory.read(addr);
+        }
+        let bank = (self.chr_bank as usize) % chr_count;
+        self.chr_memory
+            .read_at_index(bank * Self::CHR_BANK_SIZE + offset)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.chr_memory.write(addr, value);
+    }
+
+    fn get_mirroring(&self) -> NametableLayout {
+        self.mirroring
+    }
+
+    fn mapper_number(&self) -> u8 {
+        Self::MAPPER_NUMBER
+    }
+
+    fn wram_size(&self) -> usize {
+        0
+    }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
+        self.chr_memory.initialize(mode);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        vec![self.prg_bank, self.chr_bank, self.latch]
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if data.len() >= 3 {
+            self.prg_bank = data[0];
+            self.chr_bank = data[1];
+            self.latch = data[2];
+        }
+    }
+
+    fn reset(&mut self) {
+        self.prg_bank = 0;
+        self.chr_bank = 0;
+        self.latch = 0;
+    }
+
+    fn capabilities(&self) -> MapperCapabilities {
+        MapperCapabilities {
+            has_chr_banking: true,
+            prg_bank_size_kb: 16,
+            chr_bank_size_kb: 8,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cartridge::NametableLayout;
+    use crate::cartridge::mapper::{MapperContext, create_mapper};
+    use crate::cartridge::test_helpers::banked_data;
+
+    // Non-power-of-two bank counts to prevent false-pass modulo wrapping
+    const PRG_BANKS: usize = 3; // 3 × 16KB = 48KB
+    const CHR_BANKS: usize = 5; // 5 × 8KB  = 40KB
+
+    /// Build a Mapper72 whose PRG ROM is filled with 0xFF so bus-conflict AND is transparent.
+    fn make_mapper() -> Mapper72 {
+        let prg = vec![0xFFu8; PRG_BANKS * 16 * 1024];
+        let chr = banked_data(8 * 1024, CHR_BANKS);
+        Mapper72::new(MapperContext::new_for_test(
+            72,
+            prg,
+            chr,
+            NametableLayout::Horizontal,
+        ))
+    }
+
+    // Helper: write a register value; since PRG ROM is 0xFF the effective value
+    // equals the written value (no bus-conflict masking).
+    fn write(mapper: &mut Mapper72, value: u8) {
+        mapper.write_prg(0x8000, value);
+    }
+
+    // --- Registration ---
+
+    #[test]
+    fn mapper_72_is_registered() {
+        let prg = vec![0xFFu8; PRG_BANKS * 16 * 1024];
+        let chr = banked_data(8 * 1024, CHR_BANKS);
+        let result = create_mapper(MapperContext::new_for_test(
+            72,
+            prg,
+            chr,
+            NametableLayout::Horizontal,
+        ));
+        assert!(
+            result.is_ok(),
+            "Mapper 72 must be registered in the factory"
+        );
+    }
+
+    // --- Power-on state ---
+
+    #[test]
+    fn power_on_prg_bank_is_0() {
+        // PRG ROM is 0xFF; we need distinguishable banks → use banked_data + no-conflict
+        // Make a fresh mapper with banked PRG (0xFF fill loses bank identity), so we
+        // test indirectly via the latch/bank fields.
+        let mapper = make_mapper();
+        assert_eq!(mapper.prg_bank, 0, "PRG bank must default to 0 at power-on");
+    }
+
+    #[test]
+    fn power_on_chr_bank_is_0() {
+        let mut mapper = make_mapper();
+        // CHR is banked data: bank N filled with byte N. Bank 0 → 0x00.
+        assert_eq!(
+            mapper.read_chr(0x0000),
+            0,
+            "CHR bank must default to 0 at power-on"
+        );
+    }
+
+    #[test]
+    fn prg_c000_is_fixed_to_last_bank() {
+        // Build a mapper with banked PRG (0xFF would make all banks identical).
+        // Use a distinct fill so we can verify the last bank.
+        let prg = banked_data(16 * 1024, PRG_BANKS);
+        let chr = banked_data(8 * 1024, CHR_BANKS);
+        let mapper = Mapper72::new(MapperContext::new_for_test(
+            72,
+            prg,
+            chr,
+            NametableLayout::Horizontal,
+        ));
+        // Last bank index = PRG_BANKS - 1 = 2; banked_data fills it with 2.
+        assert_eq!(
+            mapper.read_prg(0xC000),
+            (PRG_BANKS - 1) as u8,
+            "$C000-$FFFF must be fixed to the last PRG bank"
+        );
+    }
+
+    // --- PRG bank switching (latch / rising-edge detection) ---
+
+    #[test]
+    fn prg_bank_switches_on_p_bit_rising_edge() {
+        // Build mapper with banked PRG so bank reads are distinguishable, but ROM
+        // bytes at $8000 must be 0xFF for the bus-conflict AND to be transparent.
+        // Since banked_data fills bank N with byte N (not 0xFF), use 0xFF PRG for
+        // the write; verify bank switch via the prg_bank field directly.
+        let mut mapper = make_mapper();
+        // Reset latch to 0
+        write(&mut mapper, 0x00); // latch = 0
+        // Write 0x82: P=1, D=2 → rising edge on P → load PRG bank 2
+        write(&mut mapper, 0x82);
+        assert_eq!(
+            mapper.prg_bank, 2,
+            "PRG bank must switch to 2 on P-bit rising edge"
+        );
+    }
+
+    #[test]
+    fn prg_bank_does_not_switch_on_p_bit_already_high() {
+        let mut mapper = make_mapper();
+        write(&mut mapper, 0x00);
+        write(&mut mapper, 0x82); // rising edge → bank 2
+        // Write 0x83: P still 1 (no rising edge) → bank must stay at 2 not switch to 3
+        write(&mut mapper, 0x83);
+        assert_eq!(
+            mapper.prg_bank, 2,
+            "PRG bank must NOT switch when P bit was already high"
+        );
+    }
+
+    #[test]
+    fn chr_bank_switches_on_c_bit_rising_edge() {
+        let mut mapper = make_mapper();
+        write(&mut mapper, 0x00); // latch = 0
+        // Write 0x43: C=1, D=3 → rising edge on C → load CHR bank 3
+        write(&mut mapper, 0x43);
+        assert_eq!(
+            mapper.chr_bank, 3,
+            "CHR bank must switch to 3 on C-bit rising edge"
+        );
+    }
+
+    #[test]
+    fn chr_bank_does_not_switch_on_c_bit_already_high() {
+        let mut mapper = make_mapper();
+        write(&mut mapper, 0x00);
+        write(&mut mapper, 0x43); // rising edge → bank 3
+        // Write 0x45: C still 1 (no rising edge) → CHR bank stays at 3 not 5
+        write(&mut mapper, 0x45);
+        assert_eq!(
+            mapper.chr_bank, 3,
+            "CHR bank must NOT switch when C bit was already high"
+        );
+    }
+
+    #[test]
+    fn both_banks_switch_simultaneously_with_pc_bits_set() {
+        let mut mapper = make_mapper();
+        write(&mut mapper, 0x00); // latch = 0
+        // Write 0xC5: P=1, C=1, D=5 → both rising edges → PRG bank 5%8=5, CHR bank 5
+        // But with only 3 PRG banks, PRG bank 5%3=2. Verify with field values.
+        write(&mut mapper, 0xC5);
+        // D[2:0] = 5, D[3:0] = 5
+        assert_eq!(mapper.prg_bank, 5, "PRG bank field must be set to 5");
+        assert_eq!(mapper.chr_bank, 5, "CHR bank field must be set to 5");
+    }
+
+    // --- Snapshot / restore ---
+
+    #[test]
+    fn registers_snapshot_round_trips() {
+        let mut mapper = make_mapper();
+        write(&mut mapper, 0x00);
+        write(&mut mapper, 0x82); // prg_bank = 2
+        write(&mut mapper, 0x00);
+        write(&mut mapper, 0x43); // chr_bank = 3
+
+        let snap = mapper.registers_snapshot();
+        let mut restored = make_mapper();
+        restored.restore_registers(&snap);
+
+        assert_eq!(
+            restored.prg_bank, mapper.prg_bank,
+            "Snapshot must preserve PRG bank"
+        );
+        assert_eq!(
+            restored.chr_bank, mapper.chr_bank,
+            "Snapshot must preserve CHR bank"
+        );
+        assert_eq!(restored.latch, mapper.latch, "Snapshot must preserve latch");
+    }
+
+    // --- CHR RAM fallback ---
+
+    #[test]
+    fn chr_ram_works_when_no_chr_rom() {
+        let prg = vec![0xFFu8; PRG_BANKS * 16 * 1024];
+        let mut mapper = Mapper72::new(MapperContext::new_for_test(
+            72,
+            prg,
+            vec![],
+            NametableLayout::Horizontal,
+        ));
+        mapper.write_chr(0x0100, 0xAB);
+        assert_eq!(
+            mapper.read_chr(0x0100),
+            0xAB,
+            "CHR-RAM must be writable when no CHR-ROM is present"
+        );
+    }
+}

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -40,6 +40,7 @@ mod mapper61;
 mod mapper62;
 mod mapper64;
 mod mapper65;
+mod mapper72;
 mod mapper_templates;
 mod mmc1;
 mod mmc2;


### PR DESCRIPTION
Implements mapper 72 (Jaleco JF-17) for Pinball Quest, Moero!! Judo Warriors, Moero!! Pro Tennis.

## Changes
- New `src/cartridge/mapper72.rs` with full mapper 72 implementation
- Registered in mapper factory and `SUPPORTED_MAPPERS`

## Specification (nesdev.org)
- PRG-ROM: 16KB switchable bank at $8000-$BFFF; last 16KB fixed at $C000-$FFFF
- CHR: 8KB switchable bank (CHR-RAM fallback when no CHR-ROM)
- Mirroring: fixed from header
- Register ($8000-$FFFF): latch-based 0 to 1 edge detection on P (bit 7) and C (bit 6) bits
- Bus conflicts: written value ANDed with ROM byte at address

## Tests (11 passing)
Non-power-of-two bank counts (3 PRG, 5 CHR) used to prevent modulo false-passes.

Closes #740
