### PR TITLE
Sub-issue (1549): Automate allpads Super NES controller adapter scenario (#1577)

### DIFF
--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -10,7 +10,7 @@ use crate::cartridge::Cartridge;
 use crate::debugging::log_info;
 use crate::input::{
     ArkanoidController, ArkanoidState, Button, Controller, ControllerType, JoypadState, NesJoypad,
-    Zapper, ZapperState,
+    SnesAdapter, SnesAdapterState, Zapper, ZapperState,
 };
 use crate::ppu::{self, SharedPpu};
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,7 @@ use std::ops::RangeInclusive;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ControllerStateWrapper {
     Joypad(JoypadState),
+    SnesAdapter(SnesAdapterState),
     Arkanoid(ArkanoidState),
     Zapper(ZapperState),
 }
@@ -77,6 +78,7 @@ impl Bus {
     ) -> Box<dyn Controller> {
         match controller_type {
             ControllerType::Joypad => Box::new(NesJoypad::new()),
+            ControllerType::SnesAdapter => Box::new(SnesAdapter::new()),
             ControllerType::Arkanoid => Box::new(ArkanoidController::new()),
             ControllerType::Zapper => Box::new(Zapper::new(ppu, app_context)),
         }
@@ -652,11 +654,17 @@ impl Bus {
             oam_dma_page: *self.oam_dma_page.borrow(),
             port1_controller: match port1_state {
                 crate::input::ControllerState::Joypad(s) => ControllerStateWrapper::Joypad(s),
+                crate::input::ControllerState::SnesAdapter(s) => {
+                    ControllerStateWrapper::SnesAdapter(s)
+                }
                 crate::input::ControllerState::Paddle(s) => ControllerStateWrapper::Arkanoid(s),
                 crate::input::ControllerState::Zapper(s) => ControllerStateWrapper::Zapper(s),
             },
             port2_controller: match port2_state {
                 crate::input::ControllerState::Joypad(s) => ControllerStateWrapper::Joypad(s),
+                crate::input::ControllerState::SnesAdapter(s) => {
+                    ControllerStateWrapper::SnesAdapter(s)
+                }
                 crate::input::ControllerState::Paddle(s) => ControllerStateWrapper::Arkanoid(s),
                 crate::input::ControllerState::Zapper(s) => ControllerStateWrapper::Zapper(s),
             },
@@ -678,6 +686,15 @@ impl Bus {
                     ControllerType::Joypad,
                 );
                 controller.restore_state(&crate::input::ControllerState::Joypad(s.clone()));
+                *self.controllers[0].borrow_mut() = controller;
+            }
+            ControllerStateWrapper::SnesAdapter(s) => {
+                let mut controller = Self::build_controller(
+                    self.ppu.clone(),
+                    self.app_context.clone(),
+                    ControllerType::SnesAdapter,
+                );
+                controller.restore_state(&crate::input::ControllerState::SnesAdapter(s.clone()));
                 *self.controllers[0].borrow_mut() = controller;
             }
             ControllerStateWrapper::Arkanoid(s) => {
@@ -709,6 +726,15 @@ impl Bus {
                     ControllerType::Joypad,
                 );
                 controller.restore_state(&crate::input::ControllerState::Joypad(s.clone()));
+                *self.controllers[1].borrow_mut() = controller;
+            }
+            ControllerStateWrapper::SnesAdapter(s) => {
+                let mut controller = Self::build_controller(
+                    self.ppu.clone(),
+                    self.app_context.clone(),
+                    ControllerType::SnesAdapter,
+                );
+                controller.restore_state(&crate::input::ControllerState::SnesAdapter(s.clone()));
                 *self.controllers[1].borrow_mut() = controller;
             }
             ControllerStateWrapper::Arkanoid(s) => {

--- a/src/bus/controller_device.rs
+++ b/src/bus/controller_device.rs
@@ -79,8 +79,7 @@ impl ControllerDevice {
         controller_state = (controller_state & !0x01) | serial_bit;
 
         if !is_dummy_read && !self.four_score_strobe {
-            self.four_score_index[port_index] =
-                self.four_score_index[port_index].saturating_add(1);
+            self.four_score_index[port_index] = self.four_score_index[port_index].saturating_add(1);
         }
 
         controller_state

--- a/src/console/config.rs
+++ b/src/console/config.rs
@@ -97,12 +97,12 @@ const CLI_FLAGS: &[CliFlag] = &[
     },
     CliFlag {
         flag: "--controller-port1",
-        help: Some("Controller type for port 1: joypad, zapper, arkanoid"),
+        help: Some("Controller type for port 1: joypad, snes-adapter, zapper, arkanoid"),
         has_value: true,
     },
     CliFlag {
         flag: "--controller-port2",
-        help: Some("Controller type for port 2: joypad, zapper, arkanoid"),
+        help: Some("Controller type for port 2: joypad, snes-adapter, zapper, arkanoid"),
         has_value: true,
     },
     CliFlag {

--- a/src/console/nes.rs
+++ b/src/console/nes.rs
@@ -195,6 +195,7 @@ impl Nes {
                 ControllerType::Arkanoid => "Arkanoid",
                 ControllerType::Zapper => "Zapper",
                 ControllerType::Joypad => "Joypad",
+                ControllerType::SnesAdapter => "SNES adapter",
             };
             log_info(format!(
                 "Enabling {} controller on port {} for inserted cartridge. If you don't want this behavior, explicitly configure controller_port1/controller_port2 in config (or via CLI). Note that some games expect the controller on a specific port, so be sure to configure the correct one if you have issues with input not working in certain games.",

--- a/src/input/controller.rs
+++ b/src/input/controller.rs
@@ -1,12 +1,14 @@
 use crate::input::Button;
 use crate::input::arkanoid_controller::ArkanoidState;
 use crate::input::nes_joypad::JoypadState;
+use crate::input::snes_adapter::SnesAdapterState;
 use crate::input::zapper::ZapperState;
 
 /// Unified controller state for save-state support.
 #[derive(Debug, Clone)]
 pub enum ControllerState {
     Joypad(JoypadState),
+    SnesAdapter(SnesAdapterState),
     Paddle(ArkanoidState),
     Zapper(ZapperState),
 }
@@ -15,6 +17,7 @@ pub enum ControllerState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControllerType {
     Joypad,
+    SnesAdapter,
     Arkanoid,
     Zapper,
 }
@@ -24,6 +27,7 @@ impl ControllerType {
     pub fn parse(value: &str) -> Option<Self> {
         match value.to_lowercase().as_str() {
             "joypad" => Some(Self::Joypad),
+            "snes-adapter" | "snes_adapter" | "snesadapter" | "snes" => Some(Self::SnesAdapter),
             "arkanoid" | "paddle" => Some(Self::Arkanoid),
             "zapper" => Some(Self::Zapper),
             _ => None,
@@ -45,6 +49,7 @@ pub enum ControllerInput {
 pub fn controller_input_type(controller_type: ControllerType) -> ControllerInput {
     match controller_type {
         ControllerType::Joypad => ControllerInput::Gamepad,
+        ControllerType::SnesAdapter => ControllerInput::Gamepad,
         ControllerType::Arkanoid => ControllerInput::Mouse,
         ControllerType::Zapper => ControllerInput::Mouse,
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,6 +1,7 @@
 mod arkanoid_controller;
 mod controller;
 mod nes_joypad;
+mod snes_adapter;
 mod zapper;
 
 pub use arkanoid_controller::ArkanoidController;
@@ -10,5 +11,6 @@ pub use controller::{
 };
 pub use nes_joypad::JoypadState;
 pub use nes_joypad::{Button, NesJoypad};
+pub use snes_adapter::{SnesAdapter, SnesAdapterState};
 pub use zapper::Zapper;
 pub use zapper::ZapperState;

--- a/src/input/snes_adapter.rs
+++ b/src/input/snes_adapter.rs
@@ -1,0 +1,188 @@
+use super::ControllerInput;
+use serde::{Deserialize, Serialize};
+
+/// SNES adapter controller state for save-state support.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SnesAdapterState {
+    pub strobe: bool,
+    pub bit_index: u8,
+    pub button_states: u16,
+}
+
+/// Super NES controller connected through a NES pin adapter.
+///
+/// Serial protocol:
+/// - bits 0..=11: SNES buttons (B, Y, Select, Start, Up, Down, Left, Right, A, X, L, R)
+/// - bits 12..=15: always 1
+/// - bits 16+: always 1
+///
+/// The adapter exposes serial data on D1 (bit 1), which is what allpads-r9
+/// probes for the SNES controller adapter path.
+pub struct SnesAdapter {
+    strobe: bool,
+    bit_index: u8,
+    button_states: u16,
+}
+
+impl Default for SnesAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SnesAdapter {
+    pub fn new() -> Self {
+        Self {
+            strobe: false,
+            bit_index: 0,
+            button_states: 0,
+        }
+    }
+
+    pub fn write_strobe(&mut self, value: u8) {
+        let new_strobe = value & 0x01 != 0;
+        if self.strobe && !new_strobe {
+            self.bit_index = 0;
+        }
+        self.strobe = new_strobe;
+    }
+
+    fn button_bit_for_nes_button(button: crate::input::Button) -> Option<u8> {
+        match button {
+            crate::input::Button::B => Some(0),
+            crate::input::Button::A => Some(1),
+            crate::input::Button::Select => Some(2),
+            crate::input::Button::Start => Some(3),
+            crate::input::Button::Up => Some(4),
+            crate::input::Button::Down => Some(5),
+            crate::input::Button::Left => Some(6),
+            crate::input::Button::Right => Some(7),
+        }
+    }
+
+    fn current_serial_bit(&self) -> u8 {
+        match self.bit_index {
+            0..=7 => ((self.button_states >> self.bit_index) & 0x01) as u8,
+            8..=11 => 1,
+            12..=15 => 0,
+            _ => 1,
+        }
+    }
+
+    pub fn read(&mut self, is_dummy_read: bool) -> u8 {
+        let bit = self.current_serial_bit();
+
+        if !self.strobe && !is_dummy_read {
+            self.bit_index = self.bit_index.saturating_add(1);
+        }
+
+        if bit != 0 { 0x03 } else { 0x00 }
+    }
+
+    pub fn set_button(&mut self, button: crate::input::Button, pressed: bool) {
+        if let Some(bit) = Self::button_bit_for_nes_button(button) {
+            if pressed {
+                self.button_states |= 1u16 << bit;
+            } else {
+                self.button_states &= !(1u16 << bit);
+            }
+        }
+    }
+
+    pub fn capture_state(&self) -> SnesAdapterState {
+        SnesAdapterState {
+            strobe: self.strobe,
+            bit_index: self.bit_index,
+            button_states: self.button_states,
+        }
+    }
+
+    pub fn restore_state(&mut self, state: &SnesAdapterState) {
+        self.strobe = state.strobe;
+        self.bit_index = state.bit_index;
+        self.button_states = state.button_states;
+    }
+}
+
+impl crate::input::Controller for SnesAdapter {
+    fn write_strobe(&mut self, value: u8) {
+        self.write_strobe(value)
+    }
+
+    fn read(&mut self, is_dummy_read: bool) -> u8 {
+        self.read(is_dummy_read)
+    }
+
+    fn capture_state(&self) -> crate::input::ControllerState {
+        crate::input::ControllerState::SnesAdapter(self.capture_state())
+    }
+
+    fn restore_state(&mut self, state: &crate::input::ControllerState) {
+        if let crate::input::ControllerState::SnesAdapter(snes_state) = state {
+            self.restore_state(snes_state);
+        }
+    }
+
+    fn set_button(&mut self, button: crate::input::Button, pressed: bool) -> bool {
+        self.set_button(button, pressed);
+        true
+    }
+
+    fn set_mouse_x_position(&mut self, _position: u8) -> bool {
+        false
+    }
+
+    fn set_mouse_y_position(&mut self, _position: u8) -> bool {
+        false
+    }
+
+    fn set_mouse_left_button(&mut self, _pressed: bool) -> bool {
+        false
+    }
+
+    fn input_type(&self) -> ControllerInput {
+        crate::input::controller_input_type(crate::input::ControllerType::SnesAdapter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snes_adapter_serial_stream_defaults_to_expected_padding() {
+        let mut adapter = SnesAdapter::new();
+
+        adapter.write_strobe(1);
+        adapter.write_strobe(0);
+
+        let mut bits = Vec::new();
+        for _ in 0..24 {
+            bits.push((adapter.read(false) >> 1) & 0x01);
+        }
+
+        assert_eq!(&bits[0..8], &[0; 8]);
+        assert_eq!(&bits[8..12], &[1, 1, 1, 1]);
+        assert_eq!(&bits[12..16], &[0, 0, 0, 0]);
+        assert_eq!(&bits[16..24], &[1; 8]);
+    }
+
+    #[test]
+    fn snes_adapter_maps_b_to_first_bit_and_right_to_eighth_bit() {
+        let mut adapter = SnesAdapter::new();
+        adapter.set_button(crate::input::Button::B, true);
+        adapter.set_button(crate::input::Button::Right, true);
+
+        adapter.write_strobe(1);
+        adapter.write_strobe(0);
+
+        let first = (adapter.read(false) >> 1) & 0x01;
+        for _ in 0..6 {
+            adapter.read(false);
+        }
+        let eighth = (adapter.read(false) >> 1) & 0x01;
+
+        assert_eq!(first, 1);
+        assert_eq!(eighth, 1);
+    }
+}

--- a/src/integration_tests/allpads_harness.rs
+++ b/src/integration_tests/allpads_harness.rs
@@ -24,6 +24,13 @@ pub(crate) mod tests {
             }
         }
 
+        pub fn snes_adapter_port1() -> Self {
+            Self {
+                port1: ControllerType::SnesAdapter,
+                port2: ControllerType::SnesAdapter,
+            }
+        }
+
         pub fn zapper() -> Self {
             Self {
                 port1: ControllerType::Joypad,

--- a/src/integration_tests/miscellaneous_tests.rs
+++ b/src/integration_tests/miscellaneous_tests.rs
@@ -238,6 +238,140 @@ mod tests {
     }
 
     /////////////////////////////////////
+    // Allpads SNES adapter scenario (#1577)
+    /////////////////////////////////////
+
+    fn script_enter_snes_test_and_press(button: Button) -> Vec<ScriptEntry> {
+        vec![
+            ScriptEntry {
+                frame: 300,
+                actions: vec![InputAction::Button {
+                    port: 1,
+                    button: Button::B,
+                    pressed: true,
+                }],
+            },
+            ScriptEntry {
+                frame: 305,
+                actions: vec![InputAction::Button {
+                    port: 1,
+                    button: Button::B,
+                    pressed: false,
+                }],
+            },
+            ScriptEntry {
+                frame: 400,
+                actions: vec![InputAction::Button {
+                    port: 1,
+                    button,
+                    pressed: true,
+                }],
+            },
+        ]
+    }
+
+    fn snes_button_attrs(oam: &[u8]) -> Vec<u8> {
+        (0..12).map(|sprite| oam_sprite_attr(oam, sprite)).collect()
+    }
+
+    #[test]
+    fn allpads_snes_adapter_probe_identifies_super_nes_controller() {
+        let config = ControllerConfig::snes_adapter_port1();
+        let result = run_allpads(&config, &[], 300, 0);
+        let cap = &result.captures[0];
+        let text = cap.nametable_text.to_ascii_uppercase();
+
+        assert!(
+            text.contains("SUPER NES"),
+            "Probe screen should show 'Super NES', got:\n{}",
+            cap.nametable_text
+        );
+        assert!(
+            text.contains("CONTROLLER"),
+            "Probe screen should show 'Controller', got:\n{}",
+            cap.nametable_text
+        );
+    }
+
+    #[test]
+    fn allpads_snes_adapter_b_press_enters_test_screen() {
+        let config = ControllerConfig::snes_adapter_port1();
+        let script = script_enter_snes_test_and_press(Button::B);
+        let result = run_allpads(&config, &script, 430, 0);
+        let cap = &result.captures[0];
+        let text = cap.nametable_text.to_ascii_uppercase();
+
+        assert!(
+            text.contains("SUPER NES CONTROLLER"),
+            "SNES test screen should show title, got:\n{}",
+            cap.nametable_text
+        );
+        assert!(
+            text.contains("RESET: EXIT"),
+            "SNES test screen should be active after pressing B, got:\n{}",
+            cap.nametable_text
+        );
+    }
+
+    #[test]
+    fn allpads_snes_adapter_scripted_input_changes_button_highlight() {
+        let config = ControllerConfig::snes_adapter_port1();
+
+        let baseline_script = vec![
+            ScriptEntry {
+                frame: 300,
+                actions: vec![InputAction::Button {
+                    port: 1,
+                    button: Button::B,
+                    pressed: true,
+                }],
+            },
+            ScriptEntry {
+                frame: 305,
+                actions: vec![InputAction::Button {
+                    port: 1,
+                    button: Button::B,
+                    pressed: false,
+                }],
+            },
+        ];
+        let baseline = run_allpads(&config, &baseline_script, 430, 0);
+
+        let active_script = script_enter_snes_test_and_press(Button::Right);
+        let active = run_allpads(&config, &active_script, 430, 0);
+
+        let baseline_attrs = snes_button_attrs(&baseline.captures[0].oam_data);
+        let active_attrs = snes_button_attrs(&active.captures[0].oam_data);
+
+        assert_ne!(
+            baseline_attrs, active_attrs,
+            "Scripted SNES input should change highlighted button sprite attrs"
+        );
+        assert!(
+            active_attrs.contains(&0x01),
+            "At least one SNES button sprite should be highlighted after input, attrs={:?}",
+            active_attrs
+        );
+    }
+
+    #[test]
+    fn allpads_snes_adapter_scenario_is_deterministic() {
+        let config = ControllerConfig::snes_adapter_port1();
+        let script = script_enter_snes_test_and_press(Button::Right);
+        let result1 = run_allpads(&config, &script, 430, 0);
+        let result2 = run_allpads(&config, &script, 430, 0);
+
+        assert_eq!(
+            result1.captures[0].nametable_raw, result2.captures[0].nametable_raw,
+            "Nametable should be identical across repeated SNES adapter runs"
+        );
+        assert_eq!(
+            result1.captures[0].oam_data, result2.captures[0].oam_data,
+            "OAM data should be identical across repeated SNES adapter runs"
+        );
+    }
+
+    /////////////////////////////////////
     // Allpads Zapper scenario (#1556)
     /////////////////////////////////////
 

--- a/src/web_frontend/wasm_tests.rs
+++ b/src/web_frontend/wasm_tests.rs
@@ -56,6 +56,9 @@ fn port1_arkanoid_state(state: &SaveState) -> ArkanoidState {
     match &state.bus.port1_controller {
         ControllerStateWrapper::Arkanoid(arkanoid) => arkanoid.clone(),
         ControllerStateWrapper::Joypad(_) => panic!("expected Arkanoid controller on port 1"),
+        ControllerStateWrapper::SnesAdapter(_) => {
+            panic!("expected Arkanoid controller on port 1")
+        }
         ControllerStateWrapper::Zapper(_) => panic!("expected Arkanoid controller on port 1"),
     }
 }


### PR DESCRIPTION
## Summary
- Automates allpads-r9 Super NES controller adapter scenario for issue #1577.
- Adds SNES adapter controller emulation path and wires it through controller selection/save-state.
- Adds deterministic integration assertions for probe, test entry, and observable button-highlight changes.

## What changed
- Added new controller implementation:
  - `src/input/snes_adapter.rs`
- Wired SNES adapter into controller infrastructure:
  - `src/input/controller.rs`
  - `src/input/mod.rs`
  - `src/bus/bus.rs`
  - `src/console/nes.rs`
  - `src/console/config.rs`
- Added allpads harness and scenario coverage:
  - `src/integration_tests/allpads_harness.rs`
  - `src/integration_tests/miscellaneous_tests.rs`
- Updated wasm test match exhaustiveness for new controller variant:
  - `src/web_frontend/wasm_tests.rs`

## Acceptance criteria coverage (#1577)
- Detect SNES controller adapter path in allpads-r9.
- Scripted button input produces expected observable state changes.
- Deterministic pass in repeated local runs.

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all`
- `cargo nextest run --all-features --lib`
- `cargo test --all-features`
- `wasm-pack test --headless --chrome --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts/mappertool -s scripts/scraper -s scripts -t . -p "test_*.py"`
- `npm test`

Fixes #1577
