### PR TITLE
Refactor: extract shared VRC IRQ core (fix #810)

### DIFF
--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -72,6 +72,7 @@ pub mod test_helpers;
 mod uxrom;
 mod vrc2_vrc4;
 mod vrc6;
+mod vrc_irq;
 
 #[allow(unused_imports)]
 pub use base_mapper::BaseMapper;

--- a/src/cartridge/vrc2_vrc4.rs
+++ b/src/cartridge/vrc2_vrc4.rs
@@ -5,6 +5,7 @@
 
 use crate::cartridge::BaseMapper;
 use crate::cartridge::common::{DEFAULT_PRG_RAM_SIZE, PrgRam};
+use crate::cartridge::vrc_irq::VrcIrq;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 use crate::trace_mapper;
 
@@ -161,13 +162,7 @@ pub struct Vrc2Vrc4Mapper {
     mirroring_reg: u8,
 
     // --- VRC IRQ (used by VRC4 variants only) ---
-    irq_latch: u8,
-    irq_counter: u8,
-    irq_enabled: bool,
-    irq_mode_cycle: bool,
-    irq_enable_after_ack: bool,
-    irq_asserted: bool,
-    irq_prescaler: i32,
+    irq: VrcIrq,
 }
 
 impl Vrc2Vrc4Mapper {
@@ -176,11 +171,6 @@ impl Vrc2Vrc4Mapper {
     const CHR_LOW_NIBBLE_MASK: u16 = 0x000F;
     /// Mask to preserve the high 5 bits of a 9-bit CHR bank value.
     const CHR_HIGH_BITS_MASK: u16 = 0x01F0;
-
-    /// Starting value for the IRQ scanline prescaler (341 master clocks per scanline).
-    const IRQ_PRESCALER_INIT: i32 = 341;
-    /// Master clocks consumed per CPU cycle.
-    const IRQ_PRESCALER_STEP: i32 = 3;
 
     /// Expected byte length of the registers snapshot produced by `registers_snapshot`.
     const SNAPSHOT_SIZE: usize = 27;
@@ -242,13 +232,7 @@ impl Vrc2Vrc4Mapper {
             prg_swap_mode: false,
             chr_banks_1k: [0u16; 8],
             mirroring_reg: 0,
-            irq_latch: 0,
-            irq_counter: 0,
-            irq_enabled: false,
-            irq_mode_cycle: false,
-            irq_enable_after_ack: false,
-            irq_asserted: false,
-            irq_prescaler: 0,
+            irq: VrcIrq::new(341, 3),
         };
         mapper.update_banks();
         mapper
@@ -371,47 +355,6 @@ impl Vrc2Vrc4Mapper {
         self.base.set_mirroring(layout);
     }
 
-    fn reset_irq_prescaler(&mut self) {
-        // VRC IRQ scanline-mode prescaler (nesdev): 341 master ticks / 3 per CPU cycle.
-        self.irq_prescaler = Self::IRQ_PRESCALER_INIT;
-    }
-
-    fn acknowledge_irq(&mut self) {
-        self.irq_asserted = false;
-    }
-
-    fn clock_vrc_irq_counter(&mut self) {
-        // VRC IRQ (nesdev):
-        // If counter is $FF, reload from latch and trip IRQ; otherwise increment.
-        if self.irq_counter == 0xFF {
-            self.irq_counter = self.irq_latch;
-            self.irq_asserted = true;
-        } else {
-            self.irq_counter = self.irq_counter.wrapping_add(1);
-        }
-    }
-
-    fn tick_vrc_irq(&mut self) {
-        if !self.variant.has_irq() {
-            return;
-        }
-
-        if !self.irq_enabled {
-            return;
-        }
-
-        if self.irq_mode_cycle {
-            self.clock_vrc_irq_counter();
-            return;
-        }
-
-        self.irq_prescaler -= Self::IRQ_PRESCALER_STEP;
-        if self.irq_prescaler <= 0 {
-            self.irq_prescaler += Self::IRQ_PRESCALER_INIT;
-            self.clock_vrc_irq_counter();
-        }
-    }
-
     /// Update a single 1KB CHR bank slot with either the low or high nibble of
     /// the 9-bit bank number.  Low nibble sets bits [3:0]; high nibble sets bits [8:4].
     fn write_chr_bank_nibble(&mut self, bank_idx: usize, is_high_nibble: bool, value: u8) {
@@ -468,25 +411,10 @@ impl Vrc2Vrc4Mapper {
             return;
         }
         match reg {
-            0xF000 => self.irq_latch = (self.irq_latch & 0xF0) | (value & 0x0F),
-            0xF001 => self.irq_latch = (self.irq_latch & 0x0F) | ((value & 0x0F) << 4),
-            0xF002 => {
-                self.acknowledge_irq();
-                self.reset_irq_prescaler();
-                self.irq_mode_cycle = (value & 0b0000_0100) != 0;
-                let enable = (value & 0b0000_0010) != 0;
-                self.irq_enable_after_ack = (value & 0b0000_0001) != 0;
-                if enable {
-                    self.irq_enabled = true;
-                    self.irq_counter = self.irq_latch;
-                } else {
-                    self.irq_enabled = false;
-                }
-            }
-            0xF003 => {
-                self.acknowledge_irq();
-                self.irq_enabled = self.irq_enable_after_ack;
-            }
+            0xF000 => self.irq.write_latch_low_nibble(value),
+            0xF001 => self.irq.write_latch_high_nibble(value),
+            0xF002 => self.irq.write_control(value),
+            0xF003 => self.irq.write_acknowledge(),
             _ => {}
         }
     }
@@ -540,13 +468,13 @@ impl Mapper for Vrc2Vrc4Mapper {
     fn cpu_cycle(&mut self) {
         trace_mapper!(5; "[vrc2_vrc4] cpu_cycle (irq)");
         if self.variant.has_irq() {
-            self.tick_vrc_irq();
+            self.irq.tick();
         }
     }
 
     fn irq_pending(&self) -> bool {
         if self.variant.has_irq() {
-            self.irq_asserted
+            self.irq.pending()
         } else {
             false
         }
@@ -582,19 +510,19 @@ impl Mapper for Vrc2Vrc4Mapper {
             snapshot.extend_from_slice(&bank.to_le_bytes());
         }
         snapshot.push(self.mirroring_reg);
-        snapshot.push(self.irq_latch);
-        snapshot.push(self.irq_counter);
+        snapshot.push(self.irq.latch());
+        snapshot.push(self.irq.counter());
         let mut flags = 0u8;
-        if self.irq_enabled {
+        if self.irq.enabled() {
             flags |= Self::FLAG_IRQ_ENABLED;
         }
-        if self.irq_mode_cycle {
+        if self.irq.mode_cycle() {
             flags |= Self::FLAG_IRQ_MODE_CYCLE;
         }
-        if self.irq_enable_after_ack {
+        if self.irq.enable_after_ack() {
             flags |= Self::FLAG_IRQ_ENABLE_AFTER_ACK;
         }
-        if self.irq_asserted {
+        if self.irq.pending() {
             flags |= Self::FLAG_IRQ_ASSERTED;
         }
         if self.prg_swap_mode {
@@ -604,7 +532,7 @@ impl Mapper for Vrc2Vrc4Mapper {
             flags |= Self::FLAG_PRG_RAM_ENABLED;
         }
         snapshot.push(flags);
-        snapshot.extend_from_slice(&self.irq_prescaler.to_le_bytes());
+        snapshot.extend_from_slice(&self.irq.prescaler().to_le_bytes());
         let mirroring = match self.base.mirroring() {
             NametableLayout::Horizontal => 0u8,
             NametableLayout::Vertical => 1,
@@ -624,16 +552,20 @@ impl Mapper for Vrc2Vrc4Mapper {
                 *bank = u16::from_le_bytes([data[2 + i * 2], data[2 + i * 2 + 1]]);
             }
             self.mirroring_reg = data[18];
-            self.irq_latch = data[19];
-            self.irq_counter = data[20];
+            self.irq.write_latch(data[19]);
+            self.irq.set_counter(data[20]);
             let flags = data[21];
-            self.irq_enabled = (flags & Self::FLAG_IRQ_ENABLED) != 0;
-            self.irq_mode_cycle = (flags & Self::FLAG_IRQ_MODE_CYCLE) != 0;
-            self.irq_enable_after_ack = (flags & Self::FLAG_IRQ_ENABLE_AFTER_ACK) != 0;
-            self.irq_asserted = (flags & Self::FLAG_IRQ_ASSERTED) != 0;
+            self.irq.set_enabled((flags & Self::FLAG_IRQ_ENABLED) != 0);
+            self.irq
+                .set_mode_cycle((flags & Self::FLAG_IRQ_MODE_CYCLE) != 0);
+            self.irq
+                .set_enable_after_ack((flags & Self::FLAG_IRQ_ENABLE_AFTER_ACK) != 0);
+            self.irq
+                .set_asserted((flags & Self::FLAG_IRQ_ASSERTED) != 0);
             self.prg_swap_mode = (flags & Self::FLAG_PRG_SWAP_MODE) != 0;
             self.prg_ram_enabled = (flags & Self::FLAG_PRG_RAM_ENABLED) != 0;
-            self.irq_prescaler = i32::from_le_bytes([data[22], data[23], data[24], data[25]]);
+            self.irq
+                .set_prescaler(i32::from_le_bytes([data[22], data[23], data[24], data[25]]));
             self.base.set_mirroring(match data[26] {
                 0 => NametableLayout::Horizontal,
                 1 => NametableLayout::Vertical,

--- a/src/cartridge/vrc6.rs
+++ b/src/cartridge/vrc6.rs
@@ -11,6 +11,7 @@
 
 use crate::cartridge::BaseMapper;
 use crate::cartridge::common::{DEFAULT_PRG_RAM_SIZE, PrgRam};
+use crate::cartridge::vrc_irq::VrcIrq;
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 use crate::trace_mapper;
 
@@ -255,13 +256,7 @@ pub struct VRC6Mapper {
     prg_ram_enabled: bool,
 
     // --- VRC IRQ (used by VRC6) ---
-    irq_latch: u8,
-    irq_counter: u8,
-    irq_enabled: bool,
-    irq_mode_cycle: bool,
-    irq_enable_after_ack: bool,
-    irq_asserted: bool,
-    irq_prescaler: i32,
+    irq: VrcIrq,
 
     // --- VRC6 expansion audio ---
     audio: Vrc6Audio,
@@ -303,13 +298,7 @@ impl VRC6Mapper {
             b003: 0,
             prg_ram_enabled: false,
 
-            irq_latch: 0,
-            irq_counter: 0,
-            irq_enabled: false,
-            irq_mode_cycle: false,
-            irq_enable_after_ack: false,
-            irq_asserted: false,
-            irq_prescaler: 0,
+            irq: VrcIrq::new(341, 3),
 
             audio: Vrc6Audio::default(),
         };
@@ -347,45 +336,6 @@ impl VRC6Mapper {
             _ => self.base.mirroring(),
         };
         self.base.set_mirroring(new_mirroring);
-    }
-
-    fn reset_irq_prescaler(&mut self) {
-        // VRC IRQ scanline-mode prescaler (nesdev): 341 master ticks / 3 per CPU cycle.
-        // Using the simple model: start at 341 and subtract 3 each CPU cycle; when <= 0,
-        // add 341 and clock the IRQ counter. This makes the first clock after 114 cycles.
-        self.irq_prescaler = 341;
-    }
-
-    fn acknowledge_irq(&mut self) {
-        self.irq_asserted = false;
-    }
-
-    fn clock_vrc_irq_counter(&mut self) {
-        // VRC IRQ (nesdev):
-        // If counter is $FF, reload from latch and trip IRQ; otherwise increment.
-        if self.irq_counter == 0xFF {
-            self.irq_counter = self.irq_latch;
-            self.irq_asserted = true;
-        } else {
-            self.irq_counter = self.irq_counter.wrapping_add(1);
-        }
-    }
-
-    fn tick_vrc_irq(&mut self) {
-        if !self.irq_enabled {
-            return;
-        }
-
-        if self.irq_mode_cycle {
-            self.clock_vrc_irq_counter();
-            return;
-        }
-
-        self.irq_prescaler -= 3;
-        if self.irq_prescaler <= 0 {
-            self.irq_prescaler += 341;
-            self.clock_vrc_irq_counter();
-        }
     }
 
     fn update_banks(&mut self) {
@@ -459,32 +409,19 @@ impl Mapper for VRC6Mapper {
                 }
                 0xF000 => {
                     // IRQ Latch
-                    self.irq_latch = value;
+                    self.irq.write_latch(value);
                 }
                 0xF001 => {
                     // IRQ Control (.... .MEA)
                     // M: mode (1=cycle, 0=scanline)
                     // E: enable (1=enabled)
                     // A: enable after acknowledgement (copied to E on $F002 writes)
-                    self.acknowledge_irq();
-                    self.reset_irq_prescaler();
-
-                    self.irq_mode_cycle = (value & 0b0000_0100) != 0;
-                    let enable = (value & 0b0000_0010) != 0;
-                    self.irq_enable_after_ack = (value & 0b0000_0001) != 0;
-
-                    if enable {
-                        self.irq_enabled = true;
-                        self.irq_counter = self.irq_latch;
-                    } else {
-                        self.irq_enabled = false;
-                    }
+                    self.irq.write_control(value);
                 }
                 0xF002 => {
                     // IRQ Acknowledge
                     // Any write acknowledges pending IRQ and copies A->E.
-                    self.acknowledge_irq();
-                    self.irq_enabled = self.irq_enable_after_ack;
+                    self.irq.write_acknowledge();
                 }
                 0xD000..=0xD003 => {
                     let idx = (reg & 0x0003) as usize;
@@ -505,11 +442,11 @@ impl Mapper for VRC6Mapper {
     fn cpu_cycle(&mut self) {
         trace_mapper!(5; "[vrc6] cpu_cycle (irq)");
         self.audio.cpu_cycle();
-        self.tick_vrc_irq();
+        self.irq.tick();
     }
 
     fn irq_pending(&self) -> bool {
-        self.irq_asserted
+        self.irq.pending()
     }
 
     fn expansion_audio_sample(&self) -> f32 {
@@ -549,14 +486,14 @@ impl Mapper for VRC6Mapper {
         snapshot.push(self.prg_bank_8k);
         snapshot.extend_from_slice(&self.chr_banks_1k);
         snapshot.push(self.b003);
-        snapshot.push(self.irq_latch);
-        snapshot.push(self.irq_counter);
-        let flags = (self.irq_enabled as u8)
-            | ((self.irq_mode_cycle as u8) << 1)
-            | ((self.irq_enable_after_ack as u8) << 2)
-            | ((self.irq_asserted as u8) << 3);
+        snapshot.push(self.irq.latch());
+        snapshot.push(self.irq.counter());
+        let flags = (self.irq.enabled() as u8)
+            | ((self.irq.mode_cycle() as u8) << 1)
+            | ((self.irq.enable_after_ack() as u8) << 2)
+            | ((self.irq.pending() as u8) << 3);
         snapshot.push(flags);
-        let prescaler_bytes = self.irq_prescaler.to_le_bytes();
+        let prescaler_bytes = self.irq.prescaler().to_le_bytes();
         snapshot.extend_from_slice(&prescaler_bytes);
         snapshot.push(match self.base.mirroring() {
             NametableLayout::Horizontal => 0,
@@ -600,14 +537,15 @@ impl Mapper for VRC6Mapper {
             self.chr_banks_1k.copy_from_slice(&data[2..10]);
             self.b003 = data[10];
             self.prg_ram_enabled = (self.b003 & 0x80) != 0;
-            self.irq_latch = data[11];
-            self.irq_counter = data[12];
+            self.irq.write_latch(data[11]);
+            self.irq.set_counter(data[12]);
             let flags = data[13];
-            self.irq_enabled = (flags & 1) != 0;
-            self.irq_mode_cycle = (flags & 2) != 0;
-            self.irq_enable_after_ack = (flags & 4) != 0;
-            self.irq_asserted = (flags & 8) != 0;
-            self.irq_prescaler = i32::from_le_bytes([data[14], data[15], data[16], data[17]]);
+            self.irq.set_enabled((flags & 1) != 0);
+            self.irq.set_mode_cycle((flags & 2) != 0);
+            self.irq.set_enable_after_ack((flags & 4) != 0);
+            self.irq.set_asserted((flags & 8) != 0);
+            self.irq
+                .set_prescaler(i32::from_le_bytes([data[14], data[15], data[16], data[17]]));
             self.base.set_mirroring(match data[18] {
                 0 => NametableLayout::Horizontal,
                 1 => NametableLayout::Vertical,

--- a/src/cartridge/vrc_irq.rs
+++ b/src/cartridge/vrc_irq.rs
@@ -1,0 +1,209 @@
+#[derive(Debug, Clone)]
+pub struct VrcIrq {
+    latch: u8,
+    counter: u8,
+    enabled: bool,
+    mode_cycle: bool,
+    enable_after_ack: bool,
+    asserted: bool,
+    prescaler: i32,
+    prescaler_init: i32,
+    prescaler_step: i32,
+}
+
+impl Default for VrcIrq {
+    fn default() -> Self {
+        Self {
+            latch: 0,
+            counter: 0,
+            enabled: false,
+            mode_cycle: false,
+            enable_after_ack: false,
+            asserted: false,
+            prescaler: 0,
+            prescaler_init: 341,
+            prescaler_step: 3,
+        }
+    }
+}
+
+impl VrcIrq {
+    pub fn new(prescaler_init: i32, prescaler_step: i32) -> Self {
+        Self {
+            prescaler_init,
+            prescaler_step,
+            ..Self::default()
+        }
+    }
+
+    pub fn write_latch(&mut self, value: u8) {
+        self.latch = value;
+    }
+
+    pub fn write_latch_low_nibble(&mut self, value: u8) {
+        self.latch = (self.latch & 0xF0) | (value & 0x0F);
+    }
+
+    pub fn write_latch_high_nibble(&mut self, value: u8) {
+        self.latch = (self.latch & 0x0F) | ((value & 0x0F) << 4);
+    }
+
+    pub fn write_control(&mut self, value: u8) {
+        self.asserted = false;
+        self.prescaler = self.prescaler_init;
+
+        self.mode_cycle = (value & 0b0000_0100) != 0;
+        let enable = (value & 0b0000_0010) != 0;
+        self.enable_after_ack = (value & 0b0000_0001) != 0;
+
+        if enable {
+            self.enabled = true;
+            self.counter = self.latch;
+        } else {
+            self.enabled = false;
+        }
+    }
+
+    pub fn write_acknowledge(&mut self) {
+        self.asserted = false;
+        self.enabled = self.enable_after_ack;
+    }
+
+    pub fn tick(&mut self) {
+        if !self.enabled {
+            return;
+        }
+
+        if self.mode_cycle {
+            self.clock_counter();
+            return;
+        }
+
+        self.prescaler -= self.prescaler_step;
+        if self.prescaler <= 0 {
+            self.prescaler += self.prescaler_init;
+            self.clock_counter();
+        }
+    }
+
+    pub fn pending(&self) -> bool {
+        self.asserted
+    }
+
+    pub fn latch(&self) -> u8 {
+        self.latch
+    }
+
+    pub fn counter(&self) -> u8 {
+        self.counter
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn mode_cycle(&self) -> bool {
+        self.mode_cycle
+    }
+
+    pub fn enable_after_ack(&self) -> bool {
+        self.enable_after_ack
+    }
+
+    pub fn prescaler(&self) -> i32 {
+        self.prescaler
+    }
+
+    pub fn set_counter(&mut self, counter: u8) {
+        self.counter = counter;
+    }
+
+    pub fn set_asserted(&mut self, asserted: bool) {
+        self.asserted = asserted;
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    pub fn set_mode_cycle(&mut self, mode_cycle: bool) {
+        self.mode_cycle = mode_cycle;
+    }
+
+    pub fn set_enable_after_ack(&mut self, enable_after_ack: bool) {
+        self.enable_after_ack = enable_after_ack;
+    }
+
+    pub fn set_prescaler(&mut self, prescaler: i32) {
+        self.prescaler = prescaler;
+    }
+
+    fn clock_counter(&mut self) {
+        if self.counter == 0xFF {
+            self.counter = self.latch;
+            self.asserted = true;
+        } else {
+            self.counter = self.counter.wrapping_add(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_control_in_cycle_mode_reloads_counter_and_asserts_after_overflow() {
+        let mut irq = VrcIrq::new(341, 3);
+
+        irq.write_latch(0xFE);
+        irq.write_control(0b0000_0110); // M=1, E=1, A=0
+
+        irq.tick();
+        assert!(!irq.pending());
+        irq.tick();
+        assert!(irq.pending());
+    }
+
+    #[test]
+    fn write_control_in_scanline_mode_asserts_after_114_ticks_from_ff() {
+        let mut irq = VrcIrq::new(341, 3);
+
+        irq.write_latch(0xFF);
+        irq.write_control(0b0000_0010); // M=0, E=1, A=0
+
+        for _ in 0..113 {
+            irq.tick();
+        }
+        assert!(!irq.pending());
+
+        irq.tick();
+        assert!(irq.pending());
+    }
+
+    #[test]
+    fn acknowledge_clears_pending_and_copies_enable_after_ack() {
+        let mut irq = VrcIrq::new(341, 3);
+
+        irq.write_latch(0xFE);
+        irq.write_control(0b0000_0111); // M=1, E=1, A=1
+        irq.tick();
+        irq.tick();
+        assert!(irq.pending());
+
+        irq.write_acknowledge();
+
+        assert!(!irq.pending());
+        assert!(irq.enabled());
+    }
+
+    #[test]
+    fn split_latch_writes_build_full_byte() {
+        let mut irq = VrcIrq::new(341, 3);
+
+        irq.write_latch_low_nibble(0x0E);
+        irq.write_latch_high_nibble(0x0F);
+
+        assert_eq!(irq.latch(), 0xFE);
+    }
+}


### PR DESCRIPTION
## Summary

Extract shared VRC IRQ behavior into a reusable `VrcIrq` core and refactor both VRC mapper implementations to use it.

## What changed

- Added shared IRQ module: `src/cartridge/vrc_irq.rs`
- Refactored `Vrc2Vrc4Mapper` to replace duplicated IRQ fields/methods with `irq: VrcIrq`
- Refactored `VRC6Mapper` to replace duplicated IRQ fields/methods with `irq: VrcIrq`
- Preserved existing snapshot byte layouts and register mappings for both mappers
- Registered new module in `src/cartridge/mod.rs`

## Behavior preservation notes

- VRC2/VRC4 still gates IRQ behavior behind `variant.has_irq()` (VRC2 paths remain no-op)
- VRC2/VRC4 normalized writes map to shared core exactly as before:
  - `$F000`: low nibble latch
  - `$F001`: high nibble latch
  - `$F002`: control (M/E/A + reload)
  - `$F003`: acknowledge
- VRC6 mapping remains:
  - `$F000`: latch
  - `$F001`: control
  - `$F002`: acknowledge
- Prescaler constants remain `341` and `3`

## Validation

- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test vrc2_vrc4::tests:: -- --nocapture`
- `cargo test vrc6::tests:: -- --nocapture`
- `cargo test vrc_irq::tests:: -- --nocapture`
- `cargo test --all-features`

Fixes #810
