### PR TITLE
Migrate raw PRG-RAM to PrgRam struct (#820)

### DIFF
--- a/src/cartridge/mapper56.rs
+++ b/src/cartridge/mapper56.rs
@@ -48,7 +48,6 @@ pub struct Mapper56 {
     irq_enabled: bool,
     irq_after_ack: bool, // "A" bit from $C000
     irq_pending: bool,
-    prg_ram: [u8; 8192],
 }
 
 impl Mapper56 {
@@ -77,7 +76,6 @@ impl Mapper56 {
             irq_enabled: false,
             irq_after_ack: false,
             irq_pending: false,
-            prg_ram: [0; 8192],
         };
         mapper.update_banks();
         mapper
@@ -117,7 +115,7 @@ impl Mapper for Mapper56 {
 
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
-            0x6000..=0x7FFF => self.prg_ram[(addr as usize) & 0x1FFF],
+            0x6000..=0x7FFF => self.base.try_read_prg_ram(addr).unwrap_or(0),
             0x8000..=0xFFFF => self.base.read_prg_banked(addr),
             _ => 0,
         }
@@ -126,7 +124,7 @@ impl Mapper for Mapper56 {
     fn write_prg(&mut self, addr: u16, value: u8) {
         match addr {
             0x6000..=0x7FFF => {
-                self.prg_ram[(addr as usize) & 0x1FFF] = value;
+                self.base.try_write_prg_ram(addr, value);
             }
             0x8000..=0x8FFF => {
                 self.irq_latch = (self.irq_latch & 0xFFF0) | ((value as u16) & 0x0F);
@@ -191,10 +189,6 @@ impl Mapper for Mapper56 {
         }
     }
 
-    fn wram_size(&self) -> usize {
-        8192
-    }
-
     fn irq_pending(&self) -> bool {
         self.irq_pending
     }
@@ -208,15 +202,6 @@ impl Mapper for Mapper56 {
             self.irq_pending = true;
             self.irq_enabled = false; // counter stops, like VRC3
         }
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.to_vec()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        let len = data.len().min(self.prg_ram.len());
-        self.prg_ram[..len].copy_from_slice(&data[..len]);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -437,5 +422,38 @@ mod tests {
         assert!(mapper.irq_pending());
         mapper.write_prg(0xD000, 0); // acknowledge
         assert!(!mapper.irq_pending());
+    }
+
+    // -----------------------------------------------------------------------
+    // PRG-RAM ($6000-$7FFF)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prg_ram_readable_and_writable_at_6000() {
+        let mut mapper = make_mapper();
+        mapper.write_prg(0x6000, 0xAB);
+        assert_eq!(mapper.read_prg(0x6000), 0xAB);
+        mapper.write_prg(0x7FFF, 0xCD);
+        assert_eq!(mapper.read_prg(0x7FFF), 0xCD);
+    }
+
+    #[test]
+    fn wram_snapshot_round_trip() {
+        let mut mapper = make_mapper();
+        mapper.write_prg(0x6000, 0x11);
+        mapper.write_prg(0x6100, 0x22);
+        mapper.write_prg(0x7FFF, 0x33);
+        let snapshot = mapper.wram_snapshot();
+        assert_eq!(snapshot.len(), 8192);
+        assert_eq!(snapshot[0x0000], 0x11);
+        assert_eq!(snapshot[0x0100], 0x22);
+        assert_eq!(snapshot[0x1FFF], 0x33);
+
+        // Restore into a fresh mapper
+        let mut mapper2 = make_mapper();
+        mapper2.load_wram_snapshot(&snapshot);
+        assert_eq!(mapper2.read_prg(0x6000), 0x11);
+        assert_eq!(mapper2.read_prg(0x6100), 0x22);
+        assert_eq!(mapper2.read_prg(0x7FFF), 0x33);
     }
 }

--- a/src/cartridge/mapper73.rs
+++ b/src/cartridge/mapper73.rs
@@ -32,7 +32,6 @@ use crate::cartridge::mapper::{Mapper, MapperCapabilities};
 /// - $F000-$FFFF: PRG bank select [.... .PPP]
 pub struct Mapper73 {
     base: BaseMapper,
-    prg_ram: Vec<u8>,
     prg_bank: u8,
     irq_latch: u16,
     irq_counter: u16,
@@ -44,11 +43,9 @@ pub struct Mapper73 {
 
 impl Mapper73 {
     const PRG_BANK_SIZE: usize = 0x4000; // 16 KiB
-    const PRG_RAM_SIZE: usize = 0x2000; // 8 KiB
 
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
         let mirroring = ctx.mirroring;
-        let prg_ram_size = (ctx.prg_ram_banks_8k as usize).max(1) * Self::PRG_RAM_SIZE;
         let capabilities = MapperCapabilities {
             has_irq: true,
             max_prg_ram_kb: 8,
@@ -62,7 +59,6 @@ impl Mapper73 {
 
         let mut mapper = Self {
             base,
-            prg_ram: vec![0u8; prg_ram_size],
             prg_bank: 0,
             irq_latch: 0,
             irq_counter: 0,
@@ -116,10 +112,7 @@ impl Mapper for Mapper73 {
 
     fn read_prg(&self, addr: u16) -> u8 {
         match addr {
-            0x6000..=0x7FFF => {
-                let idx = (addr as usize) - 0x6000;
-                self.prg_ram.get(idx).copied().unwrap_or(0)
-            }
+            0x6000..=0x7FFF => self.base.try_read_prg_ram(addr).unwrap_or(0),
             0x8000..=0xFFFF => self.base.read_prg_banked(addr),
             _ => 0,
         }
@@ -128,10 +121,7 @@ impl Mapper for Mapper73 {
     fn write_prg(&mut self, addr: u16, value: u8) {
         match addr {
             0x6000..=0x7FFF => {
-                let idx = (addr as usize) - 0x6000;
-                if let Some(b) = self.prg_ram.get_mut(idx) {
-                    *b = value;
-                }
+                self.base.try_write_prg_ram(addr, value);
             }
             0x8000..=0x8FFF => {
                 self.irq_latch = (self.irq_latch & 0xFFF0) | ((value as u16) & 0x000F);
@@ -168,19 +158,6 @@ impl Mapper for Mapper73 {
         }
     }
 
-    fn wram_size(&self) -> usize {
-        Self::PRG_RAM_SIZE
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.clone()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        let to_copy = data.len().min(self.prg_ram.len());
-        self.prg_ram[..to_copy].copy_from_slice(&data[..to_copy]);
-    }
-
     fn cpu_cycle(&mut self) {
         if !self.irq_enable {
             return;
@@ -190,11 +167,6 @@ impl Mapper for Mapper73 {
 
     fn irq_pending(&self) -> bool {
         self.irq_pending
-    }
-
-    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        self.base.initialize_ram(mode);
-        crate::console::initialize_ram(&mut self.prg_ram, mode);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -500,5 +472,28 @@ mod tests {
         assert_eq!(restored.irq_enable, original.irq_enable);
         assert_eq!(restored.irq_enable_on_ack, original.irq_enable_on_ack);
         assert_eq!(restored.irq_pending, original.irq_pending);
+    }
+
+    // -----------------------------------------------------------------------
+    // WRAM snapshot/restore
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn wram_snapshot_round_trip() {
+        let mut mapper = make_mapper();
+        mapper.write_prg(0x6000, 0x11);
+        mapper.write_prg(0x6100, 0x22);
+        mapper.write_prg(0x7FFF, 0x33);
+        let snapshot = mapper.wram_snapshot();
+        assert_eq!(snapshot.len(), 8192);
+        assert_eq!(snapshot[0x0000], 0x11);
+        assert_eq!(snapshot[0x0100], 0x22);
+        assert_eq!(snapshot[0x1FFF], 0x33);
+
+        let mut mapper2 = make_mapper();
+        mapper2.load_wram_snapshot(&snapshot);
+        assert_eq!(mapper2.read_prg(0x6000), 0x11);
+        assert_eq!(mapper2.read_prg(0x6100), 0x22);
+        assert_eq!(mapper2.read_prg(0x7FFF), 0x33);
     }
 }

--- a/src/cartridge/sunsoft_fme7.rs
+++ b/src/cartridge/sunsoft_fme7.rs
@@ -47,7 +47,6 @@ use super::cpu_cycle_irq::{CpuCycleIrq, CpuCycleIrqMode};
 
 pub struct SunsoftFme7Mapper {
     base: BaseMapper,
-    prg_ram: Vec<u8>,
 
     // Register selection
     command: u8,
@@ -66,8 +65,6 @@ pub struct SunsoftFme7Mapper {
 }
 
 impl SunsoftFme7Mapper {
-    const PRG_RAM_SIZE: usize = 8 * 1024; // 8KB
-
     pub fn new(ctx: super::mapper::MapperContext) -> Self {
         let capabilities = MapperCapabilities {
             has_irq: true,
@@ -84,7 +81,6 @@ impl SunsoftFme7Mapper {
         base.configure_chr_banking(0x0400);
         let mut mapper = Self {
             base,
-            prg_ram: vec![0u8; Self::PRG_RAM_SIZE],
             command: 0,
             prg_banks: [0, 0, 0, 0],
             prg_ram_enabled: false,
@@ -192,8 +188,7 @@ impl Mapper for SunsoftFme7Mapper {
         match addr {
             0x6000..=0x7FFF => {
                 if self.prg_ram_enabled {
-                    let offset = (addr - 0x6000) as usize;
-                    self.prg_ram.get(offset).copied().unwrap_or(0)
+                    self.base.try_read_prg_ram(addr).unwrap_or(0)
                 } else {
                     self.base.try_read_prg_6000(addr).unwrap_or(0)
                 }
@@ -208,10 +203,7 @@ impl Mapper for SunsoftFme7Mapper {
             0x6000..=0x7FFF => {
                 // PRG-RAM writes (if enabled and not readonly)
                 if self.prg_ram_enabled && !self.prg_ram_readonly {
-                    let offset = (addr - 0x6000) as usize;
-                    if offset < self.prg_ram.len() {
-                        self.prg_ram[offset] = value;
-                    }
+                    self.base.try_write_prg_ram(addr, value);
                 }
             }
             0x8000..=0x9FFF => {
@@ -236,24 +228,6 @@ impl Mapper for SunsoftFme7Mapper {
 
     fn irq_pending(&self) -> bool {
         self.irq.is_pending()
-    }
-
-    fn wram_size(&self) -> usize {
-        Self::PRG_RAM_SIZE
-    }
-
-    fn wram_snapshot(&self) -> Vec<u8> {
-        self.prg_ram.clone()
-    }
-
-    fn load_wram_snapshot(&mut self, data: &[u8]) {
-        let to_copy = data.len().min(self.prg_ram.len());
-        self.prg_ram[..to_copy].copy_from_slice(&data[..to_copy]);
-    }
-
-    fn initialize_ram(&mut self, mode: crate::console::RamInitMode) {
-        crate::console::initialize_ram(&mut self.prg_ram, mode);
-        self.base.initialize_ram(mode);
     }
 
     fn registers_snapshot(&self) -> Vec<u8> {
@@ -557,5 +531,48 @@ mod tests {
         assert_eq!(restored.get_mirroring(), NametableLayout::SingleScreenUpper);
         assert_eq!(restored.read_prg(0x8000), 3);
         assert_eq!(restored.read_chr(0x0000), 4);
+    }
+
+    // -----------------------------------------------------------------------
+    // WRAM snapshot/restore
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_wram_snapshot_round_trip() {
+        let prg_rom = banked_data(8 * 1024, 8);
+        let chr_rom = banked_data(1024, 8);
+        let mut mapper = SunsoftFme7Mapper::new(MapperContext::new_for_test(
+            69,
+            prg_rom.clone(),
+            chr_rom.clone(),
+            NametableLayout::Horizontal,
+        ));
+
+        // Enable RAM (command 8, bit 7 = 1)
+        mapper.write_prg(0x8000, 0x08);
+        mapper.write_prg(0xA000, 0x80);
+
+        mapper.write_prg(0x6000, 0x11);
+        mapper.write_prg(0x6100, 0x22);
+        mapper.write_prg(0x7FFF, 0x33);
+        let snapshot = mapper.wram_snapshot();
+        assert_eq!(snapshot.len(), 8192);
+        assert_eq!(snapshot[0x0000], 0x11);
+        assert_eq!(snapshot[0x0100], 0x22);
+        assert_eq!(snapshot[0x1FFF], 0x33);
+
+        let mut mapper2 = SunsoftFme7Mapper::new(MapperContext::new_for_test(
+            69,
+            prg_rom,
+            chr_rom,
+            NametableLayout::Horizontal,
+        ));
+        mapper2.load_wram_snapshot(&snapshot);
+        // Enable RAM to read back
+        mapper2.write_prg(0x8000, 0x08);
+        mapper2.write_prg(0xA000, 0x80);
+        assert_eq!(mapper2.read_prg(0x6000), 0x11);
+        assert_eq!(mapper2.read_prg(0x6100), 0x22);
+        assert_eq!(mapper2.read_prg(0x7FFF), 0x33);
     }
 }


### PR DESCRIPTION
## Summary

Migrates mapper56 (Kaiser KS202), mapper73 (VRC3), and sunsoft_fme7 (Sunsoft FME-7) from manually managed PRG-RAM (raw [u8; 8192] or Vec) to BaseMapper's existing PrgRam struct.

## Changes

- mapper56: Removed prg_ram field. PRG-RAM reads/writes at $6000-$7FFF now delegate to base.try_read_prg_ram()/base.try_write_prg_ram(). Removed manual wram_size(), wram_snapshot(), load_wram_snapshot() overrides.
- mapper73: Removed prg_ram field and PRG_RAM_SIZE constant. Same delegation pattern. Removed redundant initialize_ram() override.
- sunsoft_fme7: Removed prg_ram field and PRG_RAM_SIZE constant. Kept conditional enable/readonly logic around PrgRam access. Removed redundant initialize_ram() override.

## Tests

- Added safety-net tests for all 3 mappers: prg_ram_readable_and_writable_at_6000 (mapper56), wram_snapshot_round_trip (all 3)
- All 6330 Rust, 46 WASM, 27 Python, and npm tests pass
- Clippy clean

Closes #820
