### PR TITLE
Switch read_chr/write_chr trait defaults from unbanked to banked

### DIFF
--- a/src/cartridge/axrom.rs
+++ b/src/cartridge/axrom.rs
@@ -131,6 +131,14 @@ impl Mapper for AxROMMapper {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.register]
     }

--- a/src/cartridge/bandai_fcg.rs
+++ b/src/cartridge/bandai_fcg.rs
@@ -200,14 +200,6 @@ impl Mapper for BandaiFcgMapper {
         self.update_banks();
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn cpu_cycle(&mut self) {
         trace_mapper!(5; "[bandai_fcg] cpu_cycle");
         // IRQ counter decrements every CPU cycle when enabled

--- a/src/cartridge/camerica.rs
+++ b/src/cartridge/camerica.rs
@@ -103,6 +103,14 @@ impl Mapper for CamericaMapper {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn registers_snapshot(&self) -> Vec<u8> {
         let one_screen_upper = matches!(self.base.mirroring(), NametableLayout::SingleScreenUpper);
         vec![self.bank_select, one_screen_upper as u8]

--- a/src/cartridge/colordreams.rs
+++ b/src/cartridge/colordreams.rs
@@ -96,10 +96,6 @@ impl Mapper for ColorDreamsMapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
     fn write_chr(&mut self, _addr: u16, _value: u8) {
         // CHR-ROM is read-only
     }

--- a/src/cartridge/cprom.rs
+++ b/src/cartridge/cprom.rs
@@ -81,14 +81,6 @@ impl Mapper for CpromMapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.chr_bank_select]
     }

--- a/src/cartridge/irem_g101.rs
+++ b/src/cartridge/irem_g101.rs
@@ -165,14 +165,6 @@ impl Mapper for IremG101Mapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         let mut snap = Vec::with_capacity(12);
         snap.extend_from_slice(&self.prg_regs);

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -267,17 +267,19 @@ pub trait Mapper {
     /// Read a byte from CHR address space (PPU $0000-$1FFF)
     /// Returns the byte at the given address after bank translation.
     ///
-    /// Default delegates to `BaseMapper` if available.
+    /// Default uses banked CHR access via `BaseMapper::read_chr_banked`.
+    /// Mappers without CHR banking must override this to use `self.base().read_chr(addr)`.
     fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base().read_chr(addr)
+        self.base().read_chr_banked(addr)
     }
 
     /// Write a byte to CHR address space (PPU $0000-$1FFF)
     /// Only works for CHR-RAM, CHR-ROM is read-only.
     ///
-    /// Default delegates to `BaseMapper` if available.
+    /// Default uses banked CHR access via `BaseMapper::write_chr_banked`.
+    /// Mappers without CHR banking must override this to use `self.base_mut().write_chr(addr, value)`.
     fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base_mut().write_chr(addr, value);
+        self.base_mut().write_chr_banked(addr, value);
     }
 
     /// Notify mapper of PPU address bus changes

--- a/src/cartridge/mapper140.rs
+++ b/src/cartridge/mapper140.rs
@@ -67,14 +67,6 @@ impl Mapper for Mapper140 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.register]
     }

--- a/src/cartridge/mapper241.rs
+++ b/src/cartridge/mapper241.rs
@@ -66,6 +66,14 @@ impl Mapper for Mapper241 {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.base.prg_page(0) as u8]
     }

--- a/src/cartridge/mapper242.rs
+++ b/src/cartridge/mapper242.rs
@@ -79,6 +79,14 @@ impl Mapper for Mapper242 {
         let _ = value; // Data value is ignored
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn registers_snapshot(&self) -> Vec<u8> {
         let mirroring_byte = match self.base.mirroring() {
             NametableLayout::Horizontal => 1,

--- a/src/cartridge/mapper243.rs
+++ b/src/cartridge/mapper243.rs
@@ -131,14 +131,6 @@ impl Mapper for Mapper243 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![
             self.command,

--- a/src/cartridge/mapper244.rs
+++ b/src/cartridge/mapper244.rs
@@ -87,10 +87,6 @@ impl Mapper for Mapper244 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
     fn write_chr(&mut self, _addr: u16, _value: u8) {
         // CHR-ROM is read-only
     }

--- a/src/cartridge/mapper246.rs
+++ b/src/cartridge/mapper246.rs
@@ -104,14 +104,6 @@ impl Mapper for Mapper246 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         let mut regs = Vec::with_capacity(8);
         regs.extend_from_slice(&self.prg_banks);

--- a/src/cartridge/mapper255.rs
+++ b/src/cartridge/mapper255.rs
@@ -150,14 +150,6 @@ impl Mapper for Mapper255 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         let mut regs = Vec::with_capacity(9);
         regs.push(self.chip_select);

--- a/src/cartridge/mapper42.rs
+++ b/src/cartridge/mapper42.rs
@@ -141,14 +141,6 @@ impl Mapper for Mapper42 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn wram_size(&self) -> usize {
         // No WRAM: $6000-$7FFF is mapped to PRG ROM, not RAM.
         0

--- a/src/cartridge/mapper43.rs
+++ b/src/cartridge/mapper43.rs
@@ -124,6 +124,14 @@ impl Mapper for Mapper43 {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn cpu_cycle(&mut self) {
         self.irq_counter = self.irq_counter.wrapping_add(1);
         if self.irq_counter >= Self::IRQ_OVERFLOW {

--- a/src/cartridge/mapper46.rs
+++ b/src/cartridge/mapper46.rs
@@ -92,14 +92,6 @@ impl Mapper for Mapper46 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.outer, self.inner]
     }

--- a/src/cartridge/mapper48.rs
+++ b/src/cartridge/mapper48.rs
@@ -210,14 +210,6 @@ impl Mapper for Mapper48 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn ppu_address_changed(&mut self, addr: u16) {
         let a12 = (addr & 0x1000) != 0;
         let was_low = !self.prev_a12;

--- a/src/cartridge/mapper50.rs
+++ b/src/cartridge/mapper50.rs
@@ -156,6 +156,14 @@ impl Mapper for Mapper50 {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn cpu_cycle(&mut self) {
         if !self.irq_enabled {
             return;

--- a/src/cartridge/mapper51.rs
+++ b/src/cartridge/mapper51.rs
@@ -170,6 +170,14 @@ impl Mapper for Mapper51 {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
         match addr {
             0x0000..=0x5FFF => open_bus,

--- a/src/cartridge/mapper53.rs
+++ b/src/cartridge/mapper53.rs
@@ -157,6 +157,14 @@ impl Mapper for Mapper53 {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.cmd0, self.cmd1]
     }

--- a/src/cartridge/mapper56.rs
+++ b/src/cartridge/mapper56.rs
@@ -195,14 +195,6 @@ impl Mapper for Mapper56 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn wram_size(&self) -> usize {
         8192
     }

--- a/src/cartridge/mapper57.rs
+++ b/src/cartridge/mapper57.rs
@@ -141,14 +141,6 @@ impl Mapper for Mapper57 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.reg0, self.reg1]
     }

--- a/src/cartridge/mapper58.rs
+++ b/src/cartridge/mapper58.rs
@@ -111,14 +111,6 @@ impl Mapper for Mapper58 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         let flags = (self.prg_mode as u8)
             | ((matches!(self.base.mirroring(), NametableLayout::Horizontal) as u8) << 1);

--- a/src/cartridge/mapper59.rs
+++ b/src/cartridge/mapper59.rs
@@ -136,14 +136,6 @@ impl Mapper for Mapper59 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         let flags = (self.prg_mode_128 as u8)
             | ((self.jumper_mode as u8) << 1)

--- a/src/cartridge/mapper60.rs
+++ b/src/cartridge/mapper60.rs
@@ -76,10 +76,6 @@ impl Mapper for Mapper60 {
         // No writable registers
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.game_select]
     }

--- a/src/cartridge/mapper61.rs
+++ b/src/cartridge/mapper61.rs
@@ -155,10 +155,6 @@ impl Mapper for Mapper61 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         let flags = (self.prg_mode as u8)
             | ((self.prg_a14) << 1)

--- a/src/cartridge/mapper62.rs
+++ b/src/cartridge/mapper62.rs
@@ -123,14 +123,6 @@ impl Mapper for Mapper62 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         let flags = (self.prg_mode as u8)
             | ((matches!(self.base.mirroring(), NametableLayout::Horizontal) as u8) << 1);

--- a/src/cartridge/mapper64.rs
+++ b/src/cartridge/mapper64.rs
@@ -243,14 +243,6 @@ impl Mapper for Mapper64 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn irq_pending(&self) -> bool {
         self.irq_pending
     }

--- a/src/cartridge/mapper65.rs
+++ b/src/cartridge/mapper65.rs
@@ -166,14 +166,6 @@ impl Mapper for Mapper65 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn irq_pending(&self) -> bool {
         self.irq_pending
     }

--- a/src/cartridge/mapper67.rs
+++ b/src/cartridge/mapper67.rs
@@ -167,14 +167,6 @@ impl Mapper for Mapper67 {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn irq_pending(&self) -> bool {
         self.irq_pending
     }

--- a/src/cartridge/mapper72.rs
+++ b/src/cartridge/mapper72.rs
@@ -100,14 +100,6 @@ impl Mapper for Mapper72 {
         self.latch = effective;
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.prg_bank, self.chr_bank, self.latch]
     }

--- a/src/cartridge/mapper73.rs
+++ b/src/cartridge/mapper73.rs
@@ -168,6 +168,14 @@ impl Mapper for Mapper73 {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn wram_size(&self) -> usize {
         Self::PRG_RAM_SIZE
     }

--- a/src/cartridge/mapper_templates.rs
+++ b/src/cartridge/mapper_templates.rs
@@ -191,10 +191,6 @@ impl<const CHR_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.chr_bank_raw]
     }
@@ -304,6 +300,14 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
             self.bank_select = effective & self.bank_select_mask;
             self.base.select_prg_page(0, self.bank_select as i16);
         }
+    }
+
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -428,10 +432,6 @@ impl<
             self.base.select_chr_page(0, self.chr_bank_raw as i16);
             self.base.select_prg_page(0, self.prg_bank_raw as i16);
         }
-    }
-
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {

--- a/src/cartridge/mmc1.rs
+++ b/src/cartridge/mmc1.rs
@@ -523,14 +523,6 @@ impl Mapper for MMC1Mapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn wram_size(&self) -> usize {
         self.prg_ram.len()
     }

--- a/src/cartridge/mmc2.rs
+++ b/src/cartridge/mmc2.rs
@@ -180,10 +180,6 @@ impl Mapper for MMC2Mapper {
         value
     }
 
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn ppu_address_changed(&mut self, addr: u16) {
         let _ = addr;
     }

--- a/src/cartridge/mmc3.rs
+++ b/src/cartridge/mmc3.rs
@@ -1472,14 +1472,6 @@ impl Mapper for MMC3Mapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn ppu_address_changed(&mut self, addr: u16) {
         if self.should_clock_irq_on_a12_change(addr) {
             self.clock_irq_counter_on_a12_rising_edge();

--- a/src/cartridge/mmc4.rs
+++ b/src/cartridge/mmc4.rs
@@ -187,11 +187,6 @@ impl Mapper for MMC4Mapper {
         value
     }
 
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        // Write to current bank — do NOT update latches
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![
             self.prg_bank_16k,

--- a/src/cartridge/multicart_15.rs
+++ b/src/cartridge/multicart_15.rs
@@ -142,6 +142,10 @@ impl Mapper for Multicart15Mapper {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
     fn write_chr(&mut self, addr: u16, value: u8) {
         if self.is_chr_ram_writable() {
             self.base.write_chr(addr, value);

--- a/src/cartridge/namco118.rs
+++ b/src/cartridge/namco118.rs
@@ -166,14 +166,6 @@ impl Mapper for Namco118Mapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         let mut snapshot = Vec::with_capacity(9);
         snapshot.push(self.bank_select);

--- a/src/cartridge/nina_tengen.rs
+++ b/src/cartridge/nina_tengen.rs
@@ -117,10 +117,6 @@ impl Mapper for NinaTengenMapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
     fn write_chr(&mut self, _addr: u16, _value: u8) {
         // Mapper 78 uses CHR-ROM, writes are ignored
     }

--- a/src/cartridge/nrom.rs
+++ b/src/cartridge/nrom.rs
@@ -77,6 +77,14 @@ impl Mapper for NROMMapper {
         // PRG-RAM at $6000-$7FFF (only if present)
         self.base.try_write_prg_ram(addr, value);
     }
+
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
 }
 
 #[cfg(test)]

--- a/src/cartridge/ntdec_2722.rs
+++ b/src/cartridge/ntdec_2722.rs
@@ -137,6 +137,14 @@ impl Mapper for Ntdec2722Mapper {
         }
     }
 
+    fn read_chr(&mut self, addr: u16) -> u8 {
+        self.base().read_chr(addr)
+    }
+
+    fn write_chr(&mut self, addr: u16, value: u8) {
+        self.base_mut().write_chr(addr, value);
+    }
+
     fn wram_size(&self) -> usize {
         // No WRAM: $6000-$7FFF is mapped to PRG ROM bank 6, not RAM.
         0

--- a/src/cartridge/sunsoft_fme7.rs
+++ b/src/cartridge/sunsoft_fme7.rs
@@ -235,14 +235,6 @@ impl Mapper for SunsoftFme7Mapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn cpu_cycle(&mut self) {
         // IRQ counter decrements every CPU cycle when counter enable (bit 7) is set
         // IRQ triggers on underflow only if IRQ enable (bit 0) is also set

--- a/src/cartridge/taito_tc0190.rs
+++ b/src/cartridge/taito_tc0190.rs
@@ -168,14 +168,6 @@ impl Mapper for TaitoTc0190Mapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
-    fn write_chr(&mut self, addr: u16, value: u8) {
-        self.base.write_chr_banked(addr, value);
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         // [0]: mirroring (0=Vert, 1=Horz)
         // [1..=2]: prg_bank[0..1]

--- a/src/cartridge/vrc2_vrc4.rs
+++ b/src/cartridge/vrc2_vrc4.rs
@@ -537,10 +537,6 @@ impl Mapper for Vrc2Vrc4Mapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
     fn cpu_cycle(&mut self) {
         trace_mapper!(5; "[vrc2_vrc4] cpu_cycle (irq)");
         if self.variant.has_irq() {

--- a/src/cartridge/vrc6.rs
+++ b/src/cartridge/vrc6.rs
@@ -502,10 +502,6 @@ impl Mapper for VRC6Mapper {
         }
     }
 
-    fn read_chr(&mut self, addr: u16) -> u8 {
-        self.base.read_chr_banked(addr)
-    }
-
     fn cpu_cycle(&mut self) {
         trace_mapper!(5; "[vrc6] cpu_cycle (irq)");
         self.audio.cpu_cycle();


### PR DESCRIPTION
Switch Mapper trait defaults from unbanked to banked CHR access. Removes ~33 redundant overrides, adds 13 explicit unbanked overrides. All tests pass. Fixes #801