### PR TITLE
Add default read_prg to Mapper trait

### DIFF
--- a/src/cartridge/axrom.rs
+++ b/src/cartridge/axrom.rs
@@ -92,14 +92,6 @@ impl Mapper for AxROMMapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x6000..=0x7FFF => self.base.try_read_prg_ram(addr).unwrap_or(0),
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/bandai_fcg.rs
+++ b/src/cartridge/bandai_fcg.rs
@@ -107,13 +107,6 @@ impl Mapper for BandaiFcgMapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         // Determine which address range this write falls into and if it's valid
         let is_6000_range = (0x6000..=0x7FFF).contains(&addr);

--- a/src/cartridge/bnrom_nina.rs
+++ b/src/cartridge/bnrom_nina.rs
@@ -164,20 +164,6 @@ impl Mapper for BnromNinaMapper {
         self.trace_state("reset", 0, 0);
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        // PRG-RAM at $6000-$7FFF (NINA only)
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-
-        // PRG ROM at $8000-$FFFF (32KB switchable bank)
-        if addr >= 0x8000 {
-            self.base.read_prg_banked(addr)
-        } else {
-            0
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         // NINA-001 registers overlap PRG-RAM at $7FFD-$7FFF.
         // A write updates both the register and underlying RAM byte.

--- a/src/cartridge/camerica.rs
+++ b/src/cartridge/camerica.rs
@@ -70,16 +70,6 @@ impl Mapper for CamericaMapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/colordreams.rs
+++ b/src/cartridge/colordreams.rs
@@ -72,13 +72,6 @@ impl Mapper for ColorDreamsMapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
         match addr {
             0x0000..=0x7FFF => open_bus,

--- a/src/cartridge/irem_g101.rs
+++ b/src/cartridge/irem_g101.rs
@@ -131,13 +131,6 @@ impl Mapper for IremG101Mapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         match addr & 0xF000 {
             0x8000 => {

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -244,8 +244,20 @@ pub trait Mapper {
     /// Read a byte from PRG address space (CPU $6000-$FFFF)
     /// - $6000-$7FFF: PRG-RAM (8KB, battery-backed on some cartridges)
     /// - $8000-$FFFF: PRG-ROM (with bank switching on advanced mappers)
-    ///   Returns the byte at the given address after bank translation
-    fn read_prg(&self, addr: u16) -> u8;
+    ///   Returns the byte at the given address after bank translation.
+    ///
+    /// Default tries PRG-RAM first via `BaseMapper::try_read_prg_ram`, then
+    /// falls back to banked PRG-ROM via `BaseMapper::read_prg_banked`.
+    /// Mappers with custom PRG address decoding must override this.
+    fn read_prg(&self, addr: u16) -> u8 {
+        if let Some(value) = self.base().try_read_prg_ram(addr) {
+            return value;
+        }
+        match addr {
+            0x8000..=0xFFFF => self.base().read_prg_banked(addr),
+            _ => 0,
+        }
+    }
 
     /// Read a byte from PRG address space (CPU $6000-$FFFF), with open-bus context.
     ///

--- a/src/cartridge/mapper140.rs
+++ b/src/cartridge/mapper140.rs
@@ -54,13 +54,6 @@ impl Mapper for Mapper140 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if (0x6000..=0x7FFF).contains(&addr) {
             self.apply_register(value);

--- a/src/cartridge/mapper241.rs
+++ b/src/cartridge/mapper241.rs
@@ -47,16 +47,6 @@ impl Mapper for Mapper241 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/mapper242.rs
+++ b/src/cartridge/mapper242.rs
@@ -51,16 +51,6 @@ impl Mapper for Mapper242 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/mapper243.rs
+++ b/src/cartridge/mapper243.rs
@@ -93,13 +93,6 @@ impl Mapper for Mapper243 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if addr & 0x4101 == 0x4100 {
             self.command = value & 0x07;

--- a/src/cartridge/mapper244.rs
+++ b/src/cartridge/mapper244.rs
@@ -60,16 +60,6 @@ impl Mapper for Mapper244 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/mapper46.rs
+++ b/src/cartridge/mapper46.rs
@@ -71,13 +71,6 @@ impl Mapper for Mapper46 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         match addr {
             0x6000..=0x7FFF => {

--- a/src/cartridge/mapper48.rs
+++ b/src/cartridge/mapper48.rs
@@ -148,13 +148,6 @@ impl Mapper for Mapper48 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         match addr & Self::REGISTER_MASK {
             0x8000 => {

--- a/src/cartridge/mapper57.rs
+++ b/src/cartridge/mapper57.rs
@@ -123,13 +123,6 @@ impl Mapper for Mapper57 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if let 0x8000..=0xFFFF = addr {
             if (addr & 0x0800) != 0 {

--- a/src/cartridge/mapper58.rs
+++ b/src/cartridge/mapper58.rs
@@ -87,13 +87,6 @@ impl Mapper for Mapper58 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         let _ = value; // data bus is not used; bank selection is from address
         if (0x8000..=0xFFFF).contains(&addr) {

--- a/src/cartridge/mapper60.rs
+++ b/src/cartridge/mapper60.rs
@@ -65,13 +65,6 @@ impl Mapper for Mapper60 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, _addr: u16, _value: u8) {
         // No writable registers
     }

--- a/src/cartridge/mapper61.rs
+++ b/src/cartridge/mapper61.rs
@@ -142,13 +142,6 @@ impl Mapper for Mapper61 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, _value: u8) {
         if (0x8000..=0xFFFF).contains(&addr) {
             self.latch_address(addr);

--- a/src/cartridge/mapper62.rs
+++ b/src/cartridge/mapper62.rs
@@ -95,13 +95,6 @@ impl Mapper for Mapper62 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if (0x8000..=0xFFFF).contains(&addr) {
             let prg_low = ((addr >> 8) & 0x3F) as u8;

--- a/src/cartridge/mapper64.rs
+++ b/src/cartridge/mapper64.rs
@@ -182,13 +182,6 @@ impl Mapper for Mapper64 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         let even = (addr & 1) == 0;
         match addr & 0xE000 {

--- a/src/cartridge/mapper65.rs
+++ b/src/cartridge/mapper65.rs
@@ -115,13 +115,6 @@ impl Mapper for Mapper65 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         match addr {
             0x8000 => {

--- a/src/cartridge/mapper67.rs
+++ b/src/cartridge/mapper67.rs
@@ -109,13 +109,6 @@ impl Mapper for Mapper67 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         match addr & 0xF800 {
             0x8000 => {

--- a/src/cartridge/mapper72.rs
+++ b/src/cartridge/mapper72.rs
@@ -73,13 +73,6 @@ impl Mapper for Mapper72 {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if !(0x8000..=0xFFFF).contains(&addr) {
             return;

--- a/src/cartridge/mapper_templates.rs
+++ b/src/cartridge/mapper_templates.rs
@@ -279,16 +279,6 @@ impl<const PRG_BANK_KB: usize, const MAPPER_NUM: u8> Mapper
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;
@@ -408,16 +398,6 @@ impl<
 
     fn base_mut(&mut self) -> &mut BaseMapper {
         &mut self.base
-    }
-
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {

--- a/src/cartridge/mmc2.rs
+++ b/src/cartridge/mmc2.rs
@@ -119,16 +119,6 @@ impl Mapper for MMC2Mapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/mmc4.rs
+++ b/src/cartridge/mmc4.rs
@@ -130,16 +130,6 @@ impl Mapper for MMC4Mapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/multicart_15.rs
+++ b/src/cartridge/multicart_15.rs
@@ -114,13 +114,6 @@ impl Mapper for Multicart15Mapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        self.base.read_prg_banked(addr)
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/namco118.rs
+++ b/src/cartridge/namco118.rs
@@ -134,16 +134,6 @@ impl Mapper for Namco118Mapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        match addr {
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/nina_tengen.rs
+++ b/src/cartridge/nina_tengen.rs
@@ -86,13 +86,6 @@ impl Mapper for NinaTengenMapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        self.base.read_prg_banked(addr)
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;

--- a/src/cartridge/taito_tc0190.rs
+++ b/src/cartridge/taito_tc0190.rs
@@ -113,13 +113,6 @@ impl Mapper for TaitoTc0190Mapper {
         &mut self.base
     }
 
-    fn read_prg(&self, addr: u16) -> u8 {
-        if let Some(value) = self.base.try_read_prg_ram(addr) {
-            return value;
-        }
-        self.base.read_prg_banked(addr)
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if self.base.try_write_prg_ram(addr, value) {
             return;


### PR DESCRIPTION
Add default read_prg implementation to Mapper trait and remove 30 redundant overrides.

## Changes

- Added default `read_prg` to Mapper trait: tries PRG-RAM first via `try_read_prg_ram`, then falls back to banked PRG-ROM via `read_prg_banked`
- Removed 30 redundant `read_prg` overrides:
  - 12 Pattern A (try-RAM + banked): nina_tengen, multicart_15, taito_tc0190, mapper241, mapper242, mapper244, camerica, mmc2, mmc4, namco118, SimpleBankedPrgMapper, DualBank32Mapper
  - 16 Pattern B (banked only, no PRG-RAM): mapper46, mapper48, mapper57, mapper58, mapper60, mapper61, mapper62, mapper64, mapper65, mapper67, mapper72, mapper140, mapper243, colordreams, bandai_fcg, irem_g101
  - 2 equivalent variants: axrom (unwrap_or), bnrom_nina (if-guard)
- 36 mappers retain custom `read_prg` overrides for specialized behavior

## Verification

- All 6180 Rust tests pass
- All 46 WASM tests pass
- All 27 Python tests pass
- All 154 JS tests pass
- Clippy clean, cargo fmt applied

Closes #802
