### PR TITLE
Add PRG-ROM banking at $6000-$7FFF to BaseMapper

### DIFF
--- a/src/cartridge/base_mapper.rs
+++ b/src/cartridge/base_mapper.rs
@@ -54,6 +54,9 @@ pub struct BaseMapper {
     chr_pages: Vec<usize>,
     /// Whether bus conflicts are enabled (write value ANDed with ROM at same address).
     bus_conflicts: bool,
+    /// Optional PRG-ROM bank resolved for the $6000-$7FFF region.
+    /// `None` means $6000 banking is not configured (default: PRG-RAM or open bus).
+    prg_6000_bank: Option<usize>,
 }
 
 /// Resolve a signed bank number to an unsigned index, wrapping to available banks.
@@ -107,6 +110,7 @@ impl BaseMapper {
             prg_pages: Vec::new(),
             chr_pages: Vec::new(),
             bus_conflicts: false,
+            prg_6000_bank: None,
         }
     }
 
@@ -356,6 +360,52 @@ impl BaseMapper {
             self.select_prg_page(0, even);
             self.select_prg_page(1, even | 1);
         }
+    }
+
+    /// Enable 8KB PRG-ROM banking at $6000-$7FFF.
+    ///
+    /// After calling this, `select_prg_6000_page()` can be used to choose
+    /// which 8KB bank of PRG-ROM appears at $6000-$7FFF, and
+    /// `try_read_prg_6000()` will resolve reads from that region.
+    ///
+    /// Initially maps bank 0.
+    pub fn configure_prg_6000_banking(&mut self) {
+        self.prg_6000_bank = Some(0);
+    }
+
+    /// Select which 8KB PRG-ROM bank maps to $6000-$7FFF.
+    ///
+    /// Requires `configure_prg_6000_banking()` to have been called first.
+    /// Negative values count from the end: -1 = last 8KB bank, etc.
+    pub fn select_prg_6000_page(&mut self, bank: i16) {
+        let bank_count = self.prg_rom.len() / 0x2000;
+        if bank_count > 0 {
+            self.prg_6000_bank = Some(resolve_bank(bank, bank_count));
+        }
+    }
+
+    /// Try to read a byte from the $6000-$7FFF PRG-ROM banking region.
+    ///
+    /// Returns `Some(byte)` if $6000 banking is configured and `addr` is in
+    /// $6000-$7FFF. Returns `None` otherwise (so the caller can fall through
+    /// to PRG-RAM or open bus).
+    pub fn try_read_prg_6000(&self, addr: u16) -> Option<u8> {
+        let bank = self.prg_6000_bank?;
+        if !(0x6000..=0x7FFF).contains(&addr) {
+            return None;
+        }
+        let offset = (addr as usize) - 0x6000;
+        Some(
+            self.prg_rom
+                .get(bank * 0x2000 + offset)
+                .copied()
+                .unwrap_or(0),
+        )
+    }
+
+    /// Returns `true` if $6000-$7FFF PRG-ROM banking is configured.
+    pub fn has_prg_6000_banking(&self) -> bool {
+        self.prg_6000_bank.is_some()
     }
 
     /// Select a CHR bank for the given slot.
@@ -848,6 +898,86 @@ mod tests {
         base.apply_nrom_prg_banking(4, false);
         assert_eq!(base.read_prg_banked(0x8000), 4);
         assert_eq!(base.read_prg_banked(0xC000), 5);
+    }
+
+    // ========================================================================
+    // $6000 PRG-ROM Banking Tests
+    // ========================================================================
+
+    /// Helper: create a BaseMapper with identifiable 8KB PRG-ROM banks and $6000 banking.
+    fn make_prg_6000_mapper(num_8k_banks: usize) -> BaseMapper {
+        let prg_rom = make_bank_marked_rom(num_8k_banks, 0x2000);
+        let ctx =
+            MapperContext::new_for_test(0, prg_rom, vec![0; 8192], NametableLayout::Horizontal);
+        let mut base = BaseMapper::new(&ctx, MapperCapabilities::default());
+        base.configure_prg_6000_banking();
+        base
+    }
+
+    #[test]
+    fn test_prg_6000_default_maps_bank_0() {
+        let base = make_prg_6000_mapper(6);
+        assert_eq!(base.try_read_prg_6000(0x6000), Some(0));
+        assert_eq!(base.try_read_prg_6000(0x7FFF), Some(0));
+    }
+
+    #[test]
+    fn test_prg_6000_select_bank() {
+        let mut base = make_prg_6000_mapper(6);
+        base.select_prg_6000_page(3);
+        assert_eq!(base.try_read_prg_6000(0x6000), Some(3));
+        assert_eq!(base.try_read_prg_6000(0x7FFF), Some(3));
+    }
+
+    #[test]
+    fn test_prg_6000_bank_wraps() {
+        // 6 banks → bank 7 wraps to 1 (7 % 6 = 1)
+        let mut base = make_prg_6000_mapper(6);
+        base.select_prg_6000_page(7);
+        assert_eq!(base.try_read_prg_6000(0x6000), Some(1));
+    }
+
+    #[test]
+    fn test_prg_6000_negative_bank() {
+        // 6 banks → -1 = last bank = 5
+        let mut base = make_prg_6000_mapper(6);
+        base.select_prg_6000_page(-1);
+        assert_eq!(base.try_read_prg_6000(0x6000), Some(5));
+    }
+
+    #[test]
+    fn test_prg_6000_returns_none_when_not_configured() {
+        // No configure_prg_6000_banking() call
+        let prg_rom = make_bank_marked_rom(4, 0x2000);
+        let ctx =
+            MapperContext::new_for_test(0, prg_rom, vec![0; 8192], NametableLayout::Horizontal);
+        let base = BaseMapper::new(&ctx, MapperCapabilities::default());
+        assert_eq!(base.try_read_prg_6000(0x6000), None);
+    }
+
+    #[test]
+    fn test_prg_6000_returns_none_outside_range() {
+        let base = make_prg_6000_mapper(6);
+        assert_eq!(base.try_read_prg_6000(0x5FFF), None);
+        assert_eq!(base.try_read_prg_6000(0x8000), None);
+    }
+
+    #[test]
+    fn test_has_prg_6000_banking_false_by_default() {
+        let ctx = MapperContext::new_for_test(
+            0,
+            vec![0; 0x8000],
+            vec![0; 8192],
+            NametableLayout::Horizontal,
+        );
+        let base = BaseMapper::new(&ctx, MapperCapabilities::default());
+        assert!(!base.has_prg_6000_banking());
+    }
+
+    #[test]
+    fn test_has_prg_6000_banking_true_after_configure() {
+        let base = make_prg_6000_mapper(4);
+        assert!(base.has_prg_6000_banking());
     }
 
     // ========================================================================

--- a/src/cartridge/mapper.rs
+++ b/src/cartridge/mapper.rs
@@ -260,11 +260,15 @@ pub trait Mapper {
     /// - $8000-$FFFF: PRG-ROM (with bank switching on advanced mappers)
     ///   Returns the byte at the given address after bank translation.
     ///
-    /// Default tries PRG-RAM first via `BaseMapper::try_read_prg_ram`, then
-    /// falls back to PRG-ROM via `BaseMapper::read_prg_rom` (which auto-detects
-    /// banked vs fixed access).
+    /// Default checks for $6000-$7FFF PRG-ROM banking first, then tries
+    /// PRG-RAM via `BaseMapper::try_read_prg_ram`, then falls back to
+    /// PRG-ROM via `BaseMapper::read_prg_rom` (which auto-detects banked
+    /// vs fixed access).
     /// Mappers with custom PRG address decoding must override this.
     fn read_prg(&self, addr: u16) -> u8 {
+        if let Some(value) = self.base().try_read_prg_6000(addr) {
+            return value;
+        }
         if let Some(value) = self.base().try_read_prg_ram(addr) {
             return value;
         }

--- a/src/cartridge/mapper42.rs
+++ b/src/cartridge/mapper42.rs
@@ -49,6 +49,7 @@ impl Mapper42 {
 
         let mut base = BaseMapper::new(&ctx, capabilities);
         base.configure_prg_banking(Self::PRG_BANK_SIZE);
+        base.configure_prg_6000_banking();
         base.configure_chr_banking(Self::CHR_BANK_SIZE);
         base.set_mirroring(mirroring);
 
@@ -67,6 +68,9 @@ impl Mapper42 {
     }
 
     fn update_banks(&mut self) {
+        // $6000-$7FFF: switchable PRG-ROM bank
+        self.base.select_prg_6000_page(self.prg_bank as i16);
+
         // $8000-$FFFF: fixed last 4 × 8KB banks
         self.base.select_prg_page(0, -4);
         self.base.select_prg_page(1, -3);
@@ -76,19 +80,6 @@ impl Mapper42 {
         // CHR: single 8KB bank
         self.base.select_chr_page(0, self.chr_bank as i16);
     }
-
-    fn read_prg_6000(&self, addr: u16) -> u8 {
-        let prg = self.base.prg_rom();
-        let bank_count = prg.len() / Self::PRG_BANK_SIZE;
-        if bank_count == 0 {
-            return 0;
-        }
-        let bank = (self.prg_bank as usize) % bank_count;
-        let offset = (addr as usize) & (Self::PRG_BANK_SIZE - 1);
-        prg.get(bank * Self::PRG_BANK_SIZE + offset)
-            .copied()
-            .unwrap_or(0)
-    }
 }
 
 impl Mapper for Mapper42 {
@@ -97,14 +88,6 @@ impl Mapper for Mapper42 {
     }
     fn base_mut(&mut self) -> &mut BaseMapper {
         &mut self.base
-    }
-
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x6000..=0x7FFF => self.read_prg_6000(addr),
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
@@ -117,6 +100,7 @@ impl Mapper for Mapper42 {
             0xE000 => {
                 // PRG Select: bits 3:0
                 self.prg_bank = value & 0x0F;
+                self.base.select_prg_6000_page(self.prg_bank as i16);
             }
             0xE001 => {
                 // Mirroring: bit 3 (0=Vertical, 1=Horizontal)
@@ -136,11 +120,6 @@ impl Mapper for Mapper42 {
             }
             _ => {}
         }
-    }
-
-    fn wram_size(&self) -> usize {
-        // No WRAM: $6000-$7FFF is mapped to PRG ROM, not RAM.
-        0
     }
 
     fn cpu_cycle(&mut self) {

--- a/src/cartridge/mapper43.rs
+++ b/src/cartridge/mapper43.rs
@@ -56,6 +56,7 @@ impl Mapper43 {
 
         let mut base = BaseMapper::new(&ctx, capabilities);
         base.configure_prg_banking(Self::PRG_BANK_SIZE);
+        base.configure_prg_6000_banking();
         base.set_mirroring(mirroring);
 
         let mut mapper = Self {
@@ -70,6 +71,9 @@ impl Mapper43 {
     }
 
     fn update_banks(&mut self) {
+        // $6000-$7FFF: fixed bank 2
+        self.base.select_prg_6000_page(2);
+
         // $8000=bank1, $A000=bank0, $C000=switchable, $E000=bank9
         self.base.select_prg_page(0, 1);
         self.base.select_prg_page(1, 0);
@@ -78,23 +82,11 @@ impl Mapper43 {
         self.base.select_prg_page(3, 9);
     }
 
-    fn read_prg_custom(&self, addr: u16) -> u8 {
+    fn read_prg_5000(&self, addr: u16) -> u8 {
         let prg = self.base.prg_rom();
-        match addr {
-            0x5000..=0x5FFF => {
-                // 2KB chip at 0x10000, masked to 2KB
-                let chip_offset = addr as usize & 0x7FF;
-                prg.get(0x10000 + chip_offset).copied().unwrap_or(0)
-            }
-            0x6000..=0x7FFF => {
-                // Fixed bank 2
-                let offset = (addr as usize) & (Self::PRG_BANK_SIZE - 1);
-                prg.get(2 * Self::PRG_BANK_SIZE + offset)
-                    .copied()
-                    .unwrap_or(0)
-            }
-            _ => 0,
-        }
+        // 2KB chip at 0x10000, masked to 2KB
+        let chip_offset = addr as usize & 0x7FF;
+        prg.get(0x10000 + chip_offset).copied().unwrap_or(0)
     }
 }
 
@@ -108,9 +100,16 @@ impl Mapper for Mapper43 {
 
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
-            0x5000..=0x7FFF => self.read_prg_custom(addr),
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
+            0x5000..=0x5FFF => self.read_prg_5000(addr),
+            _ => {
+                if let Some(value) = self.base.try_read_prg_6000(addr) {
+                    return value;
+                }
+                match addr {
+                    0x8000..=0xFFFF => self.base.read_prg_rom(addr),
+                    _ => 0,
+                }
+            }
         }
     }
 

--- a/src/cartridge/mapper50.rs
+++ b/src/cartridge/mapper50.rs
@@ -65,6 +65,7 @@ impl Mapper50 {
 
         let mut base = BaseMapper::new(&ctx, capabilities);
         base.configure_prg_banking(Self::PRG_BANK_SIZE);
+        base.configure_prg_6000_banking();
         base.set_mirroring(mirroring);
 
         let mut mapper = Self {
@@ -78,25 +79,15 @@ impl Mapper50 {
     }
 
     fn update_banks(&mut self) {
+        // $6000-$7FFF: fixed bank 0x0F
+        self.base.select_prg_6000_page(Self::BANK_AT_6000 as i16);
+
         // $8000=0x08, $A000=0x09, $C000=switchable, $E000=0x0B
         self.base.select_prg_page(0, 0x08);
         self.base.select_prg_page(1, 0x09);
         self.base
             .select_prg_page(2, Self::unscramble_prg(self.prg_reg) as i16);
         self.base.select_prg_page(3, 0x0B);
-    }
-
-    fn read_prg_6000(&self, addr: u16) -> u8 {
-        let prg = self.base.prg_rom();
-        let bank_count = prg.len() / Self::PRG_BANK_SIZE;
-        if bank_count == 0 {
-            return 0;
-        }
-        let bank = Self::BANK_AT_6000 % bank_count;
-        let offset = (addr as usize) & (Self::PRG_BANK_SIZE - 1);
-        prg.get(bank * Self::PRG_BANK_SIZE + offset)
-            .copied()
-            .unwrap_or(0)
     }
 
     /// Unscramble the PRG register [HLLM] to get the actual 4-bit bank number.
@@ -114,14 +105,6 @@ impl Mapper for Mapper50 {
     }
     fn base_mut(&mut self) -> &mut BaseMapper {
         &mut self.base
-    }
-
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x6000..=0x7FFF => self.read_prg_6000(addr),
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {

--- a/src/cartridge/mapper51.rs
+++ b/src/cartridge/mapper51.rs
@@ -65,6 +65,7 @@ impl Mapper51 {
 
         let mut base = BaseMapper::new(&ctx, capabilities);
         base.configure_prg_banking(0x2000); // 8KB
+        base.configure_prg_6000_banking();
 
         // Handle bad-dump CRC32 case: replace CHR-ROM with CHR-RAM initialized
         // with the ROM data. Some bad dumps carry an 8KB CHR-ROM payload in the
@@ -91,20 +92,17 @@ impl Mapper51 {
         ((value >> 3) & 0x02) | ((value >> 1) & 0x01)
     }
 
-    fn resolve_6000_bank(&self) -> usize {
-        let bank = self.bank as usize;
-        let prg_rom = self.base.prg_rom();
-        let bank_count = prg_rom.len() / 0x2000;
-        let raw = if self.mode & 0x01 != 0 {
-            0x23 | (bank << 2)
-        } else {
-            0x2F | (bank << 2)
-        };
-        if bank_count == 0 { 0 } else { raw % bank_count }
-    }
-
     fn update_banks(&mut self) {
         let bank = self.bank as usize;
+
+        // $6000-$7FFF: computed bank
+        let prg_6000 = if self.mode & 0x01 != 0 {
+            (0x23 | (bank << 2)) as i16
+        } else {
+            (0x2F | (bank << 2)) as i16
+        };
+        self.base.select_prg_6000_page(prg_6000);
+
         if self.mode & 0x01 != 0 {
             // 32KB mode: $8000-$FFFF mapped to 4 consecutive 8KB pages
             self.base.select_prg_page(0, (bank << 2) as i16);
@@ -137,18 +135,6 @@ impl Mapper for Mapper51 {
 
     fn base_mut(&mut self) -> &mut BaseMapper {
         &mut self.base
-    }
-
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x6000..=0x7FFF => {
-                let bank = self.resolve_6000_bank();
-                let offset = (addr as usize) & 0x1FFF;
-                let prg_rom = self.base.prg_rom();
-                prg_rom.get(bank * 0x2000 + offset).copied().unwrap_or(0)
-            }
-            _ => self.base.read_prg_banked(addr),
-        }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {

--- a/src/cartridge/mapper53.rs
+++ b/src/cartridge/mapper53.rs
@@ -48,9 +48,6 @@ pub struct Mapper53 {
 }
 
 impl Mapper53 {
-    const PRG_8K_SIZE: usize = 0x2000;
-    const PRG_8K_MASK: usize = Self::PRG_8K_SIZE - 1;
-
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
         let capabilities = MapperCapabilities {
             has_dynamic_mirroring: true,
@@ -61,6 +58,7 @@ impl Mapper53 {
         };
         let mut base = BaseMapper::new(&ctx, capabilities);
         base.configure_prg_banking(16 * 1024);
+        base.configure_prg_6000_banking();
         // Default: menu mode → 32KB bank 0 = 16KB banks 0 and 1
         base.select_prg_page(0, 0);
         base.select_prg_page(1, 1);
@@ -73,23 +71,6 @@ impl Mapper53 {
         mapper
     }
 
-    fn num_prg_8k_banks(&self) -> usize {
-        self.base.prg_rom().len() / Self::PRG_8K_SIZE
-    }
-
-    fn read_prg_8k_bank(&self, bank: usize, offset: usize) -> u8 {
-        let count = self.num_prg_8k_banks();
-        if count == 0 {
-            return 0;
-        }
-        let safe_bank = bank % count;
-        self.base
-            .prg_rom()
-            .get(safe_bank * Self::PRG_8K_SIZE + offset)
-            .copied()
-            .unwrap_or(0)
-    }
-
     /// $6000 bank (8KB): ((cmd0 & 0x0F) << 4 | 0x0F) + 4
     fn prg_6000_bank(&self) -> usize {
         ((((self.cmd0 & 0x0F) as usize) << 4) | 0x0F).wrapping_add(4)
@@ -100,6 +81,9 @@ impl Mapper53 {
     }
 
     fn update_banks(&mut self) {
+        // $6000-$7FFF: computed 8KB bank
+        self.base.select_prg_6000_page(self.prg_6000_bank() as i16);
+
         if self.game_selected() {
             let outer = (self.cmd0 & 0x0F) as usize;
             let switchable = ((outer << 3) | (self.cmd1 & 7) as usize).wrapping_add(2) as i16;
@@ -127,17 +111,6 @@ impl Mapper for Mapper53 {
 
     fn base_mut(&mut self) -> &mut BaseMapper {
         &mut self.base
-    }
-
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x6000..=0x7FFF => {
-                let offset = (addr as usize) & Self::PRG_8K_MASK;
-                self.read_prg_8k_bank(self.prg_6000_bank(), offset)
-            }
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {

--- a/src/cartridge/ntdec_2722.rs
+++ b/src/cartridge/ntdec_2722.rs
@@ -59,6 +59,7 @@ impl Ntdec2722Mapper {
 
         let mut base = BaseMapper::new(&ctx, capabilities);
         base.configure_prg_banking(Self::PRG_BANK_SIZE);
+        base.configure_prg_6000_banking();
         base.set_mirroring(mirroring);
 
         let mut mapper = Self {
@@ -75,24 +76,14 @@ impl Ntdec2722Mapper {
     }
 
     fn update_banks(&mut self) {
+        // $6000-$7FFF: fixed bank 6
+        self.base.select_prg_6000_page(Self::BANK_AT_6000 as i16);
+
         // $8000=bank4, $A000=bank5, $C000=switchable, $E000=bank7
         self.base.select_prg_page(0, 4);
         self.base.select_prg_page(1, 5);
         self.base.select_prg_page(2, self.prg_bank as i16);
         self.base.select_prg_page(3, 7);
-    }
-
-    fn read_prg_6000(&self, addr: u16) -> u8 {
-        let prg = self.base.prg_rom();
-        let bank_count = prg.len() / Self::PRG_BANK_SIZE;
-        if bank_count == 0 {
-            return 0;
-        }
-        let bank = Self::BANK_AT_6000 % bank_count;
-        let offset = (addr as usize) & (Self::PRG_BANK_SIZE - 1);
-        prg.get(bank * Self::PRG_BANK_SIZE + offset)
-            .copied()
-            .unwrap_or(0)
     }
 }
 
@@ -102,14 +93,6 @@ impl Mapper for Ntdec2722Mapper {
     }
     fn base_mut(&mut self) -> &mut BaseMapper {
         &mut self.base
-    }
-
-    fn read_prg(&self, addr: u16) -> u8 {
-        match addr {
-            0x6000..=0x7FFF => self.read_prg_6000(addr),
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
-            _ => 0,
-        }
     }
 
     fn write_prg(&mut self, addr: u16, value: u8) {
@@ -132,11 +115,6 @@ impl Mapper for Ntdec2722Mapper {
             }
             _ => {}
         }
-    }
-
-    fn wram_size(&self) -> usize {
-        // No WRAM: $6000-$7FFF is mapped to PRG ROM bank 6, not RAM.
-        0
     }
 
     fn cpu_cycle(&mut self) {

--- a/src/cartridge/sunsoft_fme7.rs
+++ b/src/cartridge/sunsoft_fme7.rs
@@ -80,6 +80,7 @@ impl SunsoftFme7Mapper {
         };
         let mut base = BaseMapper::new(&ctx, capabilities);
         base.configure_prg_banking(0x2000);
+        base.configure_prg_6000_banking();
         base.configure_chr_banking(0x0400);
         let mut mapper = Self {
             base,
@@ -97,6 +98,8 @@ impl SunsoftFme7Mapper {
     }
 
     fn update_banks(&mut self) {
+        // PRG: $6000-$7FFF = switchable 8KB ROM bank (when RAM not enabled)
+        self.base.select_prg_6000_page(self.prg_banks[0] as i16);
         // PRG: $8000-$FFFF = 4 x 8KB slots
         self.base.select_prg_page(0, self.prg_banks[1] as i16);
         self.base.select_prg_page(1, self.prg_banks[2] as i16);
@@ -106,18 +109,6 @@ impl SunsoftFme7Mapper {
         for i in 0..8 {
             self.base.select_chr_page(i, self.chr_banks[i] as i16);
         }
-    }
-
-    fn read_prg_6000(&self, addr: u16) -> u8 {
-        let prg_rom = self.base.prg_rom();
-        let bank_size = 0x2000;
-        let bank_count = prg_rom.len() / bank_size;
-        if bank_count == 0 {
-            return 0;
-        }
-        let bank = (self.prg_banks[0] as usize) % bank_count;
-        let offset = (addr as usize) - 0x6000;
-        prg_rom.get(bank * bank_size + offset).copied().unwrap_or(0)
     }
 
     fn write_command(&mut self, value: u8) {
@@ -204,10 +195,10 @@ impl Mapper for SunsoftFme7Mapper {
                     let offset = (addr - 0x6000) as usize;
                     self.prg_ram.get(offset).copied().unwrap_or(0)
                 } else {
-                    self.read_prg_6000(addr)
+                    self.base.try_read_prg_6000(addr).unwrap_or(0)
                 }
             }
-            0x8000..=0xFFFF => self.base.read_prg_banked(addr),
+            0x8000..=0xFFFF => self.base.read_prg_rom(addr),
             _ => 0,
         }
     }


### PR DESCRIPTION
## Summary

Add PRG-ROM banking at $6000-$7FFF to BaseMapper and refactor 7 mappers to use it.

## Changes

### BaseMapper (`base_mapper.rs`)
- New field `prg_6000_bank: Option<usize>` (None = not configured)
- `configure_prg_6000_banking()` — enables $6000 banking, sets initial bank to 0
- `select_prg_6000_page(bank: i16)` — resolves bank with wrapping (8KB granularity)
- `try_read_prg_6000(addr) -> Option<u8>` — returns Some if configured and addr in $6000-$7FFF
- `has_prg_6000_banking() -> bool` — checks if $6000 banking is configured
- 8 new unit tests

### Mapper trait (`mapper.rs`)
- Default `read_prg` now checks `try_read_prg_6000` before `try_read_prg_ram`

### Refactored mappers
All 7 mappers now delegate $6000 PRG-ROM reads to BaseMapper instead of manual implementations:

| Mapper | $6000 bank | Notes |
|--------|-----------|-------|
| 42 | Switchable via $E000 | Removed read_prg/wram_size overrides |
| 43 | Fixed bank 2 | Kept read_prg for $5000-$5FFF handling |
| 50 | Fixed bank 0x0F | Removed read_prg override |
| ntdec_2722 (40) | Fixed bank 6 | Removed read_prg/wram_size overrides |
| 51 | Computed from mode/bank | Removed resolve_6000_bank helper |
| 53 | Computed from cmd0 | Removed read_prg_8k_bank/num_prg_8k_banks helpers |
| sunsoft_fme7 (69) | Switchable, conditional | Kept read_prg for PRG-RAM vs ROM routing |

## Testing
- 8 new unit tests for BaseMapper $6000 banking
- All 6298 existing tests pass
- WASM: 46 tests pass
- Clippy: 0 warnings

Closes #816
