### PR TITLE
Add BaseMapper composition and Mapper trait defaults

### DIFF
--- a/src/cartridge/common.rs
+++ b/src/cartridge/common.rs
@@ -3,6 +3,9 @@
 //! This module provides reusable components that are shared across multiple mappers,
 //! reducing code duplication and ensuring consistent behavior.
 
+use super::mapper::MapperCapabilities;
+use crate::cartridge::NametableLayout;
+
 /// Trait for consistent state snapshot and restoration.
 ///
 /// This trait provides a standard interface for capturing and restoring mapper state,
@@ -570,6 +573,229 @@ impl StateSnapshot for BankSwitch {
     }
 }
 
+/// Common mapper infrastructure that handles the boilerplate memory management
+/// shared by most NES mappers.
+///
+/// Inspired by Mesen2's `BaseMapper` class, this struct owns the common fields
+/// (PRG-ROM, PRG-RAM, CHR memory, mirroring, mapper number) and provides
+/// default implementations for the repetitive `Mapper` trait methods.
+///
+/// Mappers embed `BaseMapper` via composition and delegate boilerplate to it,
+/// only implementing the truly mapper-specific logic themselves.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// use neser::cartridge::{BaseMapper, Mapper, NametableLayout, MapperCapabilities};
+///
+/// pub struct MyMapper {
+///     base: BaseMapper,
+///     // ... mapper-specific fields
+/// }
+///
+/// impl Mapper for MyMapper {
+///     fn read_prg(&self, addr: u16) -> u8 {
+///         if let Some(v) = self.base.try_read_prg_ram(addr) { return v; }
+///         // mapper-specific PRG-ROM read logic
+///         0
+///     }
+///     fn write_prg(&mut self, addr: u16, value: u8) {
+///         if self.base.try_write_prg_ram(addr, value) { return; }
+///         // mapper-specific register write logic
+///     }
+///     fn read_chr(&mut self, addr: u16) -> u8 { self.base.read_chr(addr) }
+///     fn write_chr(&mut self, addr: u16, value: u8) { self.base.write_chr(addr, value) }
+///     fn get_mirroring(&self) -> NametableLayout { self.base.mirroring() }
+///     fn mapper_number(&self) -> u8 { self.base.mapper_number() }
+///     fn wram_size(&self) -> usize { self.base.wram_size() }
+///     fn wram_snapshot(&self) -> Vec<u8> { self.base.wram_snapshot() }
+///     fn load_wram_snapshot(&mut self, data: &[u8]) { self.base.load_wram_snapshot(data) }
+///     fn chr_ram_snapshot(&self) -> Vec<u8> { self.base.chr_ram_snapshot() }
+///     fn restore_chr_ram(&mut self, data: &[u8]) { self.base.restore_chr_ram(data) }
+///     fn initialize_ram(&mut self, mode: neser::console::RamInitMode) {
+///         self.base.initialize_ram(mode);
+///     }
+///     fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
+///         self.base.read_prg_open_bus(addr, open_bus, |a| self.read_prg(a))
+///     }
+///     fn capabilities(&self) -> MapperCapabilities { self.base.capabilities() }
+/// }
+/// ```
+pub struct BaseMapper {
+    prg_rom: Vec<u8>,
+    prg_ram: Option<PrgRam>,
+    chr_memory: ChrMemory,
+    mirroring: NametableLayout,
+    mapper_number: u16,
+    capabilities: MapperCapabilities,
+}
+
+#[allow(dead_code)]
+impl BaseMapper {
+    /// Create a new `BaseMapper` from a `MapperContext`.
+    ///
+    /// PRG-RAM is created only when the header explicitly specifies a non-zero size.
+    /// CHR memory is ROM when `chr_rom` is non-empty, otherwise CHR-RAM is allocated.
+    pub fn new(ctx: &super::mapper::MapperContext, capabilities: MapperCapabilities) -> Self {
+        let prg_ram = if ctx.prg_ram_size_specified && ctx.prg_ram_banks_8k > 0 {
+            Some(PrgRam::new(
+                ctx.prg_ram_banks_8k as usize * DEFAULT_PRG_RAM_SIZE,
+            ))
+        } else {
+            None
+        };
+        Self {
+            prg_rom: ctx.prg_rom.clone(),
+            prg_ram,
+            chr_memory: ChrMemory::new(ctx.chr_rom.clone()),
+            mirroring: ctx.mirroring,
+            mapper_number: ctx.mapper,
+            capabilities,
+        }
+    }
+
+    // --- PRG-ROM access ---
+
+    /// Get a reference to the PRG-ROM data.
+    #[inline]
+    pub fn prg_rom(&self) -> &[u8] {
+        &self.prg_rom
+    }
+
+    /// Read a byte from fixed PRG-ROM at $8000-$FFFF with automatic mirroring.
+    ///
+    /// For mappers with no PRG banking (e.g., NROM), this maps the full
+    /// 32KB window using `offset % prg_rom.len()` which naturally handles
+    /// 16KB mirroring.
+    #[inline]
+    pub fn read_prg_rom_fixed(&self, addr: u16) -> u8 {
+        if (0x8000..=0xFFFF).contains(&addr) {
+            let index = (addr - 0x8000) as usize % self.prg_rom.len();
+            self.prg_rom.get(index).copied().unwrap_or(0)
+        } else {
+            0
+        }
+    }
+
+    // --- PRG-RAM access ---
+
+    /// Try to read from PRG-RAM if the address is in $6000-$7FFF.
+    /// Returns `Some(value)` if PRG-RAM exists and address is in range, else `None`.
+    #[inline]
+    pub fn try_read_prg_ram(&self, addr: u16) -> Option<u8> {
+        self.prg_ram.as_ref().and_then(|ram| ram.try_read(addr))
+    }
+
+    /// Try to write to PRG-RAM if the address is in $6000-$7FFF.
+    /// Returns `true` if the write was handled.
+    #[inline]
+    pub fn try_write_prg_ram(&mut self, addr: u16, value: u8) -> bool {
+        if let Some(prg_ram) = &mut self.prg_ram {
+            prg_ram.try_write(addr, value)
+        } else {
+            false
+        }
+    }
+
+    /// Whether PRG-RAM is present.
+    #[inline]
+    pub fn has_prg_ram(&self) -> bool {
+        self.prg_ram.is_some()
+    }
+
+    // --- CHR memory access ---
+
+    /// Read a byte from CHR memory (ROM or RAM) at $0000-$1FFF.
+    #[inline]
+    pub fn read_chr(&self, addr: u16) -> u8 {
+        self.chr_memory.read(addr)
+    }
+
+    /// Write a byte to CHR memory. Only succeeds for CHR-RAM.
+    #[inline]
+    pub fn write_chr(&mut self, addr: u16, value: u8) {
+        self.chr_memory.write(addr, value);
+    }
+
+    // --- Mirroring ---
+
+    /// Get the nametable mirroring layout.
+    #[inline]
+    pub fn mirroring(&self) -> NametableLayout {
+        self.mirroring
+    }
+
+    /// Set the nametable mirroring layout (for mappers with dynamic mirroring).
+    #[inline]
+    pub fn set_mirroring(&mut self, mirroring: NametableLayout) {
+        self.mirroring = mirroring;
+    }
+
+    // --- Mapper identification ---
+
+    /// Get the mapper number.
+    #[inline]
+    pub fn mapper_number(&self) -> u8 {
+        self.mapper_number as u8
+    }
+
+    // --- Save-state / WRAM support ---
+
+    /// Get the WRAM (PRG-RAM) size in bytes.
+    pub fn wram_size(&self) -> usize {
+        self.prg_ram.as_ref().map_or(0, PrgRam::size)
+    }
+
+    /// Create a snapshot of PRG-RAM for save persistence.
+    pub fn wram_snapshot(&self) -> Vec<u8> {
+        self.prg_ram
+            .as_ref()
+            .map_or_else(Vec::new, PrgRam::snapshot)
+    }
+
+    /// Load a PRG-RAM snapshot from save persistence.
+    pub fn load_wram_snapshot(&mut self, data: &[u8]) {
+        if let Some(prg_ram) = &mut self.prg_ram {
+            prg_ram.load_snapshot(data);
+        }
+    }
+
+    /// Create a snapshot of CHR-RAM for save-state.
+    pub fn chr_ram_snapshot(&self) -> Vec<u8> {
+        self.chr_memory.snapshot()
+    }
+
+    /// Restore CHR-RAM from a save-state.
+    pub fn restore_chr_ram(&mut self, data: &[u8]) {
+        self.chr_memory.load_snapshot(data);
+    }
+
+    /// Re-initialize all RAM (PRG-RAM + CHR-RAM) for cartridge insertion / hard reset.
+    pub fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
+        if let Some(prg_ram) = &mut self.prg_ram {
+            prg_ram.initialize(mode);
+        }
+        self.chr_memory.initialize(mode);
+    }
+
+    /// Read PRG with open-bus handling.
+    ///
+    /// Returns `open_bus` for addresses below $6000 and for $6000-$7FFF when
+    /// no PRG-RAM is present. Otherwise delegates to the provided `read_prg` function.
+    pub fn read_prg_open_bus(&self, addr: u16, open_bus: u8, read_prg: impl Fn(u16) -> u8) -> u8 {
+        match addr {
+            0x0000..=0x5FFF => open_bus,
+            0x6000..=0x7FFF if self.prg_ram.is_none() => open_bus,
+            _ => read_prg(addr),
+        }
+    }
+
+    /// Get the mapper capabilities.
+    pub fn capabilities(&self) -> MapperCapabilities {
+        self.capabilities.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -973,5 +1199,209 @@ mod tests {
         // Zero bank size
         let zero_bank = BankSwitch::from_rom(&rom_data, 0);
         assert_eq!(zero_bank.current(), 0);
+    }
+
+    // --- BaseMapper tests ---
+
+    use crate::cartridge::mapper::MapperContext;
+
+    fn make_base_mapper_with_prg_ram(prg_ram_banks: u8) -> BaseMapper {
+        let ctx = MapperContext::new_for_test(
+            0,
+            vec![0xAA; 0x8000],
+            vec![0; 8192],
+            NametableLayout::Horizontal,
+        )
+        .with_prg_ram_banks(prg_ram_banks);
+        BaseMapper::new(
+            &ctx,
+            MapperCapabilities {
+                max_prg_ram_kb: if prg_ram_banks > 0 {
+                    prg_ram_banks as usize * 8
+                } else {
+                    0
+                },
+                ..Default::default()
+            },
+        )
+    }
+
+    #[test]
+    fn test_base_mapper_read_prg_rom_fixed_32kb() {
+        let mut prg_rom = vec![0; 0x8000];
+        prg_rom[0x0000] = 0xAA;
+        prg_rom[0x4000] = 0xBB;
+        prg_rom[0x7FFF] = 0xCC;
+        let ctx =
+            MapperContext::new_for_test(0, prg_rom, vec![0; 8192], NametableLayout::Horizontal);
+        let base = BaseMapper::new(&ctx, MapperCapabilities::default());
+
+        assert_eq!(base.read_prg_rom_fixed(0x8000), 0xAA);
+        assert_eq!(base.read_prg_rom_fixed(0xC000), 0xBB);
+        assert_eq!(base.read_prg_rom_fixed(0xFFFF), 0xCC);
+    }
+
+    #[test]
+    fn test_base_mapper_read_prg_rom_fixed_16kb_mirrors() {
+        let mut prg_rom = vec![0; 0x4000];
+        prg_rom[0x0000] = 0xAA;
+        prg_rom[0x3FFF] = 0xBB;
+        let ctx =
+            MapperContext::new_for_test(0, prg_rom, vec![0; 8192], NametableLayout::Horizontal);
+        let base = BaseMapper::new(&ctx, MapperCapabilities::default());
+
+        assert_eq!(base.read_prg_rom_fixed(0x8000), 0xAA);
+        assert_eq!(base.read_prg_rom_fixed(0xBFFF), 0xBB);
+        assert_eq!(base.read_prg_rom_fixed(0xC000), 0xAA); // mirrored
+        assert_eq!(base.read_prg_rom_fixed(0xFFFF), 0xBB); // mirrored
+    }
+
+    #[test]
+    fn test_base_mapper_prg_ram_read_write() {
+        let mut base = make_base_mapper_with_prg_ram(1);
+
+        assert_eq!(base.try_read_prg_ram(0x6000), Some(0));
+        base.try_write_prg_ram(0x6000, 0x42);
+        assert_eq!(base.try_read_prg_ram(0x6000), Some(0x42));
+
+        // Out of range
+        assert_eq!(base.try_read_prg_ram(0x5FFF), None);
+        assert_eq!(base.try_read_prg_ram(0x8000), None);
+    }
+
+    #[test]
+    fn test_base_mapper_no_prg_ram() {
+        let base = make_base_mapper_with_prg_ram(0);
+
+        assert!(!base.has_prg_ram());
+        assert_eq!(base.try_read_prg_ram(0x6000), None);
+        assert_eq!(base.wram_size(), 0);
+        assert!(base.wram_snapshot().is_empty());
+    }
+
+    #[test]
+    fn test_base_mapper_chr_read_write_ram() {
+        let ctx = MapperContext::new_for_test(
+            0,
+            vec![0; 0x8000],
+            vec![], // empty = CHR-RAM
+            NametableLayout::Horizontal,
+        );
+        let mut base = BaseMapper::new(&ctx, MapperCapabilities::default());
+
+        base.write_chr(0x0000, 0xAA);
+        assert_eq!(base.read_chr(0x0000), 0xAA);
+    }
+
+    #[test]
+    fn test_base_mapper_chr_read_rom() {
+        let ctx = MapperContext::new_for_test(
+            0,
+            vec![0; 0x8000],
+            vec![0x55; 8192],
+            NametableLayout::Horizontal,
+        );
+        let mut base = BaseMapper::new(&ctx, MapperCapabilities::default());
+
+        assert_eq!(base.read_chr(0x0000), 0x55);
+        base.write_chr(0x0000, 0xAA); // should be ignored (ROM)
+        assert_eq!(base.read_chr(0x0000), 0x55);
+    }
+
+    #[test]
+    fn test_base_mapper_mirroring() {
+        let ctx = MapperContext::new_for_test(
+            0,
+            vec![0; 0x8000],
+            vec![0; 8192],
+            NametableLayout::Vertical,
+        );
+        let mut base = BaseMapper::new(&ctx, MapperCapabilities::default());
+
+        assert_eq!(base.mirroring(), NametableLayout::Vertical);
+        base.set_mirroring(NametableLayout::Horizontal);
+        assert_eq!(base.mirroring(), NametableLayout::Horizontal);
+    }
+
+    #[test]
+    fn test_base_mapper_wram_snapshot_restore() {
+        let mut base = make_base_mapper_with_prg_ram(1);
+        base.try_write_prg_ram(0x6000, 0x42);
+        base.try_write_prg_ram(0x7FFF, 0xAB);
+
+        let snapshot = base.wram_snapshot();
+        assert_eq!(snapshot.len(), 8192);
+
+        let mut base2 = make_base_mapper_with_prg_ram(1);
+        base2.load_wram_snapshot(&snapshot);
+        assert_eq!(base2.try_read_prg_ram(0x6000), Some(0x42));
+        assert_eq!(base2.try_read_prg_ram(0x7FFF), Some(0xAB));
+    }
+
+    #[test]
+    fn test_base_mapper_chr_ram_snapshot_restore() {
+        let ctx =
+            MapperContext::new_for_test(0, vec![0; 0x8000], vec![], NametableLayout::Horizontal);
+        let mut base = BaseMapper::new(&ctx, MapperCapabilities::default());
+        base.write_chr(0x0000, 0xAA);
+        base.write_chr(0x1FFF, 0xBB);
+
+        let snapshot = base.chr_ram_snapshot();
+
+        let ctx2 =
+            MapperContext::new_for_test(0, vec![0; 0x8000], vec![], NametableLayout::Horizontal);
+        let mut base2 = BaseMapper::new(&ctx2, MapperCapabilities::default());
+        base2.restore_chr_ram(&snapshot);
+        assert_eq!(base2.read_chr(0x0000), 0xAA);
+        assert_eq!(base2.read_chr(0x1FFF), 0xBB);
+    }
+
+    #[test]
+    fn test_base_mapper_open_bus_no_prg_ram() {
+        let base = make_base_mapper_with_prg_ram(0);
+
+        // Below $6000: open bus
+        assert_eq!(base.read_prg_open_bus(0x5000, 0x42, |_| 0xFF), 0x42);
+        // $6000-$7FFF with no PRG-RAM: open bus
+        assert_eq!(base.read_prg_open_bus(0x6000, 0x42, |_| 0xFF), 0x42);
+        // $8000+: delegates to read_prg
+        assert_eq!(base.read_prg_open_bus(0x8000, 0x42, |_| 0xAA), 0xAA);
+    }
+
+    #[test]
+    fn test_base_mapper_open_bus_with_prg_ram() {
+        let base = make_base_mapper_with_prg_ram(1);
+
+        // $6000-$7FFF with PRG-RAM: delegates to read_prg
+        assert_eq!(base.read_prg_open_bus(0x6000, 0x42, |_| 0xBB), 0xBB);
+    }
+
+    #[test]
+    fn test_base_mapper_mapper_number() {
+        let ctx = MapperContext::new_for_test(
+            7,
+            vec![0; 0x8000],
+            vec![0; 8192],
+            NametableLayout::Horizontal,
+        );
+        let base = BaseMapper::new(&ctx, MapperCapabilities::default());
+        assert_eq!(base.mapper_number(), 7);
+    }
+
+    #[test]
+    fn test_base_mapper_capabilities() {
+        let caps = MapperCapabilities {
+            has_irq: true,
+            has_chr_banking: true,
+            ..Default::default()
+        };
+        let ctx = MapperContext::new_for_test(
+            0,
+            vec![0; 0x8000],
+            vec![0; 8192],
+            NametableLayout::Horizontal,
+        );
+        let base = BaseMapper::new(&ctx, caps.clone());
+        assert_eq!(base.capabilities(), caps);
     }
 }

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -225,6 +225,29 @@ impl Default for MapperCapabilities {
 }
 
 pub trait Mapper {
+    /// Return a reference to the embedded [`BaseMapper`], if present.
+    ///
+    /// Mappers that embed a `BaseMapper` should override this (and [`base_mut`])
+    /// to return `Some(&self.base)`. The default trait methods for mirroring,
+    /// WRAM, CHR-RAM, capabilities, etc. then delegate to the `BaseMapper`,
+    /// eliminating boilerplate.
+    ///
+    /// Mappers that do **not** use `BaseMapper` can leave the default (`None`)
+    /// and override individual methods as before.
+    ///
+    /// [`BaseMapper`]: crate::cartridge::common::BaseMapper
+    /// [`base_mut`]: Mapper::base_mut
+    fn base(&self) -> Option<&super::common::BaseMapper> {
+        None
+    }
+
+    /// Return a mutable reference to the embedded [`BaseMapper`], if present.
+    ///
+    /// See [`base`](Mapper::base) for details.
+    fn base_mut(&mut self) -> Option<&mut super::common::BaseMapper> {
+        None
+    }
+
     /// Read a byte from PRG address space (CPU $6000-$FFFF)
     /// - $6000-$7FFF: PRG-RAM (8KB, battery-backed on some cartridges)
     /// - $8000-$FFFF: PRG-ROM (with bank switching on advanced mappers)
@@ -234,10 +257,15 @@ pub trait Mapper {
     /// Read a byte from PRG address space (CPU $6000-$FFFF), with open-bus context.
     ///
     /// Mappers that return open bus for disabled regions can override this method
-    /// to return `open_bus` when appropriate. Default falls back to `read_prg`.
-    fn read_prg_open_bus(&self, addr: u16, _open_bus: u8) -> u8 {
-        if addr < 0x6000 {
-            _open_bus
+    /// to return `open_bus` when appropriate.
+    ///
+    /// Default delegates to `BaseMapper` if available, otherwise falls back to
+    /// `read_prg` with open-bus below $6000.
+    fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
+        if let Some(base) = self.base() {
+            base.read_prg_open_bus(addr, open_bus, |a| self.read_prg(a))
+        } else if addr < 0x6000 {
+            open_bus
         } else {
             self.read_prg(addr)
         }
@@ -249,12 +277,24 @@ pub trait Mapper {
     fn write_prg(&mut self, addr: u16, value: u8);
 
     /// Read a byte from CHR address space (PPU $0000-$1FFF)
-    /// Returns the byte at the given address after bank translation
-    fn read_chr(&mut self, addr: u16) -> u8;
+    /// Returns the byte at the given address after bank translation.
+    ///
+    /// Default delegates to `BaseMapper` if available.
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base()
+            .map(|b| b.read_chr(addr))
+            .expect("read_chr or base() must be implemented")
+    }
 
     /// Write a byte to CHR address space (PPU $0000-$1FFF)
-    /// Only works for CHR-RAM, CHR-ROM is read-only
-    fn write_chr(&mut self, addr: u16, value: u8);
+    /// Only works for CHR-RAM, CHR-ROM is read-only.
+    ///
+    /// Default delegates to `BaseMapper` if available.
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        if let Some(base) = self.base_mut() {
+            base.write_chr(addr, value);
+        }
+    }
 
     /// Notify mapper of PPU address bus changes
     /// Used for detecting A12 rising edges (for MMC3 IRQ)
@@ -342,9 +382,13 @@ pub trait Mapper {
     ///
     /// This is called when a cartridge is inserted or on hard reset to initialize
     /// RAM contents. Soft resets should NOT call this method (RAM should be preserved).
-    /// Default implementation is a no-op for mappers without RAM or mappers that
-    /// don't use the helper types.
-    fn initialize_ram(&mut self, _mode: crate::console::RamInitMode) {}
+    ///
+    /// Default delegates to `BaseMapper` if available, otherwise is a no-op.
+    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
+        if let Some(base) = self.base_mut() {
+            base.initialize_ram(mode);
+        }
+    }
 
     /// Whether the mapper is currently asserting IRQ.
     ///
@@ -365,16 +409,24 @@ pub trait Mapper {
         0.0
     }
 
-    /// Get the current nametable mirroring mode
-    /// Some mappers can change mirroring dynamically
-    fn get_mirroring(&self) -> NametableLayout;
+    /// Get the current nametable mirroring mode.
+    /// Some mappers can change mirroring dynamically.
+    ///
+    /// Default delegates to `BaseMapper` if available.
+    fn get_mirroring(&self) -> NametableLayout {
+        self.base()
+            .map(|b| b.mirroring())
+            .expect("get_mirroring or base() must be implemented")
+    }
 
     /// Get the size of cartridge WRAM (PRG-RAM) in bytes.
     ///
     /// Returns the total size of battery-backed PRG-RAM that should be persisted to disk.
-    /// Default implementation returns 8KB (0x2000 bytes), the standard PRG-RAM size.
+    ///
+    /// Default delegates to `BaseMapper` if available, otherwise returns
+    /// 8KB (0x2000 bytes).
     fn wram_size(&self) -> usize {
-        0x2000
+        self.base().map_or(0x2000, |b| b.wram_size())
     }
 
     /// Create a snapshot of all cartridge WRAM (PRG-RAM) for persistence.
@@ -385,9 +437,13 @@ pub trait Mapper {
     /// - Current bank mapping (for mappers with banked WRAM like MMC5)
     ///
     /// Returns a Vec containing the complete WRAM contents.
-    /// Default implementation reads via read_prg at $6000-$7FFF (8KB window).
+    /// Default delegates to `BaseMapper` if available, otherwise reads via
+    /// `read_prg` at $6000-$7FFF (8KB window).
     /// **Mappers with >8KB WRAM MUST override this method to capture all banks.**
     fn wram_snapshot(&self) -> Vec<u8> {
+        if let Some(base) = self.base() {
+            return base.wram_snapshot();
+        }
         let size = self.wram_size().min(0x2000);
         let mut snapshot = Vec::with_capacity(size);
         for i in 0..size {
@@ -404,9 +460,14 @@ pub trait Mapper {
     /// - Current bank mapping (for mappers with banked WRAM like MMC5)
     ///
     /// The data slice should contain the complete WRAM contents to restore.
-    /// Default implementation writes via write_prg at $6000-$7FFF (8KB window).
+    /// Default delegates to `BaseMapper` if available, otherwise writes via
+    /// `write_prg` at $6000-$7FFF (8KB window).
     /// **Mappers with >8KB WRAM MUST override this method to restore all banks.**
     fn load_wram_snapshot(&mut self, data: &[u8]) {
+        if let Some(base) = self.base_mut() {
+            base.load_wram_snapshot(data);
+            return;
+        }
         let to_copy = data.len().min(0x2000).min(self.wram_size());
         for (i, &byte) in data.iter().take(to_copy).enumerate() {
             self.write_prg(0x6000 + i as u16, byte);
@@ -416,9 +477,10 @@ pub trait Mapper {
     /// Get the mapper number (iNES mapper ID).
     ///
     /// Returns the iNES mapper number for this mapper (e.g., 0 for NROM, 1 for MMC1).
-    /// Default implementation returns 0.
+    ///
+    /// Default delegates to `BaseMapper` if available, otherwise returns 0.
     fn mapper_number(&self) -> u8 {
-        0
+        self.base().map_or(0, |b| b.mapper_number())
     }
 
     /// Create a snapshot of PRG-RAM for save-state.
@@ -430,9 +492,10 @@ pub trait Mapper {
 
     /// Create a snapshot of CHR-RAM for save-state.
     ///
-    /// Default implementation returns empty (CHR-ROM has no state to save).
+    /// Default delegates to `BaseMapper` if available, otherwise returns
+    /// empty (CHR-ROM has no state to save).
     fn chr_ram_snapshot(&self) -> Vec<u8> {
-        Vec::new()
+        self.base().map_or_else(Vec::new, |b| b.chr_ram_snapshot())
     }
 
     /// Create a snapshot of mapper-specific registers for save-state.
@@ -451,8 +514,12 @@ pub trait Mapper {
 
     /// Restore CHR-RAM from a save-state.
     ///
-    /// Default implementation is a no-op.
-    fn restore_chr_ram(&mut self, _data: &[u8]) {}
+    /// Default delegates to `BaseMapper` if available, otherwise is a no-op.
+    fn restore_chr_ram(&mut self, data: &[u8]) {
+        if let Some(base) = self.base_mut() {
+            base.restore_chr_ram(data);
+        }
+    }
 
     /// Restore mapper-specific registers from a save-state.
     ///
@@ -463,10 +530,13 @@ pub trait Mapper {
     ///
     /// Each mapper should override this to accurately describe its features
     /// (IRQ, CHR banking, dynamic mirroring, expansion audio, etc.).
-    /// The default returns conservative defaults suitable for the simplest mappers.
+    ///
+    /// Default delegates to `BaseMapper` if available, otherwise returns
+    /// conservative defaults suitable for the simplest mappers.
     #[allow(dead_code)]
     fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities::default()
+        self.base()
+            .map_or_else(MapperCapabilities::default, |b| b.capabilities())
     }
 }
 

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -75,8 +75,8 @@ mod vrc6;
 pub use cartridge::Cartridge;
 #[allow(unused_imports)]
 pub use common::{
-    BankSwitch, BankedRom, ChrMemory, DEFAULT_CHR_RAM_SIZE, DEFAULT_PRG_RAM_SIZE, PrgRam,
-    StateSnapshot,
+    BankSwitch, BankedRom, BaseMapper, ChrMemory, DEFAULT_CHR_RAM_SIZE, DEFAULT_PRG_RAM_SIZE,
+    PrgRam, StateSnapshot,
 };
 #[allow(unused_imports)]
 pub use ines::{ConsoleType, InesHeader, NametableLayout, ParsedRom, RomParseError, TimingMode};

--- a/src/cartridge/nrom.rs
+++ b/src/cartridge/nrom.rs
@@ -7,8 +7,7 @@
 
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
-use crate::cartridge::NametableLayout;
-use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
+use crate::cartridge::common::BaseMapper;
 
 /// Mapper 0 - NROM
 ///
@@ -28,134 +27,62 @@ use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
 /// - Used in early NES games like Super Mario Bros., Ice Climber, Excitebike
 /// - Some NROM boards have no PRG-RAM (depends on board variant)
 pub struct NROMMapper {
-    prg_rom: Vec<u8>,
-    prg_ram: Option<PrgRam>,
-    chr_memory: ChrMemory,
-    mirroring: NametableLayout,
+    base: BaseMapper,
 }
 
 impl NROMMapper {
     /// Create a new NROM mapper
     /// If chr_rom is empty, 8KB of CHR-RAM is allocated
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
-        let mirroring = ctx.mirroring;
-        let prg_ram = if ctx.prg_ram_size_specified && ctx.prg_ram_banks_8k > 0 {
-            Some(PrgRam::new(
-                ctx.prg_ram_banks_8k as usize * DEFAULT_PRG_RAM_SIZE,
-            ))
-        } else {
-            None
+        let capabilities = MapperCapabilities {
+            has_irq: false,
+            has_chr_banking: false,
+            has_dynamic_mirroring: false,
+            has_expansion_audio: false,
+            max_prg_ram_kb: if ctx.prg_ram_size_specified && ctx.prg_ram_banks_8k > 0 {
+                ctx.prg_ram_banks_8k as usize * 8
+            } else {
+                0
+            },
+            prg_bank_size_kb: 32,
+            chr_bank_size_kb: 8,
+            trainer_jsr: false,
+            ..Default::default()
         };
         Self {
-            prg_rom,
-            prg_ram,
-            chr_memory: ChrMemory::new(chr_rom),
-            mirroring,
+            base: BaseMapper::new(&ctx, capabilities),
         }
     }
 }
 
 impl Mapper for NROMMapper {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         // PRG-RAM at $6000-$7FFF (only if present)
-        if let Some(prg_ram) = &self.prg_ram
-            && let Some(value) = prg_ram.try_read(addr)
-        {
+        if let Some(value) = self.base.try_read_prg_ram(addr) {
             return value;
         }
-
         // PRG ROM at $8000-$FFFF; % len naturally mirrors 16KB ROM to $C000-$FFFF
-        match addr {
-            0x8000..=0xFFFF => {
-                let index = (addr - 0x8000) as usize % self.prg_rom.len();
-                self.prg_rom.get(index).copied().unwrap_or(0)
-            }
-            _ => 0,
-        }
+        self.base.read_prg_rom_fixed(addr)
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
         // PRG-RAM at $6000-$7FFF (only if present)
-        if let Some(prg_ram) = &mut self.prg_ram {
-            let _ = prg_ram.try_write(addr, value);
-        }
-    }
-
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.chr_memory.read(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.chr_memory.write(addr, value);
-    }
-
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        0
-    }
-
-    fn wram_size(&self) -> usize {
-        self.prg_ram.as_ref().map_or(0, |r| r.size())
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram
-            .as_ref()
-            .map_or_else(Vec::new, |r| r.snapshot())
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        if let Some(prg_ram) = &mut self.prg_ram {
-            prg_ram.load_snapshot(data);
-        }
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
-    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        if let Some(prg_ram) = &mut self.prg_ram {
-            prg_ram.initialize(mode);
-        }
-        self.chr_memory.initialize(mode);
-    }
-
-    fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
-        match addr {
-            0x0000..=0x5FFF => open_bus,
-            0x6000..=0x7FFF if self.prg_ram.is_none() => open_bus,
-            _ => self.read_prg(addr),
-        }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: false,
-            has_dynamic_mirroring: false,
-            has_expansion_audio: false,
-            max_prg_ram_kb: self.prg_ram.as_ref().map_or(0, |r| r.size() / 1024),
-            prg_bank_size_kb: 32,
-            chr_bank_size_kb: 8,
-            trainer_jsr: false,
-            ..Default::default()
-        }
+        self.base.try_write_prg_ram(addr, value);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cartridge::NametableLayout;
     use crate::cartridge::mapper::MapperContext;
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `BaseMapper` struct for composition-based code reuse across mapper implementations, and extends the `Mapper` trait with `base()`/`base_mut()` returning backward-compatible defaults for 12 boilerplate methods.

## Changes

### BaseMapper struct (common.rs)
- New `BaseMapper` struct holding shared state: PRG ROM, PRG RAM, CHR memory, mirroring, mapper number, capabilities
- 15+ methods for PRG-ROM/RAM access, CHR memory, mirroring, save-state, open-bus handling
- 15 unit tests covering all functionality

### Mapper trait (mapper.rs)
- Added `base()` / `base_mut()` returning `Option<&BaseMapper>` with default `None`
- 12 trait methods now auto-delegate to BaseMapper when available: read_chr, write_chr, get_mirroring, read_prg_open_bus, initialize_ram, wram_size, wram_snapshot, load_wram_snapshot, mapper_number, chr_ram_snapshot, restore_chr_ram, capabilities
- Fully backward-compatible: existing mappers returning `None` from `base()` keep their old behavior

### NROM refactoring (nrom.rs)
- Reduced from 4 fields + ~60 lines of trait impl to 1 field (`base: BaseMapper`) + ~25 lines
- Only implements: `base()`, `base_mut()`, `read_prg()`, `write_prg()`
- All other methods come from trait defaults

## Test results

- All 3,022 tests pass with zero regressions
- Clippy clean, fmt clean

## What's next

This is the foundation for the full mapper migration planned in #784. Sub-issues #785-#791 track the remaining phases.

Closes no issue (this is incremental work toward #784).
