### PR TITLE
feat: add NametableLayout snapshot encode/decode methods (#813)

### DIFF
--- a/src/cartridge/bandai_fcg.rs
+++ b/src/cartridge/bandai_fcg.rs
@@ -234,15 +234,7 @@ impl Mapper for BandaiFcgMapper {
         snapshot.push((self.irq.counter() >> 8) as u8);
         snapshot.push((self.irq_latch & 0xFF) as u8);
         snapshot.push((self.irq_latch >> 8) as u8);
-        let mirroring = match self.base.mirroring() {
-            NametableLayout::Horizontal => 0,
-            NametableLayout::Vertical => 1,
-            NametableLayout::SingleScreenLower => 2,
-            NametableLayout::SingleScreenUpper => 3,
-            NametableLayout::SingleScreen => 2,
-            NametableLayout::FourScreen => 4,
-        };
-        snapshot.push(mirroring);
+        snapshot.push(self.base.mirroring().to_snapshot_byte());
         snapshot
     }
 
@@ -256,14 +248,8 @@ impl Mapper for BandaiFcgMapper {
             self.irq
                 .set_counter((data[10] as u16) | ((data[11] as u16) << 8));
             self.irq_latch = (data[12] as u16) | ((data[13] as u16) << 8);
-            self.base.set_mirroring(match data[14] {
-                0 => NametableLayout::Horizontal,
-                1 => NametableLayout::Vertical,
-                2 => NametableLayout::SingleScreenLower,
-                3 => NametableLayout::SingleScreenUpper,
-                4 => NametableLayout::FourScreen,
-                _ => NametableLayout::Horizontal,
-            });
+            self.base
+                .set_mirroring(NametableLayout::from_snapshot_byte(data[14]));
             self.update_banks();
         }
     }

--- a/src/cartridge/ines.rs
+++ b/src/cartridge/ines.rs
@@ -73,6 +73,37 @@ impl NametableLayout {
             Self::SingleScreen | Self::SingleScreenLower | Self::SingleScreenUpper => None,
         }
     }
+
+    /// Encode this layout as a single byte for snapshot/save-state purposes.
+    ///
+    /// Standard encoding: Horizontal=0, Vertical=1, SingleScreenLower=2,
+    /// SingleScreenUpper=3, FourScreen=4.
+    /// `SingleScreen` is treated as equivalent to `SingleScreenLower` (both → 2).
+    pub fn to_snapshot_byte(self) -> u8 {
+        match self {
+            Self::Horizontal => 0,
+            Self::Vertical => 1,
+            Self::SingleScreen | Self::SingleScreenLower => 2,
+            Self::SingleScreenUpper => 3,
+            Self::FourScreen => 4,
+        }
+    }
+
+    /// Decode a snapshot byte back into a `NametableLayout`.
+    ///
+    /// Standard encoding: 0=Horizontal, 1=Vertical, 2=SingleScreenLower,
+    /// 3=SingleScreenUpper, 4=FourScreen.
+    /// Unknown values default to `Horizontal`.
+    pub fn from_snapshot_byte(byte: u8) -> Self {
+        match byte {
+            0 => Self::Horizontal,
+            1 => Self::Vertical,
+            2 => Self::SingleScreenLower,
+            3 => Self::SingleScreenUpper,
+            4 => Self::FourScreen,
+            _ => Self::Horizontal,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -902,5 +933,99 @@ mod tests {
         let with_db = ParsedRom::parse(&rom, Some(&db)).expect("parse with db");
         assert_eq!(without_db.header.mapper, with_db.header.mapper);
         assert_eq!(without_db.header.mirroring, with_db.header.mirroring);
+    }
+
+    #[test]
+    fn to_snapshot_byte_horizontal() {
+        assert_eq!(NametableLayout::Horizontal.to_snapshot_byte(), 0);
+    }
+
+    #[test]
+    fn to_snapshot_byte_vertical() {
+        assert_eq!(NametableLayout::Vertical.to_snapshot_byte(), 1);
+    }
+
+    #[test]
+    fn to_snapshot_byte_single_screen_lower() {
+        assert_eq!(NametableLayout::SingleScreenLower.to_snapshot_byte(), 2);
+    }
+
+    #[test]
+    fn to_snapshot_byte_single_screen_aliases_lower() {
+        assert_eq!(NametableLayout::SingleScreen.to_snapshot_byte(), 2);
+    }
+
+    #[test]
+    fn to_snapshot_byte_single_screen_upper() {
+        assert_eq!(NametableLayout::SingleScreenUpper.to_snapshot_byte(), 3);
+    }
+
+    #[test]
+    fn to_snapshot_byte_four_screen() {
+        assert_eq!(NametableLayout::FourScreen.to_snapshot_byte(), 4);
+    }
+
+    #[test]
+    fn from_snapshot_byte_horizontal() {
+        assert_eq!(
+            NametableLayout::from_snapshot_byte(0),
+            NametableLayout::Horizontal
+        );
+    }
+
+    #[test]
+    fn from_snapshot_byte_vertical() {
+        assert_eq!(
+            NametableLayout::from_snapshot_byte(1),
+            NametableLayout::Vertical
+        );
+    }
+
+    #[test]
+    fn from_snapshot_byte_single_screen_lower() {
+        assert_eq!(
+            NametableLayout::from_snapshot_byte(2),
+            NametableLayout::SingleScreenLower
+        );
+    }
+
+    #[test]
+    fn from_snapshot_byte_single_screen_upper() {
+        assert_eq!(
+            NametableLayout::from_snapshot_byte(3),
+            NametableLayout::SingleScreenUpper
+        );
+    }
+
+    #[test]
+    fn from_snapshot_byte_four_screen() {
+        assert_eq!(
+            NametableLayout::from_snapshot_byte(4),
+            NametableLayout::FourScreen
+        );
+    }
+
+    #[test]
+    fn from_snapshot_byte_unknown_defaults_to_horizontal() {
+        assert_eq!(
+            NametableLayout::from_snapshot_byte(255),
+            NametableLayout::Horizontal
+        );
+    }
+
+    #[test]
+    fn snapshot_byte_roundtrip_all_variants() {
+        let variants = [
+            NametableLayout::Horizontal,
+            NametableLayout::Vertical,
+            NametableLayout::SingleScreenLower,
+            NametableLayout::SingleScreenUpper,
+            NametableLayout::FourScreen,
+        ];
+        for &layout in &variants {
+            let byte = layout.to_snapshot_byte();
+            let restored = NametableLayout::from_snapshot_byte(byte);
+            assert_eq!(restored, layout, "roundtrip failed for {layout:?}");
+        }
     }
 }

--- a/src/cartridge/multicart_15.rs
+++ b/src/cartridge/multicart_15.rs
@@ -142,14 +142,12 @@ impl Mapper for Multicart15Mapper {
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
-        let mirroring = match self.mirroring {
-            NametableLayout::Horizontal => 0,
-            NametableLayout::Vertical => 1,
-            NametableLayout::SingleScreen | NametableLayout::SingleScreenLower => 2,
-            NametableLayout::SingleScreenUpper => 3,
-            NametableLayout::FourScreen => 4,
-        };
-        vec![self.bank_select, self.sub_bank, self.mode, mirroring]
+        vec![
+            self.bank_select,
+            self.sub_bank,
+            self.mode,
+            self.mirroring.to_snapshot_byte(),
+        ]
     }
 
     fn restore_registers(&mut self, data: &[u8]) {
@@ -157,14 +155,7 @@ impl Mapper for Multicart15Mapper {
             self.bank_select = data[0];
             self.sub_bank = data[1];
             self.mode = data[2];
-            self.mirroring = match data[3] {
-                0 => NametableLayout::Horizontal,
-                1 => NametableLayout::Vertical,
-                2 => NametableLayout::SingleScreen,
-                3 => NametableLayout::SingleScreenUpper,
-                4 => NametableLayout::FourScreen,
-                _ => NametableLayout::Horizontal,
-            };
+            self.mirroring = NametableLayout::from_snapshot_byte(data[3]);
             self.update_banks();
         }
     }

--- a/src/cartridge/nina_tengen.rs
+++ b/src/cartridge/nina_tengen.rs
@@ -115,28 +115,18 @@ impl Mapper for NinaTengenMapper {
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
-        let mirroring = match self.mirroring {
-            NametableLayout::Horizontal => 0,
-            NametableLayout::Vertical => 1,
-            NametableLayout::SingleScreen | NametableLayout::SingleScreenLower => 2,
-            NametableLayout::SingleScreenUpper => 3,
-            NametableLayout::FourScreen => 4,
-        };
-        vec![self.prg_bank_select, self.chr_bank_select, mirroring]
+        vec![
+            self.prg_bank_select,
+            self.chr_bank_select,
+            self.mirroring.to_snapshot_byte(),
+        ]
     }
 
     fn restore_registers(&mut self, data: &[u8]) {
         if data.len() >= 3 {
             self.prg_bank_select = data[0];
             self.chr_bank_select = data[1];
-            self.mirroring = match data[2] {
-                0 => NametableLayout::Horizontal,
-                1 => NametableLayout::Vertical,
-                2 => NametableLayout::SingleScreen,
-                3 => NametableLayout::SingleScreenUpper,
-                4 => NametableLayout::FourScreen,
-                _ => NametableLayout::Horizontal,
-            };
+            self.mirroring = NametableLayout::from_snapshot_byte(data[2]);
             self.update_banks();
         }
     }

--- a/src/cartridge/sunsoft_fme7.rs
+++ b/src/cartridge/sunsoft_fme7.rs
@@ -285,15 +285,7 @@ impl Mapper for SunsoftFme7Mapper {
         snapshot.push(flags);
         snapshot.push((self.irq.counter() & 0xFF) as u8);
         snapshot.push((self.irq.counter() >> 8) as u8);
-        let mirroring = match self.base.mirroring() {
-            NametableLayout::Horizontal => 0,
-            NametableLayout::Vertical => 1,
-            NametableLayout::SingleScreenLower => 2,
-            NametableLayout::SingleScreenUpper => 3,
-            NametableLayout::SingleScreen => 2,
-            NametableLayout::FourScreen => 4,
-        };
-        snapshot.push(mirroring);
+        snapshot.push(self.base.mirroring().to_snapshot_byte());
         snapshot
     }
 
@@ -310,14 +302,8 @@ impl Mapper for SunsoftFme7Mapper {
             self.irq.set_pending((flags & 16) != 0);
             self.irq
                 .set_counter((data[14] as u16) | ((data[15] as u16) << 8));
-            self.base.set_mirroring(match data[16] {
-                0 => NametableLayout::Horizontal,
-                1 => NametableLayout::Vertical,
-                2 => NametableLayout::SingleScreenLower,
-                3 => NametableLayout::SingleScreenUpper,
-                4 => NametableLayout::FourScreen,
-                _ => NametableLayout::Horizontal,
-            });
+            self.base
+                .set_mirroring(NametableLayout::from_snapshot_byte(data[16]));
             self.update_banks();
         }
     }

--- a/src/cartridge/vrc2_vrc4.rs
+++ b/src/cartridge/vrc2_vrc4.rs
@@ -533,14 +533,7 @@ impl Mapper for Vrc2Vrc4Mapper {
         }
         snapshot.push(flags);
         snapshot.extend_from_slice(&self.irq.prescaler().to_le_bytes());
-        let mirroring = match self.base.mirroring() {
-            NametableLayout::Horizontal => 0u8,
-            NametableLayout::Vertical => 1,
-            NametableLayout::SingleScreenLower | NametableLayout::SingleScreen => 2,
-            NametableLayout::SingleScreenUpper => 3,
-            NametableLayout::FourScreen => 4,
-        };
-        snapshot.push(mirroring);
+        snapshot.push(self.base.mirroring().to_snapshot_byte());
         snapshot
     }
 
@@ -566,14 +559,8 @@ impl Mapper for Vrc2Vrc4Mapper {
             self.prg_ram_enabled = (flags & Self::FLAG_PRG_RAM_ENABLED) != 0;
             self.irq
                 .set_prescaler(i32::from_le_bytes([data[22], data[23], data[24], data[25]]));
-            self.base.set_mirroring(match data[26] {
-                0 => NametableLayout::Horizontal,
-                1 => NametableLayout::Vertical,
-                2 => NametableLayout::SingleScreenLower,
-                3 => NametableLayout::SingleScreenUpper,
-                4 => NametableLayout::FourScreen,
-                _ => NametableLayout::Horizontal,
-            });
+            self.base
+                .set_mirroring(NametableLayout::from_snapshot_byte(data[26]));
             self.update_banks();
         }
     }

--- a/src/cartridge/vrc6.rs
+++ b/src/cartridge/vrc6.rs
@@ -495,13 +495,7 @@ impl Mapper for VRC6Mapper {
         snapshot.push(flags);
         let prescaler_bytes = self.irq.prescaler().to_le_bytes();
         snapshot.extend_from_slice(&prescaler_bytes);
-        snapshot.push(match self.base.mirroring() {
-            NametableLayout::Horizontal => 0,
-            NametableLayout::Vertical => 1,
-            NametableLayout::SingleScreen | NametableLayout::SingleScreenLower => 2,
-            NametableLayout::SingleScreenUpper => 3,
-            NametableLayout::FourScreen => 4,
-        });
+        snapshot.push(self.base.mirroring().to_snapshot_byte());
         snapshot.push(self.audio.global_halt as u8);
         snapshot.push(self.audio.global_shift);
 
@@ -546,14 +540,8 @@ impl Mapper for VRC6Mapper {
             self.irq.set_asserted((flags & 8) != 0);
             self.irq
                 .set_prescaler(i32::from_le_bytes([data[14], data[15], data[16], data[17]]));
-            self.base.set_mirroring(match data[18] {
-                0 => NametableLayout::Horizontal,
-                1 => NametableLayout::Vertical,
-                2 => NametableLayout::SingleScreen,
-                3 => NametableLayout::SingleScreenUpper,
-                4 => NametableLayout::FourScreen,
-                _ => NametableLayout::Horizontal,
-            });
+            self.base
+                .set_mirroring(NametableLayout::from_snapshot_byte(data[18]));
         }
 
         if data.len() >= 41 {


### PR DESCRIPTION
## Summary

Adds `to_snapshot_byte()` and `from_snapshot_byte()` methods to `NametableLayout` to eliminate manual encode/decode duplication in mapper snapshot/restore code.

## Changes

- Added `NametableLayout::to_snapshot_byte()` and `NametableLayout::from_snapshot_byte()` with standard encoding (H=0, V=1, SSL/SS=2, SSU=3, FS=4)
- Replaced manual encode/decode in 6 mappers: vrc6, vrc2_vrc4, bandai_fcg, nina_tengen, multicart_15, sunsoft_fme7
- 13 new unit tests covering all variants, roundtrip, and unknown byte handling

## Not changed

Mappers with incompatible encoding schemes were intentionally left unchanged:
- mapper65, mapper67: swapped V/H encoding (V=0, H=1)
- Binary-toggle mappers (mapper48, mapper56, mapper64, mapper242, mapper255, mmc2, mmc4, irem_g101, taito_tc0190): only H/V
- MMC3, MMC5: unique variant ordering

## Testing

- 6,238 nextest tests pass
- 46 WASM tests pass
- 27 Python tests pass
- 154 web tests pass
- cargo clippy clean, cargo fmt clean

Part of #808 (mapper code deduplication).
Closes #813
