### PR TITLE
Migrate all 11 medium-complexity mappers to BaseMapper (#789)

### DIFF
--- a/src/cartridge/bnrom_nina.rs
+++ b/src/cartridge/bnrom_nina.rs
@@ -5,15 +5,11 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
+use crate::cartridge::BaseMapper;
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::NametableLayout;
-use crate::cartridge::common::{BankSwitch, BankedRom, ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
 use std::env;
-
-// Memory size constants
-const PRG_BANK_SIZE: usize = 0x8000; // 32KB
-const NINA_CHR_BANK_SIZE: usize = 0x1000; // 4KB
 
 /// Mapper 34 - BNROM / NINA-001
 ///
@@ -54,13 +50,11 @@ const NINA_CHR_BANK_SIZE: usize = 0x1000; // 4KB
 ///   long-standing hybrid mapper-34 behavior where NINA CHR banking and PRG writes
 ///   at $8000-$FFFF coexist. This mode is intentionally isolated to submapper 0.
 pub struct BnromNinaMapper {
-    prg_rom: BankedRom,
-    prg_ram: PrgRam,
-    chr_memory: ChrMemory,
+    base: BaseMapper,
     mirroring: NametableLayout,
-    prg_bank: BankSwitch,
-    chr_bank_low: BankSwitch,
-    chr_bank_high: BankSwitch,
+    prg_bank: u8,
+    chr_bank_low: u8,
+    chr_bank_high: u8,
     is_nina: bool, // true for NINA-001, false for BNROM
     // Enabled only for mapper 34 submapper 0 + CHR-ROM fallback to match common
     // FCEUX-compatible hacked ROM expectations (hybrid NINA/BNROM PRG writes).
@@ -80,15 +74,13 @@ impl BnromNinaMapper {
             "[mapper34] {event} addr={addr:04X} val={value:02X} is_nina={} compat={} prg={} chr_lo={} chr_hi={}",
             self.is_nina,
             self.mapper34_compat_mode,
-            self.prg_bank.current(),
-            self.chr_bank_low.current(),
-            self.chr_bank_high.current()
+            self.prg_bank,
+            self.chr_bank_low,
+            self.chr_bank_high
         );
     }
 
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
         let mirroring = ctx.mirroring;
         // Detect variant using explicit NES 2.0 submappers where available.
         // Submapper 1 = NINA-001/NINA-002, submapper 2 = BNROM.
@@ -97,24 +89,32 @@ impl BnromNinaMapper {
         let is_nina = match ctx.submapper {
             1 => true,
             2 => false,
-            _ => !chr_rom.is_empty(),
+            _ => !ctx.chr_rom.is_empty(),
         };
         // Compatibility mode for mapper 34 iNES/submapper 0 hacks.
         // Keeps strict hardware-style behavior for explicit submapper 1.
         let mapper34_compat_mode = is_nina && ctx.submapper == 0;
 
-        // NINA uses two independent 4KB CHR windows ($0000 and $1000).
-        // BNROM has unbanked CHR memory (typically 8KB CHR-RAM).
-        let (chr_bank_low, chr_bank_high) = if is_nina {
-            let bank_low = BankSwitch::from_rom(&chr_rom, NINA_CHR_BANK_SIZE);
-            let mut bank_high = BankSwitch::from_rom(&chr_rom, NINA_CHR_BANK_SIZE);
-            bank_high.set(1);
-            (bank_low, bank_high)
-        } else {
-            (BankSwitch::new(1), BankSwitch::new(1))
+        let capabilities = MapperCapabilities {
+            has_irq: false,
+            has_chr_banking: is_nina,
+            has_dynamic_mirroring: false,
+            has_expansion_audio: false,
+            max_prg_ram_kb: if is_nina { 8 } else { 0 },
+            prg_bank_size_kb: 32,
+            chr_bank_size_kb: if is_nina { 4 } else { 8 },
+            trainer_jsr: false,
+            ..Default::default()
         };
-        let prg_bank = BankSwitch::from_rom(&prg_rom, PRG_BANK_SIZE);
-        let prg_ram_size = if is_nina { DEFAULT_PRG_RAM_SIZE } else { 0 };
+
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(0x8000); // 32KB
+        if is_nina {
+            base.configure_chr_banking(0x1000); // 4KB
+        }
+
+        let chr_bank_high = if is_nina { 1 } else { 0 };
+
         let trace_enabled = env::var_os("NESER_TRACE_MAPPER34").is_some();
         let trace_budget = env::var("NESER_TRACE_MAPPER34_LIMIT")
             .ok()
@@ -122,54 +122,59 @@ impl BnromNinaMapper {
             .unwrap_or(200);
 
         let mut mapper = Self {
-            prg_rom: BankedRom::new(prg_rom, PRG_BANK_SIZE),
-            prg_ram: PrgRam::new(prg_ram_size),
-            chr_memory: ChrMemory::new(chr_rom),
+            base,
             mirroring,
-            prg_bank,
-            chr_bank_low,
+            prg_bank: 0,
+            chr_bank_low: 0,
             chr_bank_high,
             is_nina,
             mapper34_compat_mode,
             trace_enabled,
             trace_budget,
         };
-
+        mapper.update_banks();
         mapper.trace_state("init", 0, 0);
         mapper
     }
 
-    fn nina_chr_index(&self, addr: u16) -> usize {
-        let window_offset = (addr & 0x0FFF) as usize;
-        let bank_offset = if addr < 0x1000 {
-            self.chr_bank_low.offset(NINA_CHR_BANK_SIZE)
-        } else {
-            self.chr_bank_high.offset(NINA_CHR_BANK_SIZE)
-        };
-        bank_offset + window_offset
+    fn update_banks(&mut self) {
+        self.base.select_prg_page(0, self.prg_bank as i16);
+        if self.is_nina {
+            self.base.select_chr_page(0, self.chr_bank_low as i16);
+            self.base.select_chr_page(1, self.chr_bank_high as i16);
+        }
+        self.base.set_mirroring(self.mirroring);
     }
 }
 
 impl Mapper for BnromNinaMapper {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn reset(&mut self) {
-        self.prg_bank.set(0);
-        self.chr_bank_low.set(0);
-        self.chr_bank_high.set(if self.is_nina { 1 } else { 0 });
+        self.prg_bank = 0;
+        self.chr_bank_low = 0;
+        self.chr_bank_high = if self.is_nina { 1 } else { 0 };
+        self.update_banks();
         self.trace_state("reset", 0, 0);
     }
 
     fn read_prg(&self, addr: u16) -> u8 {
-        // PRG-RAM at $6000-$7FFF
-        if let Some(value) = self.prg_ram.try_read(addr) {
+        // PRG-RAM at $6000-$7FFF (NINA only)
+        if let Some(value) = self.base.try_read_prg_ram(addr) {
             return value;
         }
 
         // PRG ROM at $8000-$FFFF (32KB switchable bank)
-        match addr {
-            0x8000..=0xFFFF => self
-                .prg_rom
-                .read_with_base(self.prg_bank.current(), 0x8000, addr),
-            _ => 0,
+        if addr >= 0x8000 {
+            self.base.read_prg_banked(addr)
+        } else {
+            0
         }
     }
 
@@ -177,7 +182,7 @@ impl Mapper for BnromNinaMapper {
         // NINA-001 registers overlap PRG-RAM at $7FFD-$7FFF.
         // A write updates both the register and underlying RAM byte.
         if self.is_nina && (0x7FFD..=0x7FFF).contains(&addr) {
-            let _ = self.prg_ram.try_write(addr, value);
+            let _ = self.base.try_write_prg_ram(addr, value);
 
             match addr {
                 0x7FFD => {
@@ -185,122 +190,79 @@ impl Mapper for BnromNinaMapper {
                     // Submapper 0 compatibility mode: accept full register value
                     // to match FCEUX mapper-34 hack behavior.
                     if self.mapper34_compat_mode {
-                        self.prg_bank.set(value);
+                        self.prg_bank = value;
                     } else {
-                        self.prg_bank.set(value & 0x01);
+                        self.prg_bank = value & 0x01;
                     }
                 }
                 0x7FFE => {
-                    self.chr_bank_low.set(value);
+                    self.chr_bank_low = value;
                 }
                 0x7FFF => {
-                    self.chr_bank_high.set(value);
+                    self.chr_bank_high = value;
                 }
                 _ => {}
             }
+            self.update_banks();
             self.trace_state("write_nina_reg", addr, value);
             return;
         }
 
         // Submapper 0 compatibility mode accepts PRG bank writes at $8000-$FFFF
         // (FCEUX mapper-34 hybrid behavior used by several hM34 ROMs).
-        if self.is_nina && self.mapper34_compat_mode && (0x8000..=0xFFFF).contains(&addr) {
-            self.prg_bank.set(value);
+        if self.is_nina && self.mapper34_compat_mode && addr >= 0x8000 {
+            self.prg_bank = value;
+            self.update_banks();
             self.trace_state("write_nina_compat_prg", addr, value);
             return;
         }
 
-        if self.prg_ram.try_write(addr, value) {
+        if self.base.try_write_prg_ram(addr, value) {
             return;
         }
 
         // BNROM: Any write to $8000-$FFFF sets PRG bank
         // NINA-001: Writes to $8000-$FFFF are ignored (uses $7FFD-$7FFF instead)
-        if !self.is_nina && (0x8000..=0xFFFF).contains(&addr) {
+        if !self.is_nina && addr >= 0x8000 {
             // BNROM has AND-type bus conflicts: effective value = write_value & rom_value_at_addr.
-            let rom_value = self.read_prg(addr);
-            self.prg_bank.set(value & rom_value);
+            let rom_value = self.base.read_prg_banked(addr);
+            self.prg_bank = value & rom_value;
+            self.update_banks();
             self.trace_state("write_bnrom_bank", addr, value);
         }
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
         if self.is_nina {
-            self.chr_memory.read_at_index(self.nina_chr_index(addr))
+            self.base.read_chr_banked(addr)
         } else {
-            self.chr_memory.read(addr)
+            self.base.read_chr(addr)
         }
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
         if self.is_nina {
-            let index = self.nina_chr_index(addr);
-            self.chr_memory.write_at_index(index, value);
+            self.base.write_chr_banked(addr, value);
         } else {
-            self.chr_memory.write(addr, value);
+            self.base.write_chr(addr, value);
         }
     }
 
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        34
-    }
-
-    fn wram_size(&self) -> usize {
-        self.prg_ram.size()
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.snapshot()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        self.prg_ram.load_snapshot(data);
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
-        vec![
-            self.prg_bank.raw(),
-            self.chr_bank_low.raw(),
-            self.chr_bank_high.raw(),
-        ]
+        vec![self.prg_bank, self.chr_bank_low, self.chr_bank_high]
     }
 
     fn restore_registers(&mut self, data: &[u8]) {
         if let Some(&value) = data.first() {
-            self.prg_bank.set(value);
+            self.prg_bank = value;
         }
         if let Some(&value) = data.get(1) {
-            self.chr_bank_low.set(value);
+            self.chr_bank_low = value;
         }
         if let Some(&value) = data.get(2) {
-            self.chr_bank_high.set(value);
+            self.chr_bank_high = value;
         }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: self.is_nina,
-            has_dynamic_mirroring: false,
-            has_expansion_audio: false,
-            max_prg_ram_kb: if self.is_nina { 8 } else { 0 },
-            prg_bank_size_kb: 32,
-            chr_bank_size_kb: if self.is_nina { 4 } else { 8 },
-            trainer_jsr: false,
-            ..Default::default()
-        }
+        self.update_banks();
     }
 }
 

--- a/src/cartridge/common.rs
+++ b/src/cartridge/common.rs
@@ -548,6 +548,7 @@ impl BankSwitch {
     ///
     /// # Returns
     /// The offset into ROM data for the current bank
+    #[cfg(test)]
     pub fn offset(&self, bank_size: usize) -> usize {
         self.current() * bank_size
     }

--- a/src/cartridge/irem_g101.rs
+++ b/src/cartridge/irem_g101.rs
@@ -5,7 +5,7 @@
 //!
 //! Specification: <https://www.nesdev.org/wiki/INES_Mapper_032>
 
-use crate::cartridge::common::ChrMemory;
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 /// Mapper 032 - Irem G-101
@@ -34,22 +34,14 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// - Mode 0: [$8000]=reg0, [$A000]=reg1, [$C000]={-2}, [$E000]={-1}
 /// - Mode 1: [$8000]={-2}, [$A000]=reg1, [$C000]=reg0, [$E000]={-1}
 pub struct IremG101Mapper {
-    prg_rom: Vec<u8>,
-    chr_memory: ChrMemory,
+    base: BaseMapper,
     prg_regs: [u8; 2],
     chr_regs: [u8; 8],
     prg_mode: bool,
-    mirroring: NametableLayout,
     submapper: u8,
 }
 
 impl IremG101Mapper {
-    const MAPPER_NUMBER: u8 = 32;
-    const PRG_BANK_SIZE: usize = 0x2000; // 8KB
-    const PRG_BANK_MASK: usize = Self::PRG_BANK_SIZE - 1;
-    const CHR_BANK_SIZE: usize = 0x0400; // 1KB
-    const CHR_SLOT_COUNT: usize = 8;
-
     // Control register ($9000) bit masks
     const CONTROL_PRG_MODE_BIT: u8 = 0b0000_0010;
     const CONTROL_MIRROR_BIT: u8 = 0b0000_0001;
@@ -58,70 +50,57 @@ impl IremG101Mapper {
 
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
         let submapper = ctx.submapper;
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
-        let mirroring = ctx.mirroring;
-        Self::new_with_submapper(prg_rom, chr_rom, mirroring, submapper)
+        let capabilities = MapperCapabilities {
+            has_chr_banking: true,
+            has_dynamic_mirroring: submapper != 1,
+            max_prg_ram_kb: 0,
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 1,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        if submapper == 1 {
+            base.set_mirroring(NametableLayout::SingleScreenUpper);
+        }
+        base.configure_prg_banking(8 * 1024);
+        base.configure_chr_banking(1024);
+        let mut mapper = Self {
+            base,
+            prg_regs: [0; 2],
+            chr_regs: [0; 8],
+            prg_mode: false,
+            submapper,
+        };
+        mapper.update_banks();
+        mapper
     }
 
     #[cfg(test)]
     pub fn new_internal(prg_rom: Vec<u8>, chr_rom: Vec<u8>, mirroring: NametableLayout) -> Self {
-        Self::new_with_submapper(prg_rom, chr_rom, mirroring, 0)
+        let ctx = super::mapper::MapperContext::new_for_test(32, prg_rom, chr_rom, mirroring);
+        Self::new(ctx)
     }
 
-    pub fn new_with_submapper(
-        prg_rom: Vec<u8>,
-        chr_rom: Vec<u8>,
-        mirroring: NametableLayout,
-        submapper: u8,
-    ) -> Self {
-        let initial_mirroring = if submapper == 1 {
-            NametableLayout::SingleScreenUpper
+    fn update_banks(&mut self) {
+        // PRG banking
+        let r0 = self.prg_regs[0] as i16;
+        let r1 = self.prg_regs[1] as i16;
+        if !self.prg_mode {
+            self.base.select_prg_page(0, r0);
+            self.base.select_prg_page(1, r1);
+            self.base.select_prg_page(2, -2);
+            self.base.select_prg_page(3, -1);
         } else {
-            mirroring
-        };
-        Self {
-            prg_rom,
-            chr_memory: ChrMemory::new(chr_rom),
-            prg_regs: [0; 2],
-            chr_regs: [0; 8],
-            prg_mode: false,
-            mirroring: initial_mirroring,
-            submapper,
+            self.base.select_prg_page(0, -2);
+            self.base.select_prg_page(1, r1);
+            self.base.select_prg_page(2, r0);
+            self.base.select_prg_page(3, -1);
         }
-    }
 
-    fn prg_bank_count(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_BANK_SIZE
-    }
-
-    fn chr_bank_count_1k(&self) -> usize {
-        self.chr_memory.size() / Self::CHR_BANK_SIZE
-    }
-
-    fn prg_bank_index(&self, bank: u8) -> usize {
-        Self::wrapped_bank(bank, self.prg_bank_count())
-    }
-
-    fn chr_bank_index_1k(&self, bank: u8) -> usize {
-        Self::wrapped_bank(bank, self.chr_bank_count_1k())
-    }
-
-    /// Wraps a register value into a valid bank index using modulo.
-    fn wrapped_bank(register: u8, bank_count: usize) -> usize {
-        if bank_count == 0 {
-            return 0;
+        // CHR banking
+        for (slot, &bank) in self.chr_regs.iter().enumerate() {
+            self.base.select_chr_page(slot, bank as i16);
         }
-        (register as usize) % bank_count
-    }
-
-    /// Resolves a CHR bus address to a mapped index into CHR memory.
-    fn resolve_chr_addr(&self, addr: u16) -> usize {
-        let chr_addr = (addr & 0x1FFF) as usize;
-        let slot = (chr_addr / Self::CHR_BANK_SIZE).min(Self::CHR_SLOT_COUNT - 1);
-        let bank_offset = chr_addr % Self::CHR_BANK_SIZE;
-        let bank_index = self.chr_bank_index_1k(self.chr_regs[slot]);
-        bank_index * Self::CHR_BANK_SIZE + bank_offset
     }
 
     /// Decodes the mirroring control bit (bit 0 of $9000) to a `NametableLayout`.
@@ -144,92 +123,62 @@ impl IremG101Mapper {
 }
 
 impl Mapper for IremG101Mapper {
-    fn read_prg(&self, addr: u16) -> u8 {
-        let count = self.prg_bank_count();
-        if count == 0 {
-            return 0;
-        }
-        let bank_offset = (addr as usize) & Self::PRG_BANK_MASK;
-        let fixed_last = count - 1;
-        let fixed_second_last = count.saturating_sub(2);
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
 
-        let bank_index = match addr {
-            0x8000..=0x9FFF => {
-                if self.prg_mode {
-                    fixed_second_last
-                } else {
-                    self.prg_bank_index(self.prg_regs[0])
-                }
-            }
-            0xA000..=0xBFFF => self.prg_bank_index(self.prg_regs[1]),
-            0xC000..=0xDFFF => {
-                if self.prg_mode {
-                    self.prg_bank_index(self.prg_regs[0])
-                } else {
-                    fixed_second_last
-                }
-            }
-            0xE000..=0xFFFF => fixed_last,
-            _ => return 0,
-        };
-        let mapped = bank_index * Self::PRG_BANK_SIZE + bank_offset;
-        self.prg_rom.get(mapped).copied().unwrap_or(0)
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
+    fn read_prg(&self, addr: u16) -> u8 {
+        match addr {
+            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
+            _ => 0,
+        }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
         match addr & 0xF000 {
-            0x8000 => self.prg_regs[0] = value & 0x1F,
+            0x8000 => {
+                self.prg_regs[0] = value & 0x1F;
+                self.update_banks();
+            }
             0x9000 => {
                 if self.submapper != 1 {
                     self.prg_mode = (value & Self::CONTROL_PRG_MODE_BIT) != 0;
-                    self.mirroring = Self::mirroring_from_bit(value & Self::CONTROL_MIRROR_BIT);
+                    self.base
+                        .set_mirroring(Self::mirroring_from_bit(value & Self::CONTROL_MIRROR_BIT));
+                    self.update_banks();
                 }
             }
-            0xA000 => self.prg_regs[1] = value & 0x1F,
+            0xA000 => {
+                self.prg_regs[1] = value & 0x1F;
+                self.update_banks();
+            }
             0xB000 => {
                 let slot = (addr & Self::CHR_REG_SELECT_MASK) as usize;
                 self.chr_regs[slot] = value;
+                self.update_banks();
             }
             _ => {}
         }
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
-        self.chr_memory.read_at_index(self.resolve_chr_addr(addr))
+        self.base.read_chr_banked(addr)
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
-        let mapped_addr = self.resolve_chr_addr(addr);
-        self.chr_memory.write_at_index(mapped_addr, value);
-    }
-
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        Self::MAPPER_NUMBER
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
-    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        self.chr_memory.initialize(mode);
+        self.base.write_chr_banked(addr, value);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
-        // Layout: [0-1] prg_regs, [2-9] chr_regs, [10] prg_mode, [11] mirroring bit
         let mut snap = Vec::with_capacity(12);
         snap.extend_from_slice(&self.prg_regs);
         snap.extend_from_slice(&self.chr_regs);
         snap.push(self.prg_mode as u8);
-        snap.push(Self::mirroring_to_bit(self.mirroring));
+        snap.push(Self::mirroring_to_bit(self.base.mirroring()));
         snap
     }
 
@@ -239,22 +188,9 @@ impl Mapper for IremG101Mapper {
             self.chr_regs.copy_from_slice(&data[2..10]);
             self.prg_mode = data[10] != 0;
             if self.submapper != 1 {
-                self.mirroring = Self::mirroring_from_bit(data[11]);
+                self.base.set_mirroring(Self::mirroring_from_bit(data[11]));
             }
-        }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: true,
-            has_dynamic_mirroring: self.submapper != 1,
-            has_expansion_audio: false,
-            max_prg_ram_kb: 0,
-            prg_bank_size_kb: 8,
-            chr_bank_size_kb: 1,
-            trainer_jsr: false,
-            ..Default::default()
+            self.update_banks();
         }
     }
 }

--- a/src/cartridge/mapper51.rs
+++ b/src/cartridge/mapper51.rs
@@ -7,6 +7,7 @@
 //! Known Limitations:
 //! - No known gameplay-blocking functional limitations are currently documented.
 
+use crate::cartridge::BaseMapper;
 use crate::cartridge::NametableLayout;
 use crate::cartridge::common::ChrMemory;
 use crate::cartridge::mapper::{Mapper, MapperCapabilities};
@@ -42,107 +43,111 @@ use crate::cartridge::mapper::{Mapper, MapperCapabilities};
 ///
 /// CHR: Fixed 8KB bank 0
 pub struct Mapper51 {
-    prg_rom: Vec<u8>,
-    chr_memory: ChrMemory,
+    base: BaseMapper,
     bank: u8,
     mode: u8,
 }
 
+const BAD_DUMP_CHR_ROM_ON_CHR_RAM_CRC32: u32 = 0xA912_B064;
+
 impl Mapper51 {
-    const MAPPER_NUMBER: u8 = 51;
-    const PRG_BANK_SIZE: usize = 0x2000; // 8 KiB
-    const PRG_BANK_MASK: usize = Self::PRG_BANK_SIZE - 1;
-    const CHR_WINDOW_SIZE: usize = 0x2000; // 8 KiB
-    const BAD_DUMP_CHR_ROM_ON_CHR_RAM_CRC32: u32 = 0xA912_B064;
-
-    fn create_chr_memory(submapper: u8, crc32: u32, chr_rom: Vec<u8>) -> ChrMemory {
-        if submapper == 0 && crc32 == Self::BAD_DUMP_CHR_ROM_ON_CHR_RAM_CRC32 {
-            // Mapper 51 JY-010 boards use fixed 8KB CHR-RAM. Some bad dumps carry
-            // an 8KB CHR-ROM payload in the header; keep those bytes as RAM init
-            // while preserving writable CHR behavior for runtime graphics updates.
-            let mut chr_memory = ChrMemory::new_ram(Self::CHR_WINDOW_SIZE);
-            if !chr_rom.is_empty() {
-                chr_memory.load_snapshot(&chr_rom);
-            }
-            chr_memory
-        } else {
-            ChrMemory::new(chr_rom)
-        }
-    }
-
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_memory = Self::create_chr_memory(ctx.submapper, ctx.crc32, ctx.chr_rom);
-        Self {
-            prg_rom,
-            chr_memory,
+        let submapper = ctx.submapper;
+        let crc32 = ctx.crc32;
+        let chr_rom_data = ctx.chr_rom.clone();
+
+        let capabilities = MapperCapabilities {
+            has_dynamic_mirroring: true,
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 8,
+            ..Default::default()
+        };
+
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(0x2000); // 8KB
+
+        // Handle bad-dump CRC32 case: replace CHR-ROM with CHR-RAM initialized
+        // with the ROM data. Some bad dumps carry an 8KB CHR-ROM payload in the
+        // header; keep those bytes as RAM init while preserving writable CHR
+        // behavior for runtime graphics updates.
+        if submapper == 0 && crc32 == BAD_DUMP_CHR_ROM_ON_CHR_RAM_CRC32 {
+            let mut chr_memory = ChrMemory::new_ram(0x2000);
+            if !chr_rom_data.is_empty() {
+                chr_memory.load_snapshot(&chr_rom_data);
+            }
+            base.set_chr_memory(chr_memory);
+        }
+
+        let mut mapper = Self {
+            base,
             bank: 0,
             mode: 1,
-        }
-    }
-
-    #[cfg(test)]
-    pub fn new_internal(prg_rom: Vec<u8>, chr_rom: Vec<u8>, _mirroring: NametableLayout) -> Self {
-        Self {
-            prg_rom,
-            chr_memory: ChrMemory::new(chr_rom),
-            bank: 0,
-            mode: 1,
-        }
-    }
-
-    fn prg_bank_count(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_BANK_SIZE
-    }
-
-    fn wrapped_bank(bank: usize, count: usize) -> usize {
-        if count == 0 { 0 } else { bank % count }
+        };
+        mapper.update_banks();
+        mapper
     }
 
     fn decode_mode(value: u8) -> u8 {
         ((value >> 3) & 0x02) | ((value >> 1) & 0x01)
     }
 
-    fn resolve_prg_bank(&self, addr: u16) -> usize {
+    fn resolve_6000_bank(&self) -> usize {
         let bank = self.bank as usize;
+        let prg_rom = self.base.prg_rom();
+        let bank_count = prg_rom.len() / 0x2000;
         let raw = if self.mode & 0x01 != 0 {
-            // 32KB mode: $8000-$FFFF mapped to 4 consecutive 8KB pages
-            match addr {
-                0x6000..=0x7FFF => 0x23 | (bank << 2),
-                0x8000..=0x9FFF => bank << 2,
-                0xA000..=0xBFFF => (bank << 2) | 1,
-                0xC000..=0xDFFF => (bank << 2) | 2,
-                0xE000..=0xFFFF => (bank << 2) | 3,
-                _ => 0,
-            }
+            0x23 | (bank << 2)
         } else {
-            let mode = self.mode as usize;
-            // 16KB mode: $8000 and $C000 are independent 16KB windows
-            match addr {
-                0x6000..=0x7FFF => 0x2F | (bank << 2),
-                0x8000..=0x9FFF => (bank << 2) | mode,
-                0xA000..=0xBFFF => ((bank << 2) | mode) + 1,
-                0xC000..=0xDFFF => (bank << 2) | 0x0E,
-                0xE000..=0xFFFF => (bank << 2) | 0x0F,
-                _ => 0,
-            }
+            0x2F | (bank << 2)
         };
-        Self::wrapped_bank(raw, self.prg_bank_count())
+        if bank_count == 0 { 0 } else { raw % bank_count }
+    }
+
+    fn update_banks(&mut self) {
+        let bank = self.bank as usize;
+        if self.mode & 0x01 != 0 {
+            // 32KB mode: $8000-$FFFF mapped to 4 consecutive 8KB pages
+            self.base.select_prg_page(0, (bank << 2) as i16);
+            self.base.select_prg_page(1, ((bank << 2) | 1) as i16);
+            self.base.select_prg_page(2, ((bank << 2) | 2) as i16);
+            self.base.select_prg_page(3, ((bank << 2) | 3) as i16);
+        } else {
+            // 16KB mode: $8000 and $C000 are independent 16KB windows
+            let mode = self.mode as usize;
+            self.base.select_prg_page(0, ((bank << 2) | mode) as i16);
+            self.base
+                .select_prg_page(1, (((bank << 2) | mode) + 1) as i16);
+            self.base.select_prg_page(2, ((bank << 2) | 0x0E) as i16);
+            self.base.select_prg_page(3, ((bank << 2) | 0x0F) as i16);
+        }
+
+        let mirroring = if self.mode == 0x03 {
+            NametableLayout::Horizontal
+        } else {
+            NametableLayout::Vertical
+        };
+        self.base.set_mirroring(mirroring);
     }
 }
 
 impl Mapper for Mapper51 {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
-            0x6000..=0xFFFF => {
-                let bank = self.resolve_prg_bank(addr);
-                let offset = (addr as usize) & Self::PRG_BANK_MASK;
-                self.prg_rom
-                    .get(bank * Self::PRG_BANK_SIZE + offset)
-                    .copied()
-                    .unwrap_or(0)
+            0x6000..=0x7FFF => {
+                let bank = self.resolve_6000_bank();
+                let offset = (addr as usize) & 0x1FFF;
+                let prg_rom = self.base.prg_rom();
+                prg_rom.get(bank * 0x2000 + offset).copied().unwrap_or(0)
             }
-            _ => 0,
+            _ => self.base.read_prg_banked(addr),
         }
     }
 
@@ -150,52 +155,26 @@ impl Mapper for Mapper51 {
         match addr {
             0x6000..=0x7FFF => {
                 self.mode = Self::decode_mode(value);
+                self.update_banks();
             }
             0xC000..=0xDFFF => {
                 self.bank = value & 0x0F;
                 self.mode = (Self::decode_mode(value) & 0x02) | (self.mode & 0x01);
+                self.update_banks();
             }
             0x8000..=0xBFFF | 0xE000..=0xFFFF => {
                 self.bank = value & 0x0F;
+                self.update_banks();
             }
             _ => {}
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.chr_memory.read(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.chr_memory.write(addr, value);
-    }
-
-    fn get_mirroring(&self) -> NametableLayout {
-        if self.mode == 0x03 {
-            NametableLayout::Horizontal
-        } else {
-            NametableLayout::Vertical
+    fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
+        match addr {
+            0x0000..=0x5FFF => open_bus,
+            _ => self.read_prg(addr),
         }
-    }
-
-    fn mapper_number(&self) -> u8 {
-        Self::MAPPER_NUMBER
-    }
-
-    fn wram_size(&self) -> usize {
-        0
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
-    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        self.chr_memory.initialize(mode);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -206,21 +185,14 @@ impl Mapper for Mapper51 {
         if data.len() >= 2 {
             self.bank = data[0];
             self.mode = data[1];
+            self.update_banks();
         }
     }
 
     fn reset(&mut self) {
         self.bank = 0;
         self.mode = 1;
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_dynamic_mirroring: true,
-            prg_bank_size_kb: 8,
-            chr_bank_size_kb: 8,
-            ..Default::default()
-        }
+        self.update_banks();
     }
 }
 
@@ -250,7 +222,12 @@ mod tests {
         // Use Horizontal header so mirroring tests verify mode-derived value, not header passthrough
         let prg = banked_data(8 * 1024, PRG_BANKS);
         let chr = banked_data(8 * 1024, 1);
-        Mapper51::new_internal(prg, chr, NametableLayout::Horizontal)
+        Mapper51::new(MapperContext::new_for_test(
+            51,
+            prg,
+            chr,
+            NametableLayout::Horizontal,
+        ))
     }
 
     fn make_mapper_with_submapper(submapper: u8, chr: Vec<u8>, crc32: u32) -> Box<dyn Mapper> {
@@ -442,7 +419,12 @@ mod tests {
         // CHR is always fixed at bank 0; use 2-bank CHR so bank 1 would differ
         let prg = banked_data(8 * 1024, PRG_BANKS);
         let chr = banked_data(8 * 1024, 2); // bank 0 → 0, bank 1 → 1
-        let mut mapper = Mapper51::new_internal(prg, chr, NametableLayout::Vertical);
+        let mut mapper = Mapper51::new(MapperContext::new_for_test(
+            51,
+            prg,
+            chr,
+            NametableLayout::Vertical,
+        ));
         assert_eq!(mapper.read_chr(0x0000), 0, "CHR must read from bank 0");
         assert_eq!(mapper.read_chr(0x1FFF), 0, "CHR end must still be bank 0");
     }

--- a/src/cartridge/mapper53.rs
+++ b/src/cartridge/mapper53.rs
@@ -8,7 +8,7 @@
 //! - No known gameplay-blocking functional limitations are currently documented.
 
 use crate::cartridge::NametableLayout;
-use crate::cartridge::common::ChrMemory;
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mapper::{Mapper, MapperCapabilities};
 
 /// Mapper 053 - Supervision 16-in-1
@@ -42,46 +42,39 @@ use crate::cartridge::mapper::{Mapper, MapperCapabilities};
 ///
 /// CHR: Fixed 8KB bank 0 (CHR-RAM).
 pub struct Mapper53 {
-    prg_rom: Vec<u8>,
-    chr_memory: ChrMemory,
+    base: BaseMapper,
     cmd0: u8,
     cmd1: u8,
 }
 
 impl Mapper53 {
-    const MAPPER_NUMBER: u8 = 53;
     const PRG_8K_SIZE: usize = 0x2000;
     const PRG_8K_MASK: usize = Self::PRG_8K_SIZE - 1;
-    const PRG_16K_SIZE: usize = 0x4000;
-    const PRG_16K_MASK: usize = Self::PRG_16K_SIZE - 1;
-    const PRG_32K_SIZE: usize = 0x8000;
-    const PRG_32K_MASK: usize = Self::PRG_32K_SIZE - 1;
 
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
-        Self {
-            prg_rom,
-            chr_memory: ChrMemory::new_ram(if chr_rom.is_empty() {
-                8192
-            } else {
-                chr_rom.len()
-            }),
+        let capabilities = MapperCapabilities {
+            has_dynamic_mirroring: true,
+            prg_bank_size_kb: 16,
+            chr_bank_size_kb: 8,
+            max_prg_ram_kb: 0,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(16 * 1024);
+        // Default: menu mode → 32KB bank 0 = 16KB banks 0 and 1
+        base.select_prg_page(0, 0);
+        base.select_prg_page(1, 1);
+        let mut mapper = Self {
+            base,
             cmd0: 0,
             cmd1: 0,
-        }
+        };
+        mapper.update_banks();
+        mapper
     }
 
     fn num_prg_8k_banks(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_8K_SIZE
-    }
-
-    fn num_prg_16k_banks(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_16K_SIZE
-    }
-
-    fn num_prg_32k_banks(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_32K_SIZE
+        self.base.prg_rom().len() / Self::PRG_8K_SIZE
     }
 
     fn read_prg_8k_bank(&self, bank: usize, offset: usize) -> u8 {
@@ -90,32 +83,9 @@ impl Mapper53 {
             return 0;
         }
         let safe_bank = bank % count;
-        self.prg_rom
+        self.base
+            .prg_rom()
             .get(safe_bank * Self::PRG_8K_SIZE + offset)
-            .copied()
-            .unwrap_or(0)
-    }
-
-    fn read_prg_16k_bank(&self, bank: usize, offset: usize) -> u8 {
-        let count = self.num_prg_16k_banks();
-        if count == 0 {
-            return 0;
-        }
-        let safe_bank = bank % count;
-        self.prg_rom
-            .get(safe_bank * Self::PRG_16K_SIZE + offset)
-            .copied()
-            .unwrap_or(0)
-    }
-
-    fn read_prg_32k_bank(&self, bank: usize, offset: usize) -> u8 {
-        let count = self.num_prg_32k_banks();
-        if count == 0 {
-            return 0;
-        }
-        let safe_bank = bank % count;
-        self.prg_rom
-            .get(safe_bank * Self::PRG_32K_SIZE + offset)
             .copied()
             .unwrap_or(0)
     }
@@ -128,34 +98,44 @@ impl Mapper53 {
     fn game_selected(&self) -> bool {
         (self.cmd0 & 0x10) != 0
     }
+
+    fn update_banks(&mut self) {
+        if self.game_selected() {
+            let outer = (self.cmd0 & 0x0F) as usize;
+            let switchable = ((outer << 3) | (self.cmd1 & 7) as usize).wrapping_add(2) as i16;
+            let fixed = ((outer << 3) | 7).wrapping_add(2) as i16;
+            self.base.select_prg_page(0, switchable);
+            self.base.select_prg_page(1, fixed);
+        } else {
+            // Menu: 32KB bank 0 = 16KB banks 0 and 1
+            self.base.select_prg_page(0, 0);
+            self.base.select_prg_page(1, 1);
+        }
+        let mirroring = if (self.cmd0 & 0x20) != 0 {
+            NametableLayout::Horizontal
+        } else {
+            NametableLayout::Vertical
+        };
+        self.base.set_mirroring(mirroring);
+    }
 }
 
 impl Mapper for Mapper53 {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => {
                 let offset = (addr as usize) & Self::PRG_8K_MASK;
                 self.read_prg_8k_bank(self.prg_6000_bank(), offset)
             }
-            0x8000..=0xFFFF => {
-                if self.game_selected() {
-                    // Game running: $8000-$BFFF = selectable, $C000-$FFFF = fixed last in block
-                    let outer = (self.cmd0 & 0x0F) as usize;
-                    if addr < 0xC000 {
-                        let bank = (outer << 3 | (self.cmd1 & 7) as usize).wrapping_add(2);
-                        let offset = (addr as usize) & Self::PRG_16K_MASK;
-                        self.read_prg_16k_bank(bank, offset)
-                    } else {
-                        let bank = (outer << 3 | 7).wrapping_add(2);
-                        let offset = (addr as usize) & Self::PRG_16K_MASK;
-                        self.read_prg_16k_bank(bank, offset)
-                    }
-                } else {
-                    // Menu: 32KB bank 0
-                    let offset = (addr as usize) & Self::PRG_32K_MASK;
-                    self.read_prg_32k_bank(0, offset)
-                }
-            }
+            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
             _ => 0,
         }
     }
@@ -166,49 +146,15 @@ impl Mapper for Mapper53 {
                 // Only writable when bit 4 is NOT set (menu mode, not game running)
                 if !self.game_selected() {
                     self.cmd0 = value;
+                    self.update_banks();
                 }
             }
             0x8000..=0xFFFF => {
                 self.cmd1 = value;
+                self.update_banks();
             }
             _ => {}
         }
-    }
-
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.chr_memory.read(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.chr_memory.write(addr, value);
-    }
-
-    fn get_mirroring(&self) -> NametableLayout {
-        if (self.cmd0 & 0x20) != 0 {
-            NametableLayout::Horizontal
-        } else {
-            NametableLayout::Vertical
-        }
-    }
-
-    fn mapper_number(&self) -> u8 {
-        Self::MAPPER_NUMBER
-    }
-
-    fn wram_size(&self) -> usize {
-        0
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
-    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        self.chr_memory.initialize(mode);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -219,21 +165,14 @@ impl Mapper for Mapper53 {
         if data.len() >= 2 {
             self.cmd0 = data[0];
             self.cmd1 = data[1];
+            self.update_banks();
         }
     }
 
     fn reset(&mut self) {
         self.cmd0 = 0;
         self.cmd1 = 0;
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_dynamic_mirroring: true,
-            prg_bank_size_kb: 16,
-            chr_bank_size_kb: 8,
-            ..Default::default()
-        }
+        self.update_banks();
     }
 }
 

--- a/src/cartridge/mmc1.rs
+++ b/src/cartridge/mmc1.rs
@@ -5,16 +5,15 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
+use crate::cartridge::BaseMapper;
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::NametableLayout;
-use crate::cartridge::common::ChrMemory;
 use crate::trace_mapper;
 
 // Memory size constants
 const PRG_BANK_SIZE: usize = 0x4000; // 16KB
-const CHR_BANK_SIZE_4K: usize = 0x1000; // 4KB (for MMC1, MMC3)
-const CHR_BANK_SIZE_8K: usize = 0x2000; // 8KB
+const CHR_BANK_SIZE: usize = 0x1000; // 4KB
 const MMC1_SUBMAPPER_FIXED_32KB_PRG: u8 = 5;
 const MMC1_SUBMAPPER_HARDWIRED_MIRRORING: u8 = 7;
 const MMC1_SHIFT_REGISTER_RESET: u8 = 0x80; // Bit 7 set triggers reset
@@ -77,9 +76,8 @@ pub enum Mmc1Revision {
 ///
 /// Used in games like The Legend of Zelda, Metroid, Mega Man 2, Final Fantasy.
 pub struct MMC1Mapper {
-    prg_rom: Vec<u8>,
-    prg_ram: Vec<u8>,
-    chr_memory: ChrMemory,
+    base: BaseMapper,
+    prg_ram: Vec<u8>, // Separate: WRAM gating + SOROM banking not supported by PrgRam
 
     // Shift register state
     shift_register: u8, // 5-bit shift register
@@ -135,10 +133,23 @@ impl MMC1Mapper {
         let surom = ctx.prg_rom.len() > 256 * 1024;
         let sorom = ctx.prg_ram_banks_8k >= 2;
         let revision = Self::revision_from_mapper(ctx.mapper);
-        Self {
-            prg_rom: ctx.prg_rom,
+
+        let capabilities = MapperCapabilities {
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            max_prg_ram_kb: 0, // PRG-RAM managed separately (gating + banking)
+            prg_bank_size_kb: 16,
+            chr_bank_size_kb: 4,
+            ..Default::default()
+        };
+
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(PRG_BANK_SIZE);
+        base.configure_chr_banking(CHR_BANK_SIZE);
+
+        let mut mapper = Self {
+            base,
             prg_ram: vec![0; prg_ram_size],
-            chr_memory: ChrMemory::new(ctx.chr_rom),
             shift_register: MMC1_SHIFT_REGISTER_POWER_ON,
             write_count: 0,
             control: MMC1_DEFAULT_CONTROL,
@@ -157,25 +168,44 @@ impl MMC1Mapper {
             cpu_cycle_count: 0,
             last_write_cycle: 0,
             has_last_write: false,
-        }
+        };
+
+        mapper.update_banks();
+        mapper
     }
 
     #[cfg(test)]
     pub fn new_with_revision(
         prg_rom: Vec<u8>,
         chr_rom: Vec<u8>,
-        _mirroring: NametableLayout,
+        mirroring: NametableLayout,
         revision: Mmc1Revision,
     ) -> Self {
+        use crate::cartridge::mapper::MapperContext;
+
         let surom = prg_rom.len() > 256 * 1024;
         let prg_bank = Self::power_on_prg_bank_for_revision(revision);
-        Self {
-            prg_rom,
+        let ctx = MapperContext::new_for_test(1, prg_rom, chr_rom, mirroring);
+
+        let capabilities = MapperCapabilities {
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            max_prg_ram_kb: 0,
+            prg_bank_size_kb: 16,
+            chr_bank_size_kb: 4,
+            ..Default::default()
+        };
+
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(PRG_BANK_SIZE);
+        base.configure_chr_banking(CHR_BANK_SIZE);
+
+        let mut mapper = Self {
+            base,
             prg_ram: vec![0; 8192],
-            chr_memory: ChrMemory::new(chr_rom),
-            shift_register: MMC1_SHIFT_REGISTER_POWER_ON, // Power-on state: bit 4 set
+            shift_register: MMC1_SHIFT_REGISTER_POWER_ON,
             write_count: 0,
-            control: MMC1_DEFAULT_CONTROL, // Default: PRG mode 3 (fix last bank), CHR mode 0
+            control: MMC1_DEFAULT_CONTROL,
             chr_bank_0: 0,
             chr_bank_1: 0,
             prg_bank,
@@ -188,7 +218,10 @@ impl MMC1Mapper {
             cpu_cycle_count: 0,
             last_write_cycle: 0,
             has_last_write: false,
-        }
+        };
+
+        mapper.update_banks();
+        mapper
     }
 
     fn reset_shift_register(&mut self) {
@@ -234,6 +267,7 @@ impl MMC1Mapper {
         if value & MMC1_SHIFT_REGISTER_RESET != 0 {
             self.reset_shift_register();
             self.mark_serial_write_attempt();
+            self.update_banks();
             return;
         }
 
@@ -286,6 +320,8 @@ impl MMC1Mapper {
             // Reset shift register for next write sequence
             self.shift_register = MMC1_SHIFT_REGISTER_POWER_ON; // Reset to power-on state
             self.write_count = 0;
+
+            self.update_banks();
         }
     }
 
@@ -337,61 +373,6 @@ impl MMC1Mapper {
             .unwrap_or_else(|| self.mirroring_from_control_register())
     }
 
-    fn get_prg_bank_offset(&self, addr: u16) -> usize {
-        let prg_mode = self.get_prg_mode();
-        let num_banks = self.prg_rom.len() / PRG_BANK_SIZE;
-        let mmc1a_a17_bypass = self.is_mmc1a_a17_bypass_active();
-        let extra_chr_reg = self.get_extra_chr_reg();
-
-        // SUROM: chr_bank_0 bit 4 selects which 256KB outer half of 512KB PRG-ROM
-        let outer_bank = if self.surom {
-            ((extra_chr_reg >> 4) & 1) as usize
-        } else {
-            0
-        };
-
-        match prg_mode {
-            0 | 1 => {
-                // 32KB mode: switch entire $8000-$FFFF, ignore low bit of bank number
-                let inner = ((self.prg_bank & 0x0E) >> 1) as usize;
-                let bank = (outer_bank << 3) | inner;
-                let bank = bank % (num_banks / 2).max(1);
-                bank * PRG_BANK_SIZE * 2
-            }
-            2 => {
-                // Fix first bank at $8000, switch 16KB bank at $C000
-                if addr < 0xC000 {
-                    let bank = if mmc1a_a17_bypass {
-                        self.mmc1a_a17_bit() << 3
-                    } else {
-                        outer_bank << 4 // first bank of current outer half
-                    };
-                    (bank % num_banks.max(1)) * PRG_BANK_SIZE
-                } else {
-                    let bank = (outer_bank << 4) | (self.prg_bank & 0x0F) as usize;
-                    let bank = bank % num_banks.max(1);
-                    bank * PRG_BANK_SIZE
-                }
-            }
-            3 => {
-                // Switch 16KB bank at $8000, fix last bank at $C000
-                if addr < 0xC000 {
-                    let bank = (outer_bank << 4) | (self.prg_bank & 0x0F) as usize;
-                    let bank = bank % num_banks.max(1);
-                    bank * PRG_BANK_SIZE
-                } else {
-                    let bank = if mmc1a_a17_bypass {
-                        (self.mmc1a_a17_bit() << 3) | 0x07
-                    } else {
-                        (outer_bank << 4) | 0x0F // last bank of current outer half
-                    };
-                    (bank % num_banks.max(1)) * PRG_BANK_SIZE
-                }
-            }
-            _ => unreachable!(),
-        }
-    }
-
     fn prg_ram_bank_offset(&self, addr: u16) -> usize {
         let base = (addr - 0x6000) as usize;
         if self.sorom {
@@ -406,47 +387,81 @@ impl MMC1Mapper {
         self.select_extra_chr_reg_source()
     }
 
-    fn get_chr_bank_offset(&self, addr: u16) -> usize {
-        let chr_mode = self.get_chr_mode();
-        let num_4kb_banks = self.chr_memory.size() / CHR_BANK_SIZE_4K;
+    fn update_banks(&mut self) {
+        self.update_prg_banks();
+        self.update_chr_banks();
+        self.base.set_mirroring(self.get_mirroring_mode());
+    }
 
-        if chr_mode == 0 {
+    fn update_prg_banks(&mut self) {
+        if self.uses_fixed_32kb_prg_mapping() {
+            self.base.select_prg_page(0, 0);
+            self.base.select_prg_page(1, 1);
+            return;
+        }
+
+        let prg_mode = self.get_prg_mode();
+        let extra_chr_reg = self.get_extra_chr_reg();
+        let mmc1a_a17_bypass = self.is_mmc1a_a17_bypass_active();
+
+        // SUROM: chr register bit 4 selects which 256KB outer half of 512KB PRG-ROM
+        let outer_bank = if self.surom {
+            ((extra_chr_reg >> 4) & 1) as i16
+        } else {
+            0i16
+        };
+
+        match prg_mode {
+            0 | 1 => {
+                // 32KB mode: switch entire $8000-$FFFF, ignore low bit of bank number
+                let inner = ((self.prg_bank & 0x0E) >> 1) as i16;
+                let bank_32k = (outer_bank << 3) | inner;
+                self.base.select_prg_page(0, bank_32k * 2);
+                self.base.select_prg_page(1, bank_32k * 2 + 1);
+            }
+            2 => {
+                // Fix first bank at $8000, switch 16KB bank at $C000
+                let fixed_bank = if mmc1a_a17_bypass {
+                    (self.mmc1a_a17_bit() << 3) as i16
+                } else {
+                    outer_bank << 4 // first bank of current outer half
+                };
+                let switch_bank = (outer_bank << 4) | (self.prg_bank & 0x0F) as i16;
+                self.base.select_prg_page(0, fixed_bank);
+                self.base.select_prg_page(1, switch_bank);
+            }
+            3 => {
+                // Switch 16KB bank at $8000, fix last bank at $C000
+                let switch_bank = (outer_bank << 4) | (self.prg_bank & 0x0F) as i16;
+                let fixed_bank = if mmc1a_a17_bypass {
+                    ((self.mmc1a_a17_bit() << 3) | 0x07) as i16
+                } else {
+                    (outer_bank << 4) | 0x0F // last bank of current outer half
+                };
+                self.base.select_prg_page(0, switch_bank);
+                self.base.select_prg_page(1, fixed_bank);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn update_chr_banks(&mut self) {
+        if self.get_chr_mode() == 0 {
             // 8KB mode: switch entire $0000-$1FFF, ignore low bit
-            let bank = ((self.chr_bank_0 & 0x1E) >> 1) as usize;
-            let bank = bank % (num_4kb_banks / 2).max(1);
-            bank * CHR_BANK_SIZE_8K
+            let bank_8k = ((self.chr_bank_0 & 0x1E) >> 1) as i16;
+            self.base.select_chr_page(0, bank_8k * 2);
+            self.base.select_chr_page(1, bank_8k * 2 + 1);
         } else {
             // 4KB mode: two separate 4KB banks
-            if addr < 0x1000 {
-                let bank = (self.chr_bank_0 & 0x1F) as usize;
-                let bank = bank % num_4kb_banks.max(1);
-                bank * CHR_BANK_SIZE_4K
-            } else {
-                let bank = (self.chr_bank_1 & 0x1F) as usize;
-                let bank = bank % num_4kb_banks.max(1);
-                bank * CHR_BANK_SIZE_4K
-            }
+            self.base
+                .select_chr_page(0, (self.chr_bank_0 & 0x1F) as i16);
+            self.base
+                .select_chr_page(1, (self.chr_bank_1 & 0x1F) as i16);
         }
     }
 
     fn uses_fixed_32kb_prg_mapping(&self) -> bool {
         self.submapper == MMC1_SUBMAPPER_FIXED_32KB_PRG
-    }
-
-    fn read_prg_fixed_32kb(&self, addr: u16) -> u8 {
-        let index = (addr - 0x8000) as usize;
-        self.prg_rom.get(index).copied().unwrap_or(0)
-    }
-
-    fn read_prg_banked(&self, addr: u16) -> u8 {
-        let bank_offset = self.get_prg_bank_offset(addr);
-        let offset = if self.get_prg_mode() <= 1 {
-            (addr - 0x8000) as usize
-        } else {
-            (addr & 0x3FFF) as usize
-        };
-        let index = bank_offset + offset;
-        self.prg_rom.get(index).copied().unwrap_or(0)
     }
 }
 
@@ -460,12 +475,7 @@ impl Mapper for MMC1Mapper {
                 let offset = self.prg_ram_bank_offset(addr);
                 self.prg_ram.get(offset).copied().unwrap_or(0)
             }
-            0x8000..=0xFFFF => {
-                if self.uses_fixed_32kb_prg_mapping() {
-                    return self.read_prg_fixed_32kb(addr);
-                }
-                self.read_prg_banked(addr)
-            }
+            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
             _ => 0,
         }
     }
@@ -507,37 +517,19 @@ impl Mapper for MMC1Mapper {
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
-        let bank_offset = self.get_chr_bank_offset(addr);
-        let offset = if self.get_chr_mode() == 0 {
-            // 8KB mode
-            (addr & 0x1FFF) as usize
-        } else {
-            // 4KB mode
-            (addr & 0x0FFF) as usize
-        };
-        let index = bank_offset + offset;
-        self.chr_memory.read_at_index(index)
+        self.base.read_chr_banked(addr)
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
-        let bank_offset = self.get_chr_bank_offset(addr);
-        let offset = if self.get_chr_mode() == 0 {
-            // 8KB mode
-            (addr & 0x1FFF) as usize
-        } else {
-            // 4KB mode
-            (addr & 0x0FFF) as usize
-        };
-        let index = bank_offset + offset;
-        self.chr_memory.write_at_index(index, value);
+        self.base.write_chr_banked(addr, value);
     }
 
     fn get_mirroring(&self) -> NametableLayout {
-        self.get_mirroring_mode()
+        self.base.mirroring()
     }
 
     fn mapper_number(&self) -> u8 {
-        1
+        self.base.mapper_number()
     }
 
     fn wram_size(&self) -> usize {
@@ -554,16 +546,16 @@ impl Mapper for MMC1Mapper {
     }
 
     fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
+        self.base.chr_ram_snapshot()
     }
 
     fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
+        self.base.restore_chr_ram(data);
     }
 
     fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
         crate::console::initialize_ram(&mut self.prg_ram, mode);
-        self.chr_memory.initialize(mode);
+        self.base.initialize_ram(mode); // Only initializes CHR-RAM (no PRG-RAM in base)
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -634,6 +626,8 @@ impl Mapper for MMC1Mapper {
         if data.len() >= 25 {
             self.last_chr_reg_addr = u16::from_le_bytes([data[23], data[24]]);
         }
+
+        self.update_banks();
     }
 
     fn cpu_cycle(&mut self) {

--- a/src/cartridge/mmc2.rs
+++ b/src/cartridge/mmc2.rs
@@ -5,7 +5,7 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
-use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::ines::ConsoleType;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
@@ -30,12 +30,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// - Latch state determines which of two 4KB CHR banks is active per region
 /// - Used exclusively in (Mike Tyson's) Punch-Out!!
 pub struct MMC2Mapper {
-    prg_rom: Vec<u8>,
-    prg_ram: Option<PrgRam>,
-
-    chr_memory: ChrMemory,
-
-    mirroring: NametableLayout,
+    base: BaseMapper,
 
     // --- PRG banking ---
     prg_bank_8k: u8,
@@ -51,84 +46,57 @@ pub struct MMC2Mapper {
 }
 
 impl MMC2Mapper {
-    const PRG_BANK_SIZE: usize = 0x2000; // 8KB
-    const CHR_BANK_SIZE: usize = 0x1000; // 4KB
-
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_ram = matches!(ctx.console_type, ConsoleType::Playchoice10)
-            .then(|| PrgRam::new(DEFAULT_PRG_RAM_SIZE));
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
-        let mirroring = ctx.mirroring;
+        let has_prg_ram = matches!(ctx.console_type, ConsoleType::Playchoice10);
+        let capabilities = MapperCapabilities {
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            max_prg_ram_kb: if has_prg_ram { 8 } else { 0 },
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 4,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(8 * 1024);
+        base.configure_chr_banking(4 * 1024);
+        // $8000: bank 0, $A000/$C000/$E000: fixed last 3 banks
+        base.select_prg_page(0, 0);
+        base.select_prg_page(1, -3);
+        base.select_prg_page(2, -2);
+        base.select_prg_page(3, -1);
+        // CHR: both latches FE (false), all bank regs = 0
+        base.select_chr_page(0, 0);
+        base.select_chr_page(1, 0);
         Self {
-            prg_rom,
-            prg_ram,
-            chr_memory: ChrMemory::new(chr_rom),
-            mirroring,
+            base,
             prg_bank_8k: 0,
             chr_bank_0_fd: 0,
             chr_bank_0_fe: 0,
             chr_bank_1_fd: 0,
             chr_bank_1_fe: 0,
-            // Power-on latch state is hardware-defined; FE is a common default in emulators.
             latch0_is_fd: false,
             latch1_is_fd: false,
         }
     }
 
-    fn prg_bank_count_8k(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_BANK_SIZE
+    fn update_prg_banks(&mut self) {
+        self.base.select_prg_page(0, self.prg_bank_8k as i16);
+        // Slots 1-3 always fixed to last 3 banks
     }
 
-    fn chr_bank_count_4k(&self) -> usize {
-        self.chr_memory.size() / Self::CHR_BANK_SIZE
-    }
-
-    fn clamp_prg_bank_8k(&self, bank: u8) -> usize {
-        let count = self.prg_bank_count_8k();
-        if count == 0 {
-            return 0;
-        }
-        (bank as usize) % count
-    }
-
-    fn clamp_chr_bank_4k(&self, bank: u8) -> usize {
-        let count = self.chr_bank_count_4k();
-        if count == 0 {
-            return 0;
-        }
-        (bank as usize) % count
-    }
-
-    fn read_prg_rom_bank(&self, bank_index: usize, bank_offset: usize) -> u8 {
-        let addr = bank_index * Self::PRG_BANK_SIZE + bank_offset;
-        self.prg_rom.get(addr).copied().unwrap_or(0)
-    }
-
-    fn read_prg_window_8k(&self, addr: u16, window_start: u16, bank_index: usize) -> u8 {
-        let offset = (addr - window_start) as usize;
-        self.read_prg_rom_bank(bank_index, offset)
-    }
-
-    fn read_chr_bank_4k(&self, bank_index: usize, bank_offset: usize) -> u8 {
-        let addr = bank_index * Self::CHR_BANK_SIZE + bank_offset;
-        self.chr_memory.read_at_index(addr)
-    }
-
-    fn chr_bank_for_addr(&self, addr: u16) -> usize {
-        let bank = if addr < 0x1000 {
-            if self.latch0_is_fd {
-                self.chr_bank_0_fd
-            } else {
-                self.chr_bank_0_fe
-            }
-        } else if self.latch1_is_fd {
+    fn update_chr_pages(&mut self) {
+        let bank0 = if self.latch0_is_fd {
+            self.chr_bank_0_fd
+        } else {
+            self.chr_bank_0_fe
+        };
+        let bank1 = if self.latch1_is_fd {
             self.chr_bank_1_fd
         } else {
             self.chr_bank_1_fe
         };
-
-        self.clamp_chr_bank_4k(bank)
+        self.base.select_chr_page(0, bank0 as i16);
+        self.base.select_chr_page(1, bank1 as i16);
     }
 
     fn update_latches_for_chr_read(&mut self, addr: u16) {
@@ -143,51 +111,26 @@ impl MMC2Mapper {
 }
 
 impl Mapper for MMC2Mapper {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
-        // PRG-RAM at $6000-$7FFF
-        if let Some(prg_ram) = &self.prg_ram
-            && let Some(value) = prg_ram.try_read(addr)
-        {
+        if let Some(value) = self.base.try_read_prg_ram(addr) {
             return value;
         }
-
         match addr {
-            0x8000..=0x9FFF => {
-                let bank = self.clamp_prg_bank_8k(self.prg_bank_8k);
-                self.read_prg_window_8k(addr, 0x8000, bank)
-            }
-            0xA000..=0xBFFF => {
-                let count = self.prg_bank_count_8k();
-                let bank = count.saturating_sub(3);
-                self.read_prg_window_8k(addr, 0xA000, bank)
-            }
-            0xC000..=0xDFFF => {
-                let count = self.prg_bank_count_8k();
-                let bank = count.saturating_sub(2);
-                self.read_prg_window_8k(addr, 0xC000, bank)
-            }
-            0xE000..=0xFFFF => {
-                let count = self.prg_bank_count_8k();
-                let bank = count.saturating_sub(1);
-                self.read_prg_window_8k(addr, 0xE000, bank)
-            }
+            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
             _ => 0,
         }
     }
 
-    fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
-        match addr {
-            0x0000..=0x5FFF => open_bus,
-            0x6000..=0x7FFF if self.prg_ram.is_none() => open_bus,
-            _ => self.read_prg(addr),
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
-        // PRG-RAM at $6000-$7FFF
-        if let Some(prg_ram) = &mut self.prg_ram
-            && prg_ram.try_write(addr, value)
-        {
+        if self.base.try_write_prg_ram(addr, value) {
             return;
         }
 
@@ -195,21 +138,35 @@ impl Mapper for MMC2Mapper {
             // PRG bank select ($A000-$AFFF)
             0xA000..=0xAFFF => {
                 self.prg_bank_8k = value & 0x0F;
+                self.update_prg_banks();
             }
 
             // CHR bank registers
-            0xB000..=0xBFFF => self.chr_bank_0_fd = value & 0x1F,
-            0xC000..=0xCFFF => self.chr_bank_0_fe = value & 0x1F,
-            0xD000..=0xDFFF => self.chr_bank_1_fd = value & 0x1F,
-            0xE000..=0xEFFF => self.chr_bank_1_fe = value & 0x1F,
+            0xB000..=0xBFFF => {
+                self.chr_bank_0_fd = value & 0x1F;
+                self.update_chr_pages();
+            }
+            0xC000..=0xCFFF => {
+                self.chr_bank_0_fe = value & 0x1F;
+                self.update_chr_pages();
+            }
+            0xD000..=0xDFFF => {
+                self.chr_bank_1_fd = value & 0x1F;
+                self.update_chr_pages();
+            }
+            0xE000..=0xEFFF => {
+                self.chr_bank_1_fe = value & 0x1F;
+                self.update_chr_pages();
+            }
 
             // Mirroring control ($F000-$FFFF)
             0xF000..=0xFFFF => {
-                self.mirroring = if (value & 0x01) != 0 {
+                let mirroring = if (value & 0x01) != 0 {
                     NametableLayout::Horizontal
                 } else {
                     NametableLayout::Vertical
                 };
+                self.base.set_mirroring(mirroring);
             }
 
             _ => {}
@@ -217,65 +174,21 @@ impl Mapper for MMC2Mapper {
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
-        let bank = self.chr_bank_for_addr(addr);
-        let offset = (addr as usize) & (Self::CHR_BANK_SIZE - 1);
-        let value = self.read_chr_bank_4k(bank, offset);
+        let value = self.base.read_chr_banked(addr);
         self.update_latches_for_chr_read(addr);
+        self.update_chr_pages();
         value
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
-        let bank = self.chr_bank_for_addr(addr);
-        let offset = (addr as usize) & (Self::CHR_BANK_SIZE - 1);
-        let index = bank * Self::CHR_BANK_SIZE + offset;
-        self.chr_memory.write_at_index(index, value);
+        self.base.write_chr_banked(addr, value);
     }
 
     fn ppu_address_changed(&mut self, addr: u16) {
         let _ = addr;
     }
 
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        9
-    }
-
-    fn wram_size(&self) -> usize {
-        self.prg_ram.as_ref().map_or(0, PrgRam::size)
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram
-            .as_ref()
-            .map_or_else(Vec::new, PrgRam::snapshot)
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        if let Some(prg_ram) = &mut self.prg_ram {
-            prg_ram.load_snapshot(data);
-        }
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
-        // Serialize MMC2 internal registers:
-        // [0]: prg_bank_8k
-        // [1]: chr_bank_0_fd
-        // [2]: chr_bank_0_fe
-        // [3]: chr_bank_1_fd
-        // [4]: chr_bank_1_fe
-        // [5]: latches (bit 0 = latch0_is_fd, bit 1 = latch1_is_fd)
-        // [6]: mirroring
         vec![
             self.prg_bank_8k,
             self.chr_bank_0_fd,
@@ -283,7 +196,7 @@ impl Mapper for MMC2Mapper {
             self.chr_bank_1_fd,
             self.chr_bank_1_fe,
             (self.latch0_is_fd as u8) | ((self.latch1_is_fd as u8) << 1),
-            match self.mirroring {
+            match self.base.mirroring() {
                 NametableLayout::Vertical => 0,
                 NametableLayout::Horizontal => 1,
                 _ => 1,
@@ -300,25 +213,14 @@ impl Mapper for MMC2Mapper {
             self.chr_bank_1_fe = data[4];
             self.latch0_is_fd = (data[5] & 1) != 0;
             self.latch1_is_fd = (data[5] & 2) != 0;
-            self.mirroring = match data[6] {
+            let mirroring = match data[6] {
                 0 => NametableLayout::Vertical,
                 1 => NametableLayout::Horizontal,
                 _ => NametableLayout::Horizontal,
             };
-        }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: true,
-            has_dynamic_mirroring: true,
-            has_expansion_audio: false,
-            max_prg_ram_kb: if self.prg_ram.is_some() { 8 } else { 0 },
-            prg_bank_size_kb: 8,
-            chr_bank_size_kb: 4,
-            trainer_jsr: false,
-            ..Default::default()
+            self.base.set_mirroring(mirroring);
+            self.update_prg_banks();
+            self.update_chr_pages();
         }
     }
 }
@@ -337,8 +239,8 @@ mod tests {
     #[test]
     fn test_mmc2_prg_bank_8000_is_switchable_and_upper_banks_are_fixed() {
         let prg_banks = 8;
-        let prg_rom = filled_banks(MMC2Mapper::PRG_BANK_SIZE, prg_banks);
-        let chr_rom = filled_banks(MMC2Mapper::CHR_BANK_SIZE, 8);
+        let prg_rom = filled_banks(0x2000, prg_banks);
+        let chr_rom = filled_banks(0x1000, 8);
 
         let mapper = MMC2Mapper::new(MapperContext::new_for_test(
             9,
@@ -358,8 +260,8 @@ mod tests {
 
     #[test]
     fn test_mmc2_registers_snapshot_preserves_latches_and_mirroring() {
-        let prg_rom = filled_banks(MMC2Mapper::PRG_BANK_SIZE, 4);
-        let chr_rom = filled_banks(MMC2Mapper::CHR_BANK_SIZE, 8);
+        let prg_rom = filled_banks(0x2000, 4);
+        let chr_rom = filled_banks(0x1000, 8);
 
         let mut mapper = MMC2Mapper::new(MapperContext::new_for_test(
             9,
@@ -397,8 +299,8 @@ mod tests {
     #[test]
     fn test_mmc2_chr_latches_select_between_fd_and_fe_banks() {
         // Provide at least 6 4KB banks.
-        let chr_rom = filled_banks(MMC2Mapper::CHR_BANK_SIZE, 8);
-        let prg_rom = filled_banks(MMC2Mapper::PRG_BANK_SIZE, 8);
+        let chr_rom = filled_banks(0x1000, 8);
+        let prg_rom = filled_banks(0x2000, 8);
 
         let mut mapper = MMC2Mapper::new(MapperContext::new_for_test(
             9,
@@ -429,8 +331,8 @@ mod tests {
 
     #[test]
     fn test_mmc2_latch0_only_switches_on_exact_addresses() {
-        let chr_rom = filled_banks(MMC2Mapper::CHR_BANK_SIZE, 8);
-        let prg_rom = filled_banks(MMC2Mapper::PRG_BANK_SIZE, 8);
+        let chr_rom = filled_banks(0x1000, 8);
+        let prg_rom = filled_banks(0x2000, 8);
 
         let mut mapper = MMC2Mapper::new(MapperContext::new_for_test(
             9,
@@ -464,8 +366,8 @@ mod tests {
 
     #[test]
     fn test_mmc2_ppu_address_changed_does_not_switch_latches() {
-        let chr_rom = filled_banks(MMC2Mapper::CHR_BANK_SIZE, 8);
-        let prg_rom = filled_banks(MMC2Mapper::PRG_BANK_SIZE, 8);
+        let chr_rom = filled_banks(0x1000, 8);
+        let prg_rom = filled_banks(0x2000, 8);
 
         let mut mapper = MMC2Mapper::new(MapperContext::new_for_test(
             9,

--- a/src/cartridge/mmc4.rs
+++ b/src/cartridge/mmc4.rs
@@ -5,9 +5,7 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
-use std::cell::Cell;
-
-use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 /// Mapper 10 - MMC4 (FxROM boards)
@@ -30,12 +28,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// - Last 16KB PRG bank fixed at $C000-$FFFF
 /// - Used in Fire Emblem (Japan), Fire Emblem Gaiden (Japan)
 pub struct MMC4Mapper {
-    prg_rom: Vec<u8>,
-    prg_ram: PrgRam,
-
-    chr_memory: ChrMemory,
-
-    mirroring: NametableLayout,
+    base: BaseMapper,
 
     // --- PRG banking ---
     prg_bank_16k: u8,
@@ -46,89 +39,67 @@ pub struct MMC4Mapper {
     chr_bank_1_fd: u8,
     chr_bank_1_fe: u8,
 
-    latch0_is_fd: Cell<bool>,
-    latch1_is_fd: Cell<bool>,
+    latch0_is_fd: bool,
+    latch1_is_fd: bool,
 }
 
 impl MMC4Mapper {
-    const PRG_BANK_SIZE: usize = 0x4000; // 16KB
-    const CHR_BANK_SIZE: usize = 0x1000; // 4KB
-
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
-        let mirroring = ctx.mirroring;
+        let capabilities = MapperCapabilities {
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            max_prg_ram_kb: 8,
+            prg_bank_size_kb: 16,
+            chr_bank_size_kb: 4,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(16 * 1024);
+        base.configure_chr_banking(4 * 1024);
+        // $8000: bank 0, $C000: last bank
+        base.select_prg_page(0, 0);
+        base.select_prg_page(1, -1);
+        // CHR: both latches FE (false), all bank regs = 0
+        base.select_chr_page(0, 0);
+        base.select_chr_page(1, 0);
         Self {
-            prg_rom,
-            prg_ram: PrgRam::new(DEFAULT_PRG_RAM_SIZE),
-            chr_memory: ChrMemory::new(chr_rom),
-            mirroring,
+            base,
             prg_bank_16k: 0,
             chr_bank_0_fd: 0,
             chr_bank_0_fe: 0,
             chr_bank_1_fd: 0,
             chr_bank_1_fe: 0,
-            latch0_is_fd: Cell::new(false),
-            latch1_is_fd: Cell::new(false),
+            latch0_is_fd: false,
+            latch1_is_fd: false,
         }
     }
 
-    fn prg_bank_count_16k(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_BANK_SIZE
+    fn update_prg_banks(&mut self) {
+        self.base.select_prg_page(0, self.prg_bank_16k as i16);
+        // $C000-$FFFF always fixed to last bank
     }
 
-    fn chr_bank_count_4k(&self) -> usize {
-        self.chr_memory.size() / Self::CHR_BANK_SIZE
-    }
-
-    fn clamp_prg_bank_16k(&self, bank: u8) -> usize {
-        let count = self.prg_bank_count_16k();
-        if count == 0 {
-            return 0;
-        }
-        (bank as usize) % count
-    }
-
-    fn clamp_chr_bank_4k(&self, bank: u8) -> usize {
-        let count = self.chr_bank_count_4k();
-        if count == 0 {
-            return 0;
-        }
-        (bank as usize) % count
-    }
-
-    fn read_prg_rom_bank(&self, bank_index: usize, bank_offset: usize) -> u8 {
-        let addr = bank_index * Self::PRG_BANK_SIZE + bank_offset;
-        self.prg_rom.get(addr).copied().unwrap_or(0)
-    }
-
-    fn read_chr_bank_4k(&self, bank_index: usize, bank_offset: usize) -> u8 {
-        let addr = bank_index * Self::CHR_BANK_SIZE + bank_offset;
-        self.chr_memory.read_at_index(addr)
-    }
-
-    fn chr_bank_for_addr(&self, addr: u16) -> usize {
-        let bank = if addr < 0x1000 {
-            if self.latch0_is_fd.get() {
-                self.chr_bank_0_fd
-            } else {
-                self.chr_bank_0_fe
-            }
-        } else if self.latch1_is_fd.get() {
+    fn update_chr_pages(&mut self) {
+        let bank0 = if self.latch0_is_fd {
+            self.chr_bank_0_fd
+        } else {
+            self.chr_bank_0_fe
+        };
+        let bank1 = if self.latch1_is_fd {
             self.chr_bank_1_fd
         } else {
             self.chr_bank_1_fe
         };
-
-        self.clamp_chr_bank_4k(bank)
+        self.base.select_chr_page(0, bank0 as i16);
+        self.base.select_chr_page(1, bank1 as i16);
     }
 
-    fn update_latches(&self, addr: u16) {
+    fn update_latches(&mut self, addr: u16) {
         match addr {
-            0x0FD8..=0x0FDF => self.latch0_is_fd.set(true),
-            0x0FE8..=0x0FEF => self.latch0_is_fd.set(false),
-            0x1FD8..=0x1FDF => self.latch1_is_fd.set(true),
-            0x1FE8..=0x1FEF => self.latch1_is_fd.set(false),
+            0x0FD8..=0x0FDF => self.latch0_is_fd = true,
+            0x0FE8..=0x0FEF => self.latch0_is_fd = false,
+            0x1FD8..=0x1FDF => self.latch1_is_fd = true,
+            0x1FE8..=0x1FEF => self.latch1_is_fd = false,
             _ => {}
         }
     }
@@ -151,111 +122,85 @@ impl MMC4Mapper {
 }
 
 impl Mapper for MMC4Mapper {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.prg_ram.try_read(addr) {
+        if let Some(value) = self.base.try_read_prg_ram(addr) {
             return value;
         }
-
         match addr {
-            0x8000..=0xBFFF => {
-                let bank = self.clamp_prg_bank_16k(self.prg_bank_16k);
-                let offset = (addr - 0x8000) as usize;
-                self.read_prg_rom_bank(bank, offset)
-            }
-            0xC000..=0xFFFF => {
-                let count = self.prg_bank_count_16k();
-                let bank = count.saturating_sub(1);
-                let offset = (addr - 0xC000) as usize;
-                self.read_prg_rom_bank(bank, offset)
-            }
+            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
             _ => 0,
         }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
-        if self.prg_ram.try_write(addr, value) {
+        if self.base.try_write_prg_ram(addr, value) {
             return;
         }
 
         match addr {
             0xA000..=0xAFFF => {
                 self.prg_bank_16k = value & 0x0F;
+                self.update_prg_banks();
             }
-            0xB000..=0xBFFF => self.chr_bank_0_fd = value & 0x1F,
-            0xC000..=0xCFFF => self.chr_bank_0_fe = value & 0x1F,
-            0xD000..=0xDFFF => self.chr_bank_1_fd = value & 0x1F,
-            0xE000..=0xEFFF => self.chr_bank_1_fe = value & 0x1F,
+            0xB000..=0xBFFF => {
+                self.chr_bank_0_fd = value & 0x1F;
+                self.update_chr_pages();
+            }
+            0xC000..=0xCFFF => {
+                self.chr_bank_0_fe = value & 0x1F;
+                self.update_chr_pages();
+            }
+            0xD000..=0xDFFF => {
+                self.chr_bank_1_fd = value & 0x1F;
+                self.update_chr_pages();
+            }
+            0xE000..=0xEFFF => {
+                self.chr_bank_1_fe = value & 0x1F;
+                self.update_chr_pages();
+            }
             0xF000..=0xFFFF => {
-                self.mirroring = if (value & 0x01) != 0 {
+                let mirroring = if (value & 0x01) != 0 {
                     NametableLayout::Horizontal
                 } else {
                     NametableLayout::Vertical
                 };
+                self.base.set_mirroring(mirroring);
             }
             _ => {}
         }
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
-        let bank = self.chr_bank_for_addr(addr);
-        let offset = (addr as usize) & (Self::CHR_BANK_SIZE - 1);
-        let value = self.read_chr_bank_4k(bank, offset);
+        // Read from current bank (pages already set from previous latch state)
+        let value = self.base.read_chr_banked(addr);
+        // Update latches after read, then sync pages for next access
         self.update_latches(addr);
+        self.update_chr_pages();
         value
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
-        let bank = self.chr_bank_for_addr(addr);
-        let offset = (addr as usize) & (Self::CHR_BANK_SIZE - 1);
-        let index = bank * Self::CHR_BANK_SIZE + offset;
-        self.chr_memory.write_at_index(index, value);
-    }
-
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        10
-    }
-
-    fn wram_size(&self) -> usize {
-        self.prg_ram.size()
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.snapshot()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        self.prg_ram.load_snapshot(data);
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
+        // Write to current bank — do NOT update latches
+        self.base.write_chr_banked(addr, value);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
-        // Serialize MMC4 internal registers:
-        // [0]: prg_bank_16k
-        // [1]: chr_bank_0_fd
-        // [2]: chr_bank_0_fe
-        // [3]: chr_bank_1_fd
-        // [4]: chr_bank_1_fe
-        // [5]: latches (bit 0 = latch0_is_fd, bit 1 = latch1_is_fd)
-        // [6]: mirroring
         vec![
             self.prg_bank_16k,
             self.chr_bank_0_fd,
             self.chr_bank_0_fe,
             self.chr_bank_1_fd,
             self.chr_bank_1_fe,
-            (self.latch0_is_fd.get() as u8) | ((self.latch1_is_fd.get() as u8) << 1),
-            Self::encode_mirroring(self.mirroring),
+            (self.latch0_is_fd as u8) | ((self.latch1_is_fd as u8) << 1),
+            Self::encode_mirroring(self.base.mirroring()),
         ]
     }
 
@@ -266,23 +211,11 @@ impl Mapper for MMC4Mapper {
             self.chr_bank_0_fe = data[2];
             self.chr_bank_1_fd = data[3];
             self.chr_bank_1_fe = data[4];
-            self.latch0_is_fd.set((data[5] & 1) != 0);
-            self.latch1_is_fd.set((data[5] & 2) != 0);
-            self.mirroring = Self::decode_mirroring(data[6]);
-        }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: true,
-            has_dynamic_mirroring: true,
-            has_expansion_audio: false,
-            max_prg_ram_kb: 8,
-            prg_bank_size_kb: 16,
-            chr_bank_size_kb: 4,
-            trainer_jsr: false,
-            ..Default::default()
+            self.latch0_is_fd = (data[5] & 1) != 0;
+            self.latch1_is_fd = (data[5] & 2) != 0;
+            self.base.set_mirroring(Self::decode_mirroring(data[6]));
+            self.update_prg_banks();
+            self.update_chr_pages();
         }
     }
 }
@@ -301,8 +234,8 @@ mod tests {
     #[test]
     fn test_mmc4_prg_bank_8000_is_switchable_and_upper_bank_fixed() {
         let prg_banks = 4;
-        let prg_rom = filled_banks(MMC4Mapper::PRG_BANK_SIZE, prg_banks);
-        let chr_rom = filled_banks(MMC4Mapper::CHR_BANK_SIZE, 8);
+        let prg_rom = filled_banks(0x4000, prg_banks);
+        let chr_rom = filled_banks(0x1000, 8);
 
         let mut mapper = MMC4Mapper::new(MapperContext::new_for_test(
             10,
@@ -328,8 +261,8 @@ mod tests {
 
     #[test]
     fn test_mmc4_chr_latches_select_between_fd_and_fe_banks() {
-        let chr_rom = filled_banks(MMC4Mapper::CHR_BANK_SIZE, 8);
-        let prg_rom = filled_banks(MMC4Mapper::PRG_BANK_SIZE, 4);
+        let chr_rom = filled_banks(0x1000, 8);
+        let prg_rom = filled_banks(0x4000, 4);
 
         let mut mapper = MMC4Mapper::new(MapperContext::new_for_test(
             10,
@@ -363,8 +296,8 @@ mod tests {
 
     #[test]
     fn test_mmc4_registers_snapshot_preserves_latches_and_mirroring() {
-        let prg_rom = filled_banks(MMC4Mapper::PRG_BANK_SIZE, 4);
-        let chr_rom = filled_banks(MMC4Mapper::CHR_BANK_SIZE, 8);
+        let prg_rom = filled_banks(0x4000, 4);
+        let chr_rom = filled_banks(0x1000, 8);
 
         let mut mapper = MMC4Mapper::new(MapperContext::new_for_test(
             10,
@@ -414,8 +347,8 @@ mod tests {
 
     #[test]
     fn test_mmc4_trigger_read_uses_previous_bank_then_latch_updates() {
-        let chr_rom = filled_banks(MMC4Mapper::CHR_BANK_SIZE, 8);
-        let prg_rom = filled_banks(MMC4Mapper::PRG_BANK_SIZE, 4);
+        let chr_rom = filled_banks(0x1000, 8);
+        let prg_rom = filled_banks(0x4000, 4);
 
         let mut mapper = MMC4Mapper::new(MapperContext::new_for_test(
             10,
@@ -439,8 +372,8 @@ mod tests {
 
     #[test]
     fn test_mmc4_write_chr_does_not_update_latch_state() {
-        let chr_rom = filled_banks(MMC4Mapper::CHR_BANK_SIZE, 8);
-        let prg_rom = filled_banks(MMC4Mapper::PRG_BANK_SIZE, 4);
+        let chr_rom = filled_banks(0x1000, 8);
+        let prg_rom = filled_banks(0x4000, 4);
 
         let mut mapper = MMC4Mapper::new(MapperContext::new_for_test(
             10,

--- a/src/cartridge/multicart_15.rs
+++ b/src/cartridge/multicart_15.rs
@@ -5,12 +5,12 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
+use crate::cartridge::BaseMapper;
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::NametableLayout;
-use crate::cartridge::common::{ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
 
-// Memory size constants
+#[cfg(test)]
 const PRG_BANK_SIZE_8K: usize = 0x2000; // 8KB
 #[cfg(test)]
 const PRG_BANK_SIZE_16K: usize = 0x4000; // 16KB
@@ -37,9 +37,7 @@ const PRG_BANK_SIZE_16K: usize = 0x4000; // 16KB
 /// - Bit 6 of data: mirroring control
 /// - Used in various pirate multicarts (100-in-1, 168-in-1, etc.)
 pub struct Multicart15Mapper {
-    prg_rom: Vec<u8>,
-    prg_ram: PrgRam,
-    chr_memory: ChrMemory,
+    base: BaseMapper,
     bank_select: u8,
     sub_bank: u8,
     mode: u8,
@@ -48,32 +46,36 @@ pub struct Multicart15Mapper {
 
 impl Multicart15Mapper {
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
         let mirroring = ctx.mirroring;
-        // Pirate multicarts typically use CHR-RAM
-        Self {
-            prg_rom,
-            prg_ram: PrgRam::new(DEFAULT_PRG_RAM_SIZE),
-            chr_memory: ChrMemory::new(chr_rom),
+        let capabilities = MapperCapabilities {
+            has_irq: false,
+            has_chr_banking: false,
+            has_dynamic_mirroring: true,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 8,
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 8,
+            trainer_jsr: false,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(0x2000); // 8KB
+        let mut mapper = Self {
+            base,
             bank_select: 0,
             sub_bank: 0,
             mode: 0,
             mirroring,
-        }
+        };
+        mapper.update_banks();
+        mapper
     }
 
-    fn get_prg_bank_8k(&self, bank_num: u8) -> usize {
-        let total_banks = (self.prg_rom.len() / PRG_BANK_SIZE_8K).max(1);
-        let bank = (bank_num as usize) % total_banks;
-        bank * PRG_BANK_SIZE_8K
-    }
-
-    fn get_prg_page_for_slot(&self, slot: u8) -> u8 {
+    fn get_prg_page_for_slot(&self, slot: u8) -> i16 {
         let sub_bank = self.sub_bank & 0x01;
         let base = self.bank_select.wrapping_shl(1);
 
-        match self.mode {
+        let page = match self.mode {
             0 => base.wrapping_add(slot) ^ sub_bank,
             1 | 3 => {
                 let lower = base | sub_bank;
@@ -86,45 +88,46 @@ impl Multicart15Mapper {
             }
             2 => base | sub_bank,
             _ => unreachable!("Invalid banking mode"),
-        }
+        };
+        page as i16
     }
 
     fn is_chr_ram_writable(&self) -> bool {
         matches!(self.mode, 1 | 2)
     }
+
+    fn update_banks(&mut self) {
+        for slot in 0..4 {
+            let page = self.get_prg_page_for_slot(slot);
+            self.base.select_prg_page(slot as usize, page);
+        }
+        self.base.set_mirroring(self.mirroring);
+    }
 }
 
 impl Mapper for Multicart15Mapper {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
-        // PRG-RAM at $6000-$7FFF
-        if let Some(value) = self.prg_ram.try_read(addr) {
+        if let Some(value) = self.base.try_read_prg_ram(addr) {
             return value;
         }
-
-        // PRG ROM at $8000-$FFFF
-        if addr < 0x8000 {
-            return 0;
-        }
-
-        let offset = (addr - 0x8000) as usize;
-        let slot = (offset / PRG_BANK_SIZE_8K) as u8;
-        let slot_offset = offset % PRG_BANK_SIZE_8K;
-        let page = self.get_prg_page_for_slot(slot);
-        let page_offset = self.get_prg_bank_8k(page);
-        let index = page_offset + slot_offset;
-
-        self.prg_rom.get(index).copied().unwrap_or(0)
+        self.base.read_prg_banked(addr)
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
-        // PRG-RAM at $6000-$7FFF
-        if self.prg_ram.try_write(addr, value) {
+        if self.base.try_write_prg_ram(addr, value) {
             return;
         }
 
         // Mapper control registers at $8000-$FFFF
         if addr >= 0x8000 {
-            // Extract bank and mirroring from value
             self.bank_select = value & 0x7F;
             self.sub_bank = value >> 7;
             self.mirroring = if (value & 0x40) != 0 {
@@ -135,52 +138,17 @@ impl Mapper for Multicart15Mapper {
 
             // Set mode from low two address bits (SS)
             self.mode = (addr & 0x0003) as u8;
+            self.update_banks();
         }
-    }
-
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.chr_memory.read(addr)
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
         if self.is_chr_ram_writable() {
-            self.chr_memory.write(addr, value);
+            self.base.write_chr(addr, value);
         }
     }
 
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        15
-    }
-
-    fn wram_size(&self) -> usize {
-        self.prg_ram.size()
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.snapshot()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        self.prg_ram.load_snapshot(data);
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
-        // [0]: bank_select
-        // [1]: sub_bank
-        // [2]: mode
-        // [3]: mirroring
         let mirroring = match self.mirroring {
             NametableLayout::Horizontal => 0,
             NametableLayout::Vertical => 1,
@@ -204,20 +172,7 @@ impl Mapper for Multicart15Mapper {
                 4 => NametableLayout::FourScreen,
                 _ => NametableLayout::Horizontal,
             };
-        }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: false,
-            has_dynamic_mirroring: true,
-            has_expansion_audio: false,
-            max_prg_ram_kb: 8,
-            prg_bank_size_kb: 8,
-            chr_bank_size_kb: 8,
-            trainer_jsr: false,
-            ..Default::default()
+            self.update_banks();
         }
     }
 }

--- a/src/cartridge/namco118.rs
+++ b/src/cartridge/namco118.rs
@@ -5,8 +5,8 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
-use crate::cartridge::common::ChrMemory;
-use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
+use crate::cartridge::base_mapper::BaseMapper;
+use crate::cartridge::{Mapper, MapperCapabilities};
 
 /// Mapper 206 - Namco 118 / Namco 108 (DxROM boards)
 ///
@@ -34,62 +34,35 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// - Simplified MMC3 without IRQ functionality
 /// - Bank switching compatible with MMC3 behavior
 pub struct Namco118Mapper {
-    prg_rom: Vec<u8>,
-    chr_memory: ChrMemory,
-    prg_ram: Vec<u8>,
-
-    mirroring: NametableLayout,
+    base: BaseMapper,
 
     bank_select: u8,
     regs: [u8; 8],
 }
 
 impl Namco118Mapper {
-    const PRG_BANK_SIZE: usize = 0x2000; // 8KB
-    const CHR_BANK_SIZE: usize = 0x0400; // 1KB
-    const PRG_RAM_SIZE: usize = 0x2000; // 8KB
     const PRG_MODE_MASK: u8 = 0b0100_0000;
     const CHR_MODE_MASK: u8 = 0b1000_0000;
     const REG_SELECT_MASK: u8 = 0b0000_0111;
-    const EVEN_ALIGN_MASK: u8 = 0xFE;
-    const CHR_ADDR_MASK: u16 = 0x1FFF;
 
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
-        let mirroring = ctx.mirroring;
-        Self {
-            prg_rom,
-            chr_memory: ChrMemory::new(chr_rom),
-            prg_ram: vec![0; Self::PRG_RAM_SIZE],
-            mirroring,
+        let capabilities = MapperCapabilities {
+            has_chr_banking: true,
+            max_prg_ram_kb: 8,
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 1,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(8 * 1024);
+        base.configure_chr_banking(1024);
+        let mut mapper = Self {
+            base,
             bank_select: 0,
             regs: [0; 8],
-        }
-    }
-
-    fn prg_bank_count(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_BANK_SIZE
-    }
-
-    fn chr_bank_count_1k(&self) -> usize {
-        self.chr_memory.size() / Self::CHR_BANK_SIZE
-    }
-
-    fn prg_bank_index(&self, bank: u8) -> usize {
-        let count = self.prg_bank_count();
-        if count == 0 {
-            return 0;
-        }
-        (bank as usize) % count
-    }
-
-    fn chr_bank_index_1k(&self, bank: u8) -> usize {
-        let count = self.chr_bank_count_1k();
-        if count == 0 {
-            return 0;
-        }
-        (bank as usize) % count
+        };
+        mapper.update_banks();
+        mapper
     }
 
     fn prg_mode(&self) -> bool {
@@ -104,113 +77,78 @@ impl Namco118Mapper {
         (self.bank_select & Self::REG_SELECT_MASK) as usize
     }
 
-    fn read_prg_rom_bank(&self, bank_index: usize, bank_offset: usize) -> u8 {
-        let addr = bank_index * Self::PRG_BANK_SIZE + bank_offset;
-        self.prg_rom.get(addr).copied().unwrap_or(0)
-    }
-
-    fn read_chr_bank_1k(&self, bank_index: usize, bank_offset: usize) -> u8 {
-        let addr = bank_index * Self::CHR_BANK_SIZE + bank_offset;
-        self.chr_memory.read_at_index(addr)
-    }
-
-    fn map_chr_addr_to_bank_1k(&self, chr_addr: usize) -> (usize, usize) {
-        let bank_offset = chr_addr & (Self::CHR_BANK_SIZE - 1);
-
-        let r0 = self.regs[0] & Self::EVEN_ALIGN_MASK; // 2KB bank, even-aligned
-        let r1 = self.regs[1] & Self::EVEN_ALIGN_MASK; // 2KB bank, even-aligned
-        let r2 = self.regs[2];
-        let r3 = self.regs[3];
-        let r4 = self.regs[4];
-        let r5 = self.regs[5];
-
-        let bank_1k = if !self.chr_mode() {
-            // CHR mode 0
-            match chr_addr {
-                0x0000..=0x03FF => r0,
-                0x0400..=0x07FF => r0.wrapping_add(1),
-                0x0800..=0x0BFF => r1,
-                0x0C00..=0x0FFF => r1.wrapping_add(1),
-                0x1000..=0x13FF => r2,
-                0x1400..=0x17FF => r3,
-                0x1800..=0x1BFF => r4,
-                0x1C00..=0x1FFF => r5,
-                _ => 0,
-            }
+    fn update_banks(&mut self) {
+        // PRG banking
+        let r6 = self.regs[6] as i16;
+        let r7 = self.regs[7] as i16;
+        if !self.prg_mode() {
+            self.base.select_prg_page(0, r6);
+            self.base.select_prg_page(1, r7);
+            self.base.select_prg_page(2, -2);
+            self.base.select_prg_page(3, -1);
         } else {
-            // CHR mode 1
-            match chr_addr {
-                0x0000..=0x03FF => r2,
-                0x0400..=0x07FF => r3,
-                0x0800..=0x0BFF => r4,
-                0x0C00..=0x0FFF => r5,
-                0x1000..=0x13FF => r0,
-                0x1400..=0x17FF => r0.wrapping_add(1),
-                0x1800..=0x1BFF => r1,
-                0x1C00..=0x1FFF => r1.wrapping_add(1),
-                _ => 0,
-            }
-        };
+            self.base.select_prg_page(0, -2);
+            self.base.select_prg_page(1, r7);
+            self.base.select_prg_page(2, r6);
+            self.base.select_prg_page(3, -1);
+        }
 
-        (self.chr_bank_index_1k(bank_1k), bank_offset)
+        // CHR banking
+        let r0 = (self.regs[0] & 0xFE) as i16; // even-aligned
+        let r1 = (self.regs[1] & 0xFE) as i16;
+        let r2 = self.regs[2] as i16;
+        let r3 = self.regs[3] as i16;
+        let r4 = self.regs[4] as i16;
+        let r5 = self.regs[5] as i16;
+
+        if !self.chr_mode() {
+            // Mode 0: R0/R1 2KB at low, R2-R5 1KB at high
+            self.base.select_chr_page(0, r0);
+            self.base.select_chr_page(1, r0 + 1);
+            self.base.select_chr_page(2, r1);
+            self.base.select_chr_page(3, r1 + 1);
+            self.base.select_chr_page(4, r2);
+            self.base.select_chr_page(5, r3);
+            self.base.select_chr_page(6, r4);
+            self.base.select_chr_page(7, r5);
+        } else {
+            // Mode 1: R2-R5 1KB at low, R0/R1 2KB at high
+            self.base.select_chr_page(0, r2);
+            self.base.select_chr_page(1, r3);
+            self.base.select_chr_page(2, r4);
+            self.base.select_chr_page(3, r5);
+            self.base.select_chr_page(4, r0);
+            self.base.select_chr_page(5, r0 + 1);
+            self.base.select_chr_page(6, r1);
+            self.base.select_chr_page(7, r1 + 1);
+        }
     }
 }
 
 impl Mapper for Namco118Mapper {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
+        if let Some(value) = self.base.try_read_prg_ram(addr) {
+            return value;
+        }
         match addr {
-            0x6000..=0x7FFF => {
-                let offset = (addr - 0x6000) as usize;
-                self.prg_ram.get(offset).copied().unwrap_or(0)
-            }
-            0x8000..=0xFFFF => {
-                let prg_count = self.prg_bank_count();
-                if prg_count == 0 {
-                    return 0;
-                }
-
-                let bank_offset = (addr as usize) & (Self::PRG_BANK_SIZE - 1);
-
-                let fixed_last = prg_count.saturating_sub(1);
-                let fixed_second_last = prg_count.saturating_sub(2);
-
-                let r6 = self.prg_bank_index(self.regs[6]);
-                let r7 = self.prg_bank_index(self.regs[7]);
-
-                let bank_index = match addr {
-                    0x8000..=0x9FFF => {
-                        if self.prg_mode() {
-                            fixed_second_last
-                        } else {
-                            r6
-                        }
-                    }
-                    0xA000..=0xBFFF => r7,
-                    0xC000..=0xDFFF => {
-                        if self.prg_mode() {
-                            r6
-                        } else {
-                            fixed_second_last
-                        }
-                    }
-                    0xE000..=0xFFFF => fixed_last,
-                    _ => 0,
-                };
-
-                self.read_prg_rom_bank(bank_index, bank_offset)
-            }
+            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
             _ => 0,
         }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
+        if self.base.try_write_prg_ram(addr, value) {
+            return;
+        }
         match addr {
-            0x6000..=0x7FFF => {
-                let offset = (addr - 0x6000) as usize;
-                if let Some(byte) = self.prg_ram.get_mut(offset) {
-                    *byte = value;
-                }
-            }
             0x8000..=0x9FFF => {
                 if (addr & 1) == 0 {
                     // Bank select
@@ -220,66 +158,23 @@ impl Mapper for Namco118Mapper {
                     let reg = self.selected_reg();
                     self.regs[reg] = value;
                 }
+                self.update_banks();
             }
-            // $A000/$A001 (mirroring / PRG-RAM protect on MMC3) are ignored; mirroring is hardwired.
-            0xA000..=0xBFFF => {}
-            // $C000/$C001 and $E000/$E001 are IRQ-related on MMC3; ignored for Namco 118.
-            0xC000..=0xFFFF => {}
+            // Mirroring / PRG-RAM protect and IRQ registers are ignored
+            0xA000..=0xFFFF => {}
             _ => {}
         }
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
-        let chr_addr = (addr & Self::CHR_ADDR_MASK) as usize;
-        let (bank_index, bank_offset) = self.map_chr_addr_to_bank_1k(chr_addr);
-        self.read_chr_bank_1k(bank_index, bank_offset)
+        self.base.read_chr_banked(addr)
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
-        let chr_addr = (addr & Self::CHR_ADDR_MASK) as usize;
-        let (bank_index, bank_offset) = self.map_chr_addr_to_bank_1k(chr_addr);
-        let mapped_addr = bank_index * Self::CHR_BANK_SIZE + bank_offset;
-        self.chr_memory.write_at_index(mapped_addr, value);
-    }
-
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        206
-    }
-
-    fn wram_size(&self) -> usize {
-        self.prg_ram.len()
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.clone()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        let to_copy = data.len().min(self.prg_ram.len());
-        self.prg_ram[..to_copy].copy_from_slice(&data[..to_copy]);
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
-    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        crate::console::initialize_ram(&mut self.prg_ram, mode);
-        self.chr_memory.initialize(mode);
+        self.base.write_chr_banked(addr, value);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
-        // Serialize Namco118 internal registers:
-        // [0]: bank_select
-        // [1-8]: regs[0-7]
         let mut snapshot = Vec::with_capacity(9);
         snapshot.push(self.bank_select);
         snapshot.extend_from_slice(&self.regs);
@@ -290,20 +185,7 @@ impl Mapper for Namco118Mapper {
         if data.len() >= 9 {
             self.bank_select = data[0];
             self.regs.copy_from_slice(&data[1..9]);
-        }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: true,
-            has_dynamic_mirroring: false,
-            has_expansion_audio: false,
-            max_prg_ram_kb: 8,
-            prg_bank_size_kb: 8,
-            chr_bank_size_kb: 1,
-            trainer_jsr: false,
-            ..Default::default()
+            self.update_banks();
         }
     }
 }

--- a/src/cartridge/nina_tengen.rs
+++ b/src/cartridge/nina_tengen.rs
@@ -5,14 +5,10 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
+use crate::cartridge::BaseMapper;
 use crate::cartridge::Mapper;
 use crate::cartridge::MapperCapabilities;
 use crate::cartridge::NametableLayout;
-use crate::cartridge::common::{BankedRom, DEFAULT_PRG_RAM_SIZE, PrgRam};
-
-// Memory size constants
-const PRG_BANK_SIZE: usize = 0x4000; // 16KB
-const CHR_BANK_SIZE: usize = 0x2000; // 8KB
 
 /// Mapper 78 - Irem Holy Diver / Jaleco JF-16
 ///
@@ -40,9 +36,7 @@ const CHR_BANK_SIZE: usize = 0x2000; // 8KB
 /// - Games: Holy Diver (Irem), Uchuusen: Cosmo Carrier (Irem)
 /// - Also used by Tengen: Pac-Man, RBI Baseball, Tetris (unlicensed)
 pub struct NinaTengenMapper {
-    prg_rom: BankedRom,
-    prg_ram: PrgRam,
-    chr_rom: BankedRom,
+    base: BaseMapper,
     prg_bank_select: u8,
     chr_bank_select: u8,
     mirroring: NametableLayout,
@@ -50,52 +44,57 @@ pub struct NinaTengenMapper {
 
 impl NinaTengenMapper {
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
         let mirroring = ctx.mirroring;
-        Self {
-            prg_rom: BankedRom::new(prg_rom, PRG_BANK_SIZE),
-            prg_ram: PrgRam::new(DEFAULT_PRG_RAM_SIZE),
-            chr_rom: BankedRom::new(chr_rom, CHR_BANK_SIZE),
+        let capabilities = MapperCapabilities {
+            has_irq: false,
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 8,
+            prg_bank_size_kb: 16,
+            chr_bank_size_kb: 8,
+            trainer_jsr: false,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(0x4000); // 16KB
+        base.configure_chr_banking(0x2000); // 8KB
+        let mut mapper = Self {
+            base,
             prg_bank_select: 0,
             chr_bank_select: 0,
             mirroring,
-        }
+        };
+        mapper.update_banks();
+        mapper
     }
 
-    fn get_last_prg_bank(&self) -> usize {
-        // Get the last bank number (num_banks - 1)
-        let num_banks = self.prg_rom.num_banks();
-        if num_banks == 0 { 0 } else { num_banks - 1 }
+    fn update_banks(&mut self) {
+        self.base.select_prg_page(0, self.prg_bank_select as i16);
+        self.base.select_prg_page(1, -1); // Fixed last bank
+        self.base.select_chr_page(0, self.chr_bank_select as i16);
+        self.base.set_mirroring(self.mirroring);
     }
 }
 
 impl Mapper for NinaTengenMapper {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
-        // PRG-RAM at $6000-$7FFF
-        if let Some(value) = self.prg_ram.try_read(addr) {
+        if let Some(value) = self.base.try_read_prg_ram(addr) {
             return value;
         }
-
-        // PRG ROM at $8000-$FFFF
-        match addr {
-            0x8000..=0xBFFF => {
-                // Switchable 16KB bank
-                self.prg_rom
-                    .read_with_base(self.prg_bank_select as usize, 0x8000, addr)
-            }
-            0xC000..=0xFFFF => {
-                // Fixed to last 16KB bank
-                let last_bank = self.get_last_prg_bank();
-                self.prg_rom.read_with_base(last_bank, 0xC000, addr)
-            }
-            _ => 0,
-        }
+        self.base.read_prg_banked(addr)
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
-        // PRG-RAM at $6000-$7FFF
-        if self.prg_ram.try_write(addr, value) {
+        if self.base.try_write_prg_ram(addr, value) {
             return;
         }
 
@@ -113,36 +112,17 @@ impl Mapper for NinaTengenMapper {
 
             // Bits 4-7: CHR bank select
             self.chr_bank_select = (value >> 4) & 0x0F;
+
+            self.update_banks();
         }
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
-        self.chr_rom
-            .read_with_base(self.chr_bank_select as usize, 0x0000, addr)
+        self.base.read_chr_banked(addr)
     }
 
     fn write_chr(&mut self, _addr: u16, _value: u8) {
         // Mapper 78 uses CHR-ROM, writes are ignored
-    }
-
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        78
-    }
-
-    fn wram_size(&self) -> usize {
-        self.prg_ram.size()
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.snapshot()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        self.prg_ram.load_snapshot(data);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -168,20 +148,7 @@ impl Mapper for NinaTengenMapper {
                 4 => NametableLayout::FourScreen,
                 _ => NametableLayout::Horizontal,
             };
-        }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: true,
-            has_dynamic_mirroring: true,
-            has_expansion_audio: false,
-            max_prg_ram_kb: 8,
-            prg_bank_size_kb: 16,
-            chr_bank_size_kb: 8,
-            trainer_jsr: false,
-            ..Default::default()
+            self.update_banks();
         }
     }
 }

--- a/src/cartridge/taito_tc0190.rs
+++ b/src/cartridge/taito_tc0190.rs
@@ -5,7 +5,7 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
-use crate::cartridge::common::ChrMemory;
+use crate::cartridge::BaseMapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 /// Mapper 033 – Taito TC0190
@@ -44,144 +44,88 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// - `$A002` [CCCC CCCC]: CHR bank 4 (1KB @ $1800)
 /// - `$A003` [CCCC CCCC]: CHR bank 5 (1KB @ $1C00)
 pub struct TaitoTc0190Mapper {
-    prg_rom: Vec<u8>,
-    chr_memory: ChrMemory,
-    prg_ram: Vec<u8>,
-
+    base: BaseMapper,
     mirroring: NametableLayout,
-
     prg_bank: [u8; 2],
     chr_bank_2k: [u8; 2],
     chr_bank_1k: [u8; 4],
 }
 
 impl TaitoTc0190Mapper {
-    const PRG_BANK_SIZE: usize = 0x2000; // 8KB
-    const CHR_BANK_2K_SIZE: usize = 0x0800; // 2KB
-    const CHR_BANK_1K_SIZE: usize = 0x0400; // 1KB
-    const PRG_RAM_SIZE: usize = 0x2000; // 8KB
     const REGISTER_MASK: u16 = 0xA003; // bits 13, 1, 0 select the active register
 
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
         let mirroring = ctx.mirroring;
-        Self {
-            prg_rom,
-            chr_memory: ChrMemory::new(chr_rom),
-            prg_ram: vec![0; Self::PRG_RAM_SIZE],
+        let capabilities = MapperCapabilities {
+            has_irq: false,
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 8,
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 1,
+            trainer_jsr: false,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, capabilities);
+        base.configure_prg_banking(0x2000); // 8KB
+        base.configure_chr_banking(0x0400); // 1KB
+        let mut mapper = Self {
+            base,
             mirroring,
             prg_bank: [0; 2],
             chr_bank_2k: [0; 2],
             chr_bank_1k: [0; 4],
-        }
-    }
-
-    fn prg_bank_count(&self) -> usize {
-        self.prg_rom.len() / Self::PRG_BANK_SIZE
-    }
-
-    fn prg_bank_index(&self, bank: u8) -> usize {
-        Self::bank_index(bank, self.prg_bank_count())
-    }
-
-    fn read_prg_rom_bank(&self, bank_index: usize, offset: usize) -> u8 {
-        let addr = bank_index * Self::PRG_BANK_SIZE + offset;
-        self.prg_rom.get(addr).copied().unwrap_or(0)
-    }
-
-    fn chr_bank_count_2k(&self) -> usize {
-        self.chr_memory.size() / Self::CHR_BANK_2K_SIZE
-    }
-
-    fn chr_bank_count_1k(&self) -> usize {
-        self.chr_memory.size() / Self::CHR_BANK_1K_SIZE
-    }
-
-    fn chr_bank_index_2k(&self, bank: u8) -> usize {
-        Self::bank_index(bank, self.chr_bank_count_2k())
-    }
-
-    fn chr_bank_index_1k(&self, bank: u8) -> usize {
-        Self::bank_index(bank, self.chr_bank_count_1k())
-    }
-
-    /// Returns `bank % count`, or 0 when no banks are present.
-    fn bank_index(bank: u8, count: usize) -> usize {
-        if count == 0 {
-            return 0;
-        }
-        (bank as usize) % count
-    }
-
-    fn map_chr_to_byte_index(&self, addr: u16) -> usize {
-        let addr = (addr & 0x1FFF) as usize;
-        let (bank_index, bank_size) = match addr {
-            0x0000..=0x07FF => (
-                self.chr_bank_index_2k(self.chr_bank_2k[0]),
-                Self::CHR_BANK_2K_SIZE,
-            ),
-            0x0800..=0x0FFF => (
-                self.chr_bank_index_2k(self.chr_bank_2k[1]),
-                Self::CHR_BANK_2K_SIZE,
-            ),
-            0x1000..=0x13FF => (
-                self.chr_bank_index_1k(self.chr_bank_1k[0]),
-                Self::CHR_BANK_1K_SIZE,
-            ),
-            0x1400..=0x17FF => (
-                self.chr_bank_index_1k(self.chr_bank_1k[1]),
-                Self::CHR_BANK_1K_SIZE,
-            ),
-            0x1800..=0x1BFF => (
-                self.chr_bank_index_1k(self.chr_bank_1k[2]),
-                Self::CHR_BANK_1K_SIZE,
-            ),
-            0x1C00..=0x1FFF => (
-                self.chr_bank_index_1k(self.chr_bank_1k[3]),
-                Self::CHR_BANK_1K_SIZE,
-            ),
-            _ => return 0,
         };
-        bank_index * bank_size + (addr & (bank_size - 1))
+        mapper.update_banks();
+        mapper
+    }
+
+    fn update_banks(&mut self) {
+        // PRG: slots 0-1 switchable, slots 2-3 fixed second-last and last
+        self.base.select_prg_page(0, self.prg_bank[0] as i16);
+        self.base.select_prg_page(1, self.prg_bank[1] as i16);
+        self.base.select_prg_page(2, -2); // second-last
+        self.base.select_prg_page(3, -1); // last
+
+        // CHR (1KB slots): 2KB banks expand to 2 consecutive 1KB slots
+        let b2k0 = self.chr_bank_2k[0] as i16 * 2;
+        let b2k1 = self.chr_bank_2k[1] as i16 * 2;
+        self.base.select_chr_page(0, b2k0);
+        self.base.select_chr_page(1, b2k0 + 1);
+        self.base.select_chr_page(2, b2k1);
+        self.base.select_chr_page(3, b2k1 + 1);
+        self.base.select_chr_page(4, self.chr_bank_1k[0] as i16);
+        self.base.select_chr_page(5, self.chr_bank_1k[1] as i16);
+        self.base.select_chr_page(6, self.chr_bank_1k[2] as i16);
+        self.base.select_chr_page(7, self.chr_bank_1k[3] as i16);
+
+        self.base.set_mirroring(self.mirroring);
     }
 }
 
 impl Mapper for TaitoTc0190Mapper {
+    fn base(&self) -> Option<&BaseMapper> {
+        Some(&self.base)
+    }
+
+    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
+        Some(&mut self.base)
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x6000..=0x7FFF => {
-                let offset = (addr - 0x6000) as usize;
-                self.prg_ram.get(offset).copied().unwrap_or(0)
-            }
-            0x8000..=0xFFFF => {
-                let count = self.prg_bank_count();
-                if count == 0 {
-                    return 0;
-                }
-                let bank_offset = (addr as usize) & (Self::PRG_BANK_SIZE - 1);
-                let bank_index = match addr {
-                    0x8000..=0x9FFF => self.prg_bank_index(self.prg_bank[0]),
-                    0xA000..=0xBFFF => self.prg_bank_index(self.prg_bank[1]),
-                    0xC000..=0xDFFF => count.saturating_sub(2),
-                    0xE000..=0xFFFF => count.saturating_sub(1),
-                    _ => 0,
-                };
-                self.read_prg_rom_bank(bank_index, bank_offset)
-            }
-            _ => 0,
+        if let Some(value) = self.base.try_read_prg_ram(addr) {
+            return value;
         }
+        self.base.read_prg_banked(addr)
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
-        match addr {
-            0x6000..=0x7FFF => {
-                let offset = (addr - 0x6000) as usize;
-                if let Some(byte) = self.prg_ram.get_mut(offset) {
-                    *byte = value;
-                }
-            }
-            0x8000..=0xBFFF => match addr & Self::REGISTER_MASK {
+        if self.base.try_write_prg_ram(addr, value) {
+            return;
+        }
+        if (0x8000..=0xBFFF).contains(&addr) {
+            match addr & Self::REGISTER_MASK {
                 0x8000 => {
                     self.prg_bank[0] = value & 0x3F;
                     self.mirroring = if (value & 0x40) != 0 {
@@ -189,62 +133,47 @@ impl Mapper for TaitoTc0190Mapper {
                     } else {
                         NametableLayout::Vertical
                     };
+                    self.update_banks();
                 }
-                0x8001 => self.prg_bank[1] = value & 0x3F,
-                0x8002 => self.chr_bank_2k[0] = value,
-                0x8003 => self.chr_bank_2k[1] = value,
-                0xA000 => self.chr_bank_1k[0] = value,
-                0xA001 => self.chr_bank_1k[1] = value,
-                0xA002 => self.chr_bank_1k[2] = value,
-                0xA003 => self.chr_bank_1k[3] = value,
+                0x8001 => {
+                    self.prg_bank[1] = value & 0x3F;
+                    self.update_banks();
+                }
+                0x8002 => {
+                    self.chr_bank_2k[0] = value;
+                    self.update_banks();
+                }
+                0x8003 => {
+                    self.chr_bank_2k[1] = value;
+                    self.update_banks();
+                }
+                0xA000 => {
+                    self.chr_bank_1k[0] = value;
+                    self.update_banks();
+                }
+                0xA001 => {
+                    self.chr_bank_1k[1] = value;
+                    self.update_banks();
+                }
+                0xA002 => {
+                    self.chr_bank_1k[2] = value;
+                    self.update_banks();
+                }
+                0xA003 => {
+                    self.chr_bank_1k[3] = value;
+                    self.update_banks();
+                }
                 _ => {}
-            },
-            _ => {}
+            }
         }
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
-        let byte_index = self.map_chr_to_byte_index(addr);
-        self.chr_memory.read_at_index(byte_index)
+        self.base.read_chr_banked(addr)
     }
 
     fn write_chr(&mut self, addr: u16, value: u8) {
-        let byte_index = self.map_chr_to_byte_index(addr);
-        self.chr_memory.write_at_index(byte_index, value);
-    }
-
-    fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
-    }
-
-    fn mapper_number(&self) -> u8 {
-        33
-    }
-
-    fn wram_size(&self) -> usize {
-        self.prg_ram.len()
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.clone()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        let to_copy = data.len().min(self.prg_ram.len());
-        self.prg_ram[..to_copy].copy_from_slice(&data[..to_copy]);
-    }
-
-    fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
-    }
-
-    fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
-    }
-
-    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        crate::console::initialize_ram(&mut self.prg_ram, mode);
-        self.chr_memory.initialize(mode);
+        self.base.write_chr_banked(addr, value);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -274,20 +203,7 @@ impl Mapper for TaitoTc0190Mapper {
             self.prg_bank.copy_from_slice(&data[1..3]);
             self.chr_bank_2k.copy_from_slice(&data[3..5]);
             self.chr_bank_1k.copy_from_slice(&data[5..9]);
-        }
-    }
-
-    fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: true,
-            has_dynamic_mirroring: true,
-            has_expansion_audio: false,
-            max_prg_ram_kb: 8,
-            prg_bank_size_kb: 8,
-            chr_bank_size_kb: 1,
-            trainer_jsr: false,
-            ..Default::default()
+            self.update_banks();
         }
     }
 }


### PR DESCRIPTION
Migrates all 11 medium-complexity mappers to BaseMapper composition pattern, completing Phase 5 of the BaseMapper migration (#789, parent #784).

## Mappers migrated

Batch 1: mapper53 (7), mmc4 (11), namco118 (4), irem_g101 (18)
Batch 2: mmc2 (7), nina_tengen (10), mapper51 (24)
Batch 3: taito_tc0190 (16), multicart_15 (17), bnrom_nina (19)
Batch 4: mmc1 (43) - most complex with shift register, 4 PRG modes, SUROM/SOROM, PRG-RAM gating

## Summary
- Net reduction: -631 lines (864 insertions, 1495 deletions)
- All 6180 Rust tests pass, all 46 WASM tests pass
- Clippy clean, formatted
- BankSwitch::offset marked cfg(test) since only used in tests

Closes #789
Part of #784
