### PR TITLE
feat(mapper48): implement Taito TC0690 mapper (closes #736)

### DIFF
--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -16,6 +16,7 @@ use super::mapper44::Mapper44;
 use super::mapper45::Mapper45;
 use super::mapper46::Mapper46;
 use super::mapper47::Mapper47;
+use super::mapper48::Mapper48;
 use super::mapper49::Mapper49;
 use super::mapper50::Mapper50;
 use super::mapper51::Mapper51;
@@ -514,6 +515,7 @@ mapper_registry! {
     45 => Mapper45::new,
     46 => Mapper46::new,
     47 => Mapper47::new,
+    48 => Mapper48::new,
     49 => Mapper49::new,
     50 => Mapper50::new,
     51 => Mapper51::new,
@@ -551,8 +553,8 @@ mapper_registry! {
 #[cfg(test)]
 const SUPPORTED_MAPPERS: &[u8] = &[
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 32, 33, 34,
-    40, 42, 44, 45, 46, 47, 49, 50, 51, 52, 53, 56, 57, 58, 60, 61, 62, 64, 65, 66, 67, 68, 69, 71,
-    72, 73, 78, 185, 206, 241, 242, 243, 244, 245, 246, 251, 254, 255,
+    40, 42, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 56, 57, 58, 60, 61, 62, 64, 65, 66, 67, 68, 69,
+    71, 72, 73, 78, 185, 206, 241, 242, 243, 244, 245, 246, 251, 254, 255,
 ];
 
 /// List of supported iNES mapper IDs handled by the factory.

--- a/src/cartridge/mapper48.rs
+++ b/src/cartridge/mapper48.rs
@@ -1,0 +1,659 @@
+//! Mapper 048 – Taito TC0690
+//!
+//! Known Limitations:
+//! - No mapper-specific gameplay-blocking functional limitations are currently documented.
+//! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
+//! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
+
+use crate::cartridge::common::ChrMemory;
+use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
+
+/// Mapper 048 – Taito TC0690
+///
+/// Hardware: Taito TC0690
+///
+/// Specifications:
+/// - Main: <https://www.nesdev.org/wiki/INES_Mapper_048>
+/// - PRG-ROM: Up to 512KB, two 8KB switchable banks + two fixed banks
+/// - CHR: Two 2KB switchable banks + four 1KB switchable banks
+/// - Mirroring: Programmable (H/V) via bit 6 of register $E000
+/// - IRQ: MMC3-style scanline IRQ with different register layout
+///
+/// PRG layout ($8000 CPU):
+/// ```text
+///   $8000   $A000   $C000   $E000
+/// +-------+-------+-------+-------+
+/// | $8000 | $8001 | { -2} | { -1} |
+/// +-------+-------+-------+-------+
+/// ```
+///
+/// CHR layout ($0000 PPU):
+/// ```text
+///   $0000   $0800   $1000   $1400   $1800   $1C00
+/// +-------+-------+-------+-------+-------+-------+
+/// | $8002 | $8003 | $A000 | $A001 | $A002 | $A003 |
+/// +-------+-------+-------+-------+-------+-------+
+/// ```
+///
+/// Registers (mask $E003):
+/// - `$8000` [..PP PPPP]: PRG bank 0 (8KB @ $8000)
+/// - `$8001` [..PP PPPP]: PRG bank 1 (8KB @ $A000)
+/// - `$8002` [CCCC CCCC]: CHR bank 0 (2KB @ $0000)
+/// - `$8003` [CCCC CCCC]: CHR bank 1 (2KB @ $0800)
+/// - `$A000` [CCCC CCCC]: CHR bank 2 (1KB @ $1000)
+/// - `$A001` [CCCC CCCC]: CHR bank 3 (1KB @ $1400)
+/// - `$A002` [CCCC CCCC]: CHR bank 4 (1KB @ $1800)
+/// - `$A003` [CCCC CCCC]: CHR bank 5 (1KB @ $1C00)
+/// - `$C000` [CCCC CCCC]: IRQ latch (value XOR 0xFF before storing)
+/// - `$C001`: IRQ counter reload
+/// - `$C002`: IRQ enable
+/// - `$C003`: IRQ disable and acknowledge
+/// - `$E000` [.M.. ....]: M=Mirroring (0=Vert, 1=Horz) at bit 6
+pub struct Mapper48 {
+    prg_rom: Vec<u8>,
+    chr_memory: ChrMemory,
+
+    mirroring: NametableLayout,
+
+    prg_bank: [u8; 2],
+    chr_bank_2k: [u8; 2],
+    chr_bank_1k: [u8; 4],
+
+    irq_latch: u8,
+    irq_counter: u8,
+    irq_reload: bool,
+    irq_enabled: bool,
+    irq_pending: bool,
+
+    prev_a12: bool,
+    a12_low_cycles: u8,
+}
+
+impl Mapper48 {
+    const PRG_BANK_SIZE: usize = 0x2000; // 8KB
+    const CHR_BANK_2K_SIZE: usize = 0x0800; // 2KB
+    const CHR_BANK_1K_SIZE: usize = 0x0400; // 1KB
+    const REGISTER_MASK: u16 = 0xE003;
+    const A12_LOW_CYCLES_REQUIRED: u8 = 3;
+
+    pub fn new(ctx: super::mapper::MapperContext) -> Self {
+        let prg_rom = ctx.prg_rom;
+        let chr_rom = ctx.chr_rom;
+        let mirroring = ctx.mirroring;
+        Self {
+            prg_rom,
+            chr_memory: ChrMemory::new(chr_rom),
+            mirroring,
+            prg_bank: [0; 2],
+            chr_bank_2k: [0; 2],
+            chr_bank_1k: [0; 4],
+            irq_latch: 0,
+            irq_counter: 0,
+            irq_reload: false,
+            irq_enabled: false,
+            irq_pending: false,
+            prev_a12: false,
+            a12_low_cycles: 0,
+        }
+    }
+
+    fn prg_bank_count(&self) -> usize {
+        self.prg_rom.len() / Self::PRG_BANK_SIZE
+    }
+
+    fn prg_bank_index(&self, bank: u8) -> usize {
+        Self::bank_index(bank as usize, self.prg_bank_count())
+    }
+
+    fn read_prg_rom_bank(&self, bank_index: usize, offset: usize) -> u8 {
+        let addr = bank_index * Self::PRG_BANK_SIZE + offset;
+        self.prg_rom.get(addr).copied().unwrap_or(0)
+    }
+
+    fn chr_bank_count_2k(&self) -> usize {
+        self.chr_memory.size() / Self::CHR_BANK_2K_SIZE
+    }
+
+    fn chr_bank_count_1k(&self) -> usize {
+        self.chr_memory.size() / Self::CHR_BANK_1K_SIZE
+    }
+
+    fn chr_bank_index_2k(&self, bank: u8) -> usize {
+        Self::bank_index(bank as usize, self.chr_bank_count_2k())
+    }
+
+    fn chr_bank_index_1k(&self, bank: u8) -> usize {
+        Self::bank_index(bank as usize, self.chr_bank_count_1k())
+    }
+
+    fn bank_index(bank: usize, count: usize) -> usize {
+        if count == 0 {
+            return 0;
+        }
+        bank % count
+    }
+
+    fn map_chr_to_byte_index(&self, addr: u16) -> usize {
+        let addr = (addr & 0x1FFF) as usize;
+        let (bank_index, bank_size) = match addr {
+            0x0000..=0x07FF => (
+                self.chr_bank_index_2k(self.chr_bank_2k[0]),
+                Self::CHR_BANK_2K_SIZE,
+            ),
+            0x0800..=0x0FFF => (
+                self.chr_bank_index_2k(self.chr_bank_2k[1]),
+                Self::CHR_BANK_2K_SIZE,
+            ),
+            0x1000..=0x13FF => (
+                self.chr_bank_index_1k(self.chr_bank_1k[0]),
+                Self::CHR_BANK_1K_SIZE,
+            ),
+            0x1400..=0x17FF => (
+                self.chr_bank_index_1k(self.chr_bank_1k[1]),
+                Self::CHR_BANK_1K_SIZE,
+            ),
+            0x1800..=0x1BFF => (
+                self.chr_bank_index_1k(self.chr_bank_1k[2]),
+                Self::CHR_BANK_1K_SIZE,
+            ),
+            0x1C00..=0x1FFF => (
+                self.chr_bank_index_1k(self.chr_bank_1k[3]),
+                Self::CHR_BANK_1K_SIZE,
+            ),
+            _ => return 0,
+        };
+        bank_index * bank_size + (addr & (bank_size - 1))
+    }
+
+    fn clock_irq_counter(&mut self) {
+        if self.irq_counter == 0 || self.irq_reload {
+            self.irq_counter = self.irq_latch;
+            self.irq_reload = false;
+        } else {
+            self.irq_counter -= 1;
+        }
+        if self.irq_counter == 0 && self.irq_enabled {
+            self.irq_pending = true;
+        }
+    }
+}
+
+impl Mapper for Mapper48 {
+    fn read_prg(&self, addr: u16) -> u8 {
+        if !(0x8000..=0xFFFF).contains(&addr) {
+            return 0;
+        }
+        let count = self.prg_bank_count();
+        if count == 0 {
+            return 0;
+        }
+        let bank_offset = (addr as usize) & (Self::PRG_BANK_SIZE - 1);
+        let bank_index = match addr {
+            0x8000..=0x9FFF => self.prg_bank_index(self.prg_bank[0]),
+            0xA000..=0xBFFF => self.prg_bank_index(self.prg_bank[1]),
+            0xC000..=0xDFFF => count.saturating_sub(2),
+            0xE000..=0xFFFF => count.saturating_sub(1),
+            _ => 0,
+        };
+        self.read_prg_rom_bank(bank_index, bank_offset)
+    }
+
+    fn write_prg(&mut self, addr: u16, value: u8) {
+        match addr & Self::REGISTER_MASK {
+            0x8000 => self.prg_bank[0] = value & 0x3F,
+            0x8001 => self.prg_bank[1] = value & 0x3F,
+            0x8002 => self.chr_bank_2k[0] = value,
+            0x8003 => self.chr_bank_2k[1] = value,
+            0xA000 => self.chr_bank_1k[0] = value,
+            0xA001 => self.chr_bank_1k[1] = value,
+            0xA002 => self.chr_bank_1k[2] = value,
+            0xA003 => self.chr_bank_1k[3] = value,
+            0xC000 => self.irq_latch = value ^ 0xFF,
+            0xC001 => {
+                self.irq_counter = 0;
+                self.irq_reload = true;
+            }
+            0xC002 => self.irq_enabled = true,
+            0xC003 => {
+                self.irq_enabled = false;
+                self.irq_pending = false;
+            }
+            0xE000 => {
+                self.mirroring = if (value & 0x40) != 0 {
+                    NametableLayout::Horizontal
+                } else {
+                    NametableLayout::Vertical
+                };
+            }
+            _ => {}
+        }
+    }
+
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        let byte_index = self.map_chr_to_byte_index(addr);
+        self.chr_memory.read_at_index(byte_index)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        let byte_index = self.map_chr_to_byte_index(addr);
+        self.chr_memory.write_at_index(byte_index, value);
+    }
+
+    fn get_mirroring(&self) -> NametableLayout {
+        self.mirroring
+    }
+
+    fn mapper_number(&self) -> u8 {
+        48
+    }
+
+    fn ppu_address_changed(&mut self, addr: u16) {
+        let a12 = (addr & 0x1000) != 0;
+        let was_low = !self.prev_a12;
+        let rising_edge = a12 && was_low && self.a12_low_cycles >= Self::A12_LOW_CYCLES_REQUIRED;
+        if rising_edge {
+            self.clock_irq_counter();
+        }
+        if !a12 {
+            if self.a12_low_cycles < Self::A12_LOW_CYCLES_REQUIRED {
+                self.a12_low_cycles += 1;
+            }
+        } else {
+            self.a12_low_cycles = 0;
+        }
+        self.prev_a12 = a12;
+    }
+
+    fn cpu_cycle(&mut self) {
+        if !self.prev_a12 && self.a12_low_cycles < Self::A12_LOW_CYCLES_REQUIRED {
+            self.a12_low_cycles += 1;
+        }
+    }
+
+    fn irq_pending(&self) -> bool {
+        self.irq_pending
+    }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
+        self.chr_memory.initialize(mode);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        // [0]: mirroring (0=Vert, 1=Horz)
+        // [1..=2]: prg_bank[0..1]
+        // [3..=4]: chr_bank_2k[0..1]
+        // [5..=8]: chr_bank_1k[0..3]
+        // [9]: irq_latch
+        // [10]: irq_counter
+        // [11]: irq flags (bit0=reload, bit1=enabled, bit2=pending)
+        let mut snap = Vec::with_capacity(12);
+        snap.push(if self.mirroring == NametableLayout::Horizontal {
+            1
+        } else {
+            0
+        });
+        snap.extend_from_slice(&self.prg_bank);
+        snap.extend_from_slice(&self.chr_bank_2k);
+        snap.extend_from_slice(&self.chr_bank_1k);
+        snap.push(self.irq_latch);
+        snap.push(self.irq_counter);
+        let irq_flags = (self.irq_reload as u8)
+            | ((self.irq_enabled as u8) << 1)
+            | ((self.irq_pending as u8) << 2);
+        snap.push(irq_flags);
+        snap
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if data.len() >= 12 {
+            self.mirroring = if data[0] != 0 {
+                NametableLayout::Horizontal
+            } else {
+                NametableLayout::Vertical
+            };
+            self.prg_bank.copy_from_slice(&data[1..3]);
+            self.chr_bank_2k.copy_from_slice(&data[3..5]);
+            self.chr_bank_1k.copy_from_slice(&data[5..9]);
+            self.irq_latch = data[9];
+            self.irq_counter = data[10];
+            let flags = data[11];
+            self.irq_reload = (flags & 1) != 0;
+            self.irq_enabled = (flags & 2) != 0;
+            self.irq_pending = (flags & 4) != 0;
+        }
+    }
+
+    fn capabilities(&self) -> MapperCapabilities {
+        MapperCapabilities {
+            has_irq: true,
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 0,
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 1,
+            trainer_jsr: false,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cartridge::NametableLayout;
+    use crate::cartridge::mapper::{Mapper, MapperContext, create_mapper};
+    use crate::cartridge::test_helpers::banked_data;
+
+    fn create_tc0690(
+        prg_rom: Vec<u8>,
+        chr_rom: Vec<u8>,
+        mirroring: NametableLayout,
+    ) -> std::io::Result<Box<dyn Mapper>> {
+        create_mapper(MapperContext::new_for_test(48, prg_rom, chr_rom, mirroring))
+    }
+
+    fn trigger_scanline(mapper: &mut Box<dyn Mapper>) {
+        mapper.ppu_address_changed(0x0FFF);
+        for _ in 0..3 {
+            mapper.cpu_cycle();
+        }
+        mapper.ppu_address_changed(0x1000);
+    }
+
+    // -----------------------------------------------------------------------
+    // Factory registration
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mapper_48_is_registered() {
+        let result = create_tc0690(
+            banked_data(8 * 1024, 6),
+            banked_data(1024, 8),
+            NametableLayout::Vertical,
+        );
+        assert!(
+            result.is_ok(),
+            "Mapper 48 must be registered in the factory"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // PRG banking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn power_on_prg_8000_bank_0_and_a000_bank_1() {
+        // On power-on both PRG banks default to 0; bank at $C000/$E000 fixed
+        let prg = banked_data(8 * 1024, 6);
+        let mapper =
+            create_tc0690(prg, banked_data(1024, 8), NametableLayout::Vertical).expect("mapper 48");
+        assert_eq!(mapper.read_prg(0x8000), 0, "$8000 must default to bank 0");
+        assert_eq!(mapper.read_prg(0xA000), 0, "$A000 must default to bank 0");
+    }
+
+    #[test]
+    fn prg_8000_switchable_via_register() {
+        let prg = banked_data(8 * 1024, 6);
+        let mut mapper =
+            create_tc0690(prg, banked_data(1024, 8), NametableLayout::Vertical).expect("mapper 48");
+        mapper.write_prg(0x8000, 2);
+        assert_eq!(mapper.read_prg(0x8000), 2);
+        assert_eq!(mapper.read_prg(0x9FFF), 2);
+        mapper.write_prg(0x8000, 3);
+        assert_eq!(mapper.read_prg(0x8000), 3);
+    }
+
+    #[test]
+    fn prg_a000_switchable_via_register() {
+        let prg = banked_data(8 * 1024, 6);
+        let mut mapper =
+            create_tc0690(prg, banked_data(1024, 8), NametableLayout::Vertical).expect("mapper 48");
+        mapper.write_prg(0x8001, 1);
+        assert_eq!(mapper.read_prg(0xA000), 1);
+        assert_eq!(mapper.read_prg(0xBFFF), 1);
+        mapper.write_prg(0x8001, 4);
+        assert_eq!(mapper.read_prg(0xA000), 4);
+    }
+
+    #[test]
+    fn prg_c000_and_e000_fixed_to_last_two_banks() {
+        // 6 banks → second-last = 4, last = 5
+        let prg = banked_data(8 * 1024, 6);
+        let mut mapper =
+            create_tc0690(prg, banked_data(1024, 8), NametableLayout::Vertical).expect("mapper 48");
+        mapper.write_prg(0x8000, 0);
+        mapper.write_prg(0x8001, 0);
+        assert_eq!(
+            mapper.read_prg(0xC000),
+            4,
+            "$C000 must be fixed to second-last bank"
+        );
+        assert_eq!(mapper.read_prg(0xDFFF), 4);
+        assert_eq!(
+            mapper.read_prg(0xE000),
+            5,
+            "$E000 must be fixed to last bank"
+        );
+        assert_eq!(mapper.read_prg(0xFFFF), 5);
+    }
+
+    // -----------------------------------------------------------------------
+    // CHR banking – 2KB windows ($8002, $8003)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn chr_2kb_bank0_at_ppu_0000() {
+        // 3 × 2KB banks (non-power-of-two avoids modulo false passes)
+        let chr = banked_data(2 * 1024, 3);
+        let mut mapper = create_tc0690(banked_data(8 * 1024, 2), chr, NametableLayout::Vertical)
+            .expect("mapper 48");
+        mapper.write_prg(0x8002, 1);
+        assert_eq!(mapper.read_chr(0x0000), 1);
+        assert_eq!(mapper.read_chr(0x07FF), 1);
+    }
+
+    #[test]
+    fn chr_2kb_bank1_at_ppu_0800() {
+        let chr = banked_data(2 * 1024, 3);
+        let mut mapper = create_tc0690(banked_data(8 * 1024, 2), chr, NametableLayout::Vertical)
+            .expect("mapper 48");
+        mapper.write_prg(0x8003, 2);
+        assert_eq!(mapper.read_chr(0x0800), 2);
+        assert_eq!(mapper.read_chr(0x0FFF), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // CHR banking – 1KB windows ($A000–$A003)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn chr_1kb_bank2_at_ppu_1000() {
+        let chr = banked_data(1024, 48);
+        let mut mapper = create_tc0690(banked_data(8 * 1024, 2), chr, NametableLayout::Vertical)
+            .expect("mapper 48");
+        mapper.write_prg(0xA000, 10);
+        assert_eq!(mapper.read_chr(0x1000), 10);
+        assert_eq!(mapper.read_chr(0x13FF), 10);
+    }
+
+    #[test]
+    fn chr_1kb_bank3_at_ppu_1400() {
+        let chr = banked_data(1024, 48);
+        let mut mapper = create_tc0690(banked_data(8 * 1024, 2), chr, NametableLayout::Vertical)
+            .expect("mapper 48");
+        mapper.write_prg(0xA001, 20);
+        assert_eq!(mapper.read_chr(0x1400), 20);
+        assert_eq!(mapper.read_chr(0x17FF), 20);
+    }
+
+    #[test]
+    fn chr_1kb_bank4_at_ppu_1800() {
+        let chr = banked_data(1024, 48);
+        let mut mapper = create_tc0690(banked_data(8 * 1024, 2), chr, NametableLayout::Vertical)
+            .expect("mapper 48");
+        mapper.write_prg(0xA002, 30);
+        assert_eq!(mapper.read_chr(0x1800), 30);
+        assert_eq!(mapper.read_chr(0x1BFF), 30);
+    }
+
+    #[test]
+    fn chr_1kb_bank5_at_ppu_1c00() {
+        let chr = banked_data(1024, 48);
+        let mut mapper = create_tc0690(banked_data(8 * 1024, 2), chr, NametableLayout::Vertical)
+            .expect("mapper 48");
+        mapper.write_prg(0xA003, 40);
+        assert_eq!(mapper.read_chr(0x1C00), 40);
+        assert_eq!(mapper.read_chr(0x1FFF), 40);
+    }
+
+    // -----------------------------------------------------------------------
+    // Mirroring
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mirroring_controlled_by_e000_bit_6() {
+        let mut mapper = create_tc0690(
+            banked_data(8 * 1024, 2),
+            banked_data(1024, 8),
+            NametableLayout::Vertical,
+        )
+        .expect("mapper 48");
+        // bit 6 = 0 → Vertical
+        mapper.write_prg(0xE000, 0x00);
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Vertical);
+        // bit 6 = 1 → Horizontal
+        mapper.write_prg(0xE000, 0x40);
+        assert_eq!(mapper.get_mirroring(), NametableLayout::Horizontal);
+    }
+
+    // -----------------------------------------------------------------------
+    // IRQ
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn irq_latch_xored_with_ff() {
+        // Write 5 to $C000; stored latch = 5 ^ 0xFF = 0xFA (= 250).
+        // IRQ fires after 0xFB clocks: clock 1 reloads counter to 0xFA,
+        // clocks 2..0xFB decrement it; on clock 0xFB counter reaches 0.
+        // This proves XOR happened: without it, write 5 → latch 5 → fires after 6 clocks.
+        let prg = banked_data(8 * 1024, 2);
+        let chr = banked_data(1024, 8);
+        let mut mapper = create_tc0690(prg, chr, NametableLayout::Vertical).expect("mapper 48");
+        mapper.write_prg(0xC000, 5); // latch = 5 ^ 0xFF = 0xFA
+        mapper.write_prg(0xC001, 0); // reload counter from latch
+        mapper.write_prg(0xC002, 0); // enable IRQ
+
+        assert!(
+            !mapper.irq_pending(),
+            "IRQ must not be pending before enough scanlines"
+        );
+
+        // 0xFA scanlines are not enough (off by one — counter not yet 0)
+        for _ in 0..0xFA_u8 {
+            trigger_scanline(&mut mapper);
+        }
+        assert!(
+            !mapper.irq_pending(),
+            "IRQ must not yet fire after 0xFA clocks"
+        );
+
+        // The 0xFB-th clock brings counter to 0
+        trigger_scanline(&mut mapper);
+        assert!(
+            mapper.irq_pending(),
+            "IRQ must fire after 0xFB clocks (latch 0xFA = 5 XOR 0xFF)"
+        );
+    }
+
+    #[test]
+    fn irq_fires_after_n_scanlines() {
+        // Write 0xFF to $C000 → latch = 0xFF ^ 0xFF = 0x00.
+        // On the first clock, reload sets counter to 0 and IRQ fires immediately.
+        let prg = banked_data(8 * 1024, 2);
+        let chr = banked_data(1024, 8);
+        let mut mapper = create_tc0690(prg, chr, NametableLayout::Vertical).expect("mapper 48");
+        mapper.write_prg(0xC000, 0xFF); // latch = 0xFF ^ 0xFF = 0x00
+        mapper.write_prg(0xC001, 0); // reload
+        mapper.write_prg(0xC002, 0); // enable
+
+        trigger_scanline(&mut mapper);
+        assert!(
+            mapper.irq_pending(),
+            "IRQ must fire after 1 scanline when latch=0"
+        );
+    }
+
+    #[test]
+    fn irq_enable_c002_disable_c003() {
+        let prg = banked_data(8 * 1024, 2);
+        let chr = banked_data(1024, 8);
+        let mut mapper = create_tc0690(prg, chr, NametableLayout::Vertical).expect("mapper 48");
+        // latch=0 (write 0xFF) → fires on the very first scanline clock
+        mapper.write_prg(0xC000, 0xFF);
+        mapper.write_prg(0xC001, 0);
+        mapper.write_prg(0xC002, 0);
+        trigger_scanline(&mut mapper);
+        assert!(
+            mapper.irq_pending(),
+            "IRQ must be pending after scanline with enabled IRQ"
+        );
+
+        // Disable + acknowledge via $C003
+        mapper.write_prg(0xC003, 0);
+        assert!(
+            !mapper.irq_pending(),
+            "IRQ must be cleared after writing $C003"
+        );
+
+        // Trigger again without re-enabling → no IRQ
+        trigger_scanline(&mut mapper);
+        assert!(!mapper.irq_pending(), "IRQ must not fire when disabled");
+    }
+
+    // -----------------------------------------------------------------------
+    // Register snapshot round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn registers_snapshot_round_trips() {
+        let prg = banked_data(8 * 1024, 6);
+        let chr = banked_data(1024, 48);
+        let mut mapper =
+            create_tc0690(prg.clone(), chr.clone(), NametableLayout::Vertical).expect("mapper 48");
+
+        mapper.write_prg(0x8000, 2);
+        mapper.write_prg(0x8001, 3);
+        mapper.write_prg(0x8002, 1);
+        mapper.write_prg(0x8003, 2);
+        mapper.write_prg(0xA000, 10);
+        mapper.write_prg(0xA001, 20);
+        mapper.write_prg(0xA002, 30);
+        mapper.write_prg(0xA003, 40);
+        mapper.write_prg(0xE000, 0x40); // Horizontal
+        mapper.write_prg(0xC000, 0xFE); // latch = 1
+        mapper.write_prg(0xC001, 0);
+        mapper.write_prg(0xC002, 0);
+
+        let snap = mapper.registers_snapshot();
+        let mut restored =
+            create_tc0690(prg, chr, NametableLayout::Vertical).expect("mapper 48 restore");
+        restored.restore_registers(&snap);
+
+        assert_eq!(restored.get_mirroring(), NametableLayout::Horizontal);
+        assert_eq!(restored.read_prg(0x8000), 2);
+        assert_eq!(restored.read_prg(0xA000), 3);
+        assert_eq!(restored.read_chr(0x1000), 10);
+        assert_eq!(restored.read_chr(0x1400), 20);
+        assert_eq!(restored.read_chr(0x1800), 30);
+        assert_eq!(restored.read_chr(0x1C00), 40);
+        assert!(restored.irq_pending() || !restored.irq_pending()); // just checks no crash
+    }
+}

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -27,6 +27,7 @@ mod mapper44;
 mod mapper45;
 mod mapper46;
 mod mapper47;
+mod mapper48;
 mod mapper49;
 mod mapper50;
 mod mapper51;


### PR DESCRIPTION
## Summary

Implements iNES Mapper 048 (Taito TC0690), which is similar to Mapper 33 (TC0190) but adds MMC3-style scanline IRQ and changes mirroring control.

Closes #736

## Changes

### New file: `src/cartridge/mapper48.rs`
- Complete Mapper 48 (TC0690) implementation with 16 tests
- PRG-ROM: two 8KB switchable banks at $8000/$A000, two fixed banks at $C000/$E000
- CHR: two 2KB switchable windows (via $8002/$8003) + four 1KB windows (via $A000-$A003)
- Mirroring: H/V controlled by bit 6 of register $E000 (key difference from Mapper 33)
- IRQ: MMC3-style scanline counter using PPU A12 edge detection
  - `$C000`: IRQ latch (value XOR 0xFF before storing)
  - `$C001`: IRQ counter reload
  - `$C002`: IRQ enable
  - `$C003`: IRQ disable and acknowledge

### Modified: `src/cartridge/mapper.rs`
- Registered Mapper 48 in the factory (`48 => Mapper48::new`)
- Added `48` to `SUPPORTED_MAPPERS`

### Modified: `src/cartridge/mod.rs`
- Added `mod mapper48;`

## Tests (16 total)

| Test | Description |
|------|-------------|
| `mapper_48_is_registered` | Factory creates mapper 48 |
| `power_on_prg_8000_bank_0_and_a000_bank_1` | Default PRG bank state |
| `prg_8000_switchable_via_register` | $8000 bank switch |
| `prg_a000_switchable_via_register` | $A000 bank switch |
| `prg_c000_and_e000_fixed_to_last_two_banks` | Fixed upper banks |
| `chr_2kb_bank0_at_ppu_0000` | 2KB CHR bank 0 |
| `chr_2kb_bank1_at_ppu_0800` | 2KB CHR bank 1 |
| `chr_1kb_bank2_at_ppu_1000` | 1KB CHR bank 2 |
| `chr_1kb_bank3_at_ppu_1400` | 1KB CHR bank 3 |
| `chr_1kb_bank4_at_ppu_1800` | 1KB CHR bank 4 |
| `chr_1kb_bank5_at_ppu_1c00` | 1KB CHR bank 5 |
| `mirroring_controlled_by_e000_bit_6` | Mirroring register |
| `irq_latch_xored_with_ff` | IRQ latch XOR behaviour |
| `irq_fires_after_n_scanlines` | IRQ countdown |
| `irq_enable_c002_disable_c003` | IRQ enable/disable |
| `registers_snapshot_round_trips` | Save/restore state |

## Pre-existing issues

There is a pre-existing `collapsible_if` clippy warning in `sdl_eventloop.rs` that is unrelated to this change and present on the base branch.
