### PR TITLE
feat(mapper12): implement SL-5020B MMC3+CHR-A18 mapper

### DIFF
--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -11,6 +11,7 @@ use super::colordreams::ColorDreamsMapper;
 use super::cprom::CpromMapper;
 use super::gxrom::GxROMMapper;
 use super::irem_g101::IremG101Mapper;
+use super::mapper12::Mapper12;
 use super::mapper37::Mapper37;
 use super::mapper42::Mapper42;
 use super::mapper43::Mapper43;
@@ -498,6 +499,7 @@ mapper_registry! {
     9 => MMC2Mapper::new,
     10 => MMC4Mapper::new,
     11 => ColorDreamsMapper::new,
+    12 => Mapper12::new,
     13 => CpromMapper::new,
     15 => Multicart15Mapper::new,
     16 => BandaiFcgMapper::new,
@@ -558,9 +560,9 @@ mapper_registry! {
 
 #[cfg(test)]
 const SUPPORTED_MAPPERS: &[u8] = &[
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 32, 33, 34,
-    37, 40, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 56, 57, 58, 59, 60, 61, 62, 64, 65, 66,
-    67, 68, 69, 71, 72, 73, 78, 185, 206, 241, 242, 243, 244, 245, 246, 251, 254, 255,
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 32, 33,
+    34, 37, 40, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 56, 57, 58, 59, 60, 61, 62, 64, 65,
+    66, 67, 68, 69, 71, 72, 73, 78, 185, 206, 241, 242, 243, 244, 245, 246, 251, 254, 255,
 ];
 
 /// List of supported iNES mapper IDs handled by the factory.

--- a/src/cartridge/mapper12.rs
+++ b/src/cartridge/mapper12.rs
@@ -1,0 +1,441 @@
+//! Mapper 012 - SL-5020B (MMC3 + CHR A18 extension)
+//!
+//! Specifications:
+//! - Main: <https://www.nesdev.org/wiki/INES_Mapper_012>
+//!
+//! Known Limitations:
+//! - No known gameplay-blocking functional limitations are currently documented.
+
+use crate::cartridge::mmc3::MMC3Mapper;
+use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
+
+/// Mapper 012 - SL-5020B (MMC3 with CHR A18 outer bank extension)
+///
+/// Specifications:
+/// - Main: <https://www.nesdev.org/wiki/INES_Mapper_012>
+/// - Inner mapper: Full MMC3 (all registers and behavior)
+/// - PRG-ROM: Up to 512 KiB (standard MMC3, no outer extension)
+/// - CHR: Up to 512 KiB (256 KiB MMC3 window × 2 via A18 outer bit)
+/// - PRG-RAM: 8 KiB at $6000-$7FFF (standard MMC3)
+/// - Mirroring: Programmable via MMC3 ($A000)
+///
+/// Outer register (CPU $4132, detected by addr & 0xE100 == 0x4100):
+/// - Bit 0: CHR A18 for PPU $0000-$0FFF (low CHR half)
+/// - Bit 4: CHR A18 for PPU $1000-$1FFF (high CHR half)
+/// - Read returns bit 0 only
+/// - Reset value: 0
+///
+/// CHR bank resolution:
+/// - `final_bank = (outer_bit << 8) | mmc3_1k_bank`
+/// - This extends the MMC3's 256 KiB CHR window to 512 KiB.
+pub struct Mapper12 {
+    inner: MMC3Mapper,
+    chr_ext_lo: bool, // bit 0: CHR A18 for PPU $0000-$0FFF
+    chr_ext_hi: bool, // bit 4: CHR A18 for PPU $1000-$1FFF
+}
+
+impl Mapper12 {
+    const MAPPER_NUMBER: u8 = 12;
+    const CHR_1K_BANK_SIZE: usize = 0x0400; // 1 KiB
+    const CHR_BANK_MASK: usize = Self::CHR_1K_BANK_SIZE - 1;
+
+    pub fn new(ctx: super::mapper::MapperContext) -> Self {
+        let prg_rom = ctx.prg_rom;
+        let chr_rom = ctx.chr_rom;
+        let mirroring = ctx.mirroring;
+        Self {
+            inner: MMC3Mapper::new_with_irq_mode(prg_rom, chr_rom, mirroring, false),
+            chr_ext_lo: false,
+            chr_ext_hi: false,
+        }
+    }
+
+    fn is_outer_reg(addr: u16) -> bool {
+        addr & 0xE100 == 0x4100
+    }
+}
+
+impl Mapper for Mapper12 {
+    fn read_prg(&self, addr: u16) -> u8 {
+        if Self::is_outer_reg(addr) {
+            return self.chr_ext_lo as u8;
+        }
+        self.inner.read_prg(addr)
+    }
+
+    fn write_prg(&mut self, addr: u16, value: u8) {
+        if Self::is_outer_reg(addr) {
+            self.chr_ext_lo = value & 0x01 != 0;
+            self.chr_ext_hi = value & 0x10 != 0;
+        } else {
+            self.inner.write_prg(addr, value);
+        }
+    }
+
+    fn read_chr(&mut self, ppu_addr: u16) -> u8 {
+        let a12 = (ppu_addr >> 12) & 1 != 0;
+        let mmc3_bank = self.inner.mapped_chr_1k_bank(ppu_addr);
+        let ext_bit = if a12 {
+            self.chr_ext_hi
+        } else {
+            self.chr_ext_lo
+        };
+        let final_bank = ((ext_bit as usize) << 8) | mmc3_bank;
+        let offset = (ppu_addr as usize) & Self::CHR_BANK_MASK;
+        self.inner.read_chr_1k_at(final_bank, offset)
+    }
+
+    fn write_chr(&mut self, ppu_addr: u16, value: u8) {
+        let a12 = (ppu_addr >> 12) & 1 != 0;
+        let mmc3_bank = self.inner.mapped_chr_1k_bank(ppu_addr);
+        let ext_bit = if a12 {
+            self.chr_ext_hi
+        } else {
+            self.chr_ext_lo
+        };
+        let final_bank = ((ext_bit as usize) << 8) | mmc3_bank;
+        let offset = (ppu_addr as usize) & Self::CHR_BANK_MASK;
+        self.inner.write_chr_1k_at(final_bank, offset, value);
+    }
+
+    fn get_mirroring(&self) -> NametableLayout {
+        self.inner.get_mirroring()
+    }
+
+    fn mapper_number(&self) -> u8 {
+        Self::MAPPER_NUMBER
+    }
+
+    fn wram_size(&self) -> usize {
+        8 * 1024
+    }
+
+    fn ppu_address_changed(&mut self, addr: u16) {
+        self.inner.ppu_address_changed(addr);
+    }
+
+    fn cpu_cycle(&mut self) {
+        self.inner.cpu_cycle();
+    }
+
+    fn irq_pending(&self) -> bool {
+        self.inner.irq_pending()
+    }
+
+    fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.inner.chr_ram_snapshot()
+    }
+
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.inner.restore_chr_ram(data);
+    }
+
+    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
+        self.inner.initialize_ram(mode);
+    }
+
+    fn registers_snapshot(&self) -> Vec<u8> {
+        let mut snap = self.inner.registers_snapshot();
+        let outer = (self.chr_ext_lo as u8) | ((self.chr_ext_hi as u8) << 4);
+        snap.push(outer);
+        snap
+    }
+
+    fn restore_registers(&mut self, data: &[u8]) {
+        if let Some((&outer, mmc3_data)) = data.split_last() {
+            self.chr_ext_lo = outer & 0x01 != 0;
+            self.chr_ext_hi = outer & 0x10 != 0;
+            self.inner.restore_registers(mmc3_data);
+        }
+    }
+
+    fn capabilities(&self) -> MapperCapabilities {
+        MapperCapabilities {
+            has_irq: true,
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 8,
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 1,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cartridge::NametableLayout;
+    use crate::cartridge::mapper::{Mapper, MapperContext, create_mapper};
+    use crate::cartridge::test_helpers::{banked_data, banked_data_with_upper_marker};
+
+    // 32 PRG 8KB banks = 256 KiB PRG
+    const PRG_BANKS: usize = 32;
+    // 512 CHR 1KB banks = 512 KiB CHR (required for mapper 12's A18 extension)
+    const CHR_1K_BANKS: usize = 512;
+
+    /// Creates a mapper with plain lower-byte CHR markers (bank N → byte N%256).
+    /// Use for PRG tests and basic CHR banking tests within the lower 256 KiB.
+    fn make_mapper() -> Box<dyn Mapper> {
+        make_mapper_with_chr(banked_data(1024, CHR_1K_BANKS))
+    }
+
+    /// Creates a mapper with upper-byte CHR markers (banks 0–255 → byte 0,
+    /// banks 256–511 → byte 1).  Use for outer-register extension tests.
+    fn make_mapper_ext() -> Box<dyn Mapper> {
+        make_mapper_with_chr(banked_data_with_upper_marker(1024, CHR_1K_BANKS))
+    }
+
+    fn make_mapper_with_chr(chr: Vec<u8>) -> Box<dyn Mapper> {
+        let prg = banked_data(8 * 1024, PRG_BANKS);
+        create_mapper(MapperContext::new_for_test(
+            12,
+            prg,
+            chr,
+            NametableLayout::Vertical,
+        ))
+        .expect("Mapper 12 should be implemented")
+    }
+
+    // --- Factory ---
+
+    #[test]
+    fn mapper_12_is_registered() {
+        let result = create_mapper(MapperContext::new_for_test(
+            12,
+            banked_data(8 * 1024, PRG_BANKS),
+            banked_data(1024, CHR_1K_BANKS),
+            NametableLayout::Vertical,
+        ));
+        assert!(
+            result.is_ok(),
+            "Mapper 12 must be registered in the factory"
+        );
+    }
+
+    // --- PRG banking (full MMC3 delegation) ---
+
+    #[test]
+    fn all_mmc3_prg_banking_works() {
+        let mut mapper = make_mapper();
+        // Fixed-last bank ($E000) = bank 31 (last of 32)
+        assert_eq!(
+            mapper.read_prg(0xE000),
+            31,
+            "Fixed-last PRG bank must be 31"
+        );
+        // Select R6=3 → $8000 reads bank 3
+        mapper.write_prg(0x8000, 0b0000_0110); // bank_select = R6, mode 0
+        mapper.write_prg(0x8001, 3);
+        assert_eq!(
+            mapper.read_prg(0x8000),
+            3,
+            "R6=3 must map $8000 to PRG bank 3"
+        );
+    }
+
+    // --- CHR banking within lower 256 KiB (outer reg = 0) ---
+
+    #[test]
+    fn all_mmc3_chr_banking_works_in_lower_256kb() {
+        let mut mapper = make_mapper(); // banked_data: bank N → byte N%256
+        // CHR mode 0 (default): R2 → PPU $1000
+        mapper.write_prg(0x8000, 0b0000_0010); // R2
+        mapper.write_prg(0x8001, 5);
+        assert_eq!(
+            mapper.read_chr(0x1000),
+            5,
+            "R2=5 must map PPU $1000 to CHR bank 5 (lower 256 KiB)"
+        );
+        // Changing R2 must produce a different bank
+        mapper.write_prg(0x8001, 10);
+        assert_eq!(
+            mapper.read_chr(0x1000),
+            10,
+            "R2=10 must map PPU $1000 to CHR bank 10"
+        );
+    }
+
+    // --- Outer register bit 0: extends CHR low half ($0000-$0FFF) to upper 256 KiB ---
+
+    #[test]
+    fn outer_reg_bit0_extends_chr_low_half_to_upper_256kb() {
+        // Use upper-marker CHR: lower 256 KiB → marker 0; upper 256 KiB → marker 1
+        let mut mapper = make_mapper_ext();
+        // CHR mode 0: R0 is 2 KB at PPU $0000 (1 KB banks R0/R0+1 at $0000/$0400).
+        // Set R0=4; PPU $0000 uses 1 KB bank 4 (A12=0 → chr_ext_lo).
+        mapper.write_prg(0x8000, 0b0000_0000); // R0
+        mapper.write_prg(0x8001, 4);
+
+        // Without outer extension: bank 4 is in lower 256 KiB → marker 0
+        assert_eq!(
+            mapper.read_chr(0x0000),
+            0,
+            "Low half without extension: bank 4 must have upper-marker 0"
+        );
+
+        // Set outer bit0=1 (addr & 0xE100 == 0x4100 → e.g. $4132)
+        mapper.write_prg(0x4132, 0x01);
+
+        // With bit0=1: final bank = (1<<8)|4 = 260 → upper 256 KiB → marker 1
+        assert_eq!(
+            mapper.read_chr(0x0000),
+            1,
+            "Low half with bit0=1: final bank 260 must have upper-marker 1"
+        );
+    }
+
+    // --- Outer register bit 4: extends CHR high half ($1000-$1FFF) to upper 256 KiB ---
+
+    #[test]
+    fn outer_reg_bit4_extends_chr_high_half_to_upper_256kb() {
+        let mut mapper = make_mapper_ext();
+        // CHR mode 0: R2=5 → PPU $1000 = 1 KB bank 5 (A12=1 → chr_ext_hi)
+        mapper.write_prg(0x8000, 0b0000_0010); // R2
+        mapper.write_prg(0x8001, 5);
+
+        // Without ext: bank 5 → lower 256 KiB → marker 0
+        assert_eq!(
+            mapper.read_chr(0x1000),
+            0,
+            "High half without extension: bank 5 must have upper-marker 0"
+        );
+
+        // Set outer bit4=1: write 0x10 to $4132
+        mapper.write_prg(0x4132, 0x10);
+
+        // With bit4=1: final bank = (1<<8)|5 = 261 → upper 256 KiB → marker 1
+        assert_eq!(
+            mapper.read_chr(0x1000),
+            1,
+            "High half with bit4=1: final bank 261 must have upper-marker 1"
+        );
+    }
+
+    // --- Bit 0 and bit 4 are independent ---
+
+    #[test]
+    fn outer_reg_bit0_and_bit4_are_independent() {
+        let mut mapper = make_mapper_ext();
+        // Set R0=4 (2 KB at PPU $0000) and R2=6 (1 KB at PPU $1000)
+        mapper.write_prg(0x8000, 0b0000_0000); // R0
+        mapper.write_prg(0x8001, 4);
+        mapper.write_prg(0x8000, 0b0000_0010); // R2
+        mapper.write_prg(0x8001, 6);
+
+        // Set bit0=1, bit4=0: write 0x01
+        mapper.write_prg(0x4132, 0x01);
+
+        // Low half (A12=0): bit0=1 → upper 256 KiB → marker 1
+        assert_eq!(
+            mapper.read_chr(0x0000),
+            1,
+            "With bit0=1: low half must be in upper 256 KiB (marker 1)"
+        );
+        // High half (A12=1): bit4=0 → lower 256 KiB → marker 0
+        assert_eq!(
+            mapper.read_chr(0x1000),
+            0,
+            "With bit4=0: high half must be in lower 256 KiB (marker 0)"
+        );
+    }
+
+    // --- Outer register readback ---
+
+    #[test]
+    fn outer_reg_is_readable_at_4132() {
+        let mut mapper = make_mapper();
+
+        // Default: outer reg = 0
+        assert_eq!(
+            mapper.read_prg(0x4132),
+            0,
+            "Default outer reg must read as 0"
+        );
+
+        // Write bit0=1
+        mapper.write_prg(0x4132, 0x01);
+        assert_eq!(
+            mapper.read_prg(0x4132),
+            1,
+            "After writing bit0=1, read-back must return 1"
+        );
+
+        // Write bit4=1 only (bit0=0): readback must return bit0=0
+        mapper.write_prg(0x4132, 0x10);
+        assert_eq!(
+            mapper.read_prg(0x4132),
+            0,
+            "With only bit4=1 set, bit0 read-back must be 0"
+        );
+    }
+
+    // --- IRQ delegation ---
+
+    #[test]
+    fn mmc3_irq_works_through_delegation() {
+        let mut mapper = make_mapper();
+        mapper.write_prg(0xC000, 1); // IRQ latch = 1
+        mapper.write_prg(0xC001, 0); // reload
+        mapper.write_prg(0xE001, 0); // enable IRQ
+
+        // Two A12 rising edges, each preceded by ≥3 CPU cycles of A12 low
+        for _ in 0..2 {
+            mapper.ppu_address_changed(0x0FFF);
+            for _ in 0..3 {
+                mapper.cpu_cycle();
+            }
+            mapper.ppu_address_changed(0x1000);
+        }
+        assert!(mapper.irq_pending(), "MMC3 IRQ must fire via mapper 12");
+    }
+
+    // --- Mirroring delegation ---
+
+    #[test]
+    fn mmc3_mirroring_works_through_delegation() {
+        let mut mapper = make_mapper();
+        assert_eq!(
+            mapper.get_mirroring(),
+            NametableLayout::Vertical,
+            "Initial mirroring must match construction argument"
+        );
+        // Write $A000 bit0=1 → Horizontal
+        mapper.write_prg(0xA000, 0x01);
+        assert_eq!(
+            mapper.get_mirroring(),
+            NametableLayout::Horizontal,
+            "MMC3 mirroring change must propagate through mapper 12"
+        );
+    }
+
+    // --- Save state ---
+
+    #[test]
+    fn registers_snapshot_round_trips() {
+        let mut mapper = make_mapper();
+        // Set outer register: bit0=1, bit4=1
+        mapper.write_prg(0x4132, 0x11);
+        // Set R6=3 via MMC3
+        mapper.write_prg(0x8000, 0b0000_0110); // R6
+        mapper.write_prg(0x8001, 3);
+
+        let snap = mapper.registers_snapshot();
+
+        let mut mapper2 = make_mapper();
+        mapper2.restore_registers(&snap);
+
+        // PRG bank must be restored
+        assert_eq!(
+            mapper2.read_prg(0x8000),
+            3,
+            "R6=3 PRG bank state must survive snapshot round-trip"
+        );
+        // Outer reg bit0 must be restored (readable at $4132)
+        assert_eq!(
+            mapper2.read_prg(0x4132),
+            1,
+            "Outer reg bit0 must survive snapshot round-trip"
+        );
+    }
+}

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -12,6 +12,7 @@ mod gxrom;
 mod ines;
 mod irem_g101;
 mod mapper;
+mod mapper12;
 mod mapper185;
 mod mapper241;
 mod mapper242;


### PR DESCRIPTION
## Summary
Implements Mapper 12 (SL-5020B) — an MMC3-based board used by a subset of Dragon Ball Z titles, with an outer CHR A18 extension register that doubles the CHR address space to 512 KiB.

## Implementation
- Full MMC3 inner mapper (all standard registers and behavior)
- Outer register at CPU $4132 (detected by `addr & 0xE100 == 0x4100`)
  - Bit 0: CHR A18 for PPU $0000–$0FFF (low CHR half)
  - Bit 4: CHR A18 for PPU $1000–$1FFF (high CHR half)
  - Readable (returns bit 0 only)
  - Reset value: 0
- Final CHR bank = `(outer_bit << 8) | mmc3_1k_bank`
- PRG-ROM: standard MMC3 (up to 512 KiB, no outer PRG extension)
- Snapshot/restore support

## Tests (10 passing)
- Factory registration
- MMC3 PRG banking works normally
- MMC3 CHR banking works in lower 256 KiB (outer bits = 0)
- Outer bit 0 extends CHR low half to upper 256 KiB
- Outer bit 4 extends CHR high half to upper 256 KiB
- Outer bits 0 and 4 are independent
- Outer register is readable at $4132
- MMC3 IRQ delegation works
- MMC3 mirroring works
- Snapshot round-trip

## Pre-merge checks
- `cargo fmt -- --check` ✅
- `cargo test --lib --bins --tests --examples` ✅ (2989 tests)
- `cargo clippy --all-features -- -D warnings` ⚠️ Pre-existing error in `src/sdl_eventloop.rs` (line 1327, `collapsible_if`) — present on main, unrelated to mapper work

Closes #732
