### PR TITLE
Refactor: consolidate MMC2/MMC4 CHR latch logic (fix #811)

### DIFF
--- a/src/cartridge/mmc2.rs
+++ b/src/cartridge/mmc2.rs
@@ -7,6 +7,7 @@
 
 use crate::cartridge::base_mapper::BaseMapper;
 use crate::cartridge::ines::ConsoleType;
+use crate::cartridge::mmc2_mmc4_latch::{LatchTriggerMode, Mmc2Mmc4Latch};
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 /// Mapper 9 - MMC2 (PNROM boards)
@@ -36,13 +37,7 @@ pub struct MMC2Mapper {
     prg_bank_8k: u8,
 
     // --- CHR banking + latches ---
-    chr_bank_0_fd: u8,
-    chr_bank_0_fe: u8,
-    chr_bank_1_fd: u8,
-    chr_bank_1_fe: u8,
-
-    latch0_is_fd: bool,
-    latch1_is_fd: bool,
+    chr_latch: Mmc2Mmc4Latch,
 }
 
 impl MMC2Mapper {
@@ -70,12 +65,7 @@ impl MMC2Mapper {
         Self {
             base,
             prg_bank_8k: 0,
-            chr_bank_0_fd: 0,
-            chr_bank_0_fe: 0,
-            chr_bank_1_fd: 0,
-            chr_bank_1_fe: 0,
-            latch0_is_fd: false,
-            latch1_is_fd: false,
+            chr_latch: Mmc2Mmc4Latch::new(LatchTriggerMode::Mmc2),
         }
     }
 
@@ -85,28 +75,14 @@ impl MMC2Mapper {
     }
 
     fn update_chr_pages(&mut self) {
-        let bank0 = if self.latch0_is_fd {
-            self.chr_bank_0_fd
-        } else {
-            self.chr_bank_0_fe
-        };
-        let bank1 = if self.latch1_is_fd {
-            self.chr_bank_1_fd
-        } else {
-            self.chr_bank_1_fe
-        };
+        let bank0 = self.chr_latch.selected_bank_0();
+        let bank1 = self.chr_latch.selected_bank_1();
         self.base.select_chr_page(0, bank0 as i16);
         self.base.select_chr_page(1, bank1 as i16);
     }
 
     fn update_latches_for_chr_read(&mut self, addr: u16) {
-        match addr {
-            0x0FD8 => self.latch0_is_fd = true,
-            0x0FE8 => self.latch0_is_fd = false,
-            0x1FD8..=0x1FDF => self.latch1_is_fd = true,
-            0x1FE8..=0x1FEF => self.latch1_is_fd = false,
-            _ => {}
-        }
+        self.chr_latch.update_for_chr_read(addr);
     }
 }
 
@@ -133,19 +109,19 @@ impl Mapper for MMC2Mapper {
 
             // CHR bank registers
             0xB000..=0xBFFF => {
-                self.chr_bank_0_fd = value & 0x1F;
+                self.chr_latch.bank_0_fd = value & 0x1F;
                 self.update_chr_pages();
             }
             0xC000..=0xCFFF => {
-                self.chr_bank_0_fe = value & 0x1F;
+                self.chr_latch.bank_0_fe = value & 0x1F;
                 self.update_chr_pages();
             }
             0xD000..=0xDFFF => {
-                self.chr_bank_1_fd = value & 0x1F;
+                self.chr_latch.bank_1_fd = value & 0x1F;
                 self.update_chr_pages();
             }
             0xE000..=0xEFFF => {
-                self.chr_bank_1_fe = value & 0x1F;
+                self.chr_latch.bank_1_fe = value & 0x1F;
                 self.update_chr_pages();
             }
 
@@ -177,11 +153,11 @@ impl Mapper for MMC2Mapper {
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![
             self.prg_bank_8k,
-            self.chr_bank_0_fd,
-            self.chr_bank_0_fe,
-            self.chr_bank_1_fd,
-            self.chr_bank_1_fe,
-            (self.latch0_is_fd as u8) | ((self.latch1_is_fd as u8) << 1),
+            self.chr_latch.bank_0_fd,
+            self.chr_latch.bank_0_fe,
+            self.chr_latch.bank_1_fd,
+            self.chr_latch.bank_1_fe,
+            (self.chr_latch.latch0_is_fd as u8) | ((self.chr_latch.latch1_is_fd as u8) << 1),
             match self.base.mirroring() {
                 NametableLayout::Vertical => 0,
                 NametableLayout::Horizontal => 1,
@@ -193,12 +169,12 @@ impl Mapper for MMC2Mapper {
     fn restore_registers(&mut self, data: &[u8]) {
         if data.len() >= 7 {
             self.prg_bank_8k = data[0];
-            self.chr_bank_0_fd = data[1];
-            self.chr_bank_0_fe = data[2];
-            self.chr_bank_1_fd = data[3];
-            self.chr_bank_1_fe = data[4];
-            self.latch0_is_fd = (data[5] & 1) != 0;
-            self.latch1_is_fd = (data[5] & 2) != 0;
+            self.chr_latch.bank_0_fd = data[1];
+            self.chr_latch.bank_0_fe = data[2];
+            self.chr_latch.bank_1_fd = data[3];
+            self.chr_latch.bank_1_fe = data[4];
+            self.chr_latch.latch0_is_fd = (data[5] & 1) != 0;
+            self.chr_latch.latch1_is_fd = (data[5] & 2) != 0;
             let mirroring = match data[6] {
                 0 => NametableLayout::Vertical,
                 1 => NametableLayout::Horizontal,

--- a/src/cartridge/mmc2_mmc4_latch.rs
+++ b/src/cartridge/mmc2_mmc4_latch.rs
@@ -1,0 +1,136 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LatchTriggerMode {
+    Mmc2,
+    Mmc4,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Mmc2Mmc4Latch {
+    pub bank_0_fd: u8,
+    pub bank_0_fe: u8,
+    pub bank_1_fd: u8,
+    pub bank_1_fe: u8,
+    pub latch0_is_fd: bool,
+    pub latch1_is_fd: bool,
+    mode: LatchTriggerMode,
+}
+
+impl Mmc2Mmc4Latch {
+    pub fn new(mode: LatchTriggerMode) -> Self {
+        Self {
+            bank_0_fd: 0,
+            bank_0_fe: 0,
+            bank_1_fd: 0,
+            bank_1_fe: 0,
+            latch0_is_fd: false,
+            latch1_is_fd: false,
+            mode,
+        }
+    }
+
+    pub fn selected_bank_0(&self) -> u8 {
+        if self.latch0_is_fd {
+            self.bank_0_fd
+        } else {
+            self.bank_0_fe
+        }
+    }
+
+    pub fn selected_bank_1(&self) -> u8 {
+        if self.latch1_is_fd {
+            self.bank_1_fd
+        } else {
+            self.bank_1_fe
+        }
+    }
+
+    pub fn update_for_chr_read(&mut self, addr: u16) {
+        match self.mode {
+            LatchTriggerMode::Mmc2 => match addr {
+                0x0FD8 => self.latch0_is_fd = true,
+                0x0FE8 => self.latch0_is_fd = false,
+                0x1FD8..=0x1FDF => self.latch1_is_fd = true,
+                0x1FE8..=0x1FEF => self.latch1_is_fd = false,
+                _ => {}
+            },
+            LatchTriggerMode::Mmc4 => match addr {
+                0x0FD8..=0x0FDF => self.latch0_is_fd = true,
+                0x0FE8..=0x0FEF => self.latch0_is_fd = false,
+                0x1FD8..=0x1FDF => self.latch1_is_fd = true,
+                0x1FE8..=0x1FEF => self.latch1_is_fd = false,
+                _ => {}
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mmc2_latch0_switches_only_on_exact_fd8_and_fe8() {
+        let mut latch = Mmc2Mmc4Latch::new(LatchTriggerMode::Mmc2);
+
+        assert!(!latch.latch0_is_fd);
+
+        latch.update_for_chr_read(0x0FDF);
+        assert!(!latch.latch0_is_fd);
+
+        latch.update_for_chr_read(0x0FD8);
+        assert!(latch.latch0_is_fd);
+
+        latch.update_for_chr_read(0x0FEF);
+        assert!(latch.latch0_is_fd);
+
+        latch.update_for_chr_read(0x0FE8);
+        assert!(!latch.latch0_is_fd);
+    }
+
+    #[test]
+    fn mmc4_latch0_switches_on_fd8_fdf_and_fe8_fef_ranges() {
+        let mut latch = Mmc2Mmc4Latch::new(LatchTriggerMode::Mmc4);
+
+        assert!(!latch.latch0_is_fd);
+
+        latch.update_for_chr_read(0x0FDF);
+        assert!(latch.latch0_is_fd);
+
+        latch.update_for_chr_read(0x0FEF);
+        assert!(!latch.latch0_is_fd);
+    }
+
+    #[test]
+    fn both_modes_use_range_triggers_for_latch1() {
+        let mut mmc2 = Mmc2Mmc4Latch::new(LatchTriggerMode::Mmc2);
+        let mut mmc4 = Mmc2Mmc4Latch::new(LatchTriggerMode::Mmc4);
+
+        mmc2.update_for_chr_read(0x1FDF);
+        mmc4.update_for_chr_read(0x1FDF);
+        assert!(mmc2.latch1_is_fd);
+        assert!(mmc4.latch1_is_fd);
+
+        mmc2.update_for_chr_read(0x1FEF);
+        mmc4.update_for_chr_read(0x1FEF);
+        assert!(!mmc2.latch1_is_fd);
+        assert!(!mmc4.latch1_is_fd);
+    }
+
+    #[test]
+    fn selected_banks_follow_latch_states() {
+        let mut latch = Mmc2Mmc4Latch::new(LatchTriggerMode::Mmc4);
+        latch.bank_0_fd = 1;
+        latch.bank_0_fe = 2;
+        latch.bank_1_fd = 3;
+        latch.bank_1_fe = 4;
+
+        assert_eq!(latch.selected_bank_0(), 2);
+        assert_eq!(latch.selected_bank_1(), 4);
+
+        latch.latch0_is_fd = true;
+        latch.latch1_is_fd = true;
+
+        assert_eq!(latch.selected_bank_0(), 1);
+        assert_eq!(latch.selected_bank_1(), 3);
+    }
+}

--- a/src/cartridge/mmc4.rs
+++ b/src/cartridge/mmc4.rs
@@ -6,6 +6,7 @@
 //! - See CARTRIDGE_REVIEW.md sections 5 and 6 for remaining mapper test/documentation follow-up.
 
 use crate::cartridge::base_mapper::BaseMapper;
+use crate::cartridge::mmc2_mmc4_latch::{LatchTriggerMode, Mmc2Mmc4Latch};
 use crate::cartridge::{Mapper, MapperCapabilities, NametableLayout};
 
 /// Mapper 10 - MMC4 (FxROM boards)
@@ -34,13 +35,7 @@ pub struct MMC4Mapper {
     prg_bank_16k: u8,
 
     // --- CHR banking + latches ---
-    chr_bank_0_fd: u8,
-    chr_bank_0_fe: u8,
-    chr_bank_1_fd: u8,
-    chr_bank_1_fe: u8,
-
-    latch0_is_fd: bool,
-    latch1_is_fd: bool,
+    chr_latch: Mmc2Mmc4Latch,
 }
 
 impl MMC4Mapper {
@@ -65,12 +60,7 @@ impl MMC4Mapper {
         Self {
             base,
             prg_bank_16k: 0,
-            chr_bank_0_fd: 0,
-            chr_bank_0_fe: 0,
-            chr_bank_1_fd: 0,
-            chr_bank_1_fe: 0,
-            latch0_is_fd: false,
-            latch1_is_fd: false,
+            chr_latch: Mmc2Mmc4Latch::new(LatchTriggerMode::Mmc4),
         }
     }
 
@@ -80,28 +70,14 @@ impl MMC4Mapper {
     }
 
     fn update_chr_pages(&mut self) {
-        let bank0 = if self.latch0_is_fd {
-            self.chr_bank_0_fd
-        } else {
-            self.chr_bank_0_fe
-        };
-        let bank1 = if self.latch1_is_fd {
-            self.chr_bank_1_fd
-        } else {
-            self.chr_bank_1_fe
-        };
+        let bank0 = self.chr_latch.selected_bank_0();
+        let bank1 = self.chr_latch.selected_bank_1();
         self.base.select_chr_page(0, bank0 as i16);
         self.base.select_chr_page(1, bank1 as i16);
     }
 
     fn update_latches(&mut self, addr: u16) {
-        match addr {
-            0x0FD8..=0x0FDF => self.latch0_is_fd = true,
-            0x0FE8..=0x0FEF => self.latch0_is_fd = false,
-            0x1FD8..=0x1FDF => self.latch1_is_fd = true,
-            0x1FE8..=0x1FEF => self.latch1_is_fd = false,
-            _ => {}
-        }
+        self.chr_latch.update_for_chr_read(addr);
     }
 
     fn encode_mirroring(mirroring: NametableLayout) -> u8 {
@@ -141,19 +117,19 @@ impl Mapper for MMC4Mapper {
                 self.update_prg_banks();
             }
             0xB000..=0xBFFF => {
-                self.chr_bank_0_fd = value & 0x1F;
+                self.chr_latch.bank_0_fd = value & 0x1F;
                 self.update_chr_pages();
             }
             0xC000..=0xCFFF => {
-                self.chr_bank_0_fe = value & 0x1F;
+                self.chr_latch.bank_0_fe = value & 0x1F;
                 self.update_chr_pages();
             }
             0xD000..=0xDFFF => {
-                self.chr_bank_1_fd = value & 0x1F;
+                self.chr_latch.bank_1_fd = value & 0x1F;
                 self.update_chr_pages();
             }
             0xE000..=0xEFFF => {
-                self.chr_bank_1_fe = value & 0x1F;
+                self.chr_latch.bank_1_fe = value & 0x1F;
                 self.update_chr_pages();
             }
             0xF000..=0xFFFF => {
@@ -180,11 +156,11 @@ impl Mapper for MMC4Mapper {
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![
             self.prg_bank_16k,
-            self.chr_bank_0_fd,
-            self.chr_bank_0_fe,
-            self.chr_bank_1_fd,
-            self.chr_bank_1_fe,
-            (self.latch0_is_fd as u8) | ((self.latch1_is_fd as u8) << 1),
+            self.chr_latch.bank_0_fd,
+            self.chr_latch.bank_0_fe,
+            self.chr_latch.bank_1_fd,
+            self.chr_latch.bank_1_fe,
+            (self.chr_latch.latch0_is_fd as u8) | ((self.chr_latch.latch1_is_fd as u8) << 1),
             Self::encode_mirroring(self.base.mirroring()),
         ]
     }
@@ -192,12 +168,12 @@ impl Mapper for MMC4Mapper {
     fn restore_registers(&mut self, data: &[u8]) {
         if data.len() >= 7 {
             self.prg_bank_16k = data[0];
-            self.chr_bank_0_fd = data[1];
-            self.chr_bank_0_fe = data[2];
-            self.chr_bank_1_fd = data[3];
-            self.chr_bank_1_fe = data[4];
-            self.latch0_is_fd = (data[5] & 1) != 0;
-            self.latch1_is_fd = (data[5] & 2) != 0;
+            self.chr_latch.bank_0_fd = data[1];
+            self.chr_latch.bank_0_fe = data[2];
+            self.chr_latch.bank_1_fd = data[3];
+            self.chr_latch.bank_1_fe = data[4];
+            self.chr_latch.latch0_is_fd = (data[5] & 1) != 0;
+            self.chr_latch.latch1_is_fd = (data[5] & 2) != 0;
             self.base.set_mirroring(Self::decode_mirroring(data[6]));
             self.update_prg_banks();
             self.update_chr_pages();

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -53,6 +53,7 @@ mod mapper73;
 mod mapper_templates;
 mod mmc1;
 mod mmc2;
+mod mmc2_mmc4_latch;
 mod mmc3;
 mod mmc4;
 mod mmc5;


### PR DESCRIPTION
## Summary

Consolidate duplicated MMC2/MMC4 CHR latch logic into a shared helper while preserving mapper behavior and snapshot compatibility.

## What changed

- Added shared helper module: `src/cartridge/mmc2_mmc4_latch.rs`
  - `Mmc2Mmc4Latch`
  - `LatchTriggerMode::{Mmc2, Mmc4}`
- Refactored `MMC2Mapper` to use shared latch state/selection/update logic
- Refactored `MMC4Mapper` to use shared latch state/selection/update logic
- Kept existing PRG behavior, mirroring behavior, and save-state byte layout for both mappers
- Registered new module in `src/cartridge/mod.rs`

## Behavior preservation

- MMC2 low latch still switches only on exact `0x0FD8` / `0x0FE8`
- MMC4 low latch still switches on ranges `0x0FD8..=0x0FDF` / `0x0FE8..=0x0FEF`
- Both still use high latch ranges `0x1FD8..=0x1FDF` / `0x1FE8..=0x1FEF`
- Trigger read still uses old bank for that fetch; latch affects subsequent reads
- Snapshot/restore fields remain in the same order and encoding

## Validation

- `cargo test mmc2::tests:: -- --nocapture`
- `cargo test mmc4::tests:: -- --nocapture`
- `cargo test mmc2_mmc4_latch::tests:: -- --nocapture`
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

Fixes #811
