### PR TITLE
feat(#815): Add NROM-128/256 PRG banking helper to BaseMapper

### DIFF
--- a/src/cartridge/base_mapper.rs
+++ b/src/cartridge/base_mapper.rs
@@ -342,6 +342,22 @@ impl BaseMapper {
         self.prg_pages[slot] = resolve_bank(bank, self.prg_bank_count());
     }
 
+    /// Apply NROM-128 or NROM-256 PRG banking to two 16KB slots.
+    ///
+    /// - NROM-128 (`nrom_128 = true`): maps the same 16KB bank to both $8000 and $C000.
+    /// - NROM-256 (`nrom_128 = false`): maps a consecutive 16KB bank pair (even/odd).
+    ///   Bit 0 of `bank` is cleared for slot 0 and set for slot 1.
+    pub fn apply_nrom_prg_banking(&mut self, bank: u8, nrom_128: bool) {
+        if nrom_128 {
+            self.select_prg_page(0, bank as i16);
+            self.select_prg_page(1, bank as i16);
+        } else {
+            let even = (bank & !1) as i16;
+            self.select_prg_page(0, even);
+            self.select_prg_page(1, even | 1);
+        }
+    }
+
     /// Select a CHR bank for the given slot.
     ///
     /// Negative values count from the end: -1 = last bank, -2 = second-to-last, etc.
@@ -767,6 +783,71 @@ mod tests {
         base.select_prg_page(0, 1);
         assert_eq!(base.read_prg_banked(0x8000), 1);
         assert_eq!(base.read_prg_banked(0xFFFF), 1);
+    }
+
+    // ========================================================================
+    // NROM PRG Banking Tests
+    // ========================================================================
+
+    #[test]
+    fn test_nrom128_mirrors_same_bank_to_both_slots() {
+        // 6 banks avoids power-of-two wrapping false-passes
+        let mut base = make_prg_banked_mapper(6, 0x4000);
+        base.apply_nrom_prg_banking(3, true);
+        assert_eq!(base.read_prg_banked(0x8000), 3);
+        assert_eq!(base.read_prg_banked(0xC000), 3);
+    }
+
+    #[test]
+    fn test_nrom256_selects_consecutive_bank_pair() {
+        let mut base = make_prg_banked_mapper(6, 0x4000);
+        base.apply_nrom_prg_banking(2, false);
+        assert_eq!(base.read_prg_banked(0x8000), 2);
+        assert_eq!(base.read_prg_banked(0xC000), 3);
+    }
+
+    #[test]
+    fn test_nrom256_clears_bit0_for_slot0() {
+        let mut base = make_prg_banked_mapper(6, 0x4000);
+        // Passing odd bank 3: slot 0 should get bank 2 (bit 0 cleared),
+        // slot 1 should get bank 3 (bit 0 set).
+        base.apply_nrom_prg_banking(3, false);
+        assert_eq!(base.read_prg_banked(0x8000), 2);
+        assert_eq!(base.read_prg_banked(0xC000), 3);
+    }
+
+    #[test]
+    fn test_nrom128_bank_zero() {
+        let mut base = make_prg_banked_mapper(6, 0x4000);
+        base.apply_nrom_prg_banking(0, true);
+        assert_eq!(base.read_prg_banked(0x8000), 0);
+        assert_eq!(base.read_prg_banked(0xC000), 0);
+    }
+
+    #[test]
+    fn test_nrom256_bank_zero() {
+        let mut base = make_prg_banked_mapper(6, 0x4000);
+        base.apply_nrom_prg_banking(0, false);
+        assert_eq!(base.read_prg_banked(0x8000), 0);
+        assert_eq!(base.read_prg_banked(0xC000), 1);
+    }
+
+    #[test]
+    fn test_nrom128_wraps_bank_to_available() {
+        // 6 banks → bank 7 should wrap to bank 1 (7 % 6 = 1)
+        let mut base = make_prg_banked_mapper(6, 0x4000);
+        base.apply_nrom_prg_banking(7, true);
+        assert_eq!(base.read_prg_banked(0x8000), 1);
+        assert_eq!(base.read_prg_banked(0xC000), 1);
+    }
+
+    #[test]
+    fn test_nrom256_wraps_bank_to_available() {
+        // 6 banks → bank 4: slot 0 = 4 % 6 = 4, slot 1 = 5 % 6 = 5
+        let mut base = make_prg_banked_mapper(6, 0x4000);
+        base.apply_nrom_prg_banking(4, false);
+        assert_eq!(base.read_prg_banked(0x8000), 4);
+        assert_eq!(base.read_prg_banked(0xC000), 5);
     }
 
     // ========================================================================

--- a/src/cartridge/mapper58.rs
+++ b/src/cartridge/mapper58.rs
@@ -64,16 +64,8 @@ impl Mapper58 {
     }
 
     fn update_banks(&mut self) {
-        if self.prg_mode {
-            // NROM-128: same bank at both $8000 and $C000
-            self.base.select_prg_page(0, self.prg_bank as i16);
-            self.base.select_prg_page(1, self.prg_bank as i16);
-        } else {
-            // NROM-256: consecutive 16KB banks
-            let even = (self.prg_bank & !1) as i16;
-            self.base.select_prg_page(0, even);
-            self.base.select_prg_page(1, even | 1);
-        }
+        self.base
+            .apply_nrom_prg_banking(self.prg_bank, self.prg_mode);
         self.base.select_chr_page(0, self.chr_bank as i16);
     }
 }

--- a/src/cartridge/mapper59.rs
+++ b/src/cartridge/mapper59.rs
@@ -77,15 +77,8 @@ impl Mapper59 {
     }
 
     fn update_banks(&mut self) {
-        if self.prg_mode_128 {
-            let bank = ((self.prg_pp as i16) << 1) | (self.prg_p as i16);
-            self.base.select_prg_page(0, bank);
-            self.base.select_prg_page(1, bank);
-        } else {
-            let base_bank = (self.prg_pp as i16) << 1;
-            self.base.select_prg_page(0, base_bank);
-            self.base.select_prg_page(1, base_bank + 1);
-        }
+        let bank = (self.prg_pp << 1) | self.prg_p;
+        self.base.apply_nrom_prg_banking(bank, self.prg_mode_128);
         self.base.select_chr_page(0, self.chr_bank as i16);
     }
 }

--- a/src/cartridge/mapper61.rs
+++ b/src/cartridge/mapper61.rs
@@ -111,17 +111,8 @@ impl Mapper61 {
         let chr = self.effective_chr_bank();
         self.base.select_chr_page(0, chr as i16);
 
-        let base = (self.prg_base as i16) << 1;
-        if self.prg_mode {
-            // NROM-128: same bank at both slots
-            let bank = base | (self.prg_a14 as i16);
-            self.base.select_prg_page(0, bank);
-            self.base.select_prg_page(1, bank);
-        } else {
-            // NROM-256: consecutive banks
-            self.base.select_prg_page(0, base);
-            self.base.select_prg_page(1, base + 1);
-        }
+        let bank = (self.prg_base << 1) | self.prg_a14;
+        self.base.apply_nrom_prg_banking(bank, self.prg_mode);
     }
 
     fn effective_chr_bank(&self) -> usize {

--- a/src/cartridge/mapper62.rs
+++ b/src/cartridge/mapper62.rs
@@ -74,14 +74,8 @@ impl Mapper62 {
     }
 
     fn update_banks(&mut self) {
-        if self.prg_mode {
-            self.base.select_prg_page(0, self.prg_bank as i16);
-            self.base.select_prg_page(1, self.prg_bank as i16);
-        } else {
-            let even = (self.prg_bank & !1) as i16;
-            self.base.select_prg_page(0, even);
-            self.base.select_prg_page(1, even | 1);
-        }
+        self.base
+            .apply_nrom_prg_banking(self.prg_bank, self.prg_mode);
         self.base.select_chr_page(0, self.chr_bank as i16);
     }
 }


### PR DESCRIPTION
Closes #815

## Summary

Adds `BaseMapper::apply_nrom_prg_banking(bank: u8, nrom_128: bool)` to encapsulate the NROM-128/256 PRG banking pattern shared across 4 multicart mappers.

## Changes

### New helper method
- `apply_nrom_prg_banking(bank, nrom_128)` on `BaseMapper`
  - NROM-128 (`nrom_128 = true`): mirrors same 16KB bank to both $8000 and $C000
  - NROM-256 (`nrom_128 = false`): maps consecutive even/odd 16KB bank pair (clears bit 0 for slot 0, sets bit 0 for slot 1)

### Mapper refactoring
- **Mapper 58**: Replaced 8-line if/else with single `apply_nrom_prg_banking` call
- **Mapper 59**: Replaced 7-line if/else with single call (bank computed from `prg_pp`/`prg_p` fields)
- **Mapper 61**: Replaced 8-line if/else with single call (bank computed from `prg_base`/`prg_a14` fields)
- **Mapper 62**: Replaced 8-line if/else with single `apply_nrom_prg_banking` call

### Tests
- 7 new unit tests for `apply_nrom_prg_banking` covering NROM-128, NROM-256, bit 0 clearing, bank 0 edge case, and bank wrapping (using non-power-of-two bank count to avoid false passes)

## Pre-merge checks
- cargo fmt: clean
- cargo clippy: clean (0 warnings)
- cargo nextest: 6282 tests pass
- wasm-pack: 46 tests pass
- Python: 27 tests pass
- npm: all tests pass
