### PR TITLE
Phase 7: Remove Option from base() and final cleanup

### DIFF
--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -685,13 +685,27 @@ mod tests {
         last_write: Rc<RefCell<Option<(u16, u8)>>>,
     }
 
+    fn create_test_base_mapper() -> crate::cartridge::BaseMapper {
+        let ctx = crate::cartridge::MapperContext::new_for_test(
+            0,
+            vec![0; 0x8000],
+            vec![0; 8192],
+            crate::cartridge::NametableLayout::Horizontal,
+        );
+        crate::cartridge::BaseMapper::new(&ctx, crate::cartridge::MapperCapabilities::default())
+    }
+
     struct OamDmaCountingMapper {
+        base: crate::cartridge::BaseMapper,
         oam_dma_calls: Rc<RefCell<u32>>,
     }
 
     impl OamDmaCountingMapper {
         fn new(oam_dma_calls: Rc<RefCell<u32>>) -> Self {
-            Self { oam_dma_calls }
+            Self {
+                base: create_test_base_mapper(),
+                oam_dma_calls,
+            }
         }
     }
 
@@ -733,6 +747,14 @@ mod tests {
     }
 
     impl crate::cartridge::Mapper for OamDmaCountingMapper {
+        fn base(&self) -> &crate::cartridge::BaseMapper {
+            &self.base
+        }
+
+        fn base_mut(&mut self) -> &mut crate::cartridge::BaseMapper {
+            &mut self.base
+        }
+
         fn read_prg(&self, _addr: u16) -> u8 {
             0
         }

--- a/src/bus/ppu_device.rs
+++ b/src/bus/ppu_device.rs
@@ -93,10 +93,19 @@ mod tests {
     use std::cell::Cell;
 
     struct MaskTrackingMapper {
+        base: crate::cartridge::BaseMapper,
         mask_writes: Rc<Cell<usize>>,
     }
 
     impl Mapper for MaskTrackingMapper {
+        fn base(&self) -> &crate::cartridge::BaseMapper {
+            &self.base
+        }
+
+        fn base_mut(&mut self) -> &mut crate::cartridge::BaseMapper {
+            &mut self.base
+        }
+
         fn read_prg(&self, _addr: u16) -> u8 {
             0
         }
@@ -152,6 +161,18 @@ mod tests {
     fn test_ppu_mask_mirror_write_does_not_notify_mapper() {
         let mask_writes = Rc::new(Cell::new(0));
         let mapper = Box::new(MaskTrackingMapper {
+            base: {
+                let ctx = crate::cartridge::MapperContext::new_for_test(
+                    0,
+                    vec![0; 0x8000],
+                    vec![0; 8192],
+                    NametableLayout::Horizontal,
+                );
+                crate::cartridge::BaseMapper::new(
+                    &ctx,
+                    crate::cartridge::MapperCapabilities::default(),
+                )
+            },
             mask_writes: Rc::clone(&mask_writes),
         });
         let cartridge = Cartridge::from_mapper_for_test(mapper);

--- a/src/cartridge/axrom.rs
+++ b/src/cartridge/axrom.rs
@@ -84,12 +84,12 @@ impl AxROMMapper {
 }
 
 impl Mapper for AxROMMapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/bandai_fcg.rs
+++ b/src/cartridge/bandai_fcg.rs
@@ -100,6 +100,13 @@ impl BandaiFcgMapper {
 }
 
 impl Mapper for BandaiFcgMapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x8000..=0xFFFF => self.base.read_prg_banked(addr),

--- a/src/cartridge/base_mapper.rs
+++ b/src/cartridge/base_mapper.rs
@@ -25,8 +25,8 @@ use crate::cartridge::NametableLayout;
 /// }
 ///
 /// impl Mapper for MyMapper {
-///     fn base(&self) -> Option<&BaseMapper> { Some(&self.base) }
-///     fn base_mut(&mut self) -> Option<&mut BaseMapper> { Some(&mut self.base) }
+///     fn base(&self) -> &BaseMapper { &self.base }
+///     fn base_mut(&mut self) -> &mut BaseMapper { &mut self.base }
 ///     fn read_prg(&self, addr: u16) -> u8 {
 ///         if let Some(v) = self.base.try_read_prg_ram(addr) { return v; }
 ///         self.base.read_prg_banked(addr)

--- a/src/cartridge/bnrom_nina.rs
+++ b/src/cartridge/bnrom_nina.rs
@@ -148,12 +148,12 @@ impl BnromNinaMapper {
 }
 
 impl Mapper for BnromNinaMapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn reset(&mut self) {

--- a/src/cartridge/camerica.rs
+++ b/src/cartridge/camerica.rs
@@ -62,12 +62,12 @@ impl CamericaMapper {
 }
 
 impl Mapper for CamericaMapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/colordreams.rs
+++ b/src/cartridge/colordreams.rs
@@ -5,7 +5,7 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
-use crate::cartridge::common::{BankSwitch, BankedRom};
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 /// Mapper 11 - Color Dreams
@@ -33,40 +33,48 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// Implementation:
 /// - Dedicated mapper 11 implementation with `CCCC LLPP` decoding
 pub struct ColorDreamsMapper {
-    prg_rom: BankedRom,
-    chr_rom: BankedRom,
-    mirroring: NametableLayout,
-    prg_bank: BankSwitch,
-    chr_bank: BankSwitch,
+    base: BaseMapper,
+    prg_bank: u8,
+    chr_bank: u8,
 }
 
 impl ColorDreamsMapper {
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
-        let mirroring = ctx.mirroring;
-        const PRG_BANK_SIZE: usize = 32 * 1024;
-        const CHR_BANK_SIZE: usize = 8 * 1024;
-
-        let prg_bank = BankSwitch::from_rom(&prg_rom, PRG_BANK_SIZE);
-        let chr_bank = BankSwitch::from_rom(&chr_rom, CHR_BANK_SIZE);
+        let caps = MapperCapabilities {
+            has_irq: false,
+            has_chr_banking: true,
+            has_dynamic_mirroring: false,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 0,
+            prg_bank_size_kb: 32,
+            chr_bank_size_kb: 8,
+            trainer_jsr: false,
+            ..Default::default()
+        };
+        let mut base = BaseMapper::new(&ctx, caps);
+        base.configure_prg_banking(32 * 1024);
+        base.configure_chr_banking(8 * 1024);
+        base.set_bus_conflicts(true);
 
         Self {
-            prg_rom: BankedRom::new(prg_rom, PRG_BANK_SIZE),
-            chr_rom: BankedRom::new(chr_rom, CHR_BANK_SIZE),
-            mirroring,
-            prg_bank,
-            chr_bank,
+            base,
+            prg_bank: 0,
+            chr_bank: 0,
         }
     }
 }
 
 impl Mapper for ColorDreamsMapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
-            0x8000..=0xFFFF => self
-                .prg_rom
-                .read_with_base(self.prg_bank.current(), 0x8000, addr),
+            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
             _ => 0,
         }
     }
@@ -80,15 +88,16 @@ impl Mapper for ColorDreamsMapper {
 
     fn write_prg(&mut self, addr: u16, value: u8) {
         if (0x8000..=0xFFFF).contains(&addr) {
-            let register_value = value & self.read_prg(addr);
-            self.prg_bank.set(register_value & 0b0000_0011);
-            self.chr_bank.set((register_value >> 4) & 0b0000_1111);
+            let register_value = self.base.apply_bus_conflict(addr, value);
+            self.prg_bank = register_value & 0b0000_0011;
+            self.chr_bank = (register_value >> 4) & 0b0000_1111;
+            self.base.select_prg_page(0, self.prg_bank as i16);
+            self.base.select_chr_page(0, self.chr_bank as i16);
         }
     }
 
     fn read_chr(&mut self, addr: u16) -> u8 {
-        let offset = (addr & 0x1FFF) as usize;
-        self.chr_rom.read(self.chr_bank.current(), offset)
+        self.base.read_chr_banked(addr)
     }
 
     fn write_chr(&mut self, _addr: u16, _value: u8) {
@@ -96,11 +105,11 @@ impl Mapper for ColorDreamsMapper {
     }
 
     fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
+        self.base.mirroring()
     }
 
     fn mapper_number(&self) -> u8 {
-        11
+        self.base.mapper_number()
     }
 
     fn wram_size(&self) -> usize {
@@ -108,30 +117,22 @@ impl Mapper for ColorDreamsMapper {
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
-        vec![self.prg_bank.raw(), self.chr_bank.raw()]
+        vec![self.prg_bank, self.chr_bank]
     }
 
     fn restore_registers(&mut self, data: &[u8]) {
         if let Some(&value) = data.first() {
-            self.prg_bank.set(value);
+            self.prg_bank = value;
+            self.base.select_prg_page(0, value as i16);
         }
         if let Some(&value) = data.get(1) {
-            self.chr_bank.set(value);
+            self.chr_bank = value;
+            self.base.select_chr_page(0, value as i16);
         }
     }
 
     fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: true,
-            has_dynamic_mirroring: false,
-            has_expansion_audio: false,
-            max_prg_ram_kb: 0,
-            prg_bank_size_kb: 32,
-            chr_bank_size_kb: 8,
-            trainer_jsr: false,
-            ..Default::default()
-        }
+        self.base.capabilities()
     }
 }
 

--- a/src/cartridge/common.rs
+++ b/src/cartridge/common.rs
@@ -294,6 +294,7 @@ impl ChrMemory {
     }
 
     /// Check if this is CHR-RAM (writable) vs CHR-ROM (read-only).
+    #[cfg(test)]
     #[inline]
     pub fn is_ram(&self) -> bool {
         self.is_ram
@@ -371,7 +372,7 @@ impl StateSnapshot for ChrMemory {
 /// - Bounds checking
 ///
 /// # Example
-/// ```rust
+/// ```ignore
 /// use neser::cartridge::BankedRom;
 ///
 /// let prg_rom = vec![0u8; 0x8000];
@@ -387,12 +388,14 @@ impl StateSnapshot for ChrMemory {
 /// let value = banked_prg.read_with_base(bank, 0x8000, 0x9000);
 /// let _ = value;
 /// ```
+#[cfg(test)]
 #[derive(Clone)]
 pub struct BankedRom {
     data: Vec<u8>,
     bank_size: usize,
 }
 
+#[cfg(test)]
 impl BankedRom {
     /// Create a new banked ROM with the specified bank size.
     ///
@@ -474,7 +477,7 @@ impl BankedRom {
 /// Eliminates manual `.max(1)` calls and reduces duplicated bank calculation code.
 ///
 /// # Example
-/// ```rust
+/// ```ignore
 /// use neser::cartridge::BankSwitch;
 ///
 /// // PRG-ROM with 128KB (4 banks of 32KB)
@@ -490,12 +493,14 @@ impl BankedRom {
 /// bank.set(5);
 /// assert_eq!(bank.current(), 1); // 5 % 4 = 1
 /// ```
+#[cfg(test)]
 #[derive(Clone, Copy, Debug)]
 pub struct BankSwitch {
     num_banks: usize,
     bank: u8,
 }
 
+#[cfg(test)]
 impl BankSwitch {
     /// Create a new bank switch helper.
     ///
@@ -559,6 +564,7 @@ impl BankSwitch {
     }
 }
 
+#[cfg(test)]
 impl StateSnapshot for BankSwitch {
     fn snapshot(&self) -> Vec<u8> {
         vec![self.bank]

--- a/src/cartridge/cprom.rs
+++ b/src/cartridge/cprom.rs
@@ -52,12 +52,12 @@ impl CpromMapper {
 }
 
 impl Mapper for CpromMapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/irem_g101.rs
+++ b/src/cartridge/irem_g101.rs
@@ -123,12 +123,12 @@ impl IremG101Mapper {
 }
 
 impl Mapper for IremG101Mapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -227,26 +227,19 @@ impl Default for MapperCapabilities {
 pub trait Mapper {
     /// Return a reference to the embedded [`BaseMapper`], if present.
     ///
-    /// Mappers that embed a `BaseMapper` should override this (and [`base_mut`])
-    /// to return `Some(&self.base)`. The default trait methods for mirroring,
-    /// WRAM, CHR-RAM, capabilities, etc. then delegate to the `BaseMapper`,
-    /// eliminating boilerplate.
+    /// Return a reference to the embedded [`BaseMapper`].
     ///
-    /// Mappers that do **not** use `BaseMapper` can leave the default (`None`)
-    /// and override individual methods as before.
+    /// All mappers must embed a `BaseMapper` and implement this method.
+    /// The default trait methods for mirroring, WRAM, CHR-RAM, capabilities, etc.
+    /// then delegate to the `BaseMapper`, eliminating boilerplate.
     ///
-    /// [`BaseMapper`]: crate::cartridge::common::BaseMapper
-    /// [`base_mut`]: Mapper::base_mut
-    fn base(&self) -> Option<&super::base_mapper::BaseMapper> {
-        None
-    }
+    /// [`BaseMapper`]: crate::cartridge::base_mapper::BaseMapper
+    fn base(&self) -> &super::base_mapper::BaseMapper;
 
-    /// Return a mutable reference to the embedded [`BaseMapper`], if present.
+    /// Return a mutable reference to the embedded [`BaseMapper`].
     ///
     /// See [`base`](Mapper::base) for details.
-    fn base_mut(&mut self) -> Option<&mut super::base_mapper::BaseMapper> {
-        None
-    }
+    fn base_mut(&mut self) -> &mut super::base_mapper::BaseMapper;
 
     /// Read a byte from PRG address space (CPU $6000-$FFFF)
     /// - $6000-$7FFF: PRG-RAM (8KB, battery-backed on some cartridges)
@@ -262,13 +255,8 @@ pub trait Mapper {
     /// Default delegates to `BaseMapper` if available, otherwise falls back to
     /// `read_prg` with open-bus below $6000.
     fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
-        if let Some(base) = self.base() {
-            base.read_prg_open_bus(addr, open_bus, |a| self.read_prg(a))
-        } else if addr < 0x6000 {
-            open_bus
-        } else {
-            self.read_prg(addr)
-        }
+        self.base()
+            .read_prg_open_bus(addr, open_bus, |a| self.read_prg(a))
     }
 
     /// Write a byte to PRG address space (CPU $6000-$FFFF)
@@ -281,9 +269,7 @@ pub trait Mapper {
     ///
     /// Default delegates to `BaseMapper` if available.
     fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base()
-            .map(|b| b.read_chr(addr))
-            .expect("read_chr or base() must be implemented")
+        self.base().read_chr(addr)
     }
 
     /// Write a byte to CHR address space (PPU $0000-$1FFF)
@@ -291,9 +277,7 @@ pub trait Mapper {
     ///
     /// Default delegates to `BaseMapper` if available.
     fn write_chr(&mut self, addr: u16, value: u8) {
-        if let Some(base) = self.base_mut() {
-            base.write_chr(addr, value);
-        }
+        self.base_mut().write_chr(addr, value);
     }
 
     /// Notify mapper of PPU address bus changes
@@ -385,9 +369,7 @@ pub trait Mapper {
     ///
     /// Default delegates to `BaseMapper` if available, otherwise is a no-op.
     fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        if let Some(base) = self.base_mut() {
-            base.initialize_ram(mode);
-        }
+        self.base_mut().initialize_ram(mode);
     }
 
     /// Whether the mapper is currently asserting IRQ.
@@ -414,9 +396,7 @@ pub trait Mapper {
     ///
     /// Default delegates to `BaseMapper` if available.
     fn get_mirroring(&self) -> NametableLayout {
-        self.base()
-            .map(|b| b.mirroring())
-            .expect("get_mirroring or base() must be implemented")
+        self.base().mirroring()
     }
 
     /// Get the size of cartridge WRAM (PRG-RAM) in bytes.
@@ -425,8 +405,9 @@ pub trait Mapper {
     ///
     /// Default delegates to `BaseMapper` if available, otherwise returns
     /// 8KB (0x2000 bytes).
+    #[allow(dead_code)]
     fn wram_size(&self) -> usize {
-        self.base().map_or(0x2000, |b| b.wram_size())
+        self.base().wram_size()
     }
 
     /// Create a snapshot of all cartridge WRAM (PRG-RAM) for persistence.
@@ -441,15 +422,7 @@ pub trait Mapper {
     /// `read_prg` at $6000-$7FFF (8KB window).
     /// **Mappers with >8KB WRAM MUST override this method to capture all banks.**
     fn wram_snapshot(&self) -> Vec<u8> {
-        if let Some(base) = self.base() {
-            return base.wram_snapshot();
-        }
-        let size = self.wram_size().min(0x2000);
-        let mut snapshot = Vec::with_capacity(size);
-        for i in 0..size {
-            snapshot.push(self.read_prg(0x6000 + i as u16));
-        }
-        snapshot
+        self.base().wram_snapshot()
     }
 
     /// Load a WRAM snapshot from persistence.
@@ -464,14 +437,7 @@ pub trait Mapper {
     /// `write_prg` at $6000-$7FFF (8KB window).
     /// **Mappers with >8KB WRAM MUST override this method to restore all banks.**
     fn load_wram_snapshot(&mut self, data: &[u8]) {
-        if let Some(base) = self.base_mut() {
-            base.load_wram_snapshot(data);
-            return;
-        }
-        let to_copy = data.len().min(0x2000).min(self.wram_size());
-        for (i, &byte) in data.iter().take(to_copy).enumerate() {
-            self.write_prg(0x6000 + i as u16, byte);
-        }
+        self.base_mut().load_wram_snapshot(data);
     }
 
     /// Get the mapper number (iNES mapper ID).
@@ -480,7 +446,7 @@ pub trait Mapper {
     ///
     /// Default delegates to `BaseMapper` if available, otherwise returns 0.
     fn mapper_number(&self) -> u8 {
-        self.base().map_or(0, |b| b.mapper_number())
+        self.base().mapper_number()
     }
 
     /// Create a snapshot of PRG-RAM for save-state.
@@ -495,7 +461,7 @@ pub trait Mapper {
     /// Default delegates to `BaseMapper` if available, otherwise returns
     /// empty (CHR-ROM has no state to save).
     fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.base().map_or_else(Vec::new, |b| b.chr_ram_snapshot())
+        self.base().chr_ram_snapshot()
     }
 
     /// Create a snapshot of mapper-specific registers for save-state.
@@ -516,9 +482,7 @@ pub trait Mapper {
     ///
     /// Default delegates to `BaseMapper` if available, otherwise is a no-op.
     fn restore_chr_ram(&mut self, data: &[u8]) {
-        if let Some(base) = self.base_mut() {
-            base.restore_chr_ram(data);
-        }
+        self.base_mut().restore_chr_ram(data);
     }
 
     /// Restore mapper-specific registers from a save-state.
@@ -535,8 +499,7 @@ pub trait Mapper {
     /// conservative defaults suitable for the simplest mappers.
     #[allow(dead_code)]
     fn capabilities(&self) -> MapperCapabilities {
-        self.base()
-            .map_or_else(MapperCapabilities::default, |b| b.capabilities())
+        self.base().capabilities()
     }
 }
 

--- a/src/cartridge/mapper12.rs
+++ b/src/cartridge/mapper12.rs
@@ -6,6 +6,7 @@
 //! Known Limitations:
 //! - No known gameplay-blocking functional limitations are currently documented.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
@@ -29,7 +30,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// - `final_bank = (outer_bit << 8) | mmc3_1k_bank`
 /// - This extends the MMC3's 256 KiB CHR window to 512 KiB.
 pub struct Mapper12 {
-    inner: MMC3Mapper,
+    pub(crate) inner: MMC3Mapper,
     chr_ext_lo: bool, // bit 0: CHR A18 for PPU $0000-$0FFF
     chr_ext_hi: bool, // bit 4: CHR A18 for PPU $1000-$1FFF
 }
@@ -56,6 +57,13 @@ impl Mapper12 {
 }
 
 impl Mapper for Mapper12 {
+    fn base(&self) -> &BaseMapper {
+        &self.inner.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.inner.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         if Self::is_outer_reg(addr) {
             return self.chr_ext_lo as u8;

--- a/src/cartridge/mapper140.rs
+++ b/src/cartridge/mapper140.rs
@@ -46,12 +46,12 @@ impl Mapper140 {
 }
 
 impl Mapper for Mapper140 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper185.rs
+++ b/src/cartridge/mapper185.rs
@@ -53,12 +53,12 @@ impl Mapper185 {
 }
 
 impl Mapper for Mapper185 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper241.rs
+++ b/src/cartridge/mapper241.rs
@@ -39,12 +39,12 @@ impl Mapper241 {
 }
 
 impl Mapper for Mapper241 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper242.rs
+++ b/src/cartridge/mapper242.rs
@@ -43,12 +43,12 @@ impl Mapper242 {
 }
 
 impl Mapper for Mapper242 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper243.rs
+++ b/src/cartridge/mapper243.rs
@@ -85,12 +85,12 @@ impl Mapper243 {
 }
 
 impl Mapper for Mapper243 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper244.rs
+++ b/src/cartridge/mapper244.rs
@@ -52,12 +52,12 @@ impl Mapper244 {
 }
 
 impl Mapper for Mapper244 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper245.rs
+++ b/src/cartridge/mapper245.rs
@@ -6,6 +6,7 @@
 //! Known Limitations:
 //! - No known gameplay-blocking functional limitations are currently documented.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
@@ -26,7 +27,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// - PRG bank = ((R0 & 1) << 5) | (mmc3_bank & 0x3F)
 /// - This extends PRG addressing to 1MB (64 × 8KB × 2 = 128 banks)
 pub struct Mapper245 {
-    mmc3: MMC3Mapper,
+    pub(crate) mmc3: MMC3Mapper,
 }
 
 impl Mapper245 {
@@ -88,6 +89,13 @@ impl Mapper245 {
 }
 
 impl Mapper for Mapper245 {
+    fn base(&self) -> &BaseMapper {
+        &self.mmc3.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.mmc3.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.mmc3.read_prg(addr),

--- a/src/cartridge/mapper246.rs
+++ b/src/cartridge/mapper246.rs
@@ -68,12 +68,12 @@ impl Mapper246 {
 }
 
 impl Mapper for Mapper246 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper251.rs
+++ b/src/cartridge/mapper251.rs
@@ -7,12 +7,13 @@
 //! Notes:
 //! - iNES mapper 251 is treated as mapper 45 compatibility behavior.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mapper45::Mapper45;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 /// Mapper 251 implemented as a thin wrapper around Mapper 45 behavior.
 pub struct Mapper251 {
-    inner: Mapper45,
+    pub(crate) inner: Mapper45,
 }
 
 impl Mapper251 {
@@ -29,6 +30,13 @@ impl Mapper251 {
 }
 
 impl Mapper for Mapper251 {
+    fn base(&self) -> &BaseMapper {
+        &self.inner.mmc3.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.inner.mmc3.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         self.inner.read_prg(addr)
     }

--- a/src/cartridge/mapper254.rs
+++ b/src/cartridge/mapper254.rs
@@ -6,6 +6,7 @@
 //! Known Limitations:
 //! - No known gameplay-blocking functional limitations are currently documented.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::common::{DEFAULT_PRG_RAM_SIZE, PrgRam};
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
@@ -27,7 +28,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 ///
 /// Once protection is cleared, PRG-RAM reads normally.
 pub struct Mapper254 {
-    mmc3: MMC3Mapper,
+    pub(crate) mmc3: MMC3Mapper,
     prg_ram: PrgRam,
     protection_disabled: bool,
     xor_mask: u8,
@@ -50,6 +51,13 @@ impl Mapper254 {
 }
 
 impl Mapper for Mapper254 {
+    fn base(&self) -> &BaseMapper {
+        &self.mmc3.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.mmc3.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => {

--- a/src/cartridge/mapper255.rs
+++ b/src/cartridge/mapper255.rs
@@ -112,12 +112,12 @@ impl Mapper255 {
 }
 
 impl Mapper for Mapper255 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {

--- a/src/cartridge/mapper37.rs
+++ b/src/cartridge/mapper37.rs
@@ -6,6 +6,7 @@
 //! Known Limitations:
 //! - No known gameplay-blocking functional limitations are currently documented.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
@@ -34,7 +35,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 ///
 /// Known games: Super Mario Bros, Tetris, Nintendo World Cup
 pub struct Mapper37 {
-    inner: MMC3Mapper,
+    pub(crate) inner: MMC3Mapper,
     outer_reg: u8, // bits [2:0] = Q[2:0]
 }
 
@@ -81,6 +82,13 @@ impl Mapper37 {
 }
 
 impl Mapper for Mapper37 {
+    fn base(&self) -> &BaseMapper {
+        &self.inner.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.inner.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         if !(0x8000..=0xFFFF).contains(&addr) {
             return 0; // No PRG-RAM; $6000-$7FFF is the outer register only

--- a/src/cartridge/mapper42.rs
+++ b/src/cartridge/mapper42.rs
@@ -95,6 +95,13 @@ impl Mapper42 {
 }
 
 impl Mapper for Mapper42 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.read_prg_6000(addr),

--- a/src/cartridge/mapper43.rs
+++ b/src/cartridge/mapper43.rs
@@ -100,6 +100,13 @@ impl Mapper43 {
 }
 
 impl Mapper for Mapper43 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x5000..=0x7FFF => self.read_prg_custom(addr),

--- a/src/cartridge/mapper44.rs
+++ b/src/cartridge/mapper44.rs
@@ -6,6 +6,7 @@
 //! Known Limitations:
 //! - No known gameplay-blocking functional limitations are currently documented.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
@@ -33,7 +34,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 ///
 /// Known games: Super HIK 7-in-1 (A001), Super Marvelous 7-in-1
 pub struct Mapper44 {
-    mmc3: MMC3Mapper,
+    pub(crate) mmc3: MMC3Mapper,
     block: u8, // 0-6 (7 maps to 6)
 }
 
@@ -78,6 +79,13 @@ impl Mapper44 {
 }
 
 impl Mapper for Mapper44 {
+    fn base(&self) -> &BaseMapper {
+        &self.mmc3.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.mmc3.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         if !(0x8000..=0xFFFF).contains(&addr) {
             return 0;

--- a/src/cartridge/mapper45.rs
+++ b/src/cartridge/mapper45.rs
@@ -7,6 +7,7 @@
 //! - IRQ behavior is inherited from the inner MMC3 (see `mmc3.rs` Known Limitations).
 //! - Board-specific clone quirks that deviate from the NesDev spec are not modeled.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
@@ -34,7 +35,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 /// Note: Reg2 bit[6] = CHR_OR bit 10, bit[5] = CHR_OR bit 9 (per NesDev)
 /// When reg3 bit6 (lock) is set, writes in $6000-$7FFF are forwarded to WRAM/MMC3.
 pub struct Mapper45 {
-    mmc3: MMC3Mapper,
+    pub(crate) mmc3: MMC3Mapper,
     regs: [u8; 4],
     write_ptr: usize,
     locked: bool,
@@ -121,6 +122,13 @@ impl Mapper45 {
 }
 
 impl Mapper for Mapper45 {
+    fn base(&self) -> &BaseMapper {
+        &self.mmc3.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.mmc3.base
+    }
+
     fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
         if (0x5000..=0x5FFF).contains(&addr) {
             return (open_bus & 0xFE) | self.menu_selection_d0(addr);

--- a/src/cartridge/mapper46.rs
+++ b/src/cartridge/mapper46.rs
@@ -63,12 +63,12 @@ impl Mapper46 {
 }
 
 impl Mapper for Mapper46 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper47.rs
+++ b/src/cartridge/mapper47.rs
@@ -6,6 +6,7 @@
 //! Known Limitations:
 //! - No known gameplay-blocking functional limitations are currently documented.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
@@ -29,7 +30,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 ///
 /// Known games: Super Spike V'Ball + Nintendo World Cup
 pub struct Mapper47 {
-    mmc3: MMC3Mapper,
+    pub(crate) mmc3: MMC3Mapper,
     block: u8,
 }
 
@@ -60,6 +61,13 @@ impl Mapper47 {
 }
 
 impl Mapper for Mapper47 {
+    fn base(&self) -> &BaseMapper {
+        &self.mmc3.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.mmc3.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         if !(0x8000..=0xFFFF).contains(&addr) {
             return 0; // No PRG-RAM

--- a/src/cartridge/mapper48.rs
+++ b/src/cartridge/mapper48.rs
@@ -141,6 +141,13 @@ impl Mapper48 {
 }
 
 impl Mapper for Mapper48 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x8000..=0xFFFF => self.base.read_prg_banked(addr),

--- a/src/cartridge/mapper49.rs
+++ b/src/cartridge/mapper49.rs
@@ -6,6 +6,7 @@
 //! Known Limitations:
 //! - No known gameplay-blocking functional limitations are currently documented.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
@@ -32,7 +33,7 @@ use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 ///
 /// Known games: Super HIK 4-in-1, Super 8-in-1, various unlicensed multicarts
 pub struct Mapper49 {
-    mmc3: MMC3Mapper,
+    pub(crate) mmc3: MMC3Mapper,
     block: u8, // bits 7:6 of outer reg
     page: u8,  // bits 5:4 of outer reg, used in fixed-32K mode
     mmc3_mode: bool,
@@ -69,6 +70,13 @@ impl Mapper49 {
 }
 
 impl Mapper for Mapper49 {
+    fn base(&self) -> &BaseMapper {
+        &self.mmc3.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.mmc3.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         if !(0x8000..=0xFFFF).contains(&addr) {
             return 0;

--- a/src/cartridge/mapper50.rs
+++ b/src/cartridge/mapper50.rs
@@ -115,6 +115,13 @@ impl Mapper50 {
 }
 
 impl Mapper for Mapper50 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.read_prg_6000(addr),

--- a/src/cartridge/mapper51.rs
+++ b/src/cartridge/mapper51.rs
@@ -131,12 +131,12 @@ impl Mapper51 {
 }
 
 impl Mapper for Mapper51 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper52.rs
+++ b/src/cartridge/mapper52.rs
@@ -6,6 +6,7 @@
 //! Known Limitations:
 //! - Submapper 13/14 (CHR RAM variants) are not implemented.
 
+use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::mmc3::MMC3Mapper;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 use crate::trace_mapper;
@@ -43,7 +44,7 @@ use crate::trace_mapper;
 ///   A19 = B
 ///   bank = (B<<9) | (C<<8) | (A17<<7) | (mmc3_1k_bank & 0x7F)
 pub struct Mapper52 {
-    mmc3: MMC3Mapper,
+    pub(crate) mmc3: MMC3Mapper,
     outer: u8,
     locked: bool,
 }
@@ -122,6 +123,13 @@ impl Mapper52 {
 }
 
 impl Mapper for Mapper52 {
+    fn base(&self) -> &BaseMapper {
+        &self.mmc3.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.mmc3.base
+    }
+
     fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
         if Self::is_wram_window(addr) {
             return self.mmc3.read_prg_open_bus(addr, open_bus);

--- a/src/cartridge/mapper53.rs
+++ b/src/cartridge/mapper53.rs
@@ -121,12 +121,12 @@ impl Mapper53 {
 }
 
 impl Mapper for Mapper53 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper56.rs
+++ b/src/cartridge/mapper56.rs
@@ -108,6 +108,13 @@ impl Mapper56 {
 }
 
 impl Mapper for Mapper56 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.prg_ram[(addr as usize) & 0x1FFF],

--- a/src/cartridge/mapper57.rs
+++ b/src/cartridge/mapper57.rs
@@ -115,12 +115,12 @@ impl Mapper57 {
 }
 
 impl Mapper for Mapper57 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper58.rs
+++ b/src/cartridge/mapper58.rs
@@ -79,12 +79,12 @@ impl Mapper58 {
 }
 
 impl Mapper for Mapper58 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper59.rs
+++ b/src/cartridge/mapper59.rs
@@ -93,12 +93,12 @@ impl Mapper59 {
 }
 
 impl Mapper for Mapper59 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper60.rs
+++ b/src/cartridge/mapper60.rs
@@ -57,12 +57,12 @@ impl Mapper60 {
 }
 
 impl Mapper for Mapper60 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper61.rs
+++ b/src/cartridge/mapper61.rs
@@ -134,12 +134,12 @@ impl Mapper61 {
 }
 
 impl Mapper for Mapper61 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper62.rs
+++ b/src/cartridge/mapper62.rs
@@ -87,12 +87,12 @@ impl Mapper62 {
 }
 
 impl Mapper for Mapper62 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper64.rs
+++ b/src/cartridge/mapper64.rs
@@ -175,6 +175,13 @@ impl Mapper64 {
 }
 
 impl Mapper for Mapper64 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x8000..=0xFFFF => self.base.read_prg_banked(addr),

--- a/src/cartridge/mapper65.rs
+++ b/src/cartridge/mapper65.rs
@@ -108,6 +108,13 @@ impl Mapper65 {
 }
 
 impl Mapper for Mapper65 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x8000..=0xFFFF => self.base.read_prg_banked(addr),

--- a/src/cartridge/mapper67.rs
+++ b/src/cartridge/mapper67.rs
@@ -102,6 +102,13 @@ impl Mapper67 {
 }
 
 impl Mapper for Mapper67 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x8000..=0xFFFF => self.base.read_prg_banked(addr),

--- a/src/cartridge/mapper72.rs
+++ b/src/cartridge/mapper72.rs
@@ -65,12 +65,12 @@ impl Mapper72 {
 }
 
 impl Mapper for Mapper72 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mapper73.rs
+++ b/src/cartridge/mapper73.rs
@@ -108,6 +108,13 @@ impl Mapper73 {
 }
 
 impl Mapper for Mapper73 {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => {

--- a/src/cartridge/mapper_templates.rs
+++ b/src/cartridge/mapper_templates.rs
@@ -158,12 +158,12 @@ impl<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> SimpleFixedPrgMapper<CHR_BA
 impl<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
     for SimpleFixedPrgMapper<CHR_BANK_KB, MAPPER_NUM>
 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {
@@ -275,12 +275,12 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8>
 impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
     for SimpleBankedPrgMapper<PRG_BANK_KB, MAPPER_NUM>
 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {
@@ -398,12 +398,12 @@ impl<
     const MAPPER_NUM: u8,
 > Mapper for DualBank32Mapper<PRG_MASK, PRG_SHIFT, CHR_MASK, CHR_SHIFT, MAPPER_NUM>
 {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mmc1.rs
+++ b/src/cartridge/mmc1.rs
@@ -466,6 +466,13 @@ impl MMC1Mapper {
 }
 
 impl Mapper for MMC1Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => {

--- a/src/cartridge/mmc2.rs
+++ b/src/cartridge/mmc2.rs
@@ -111,12 +111,12 @@ impl MMC2Mapper {
 }
 
 impl Mapper for MMC2Mapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mmc3.rs
+++ b/src/cartridge/mmc3.rs
@@ -49,7 +49,7 @@ use crate::trace_mapper;
 /// - IRQ behavior selection is currently derived from ROM metadata/CRC heuristics.
 /// - Some board-specific clone quirks are intentionally not modeled yet.
 pub struct MMC3Mapper {
-    base: BaseMapper,
+    pub(crate) base: BaseMapper,
     prg_ram: Vec<u8>,
 
     prg_ram_enabled: bool,
@@ -1362,6 +1362,13 @@ mod tests {
 // ============================================================================
 
 impl Mapper for MMC3Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => {

--- a/src/cartridge/mmc4.rs
+++ b/src/cartridge/mmc4.rs
@@ -122,12 +122,12 @@ impl MMC4Mapper {
 }
 
 impl Mapper for MMC4Mapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/mmc5.rs
+++ b/src/cartridge/mmc5.rs
@@ -900,6 +900,13 @@ impl MMC5Mapper {
 // ============================================================================
 
 impl Mapper for MMC5Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             // Hardware multiplier output (read-only)

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -76,11 +76,11 @@ mod vrc6;
 #[allow(unused_imports)]
 pub use base_mapper::BaseMapper;
 pub use cartridge::Cartridge;
+#[cfg(test)]
 #[allow(unused_imports)]
-pub use common::{
-    BankSwitch, BankedRom, ChrMemory, DEFAULT_CHR_RAM_SIZE, DEFAULT_PRG_RAM_SIZE, PrgRam,
-    StateSnapshot,
-};
+pub use common::{BankSwitch, BankedRom};
+#[allow(unused_imports)]
+pub use common::{ChrMemory, DEFAULT_CHR_RAM_SIZE, DEFAULT_PRG_RAM_SIZE, PrgRam, StateSnapshot};
 #[allow(unused_imports)]
 pub use ines::{ConsoleType, InesHeader, NametableLayout, ParsedRom, RomParseError, TimingMode};
 #[allow(unused_imports)]

--- a/src/cartridge/multicart_15.rs
+++ b/src/cartridge/multicart_15.rs
@@ -106,12 +106,12 @@ impl Multicart15Mapper {
 }
 
 impl Mapper for Multicart15Mapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/namco118.rs
+++ b/src/cartridge/namco118.rs
@@ -126,12 +126,12 @@ impl Namco118Mapper {
 }
 
 impl Mapper for Namco118Mapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/namco163.rs
+++ b/src/cartridge/namco163.rs
@@ -436,6 +436,13 @@ impl Namco163Mapper {
 }
 
 impl Mapper for Namco163Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr & 0xF800 {
             0x4800 => self.audio_read_data(),

--- a/src/cartridge/nina_tengen.rs
+++ b/src/cartridge/nina_tengen.rs
@@ -78,12 +78,12 @@ impl NinaTengenMapper {
 }
 
 impl Mapper for NinaTengenMapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/nrom.rs
+++ b/src/cartridge/nrom.rs
@@ -56,12 +56,12 @@ impl NROMMapper {
 }
 
 impl Mapper for NROMMapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/ntdec_2722.rs
+++ b/src/cartridge/ntdec_2722.rs
@@ -100,6 +100,13 @@ impl Ntdec2722Mapper {
 }
 
 impl Mapper for Ntdec2722Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => self.read_prg_6000(addr),

--- a/src/cartridge/sunsoft_4.rs
+++ b/src/cartridge/sunsoft_4.rs
@@ -26,7 +26,8 @@
 //! - Edge-case behavior may still differ from hardware in untested timing and board-variant scenarios.
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
-use crate::cartridge::common::{BankedRom, ChrMemory, DEFAULT_PRG_RAM_SIZE, PrgRam};
+use crate::cartridge::base_mapper::BaseMapper;
+use crate::cartridge::common::{DEFAULT_PRG_RAM_SIZE, PrgRam};
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 const PRG_BANK_SIZE: usize = 0x4000; // 16KB
@@ -34,10 +35,8 @@ const CHR_BANK_SIZE_2K: usize = 0x0800; // 2KB
 const NAMETABLE_BANK_SIZE_1K: usize = 0x0400; // 1KB
 
 pub struct Sunsoft4Mapper {
-    prg_rom: BankedRom,
+    base: BaseMapper,
     prg_ram: PrgRam,
-    chr_memory: ChrMemory,
-    mirroring: NametableLayout,
     prg_bank: u8,
     chr_banks_2k: [u8; 4],
     nametable_banks_1k: [u8; 2],
@@ -48,24 +47,22 @@ pub struct Sunsoft4Mapper {
 impl Sunsoft4Mapper {
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
         let prg_ram_banks_8k = ctx.prg_ram_banks_8k;
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
-        let mirroring = ctx.mirroring;
-        Self::new_with_prg_ram_banks(prg_rom, chr_rom, mirroring, prg_ram_banks_8k)
-    }
-
-    pub fn new_with_prg_ram_banks(
-        prg_rom: Vec<u8>,
-        chr_rom: Vec<u8>,
-        mirroring: NametableLayout,
-        prg_ram_banks_8k: u8,
-    ) -> Self {
+        let caps = MapperCapabilities {
+            has_irq: false,
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 0, // PRG-RAM managed separately with enable gating
+            prg_bank_size_kb: 16,
+            chr_bank_size_kb: 2,
+            trainer_jsr: false,
+            ..Default::default()
+        };
+        let base = BaseMapper::new(&ctx, caps);
         let prg_ram_size = (prg_ram_banks_8k.max(1) as usize) * DEFAULT_PRG_RAM_SIZE;
         Self {
-            prg_rom: BankedRom::new(prg_rom, PRG_BANK_SIZE),
+            base,
             prg_ram: PrgRam::new(prg_ram_size),
-            chr_memory: ChrMemory::new(chr_rom),
-            mirroring,
             prg_bank: 0,
             chr_banks_2k: [0; 4],
             nametable_banks_1k: [0; 2],
@@ -74,27 +71,46 @@ impl Sunsoft4Mapper {
         }
     }
 
+    #[cfg(test)]
+    pub fn new_with_prg_ram_banks(
+        prg_rom: Vec<u8>,
+        chr_rom: Vec<u8>,
+        mirroring: NametableLayout,
+        prg_ram_banks_8k: u8,
+    ) -> Self {
+        let ctx = super::mapper::MapperContext {
+            mapper: 68,
+            submapper: 0,
+            mirroring,
+            console_type: crate::cartridge::ConsoleType::NesFamicom,
+            prg_rom,
+            chr_rom,
+            prg_ram_banks_8k,
+            prg_ram_size_specified: true,
+            battery_backed_prg_ram: false,
+            crc32: 0,
+        };
+        Self::new(ctx)
+    }
+
     fn read_chr_indexed(&self, bank: u8, offset: usize, bank_size: usize) -> u8 {
-        let total_banks = self.chr_memory.size() / bank_size;
+        let total_banks = self.base.chr_size() / bank_size;
         if total_banks == 0 {
             return 0;
         }
         let bank_index = (bank as usize) % total_banks;
         let index = bank_index * bank_size + offset;
-        self.chr_memory.read_at_index(index)
+        self.base.read_chr_at_index(index)
     }
 
     fn write_chr_indexed(&mut self, bank: u8, offset: usize, bank_size: usize, value: u8) {
-        if !self.chr_memory.is_ram() {
-            return;
-        }
-        let total_banks = self.chr_memory.size() / bank_size;
+        let total_banks = self.base.chr_size() / bank_size;
         if total_banks == 0 {
             return;
         }
         let bank_index = (bank as usize) % total_banks;
         let index = bank_index * bank_size + offset;
-        self.chr_memory.write_at_index(index, value);
+        self.base.write_chr_at_index(index, value);
     }
 
     fn map_nametable_to_bank(&self, addr: u16) -> (usize, usize) {
@@ -102,7 +118,7 @@ impl Sunsoft4Mapper {
         let table = ((addr - 0x2000) / 0x0400) as usize;
         let offset = (addr & 0x03FF) as usize;
 
-        let use_upper = match self.mirroring {
+        let use_upper = match self.base.mirroring() {
             NametableLayout::Vertical => table == 1 || table == 3,
             NametableLayout::Horizontal => table == 2 || table == 3,
             NametableLayout::SingleScreenLower => false,
@@ -129,6 +145,13 @@ impl Sunsoft4Mapper {
 }
 
 impl Mapper for Sunsoft4Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         if self.prg_ram_enabled
             && let Some(value) = self.prg_ram.try_read(addr)
@@ -136,14 +159,20 @@ impl Mapper for Sunsoft4Mapper {
             return value;
         }
 
+        let prg = self.base.prg_rom();
+        let num_banks = prg.len() / PRG_BANK_SIZE;
         match addr {
             0x8000..=0xBFFF => {
-                let bank = self.prg_bank as usize;
-                self.prg_rom.read_with_base(bank, 0x8000, addr)
+                let bank = (self.prg_bank as usize) % num_banks.max(1);
+                let offset = (addr - 0x8000) as usize;
+                prg.get(bank * PRG_BANK_SIZE + offset).copied().unwrap_or(0)
             }
             0xC000..=0xFFFF => {
-                let last_bank = self.prg_rom.num_banks().saturating_sub(1);
-                self.prg_rom.read_with_base(last_bank, 0xC000, addr)
+                let last_bank = num_banks.saturating_sub(1);
+                let offset = (addr - 0xC000) as usize;
+                prg.get(last_bank * PRG_BANK_SIZE + offset)
+                    .copied()
+                    .unwrap_or(0)
             }
             _ => 0,
         }
@@ -174,13 +203,14 @@ impl Mapper for Sunsoft4Mapper {
                 self.nametable_banks_1k[1] = value;
             }
             0xE000..=0xEFFF => {
-                self.mirroring = match value & 0x03 {
+                let new_mirroring = match value & 0x03 {
                     0 => NametableLayout::Vertical,
                     1 => NametableLayout::Horizontal,
                     2 => NametableLayout::SingleScreenLower,
                     3 => NametableLayout::SingleScreenUpper,
                     _ => NametableLayout::Horizontal,
                 };
+                self.base.set_mirroring(new_mirroring);
                 self.nametable_rom_mode = (value & 0x10) != 0;
             }
             0xF000..=0xFFFF => {
@@ -229,11 +259,11 @@ impl Mapper for Sunsoft4Mapper {
     }
 
     fn get_mirroring(&self) -> NametableLayout {
-        self.mirroring
+        self.base.mirroring()
     }
 
     fn mapper_number(&self) -> u8 {
-        68
+        self.base.mapper_number()
     }
 
     fn wram_size(&self) -> usize {
@@ -249,11 +279,11 @@ impl Mapper for Sunsoft4Mapper {
     }
 
     fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
+        self.base.chr_ram_snapshot()
     }
 
     fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
+        self.base.restore_chr_ram(data);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -263,7 +293,7 @@ impl Mapper for Sunsoft4Mapper {
         snapshot.extend_from_slice(&self.nametable_banks_1k);
         snapshot.push(self.nametable_rom_mode as u8);
         snapshot.push(self.prg_ram_enabled as u8);
-        let mirroring_bits = match self.mirroring {
+        let mirroring_bits = match self.base.mirroring() {
             NametableLayout::Vertical => 0,
             NametableLayout::Horizontal => 1,
             NametableLayout::SingleScreenLower => 2,
@@ -283,13 +313,13 @@ impl Mapper for Sunsoft4Mapper {
         self.nametable_banks_1k.copy_from_slice(&data[5..7]);
         self.nametable_rom_mode = data[7] != 0;
         self.prg_ram_enabled = data[8] != 0;
-        self.mirroring = match data[9] & 0x03 {
+        self.base.set_mirroring(match data[9] & 0x03 {
             0 => NametableLayout::Vertical,
             1 => NametableLayout::Horizontal,
             2 => NametableLayout::SingleScreenLower,
             3 => NametableLayout::SingleScreenUpper,
-            _ => self.mirroring,
-        };
+            _ => self.base.mirroring(),
+        });
     }
 
     fn reset(&mut self) {
@@ -301,17 +331,9 @@ impl Mapper for Sunsoft4Mapper {
     }
 
     fn capabilities(&self) -> MapperCapabilities {
-        MapperCapabilities {
-            has_irq: false,
-            has_chr_banking: true,
-            has_dynamic_mirroring: true,
-            has_expansion_audio: false,
-            max_prg_ram_kb: self.prg_ram.size() / 1024,
-            prg_bank_size_kb: 16,
-            chr_bank_size_kb: 2,
-            trainer_jsr: false,
-            ..Default::default()
-        }
+        let mut caps = self.base.capabilities();
+        caps.max_prg_ram_kb = self.prg_ram.size() / 1024;
+        caps
     }
 }
 

--- a/src/cartridge/sunsoft_fme7.rs
+++ b/src/cartridge/sunsoft_fme7.rs
@@ -190,6 +190,13 @@ impl SunsoftFme7Mapper {
 }
 
 impl Mapper for SunsoftFme7Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x6000..=0x7FFF => {

--- a/src/cartridge/super_magic_card.rs
+++ b/src/cartridge/super_magic_card.rs
@@ -14,7 +14,8 @@
 //!   (requires CPU/console-layer changes; tracked separately).
 use std::cell::Cell;
 
-use crate::cartridge::common::{BankedRom, ChrMemory};
+use crate::cartridge::base_mapper::BaseMapper;
+use crate::cartridge::common::ChrMemory;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 const PRG_BANK_SIZE_8K: usize = 0x2000;
@@ -50,8 +51,7 @@ const PRG_BANK3_LOWER_HALF: usize = 6; // 16 KiB index → 8 KiB banks 12 & 13
 ///   $6000-$7FFF — 8 KiB window into 32 KiB banked WRAM
 ///   $8000-$FFFF — latch write when latch is enabled; always updates 2M shadow slots
 pub struct SuperMagicCardMapper {
-    prg_rom: BankedRom,
-    chr_memory: ChrMemory,
+    base: BaseMapper,
     wram: Vec<u8>,
     scratch_ram: Vec<u8>, // 4 KiB scratch RAM at CPU $5000–$5FFF (Mapper 17 only)
     trainer_load_address: u16, // CPU address where the trainer is loaded (default $7000)
@@ -116,11 +116,25 @@ impl SuperMagicCardMapper {
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
         let mapper = ctx.mapper;
         let submapper = ctx.submapper;
-        let prg_rom = ctx.prg_rom;
-        let chr_rom = ctx.chr_rom;
+        let chr_is_ram = ctx.chr_rom.is_empty();
+        let caps = MapperCapabilities {
+            has_irq: true,
+            has_chr_banking: true,
+            has_dynamic_mirroring: true,
+            has_expansion_audio: false,
+            max_prg_ram_kb: 0, // WRAM managed separately
+            prg_bank_size_kb: 8,
+            chr_bank_size_kb: 8,
+            trainer_jsr: true,
+            trainer_load_address: 0x7000,
+        };
+        let mut base = BaseMapper::new(&ctx, caps);
+        if chr_is_ram {
+            base.set_chr_memory(ChrMemory::new_ram(CHR_RAM_SIZE_256K));
+        }
         let mirroring = ctx.mirroring;
         if mapper == 17 {
-            Self::new_mapper17(prg_rom, chr_rom, mirroring, submapper)
+            Self::new_mapper17(base, mirroring, submapper)
         } else {
             // mappers 6 and 8; resolve submapper for SMC power-on state
             let effective_submapper = if mapper == 8 {
@@ -130,16 +144,11 @@ impl SuperMagicCardMapper {
             } else {
                 submapper
             };
-            Self::new_with_submapper(prg_rom, chr_rom, mirroring, effective_submapper)
+            Self::new_with_submapper(base, mirroring, effective_submapper)
         }
     }
 
-    pub fn new_with_submapper(
-        prg_rom: Vec<u8>,
-        chr_rom: Vec<u8>,
-        mirroring: NametableLayout,
-        submapper: u8,
-    ) -> Self {
+    pub fn new_with_submapper(base: BaseMapper, mirroring: NametableLayout, submapper: u8) -> Self {
         // Per NesDev spec, the emulator simulates writing
         //   [$42FF] = (submapper << 5) | (horizontalMirroring ? 0x10 : 0x00)
         // at power-on:
@@ -152,15 +161,9 @@ impl SuperMagicCardMapper {
         let d4 = u8::from(matches!(mirroring, NametableLayout::Horizontal));
         // A0 = 1 (addr $42FF has bit 0 set)
         let mirroring_type = (1 << 1) | d4;
-        let chr_memory = if chr_rom.is_empty() {
-            ChrMemory::new_ram(CHR_RAM_SIZE_256K)
-        } else {
-            ChrMemory::new(chr_rom)
-        };
 
         Self {
-            prg_rom: BankedRom::new(prg_rom, PRG_BANK_SIZE_8K),
-            chr_memory,
+            base,
             wram: vec![0; WRAM_SIZE_32K],
             scratch_ram: Vec::new(),
             trainer_load_address: 0x7000,
@@ -199,13 +202,8 @@ impl SuperMagicCardMapper {
     ///   `$4510–$4517 = [0, 1, 2, 3, 4, 5, 6, 7]` — identity mapping: slot N → CHR bank N
     ///
     /// The `submapper` field encodes the trainer load address (submapper 0 → $7000).
-    pub fn new_mapper17(
-        prg_rom: Vec<u8>,
-        chr_rom: Vec<u8>,
-        mirroring: NametableLayout,
-        submapper: u8,
-    ) -> Self {
-        let num_banks_8k = prg_rom.len() / PRG_BANK_SIZE_8K;
+    pub fn new_mapper17(base: BaseMapper, mirroring: NametableLayout, submapper: u8) -> Self {
+        let num_banks_8k = base.prg_rom().len() / PRG_BANK_SIZE_8K;
         let n = num_banks_8k as u8;
 
         // $42FF = $20 | (horizontalMirroring ? 0x10 : 0x00)
@@ -227,11 +225,6 @@ impl SuperMagicCardMapper {
 
         // $4500 = $47: chr_mode_1kb=true (bit 0), chr_nt_active=false (bit 1 set → CIRAM),
         //              mmc4_disabled=true (bit 2), irq_pa12_mode=false (bit 3=0), wram_bank=0
-        let chr_memory = if chr_rom.is_empty() {
-            ChrMemory::new_ram(CHR_RAM_SIZE_256K)
-        } else {
-            ChrMemory::new(chr_rom)
-        };
 
         // Trainer load address from submapper (0→$7000, 1→$5D00, 2→$5E00, 3→$5F00)
         let trainer_load_address = match submapper {
@@ -242,8 +235,7 @@ impl SuperMagicCardMapper {
         };
 
         Self {
-            prg_rom: BankedRom::new(prg_rom, PRG_BANK_SIZE_8K),
-            chr_memory,
+            base,
             wram: vec![0; WRAM_SIZE_32K],
             scratch_ram: vec![0; 0x1000], // 4 KiB scratch RAM at $5000–$5FFF
             trainer_load_address,
@@ -456,9 +448,30 @@ impl SuperMagicCardMapper {
     fn acknowledge_irq(&mut self) {
         self.irq_pending_flag = false;
     }
+
+    /// Read a byte from PRG-ROM at the given 8KB bank and address.
+    fn read_prg_bank_8k(&self, bank: usize, base_addr: u16, addr: u16) -> u8 {
+        let prg = self.base.prg_rom();
+        let num_banks = prg.len() / PRG_BANK_SIZE_8K;
+        if num_banks == 0 {
+            return 0;
+        }
+        let bank = bank % num_banks;
+        let offset = (addr - base_addr) as usize;
+        prg.get(bank * PRG_BANK_SIZE_8K + offset)
+            .copied()
+            .unwrap_or(0)
+    }
 }
 
 impl Mapper for SuperMagicCardMapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
             0x5000..=0x5FFF => self
@@ -467,18 +480,10 @@ impl Mapper for SuperMagicCardMapper {
                 .copied()
                 .unwrap_or(0),
             0x6000..=0x7FFF => self.wram.get(self.wram_index(addr)).copied().unwrap_or(0),
-            0x8000..=0x9FFF => self
-                .prg_rom
-                .read_with_base(self.bank_for_slot(0), 0x8000, addr),
-            0xA000..=0xBFFF => self
-                .prg_rom
-                .read_with_base(self.bank_for_slot(1), 0xA000, addr),
-            0xC000..=0xDFFF => self
-                .prg_rom
-                .read_with_base(self.bank_for_slot(2), 0xC000, addr),
-            0xE000..=0xFFFF => self
-                .prg_rom
-                .read_with_base(self.bank_for_slot(3), 0xE000, addr),
+            0x8000..=0x9FFF => self.read_prg_bank_8k(self.bank_for_slot(0), 0x8000, addr),
+            0xA000..=0xBFFF => self.read_prg_bank_8k(self.bank_for_slot(1), 0xA000, addr),
+            0xC000..=0xDFFF => self.read_prg_bank_8k(self.bank_for_slot(2), 0xC000, addr),
+            0xE000..=0xFFFF => self.read_prg_bank_8k(self.bank_for_slot(3), 0xE000, addr),
             _ => 0,
         }
     }
@@ -553,7 +558,7 @@ impl Mapper for SuperMagicCardMapper {
 
     fn read_chr(&mut self, addr: u16) -> u8 {
         let index = self.chr_index_for_addr(addr);
-        let value = self.chr_memory.read_at_index(index);
+        let value = self.base.read_chr_at_index(index);
         self.update_mmc4_latches(addr);
         value
     }
@@ -561,7 +566,7 @@ impl Mapper for SuperMagicCardMapper {
     fn write_chr(&mut self, addr: u16, value: u8) {
         if !self.chr_write_protected() {
             let index = self.chr_index_for_addr(addr);
-            self.chr_memory.write_at_index(index, value);
+            self.base.write_chr_at_index(index, value);
         }
     }
 
@@ -576,8 +581,8 @@ impl Mapper for SuperMagicCardMapper {
         let bank = self.chr_nt_regs[slot] as usize;
         let offset = (addr & 0x03FF) as usize;
         Some(
-            self.chr_memory
-                .read_at_index(bank * CHR_BANK_SIZE_1K + offset),
+            self.base
+                .read_chr_at_index(bank * CHR_BANK_SIZE_1K + offset),
         )
     }
 
@@ -591,8 +596,8 @@ impl Mapper for SuperMagicCardMapper {
         }
         let bank = self.chr_nt_regs[slot] as usize;
         let offset = (addr & 0x03FF) as usize;
-        self.chr_memory
-            .write_at_index(bank * CHR_BANK_SIZE_1K + offset, value);
+        self.base
+            .write_chr_at_index(bank * CHR_BANK_SIZE_1K + offset, value);
         true
     }
 
@@ -727,11 +732,11 @@ impl Mapper for SuperMagicCardMapper {
     }
 
     fn chr_ram_snapshot(&self) -> Vec<u8> {
-        self.chr_memory.snapshot()
+        self.base.chr_ram_snapshot()
     }
 
     fn restore_chr_ram(&mut self, data: &[u8]) {
-        self.chr_memory.load_snapshot(data);
+        self.base.restore_chr_ram(data);
     }
 
     fn wram_size(&self) -> usize {

--- a/src/cartridge/taito_tc0190.rs
+++ b/src/cartridge/taito_tc0190.rs
@@ -105,12 +105,12 @@ impl TaitoTc0190Mapper {
 }
 
 impl Mapper for TaitoTc0190Mapper {
-    fn base(&self) -> Option<&BaseMapper> {
-        Some(&self.base)
+    fn base(&self) -> &BaseMapper {
+        &self.base
     }
 
-    fn base_mut(&mut self) -> Option<&mut BaseMapper> {
-        Some(&mut self.base)
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
     }
 
     fn read_prg(&self, addr: u16) -> u8 {

--- a/src/cartridge/vrc2_vrc4.rs
+++ b/src/cartridge/vrc2_vrc4.rs
@@ -493,6 +493,13 @@ impl Vrc2Vrc4Mapper {
 }
 
 impl Mapper for Vrc2Vrc4Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         // PRG-RAM at $6000-$7FFF (only when WRAM is enabled; VRC2 is always enabled)
         if (!self.variant.has_irq() || self.prg_ram_enabled)

--- a/src/cartridge/vrc6.rs
+++ b/src/cartridge/vrc6.rs
@@ -405,6 +405,13 @@ impl VRC6Mapper {
 }
 
 impl Mapper for VRC6Mapper {
+    fn base(&self) -> &BaseMapper {
+        &self.base
+    }
+    fn base_mut(&mut self) -> &mut BaseMapper {
+        &mut self.base
+    }
+
     fn read_prg(&self, addr: u16) -> u8 {
         // PRG-RAM at $6000-$7FFF, enabled by $B003 bit 7 (W)
         if self.prg_ram_enabled

--- a/src/ppu/memory.rs
+++ b/src/ppu/memory.rs
@@ -374,9 +374,29 @@ mod tests {
     use super::*;
     use crate::cartridge::Cartridge;
 
-    struct TestNametableOverrideMapper;
+    fn create_test_base_mapper() -> crate::cartridge::BaseMapper {
+        let ctx = crate::cartridge::MapperContext::new_for_test(
+            0,
+            vec![0; 0x8000],
+            vec![0; 8192],
+            crate::cartridge::NametableLayout::Horizontal,
+        );
+        crate::cartridge::BaseMapper::new(&ctx, crate::cartridge::MapperCapabilities::default())
+    }
+
+    struct TestNametableOverrideMapper {
+        base: crate::cartridge::BaseMapper,
+    }
 
     impl crate::cartridge::Mapper for TestNametableOverrideMapper {
+        fn base(&self) -> &crate::cartridge::BaseMapper {
+            &self.base
+        }
+
+        fn base_mut(&mut self) -> &mut crate::cartridge::BaseMapper {
+            &mut self.base
+        }
+
         fn read_prg(&self, _addr: u16) -> u8 {
             0
         }
@@ -415,7 +435,9 @@ mod tests {
     fn test_mapper_can_override_nametable_reads() {
         let mem = Memory::default();
         let cart = Rc::new(RefCell::new(Cartridge::from_mapper_for_test(Box::new(
-            TestNametableOverrideMapper,
+            TestNametableOverrideMapper {
+                base: create_test_base_mapper(),
+            },
         ))));
         let cartridge = Some(cart);
 

--- a/src/ppu/ppu.rs
+++ b/src/ppu/ppu.rs
@@ -997,11 +997,30 @@ mod tests {
         background, memory, registers, rendering, screen_buffer, sprites, status, timing,
     };
 
+    fn create_test_base_mapper() -> crate::cartridge::BaseMapper {
+        let ctx = crate::cartridge::MapperContext::new_for_test(
+            0,
+            vec![0; 0x8000],
+            vec![0; 8192],
+            NametableLayout::Horizontal,
+        );
+        crate::cartridge::BaseMapper::new(&ctx, crate::cartridge::MapperCapabilities::default())
+    }
+
     struct ScanlineSpyMapper {
+        base: crate::cartridge::BaseMapper,
         calls: Rc<RefCell<Vec<(u16, bool)>>>,
     }
 
     impl crate::cartridge::Mapper for ScanlineSpyMapper {
+        fn base(&self) -> &crate::cartridge::BaseMapper {
+            &self.base
+        }
+
+        fn base_mut(&mut self) -> &mut crate::cartridge::BaseMapper {
+            &mut self.base
+        }
+
         fn read_prg(&self, _addr: u16) -> u8 {
             0
         }
@@ -1109,6 +1128,7 @@ mod tests {
 
         let cart = Rc::new(RefCell::new(Cartridge::from_mapper_for_test(Box::new(
             ScanlineSpyMapper {
+                base: create_test_base_mapper(),
                 calls: calls.clone(),
             },
         ))));
@@ -1133,6 +1153,7 @@ mod tests {
 
         let cart = Rc::new(RefCell::new(Cartridge::from_mapper_for_test(Box::new(
             ScanlineSpyMapper {
+                base: create_test_base_mapper(),
                 calls: calls.clone(),
             },
         ))));
@@ -1294,10 +1315,19 @@ mod tests {
     }
 
     struct EndFrameSpyMapper {
+        base: crate::cartridge::BaseMapper,
         calls: Rc<RefCell<u32>>,
     }
 
     impl crate::cartridge::Mapper for EndFrameSpyMapper {
+        fn base(&self) -> &crate::cartridge::BaseMapper {
+            &self.base
+        }
+
+        fn base_mut(&mut self) -> &mut crate::cartridge::BaseMapper {
+            &mut self.base
+        }
+
         fn read_prg(&self, _addr: u16) -> u8 {
             0
         }
@@ -1327,6 +1357,7 @@ mod tests {
 
         let cart = Rc::new(RefCell::new(Cartridge::from_mapper_for_test(Box::new(
             EndFrameSpyMapper {
+                base: create_test_base_mapper(),
                 calls: calls.clone(),
             },
         ))));
@@ -1348,10 +1379,19 @@ mod tests {
     }
 
     struct ChrFetchKindSpyMapper {
+        base: crate::cartridge::BaseMapper,
         events: Rc<RefCell<Vec<ChrFetchEvent>>>,
     }
 
     impl crate::cartridge::Mapper for ChrFetchKindSpyMapper {
+        fn base(&self) -> &crate::cartridge::BaseMapper {
+            &self.base
+        }
+
+        fn base_mut(&mut self) -> &mut crate::cartridge::BaseMapper {
+            &mut self.base
+        }
+
         fn read_prg(&self, _addr: u16) -> u8 {
             0
         }
@@ -1380,10 +1420,19 @@ mod tests {
     }
 
     struct A12PrimingSpyMapper {
+        base: crate::cartridge::BaseMapper,
         calls: Rc<RefCell<Vec<u16>>>,
     }
 
     impl crate::cartridge::Mapper for A12PrimingSpyMapper {
+        fn base(&self) -> &crate::cartridge::BaseMapper {
+            &self.base
+        }
+
+        fn base_mut(&mut self) -> &mut crate::cartridge::BaseMapper {
+            &mut self.base
+        }
+
         fn read_prg(&self, _addr: u16) -> u8 {
             0
         }
@@ -1411,6 +1460,7 @@ mod tests {
 
         let cart = Rc::new(RefCell::new(Cartridge::from_mapper_for_test(Box::new(
             ChrFetchKindSpyMapper {
+                base: create_test_base_mapper(),
                 events: events.clone(),
             },
         ))));
@@ -1498,6 +1548,7 @@ mod tests {
 
         let cart = Rc::new(RefCell::new(Cartridge::from_mapper_for_test(Box::new(
             A12PrimingSpyMapper {
+                base: create_test_base_mapper(),
                 calls: calls.clone(),
             },
         ))));


### PR DESCRIPTION
## Summary

Phase 7 of the BaseMapper migration (#784): Remove `Option` from `base()`/`base_mut()` and perform final cleanup.

## Changes

### Mapper migrations (3 remaining old-style mappers -> BaseMapper)
- **ColorDreams** (mapper 11): Replaced `BankedRom`/`BankSwitch` with `BaseMapper` banking (32KB PRG + 8KB CHR), bus conflicts via `apply_bus_conflict()`
- **Sunsoft-4** (mapper 68): Storage-only migration from `BankedRom`/`ChrMemory` to `BaseMapper`, custom banking retained
- **SuperMagicCard** (mapper 6): Storage-only migration, added `read_prg_bank_8k()` helper, handles 256KB CHR-RAM

### Trait signature change
- `base()` now returns `&BaseMapper` instead of `Option<&BaseMapper>` (required, no default)
- `base_mut()` now returns `&mut BaseMapper` instead of `Option<&mut BaseMapper>` (required, no default)
- 12 trait default methods simplified to direct `BaseMapper` delegation (removed all `Option` matching)

### Implementation updates
- Made MMC3 `base` field `pub(crate)` for wrapper access
- Made 10 MMC3 wrapper mapper fields `pub(crate)` (inner/mmc3)
- Added `base()`/`base_mut()` to 31 mappers that were missing it
- Updated all 65 existing `base()`/`base_mut()` implementations to new return type
- Added `BaseMapper` to 7 test mock mappers (PPU and bus tests)

### Cleanup
- Gated now-unused `BankedRom`/`BankSwitch`/`ChrMemory::is_ram` with `#[cfg(test)]`

## Testing

- All 6180 tests pass (cargo nextest)
- 46 WASM tests pass
- 27 Python tests pass
- 154 web JS tests pass
- Clippy clean (`-D warnings`)
- Formatted with `cargo fmt`

## Files changed

70 files, +680/-361 lines

Closes #791
