### PR TITLE
fix: Use CL mode for MMC5 split screen (no fine Y override)

### DIFF
--- a/roms/automated_tests/mapper_verification/README.md
+++ b/roms/automated_tests/mapper_verification/README.md
@@ -426,7 +426,7 @@ setup_rom_crc_test!(
 - **Columns 0–15:** Red horizontal-striped tiles on black — split region active, ExRAM provides tile indices and attributes, split CHR bank 2 provides the stripe pattern, palette 1 (color 3 = red).
 - **Columns 16–31:** White solid tiles on black — main region, CIRAM nametable tile $01, CHR bank 0, palette 0 (color 3 = white).
 - The split region has a 32-pixel vertical scroll offset ($5201 = $20), so the left side's content is shifted up by 4 tile rows compared to the right.
-- **Tiles 0–1 fine Y offset:** Starting from screen row 1, tiles 0–1 show a 1-pixel vertical shift in their stripe pattern compared to tiles 2+. This is hardware-accurate: the PPU prefetches tiles 0–1 at the end of the previous scanline, but the MMC5's split scroll counter hasn't incremented yet, so the CHR fine Y (A0–A2) is off by 1 scanline. Row 0 has no offset because the pre-render prefetch and scanline 0 share the same initial scroll value.
+- **CL mode (default):** All commercial ExROM boards use CL mode wiring, where the PPU's own fine Y bits drive CHR A0–A2 (the MMC5's split scroll fine Y is NOT connected to CHR ROM). This means the split region's fine Y matches the PPU's fine Y. The ROM sets $5201 so its low 3 bits match the PPU's fine Y scroll to avoid tile "rolling." No fine Y offset is visible on tiles 0–1 in CL mode.
 
 **`m005.0_mmc5_sprite_chr`** — 8×16 sprite CHR A/B register separation:
 - **Background (full screen):** White solid 8×8 tiles — B registers ($5128–$512B) select CHR bank 0 (solid pattern), palette 0 (color 3 = white).

--- a/src/cartridge/mmc5.rs
+++ b/src/cartridge/mmc5.rs
@@ -1367,20 +1367,29 @@ impl Mapper for MMC5Mapper {
             let _ = (fine_y, tile_in_pattern);
         }
 
-        // MMC5 split mode: override CHR address bits A0-A2 (fine Y) with the lowest
-        // 3 bits of the split vertical scroll counter. Per NESdev:
-        // "The MMC5 provides CHR A0..3 from the lowest 3 bits of the v-split scanline
-        // counter when rendering the split region."
+        // MMC5 split mode CHR fine Y: CL mode vs SL mode
         //
-        // This allows the split region to have independent vertical scrolling.
-        // During PPU prefetch (pixels 321-336), the scanline counter hasn't incremented
-        // yet, so prefetch tiles naturally get the current scanline's fine Y (off by 1
-        // from the next scanline where they'll be rendered). This is hardware-accurate.
-        if self.split_chr_active() {
-            let split_fine_y = self.split_vertical_scroll() & 0x07;
-            let addr = (addr & !0x07) | split_fine_y as u16;
-            return self.read_chr_banked(bank, addr);
-        }
+        // The MMC5 chip outputs CHR A0-A2 from the lowest 3 bits of its split vertical
+        // scroll counter. However, the PCB wiring determines whether these signals
+        // actually reach the CHR ROM:
+        //
+        // - **CL mode** (all commercial ExROM boards): The MMC5's CHR A0-A2 outputs are
+        //   NOT connected to the CHR ROM address pins. Instead, the PPU's own fine Y
+        //   bits drive CHR A0-A2. This means the split region cannot have independent
+        //   fine vertical scrolling — games must set $5201's low 3 bits to match the
+        //   PPU's fine Y scroll, or tiles will appear to "roll" within themselves.
+        //   Per NESdev: "MMC5 boards wired in 'CL' mode should only use vertical scroll
+        //   values whose bottom 3 bits match the PPU's fine vertical scroll value."
+        //
+        // - **SL mode** (never used in any commercial game): The MMC5's CHR A0-A2 would
+        //   drive the CHR ROM, allowing fully independent fine Y scrolling for the split
+        //   region. No known ExROM board uses this configuration.
+        //
+        // We emulate CL mode (the universal default) and do NOT override CHR fine Y.
+        // The PPU's own fine Y bits pass through to CHR ROM unchanged during split reads.
+        //
+        // Reference: https://www.nesdev.org/wiki/MMC5 (Vertical Behavior, $5201)
+        // Reference: https://www.nesdev.org/wiki/MMC5_pinout (CL/SL mode wiring)
 
         self.read_chr_banked(bank, addr)
     }

--- a/src/integration_tests/mapper_tests.rs
+++ b/src/integration_tests/mapper_tests.rs
@@ -449,7 +449,7 @@ mod tests {
     setup_rom_crc_test!(
         test_mv_m005_0_mmc5_split,
         "roms/automated_tests/mapper_verification/bin/rom_singles/m005.0_mmc5_split.nes",
-        [(60, 1739200149u32)]
+        [(60, 3442676414u32)]
     );
     setup_rom_crc_test!(
         test_mv_m005_0_mmc5_sprite_chr,


### PR DESCRIPTION
## Summary

All commercial ExROM boards use **CL mode** wiring, where the PPU's own fine Y bits drive CHR A0–A2 instead of the MMC5's split scroll counter outputs. **SL mode** (which would allow fully independent fine Y scrolling for the split region) was never used in any commercial game.

This PR reverts the CHR fine Y override added in PR #1719 and defaults to CL mode behavior.

## Changes

- **Remove CHR fine Y override** in `read_chr()` for split mode — the PPU's fine Y passes through unchanged
- **Add thorough CL/SL mode documentation** explaining:
  - CL mode: MMC5's CHR A0–A2 are NOT connected to CHR ROM; PPU's fine Y drives them
  - SL mode: MMC5's CHR A0–A2 would drive CHR ROM (never used commercially)
  - Why CL mode is the correct default
- **Update README** to describe CL mode behavior (no fine Y offset on tiles 0–1)
- **Update split CRC** to reflect CL mode output

## Verification

- All 5560 tests pass
- Visual output confirmed: uniform red stripes across all 16 split columns, no fine Y offset

## References

- [NESdev MMC5 wiki](https://www.nesdev.org/wiki/MMC5) — Vertical Behavior, $5201
- [NESdev MMC5 pinout](https://www.nesdev.org/wiki/MMC5_pinout) — CL/SL mode wiring