### PR TITLE
Remove redundant write_chr no-op overrides (#818)

### DIFF
--- a/src/cartridge/base_mapper.rs
+++ b/src/cartridge/base_mapper.rs
@@ -1088,6 +1088,30 @@ mod tests {
     }
 
     #[test]
+    fn test_write_chr_rom_is_noop_unbanked() {
+        let chr_rom = vec![0x42; 0x2000];
+        let ctx =
+            MapperContext::new_for_test(0, vec![0; 0x8000], chr_rom, NametableLayout::Horizontal);
+        let mut base = BaseMapper::new(&ctx, MapperCapabilities::default());
+        // Attempt to write to CHR-ROM — should be silently ignored
+        base.write_chr(0x0000, 0xFF);
+        assert_eq!(base.read_chr(0x0000), 0x42);
+    }
+
+    #[test]
+    fn test_write_chr_rom_is_noop_banked() {
+        let chr_rom = vec![0x42; 0x2000];
+        let ctx =
+            MapperContext::new_for_test(0, vec![0; 0x8000], chr_rom, NametableLayout::Horizontal);
+        let mut base = BaseMapper::new(&ctx, MapperCapabilities::default());
+        base.configure_chr_banking(0x2000);
+        base.select_chr_page(0, 0);
+        // Attempt to write to CHR-ROM via banked path — should be silently ignored
+        base.write_chr_banked(0x0000, 0xFF);
+        assert_eq!(base.read_chr_banked(0x0000), 0x42);
+    }
+
+    #[test]
     fn test_chr_page_query() {
         let mut base = make_chr_banked_mapper(8, 0x0400);
         base.select_chr_page(3, 7);

--- a/src/cartridge/colordreams.rs
+++ b/src/cartridge/colordreams.rs
@@ -72,13 +72,6 @@ impl Mapper for ColorDreamsMapper {
         &mut self.base
     }
 
-    fn read_prg_open_bus(&self, addr: u16, open_bus: u8) -> u8 {
-        match addr {
-            0x0000..=0x7FFF => open_bus,
-            _ => self.read_prg(addr),
-        }
-    }
-
     fn write_prg(&mut self, addr: u16, value: u8) {
         if (0x8000..=0xFFFF).contains(&addr) {
             let register_value = self.base.apply_bus_conflict(addr, value);
@@ -87,10 +80,6 @@ impl Mapper for ColorDreamsMapper {
             self.base.select_prg_page(0, self.prg_bank as i16);
             self.base.select_chr_page(0, self.chr_bank as i16);
         }
-    }
-
-    fn write_chr(&mut self, _addr: u16, _value: u8) {
-        // CHR-ROM is read-only
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {

--- a/src/cartridge/mapper185.rs
+++ b/src/cartridge/mapper185.rs
@@ -78,10 +78,6 @@ impl Mapper for Mapper185 {
         self.base.read_chr(addr)
     }
 
-    fn write_chr(&mut self, _addr: u16, _value: u8) {
-        // CHR-ROM is read-only
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.register, u8::from(self.chr_enabled)]
     }

--- a/src/cartridge/mapper244.rs
+++ b/src/cartridge/mapper244.rs
@@ -77,10 +77,6 @@ impl Mapper for Mapper244 {
         }
     }
 
-    fn write_chr(&mut self, _addr: u16, _value: u8) {
-        // CHR-ROM is read-only
-    }
-
     fn registers_snapshot(&self) -> Vec<u8> {
         vec![self.base.prg_page(0) as u8, self.base.chr_page(0) as u8]
     }


### PR DESCRIPTION
Closes #818

## Summary

Removes redundant `write_chr` no-op overrides from 3 mappers and a redundant `read_prg_open_bus` override from ColorDreams, since the default trait path already handles these correctly.

## Analysis

The default `Mapper::write_chr` delegates to `BaseMapper::write_chr`, which delegates to `ChrMemory::write` / `ChrMemory::write_at_index`. Both methods check `if self.is_ram` before writing, so CHR-ROM writes are already silently ignored without any override.

Similarly, ColorDreams' `read_prg_open_bus` returns open_bus for `$0000-$7FFF` and delegates to `read_prg` for `$8000+`. The default `BaseMapper::read_prg_open_bus` does the same when no PRG-RAM is present (ColorDreams has `max_prg_ram_kb: 0`).

## Changes

- **base_mapper.rs**: Added 2 tests confirming CHR-ROM writes are no-ops through the default path (both unbanked and banked)
- **colordreams.rs**: Removed redundant `write_chr` and `read_prg_open_bus` overrides
- **mapper185.rs**: Removed redundant `write_chr` override
- **mapper244.rs**: Removed redundant `write_chr` override

## Testing

- All 6306 Rust tests pass
- 46 WASM tests pass
- 27 Python tests pass
- npm tests pass
- clippy clean with -D warnings

Part of #808
