### PR TITLE
Fix #1613: Automate homebrew mapper tests

### DIFF
--- a/src/integration_tests/mapper_tests.rs
+++ b/src/integration_tests/mapper_tests.rs
@@ -315,7 +315,94 @@ mod tests {
         "roms/automated_tests/holy-mapperel-bin-0.02/testroms/M180_P128K_H.nes"
     );
 
-    // TODO Homebrew Mappers
+    // Homebrew Mappers
+
+    // Mapper 31 (NSF / homebrew)
+    setup_rom_console_test!(
+        test_homebrew_31_test_16,
+        "roms/automated_tests/31_test_roms/31_test_16.nes",
+        "PASS"
+    );
+    setup_rom_console_test!(
+        test_homebrew_31_test_32,
+        "roms/automated_tests/31_test_roms/31_test_32.nes",
+        "PASS"
+    );
+    setup_rom_console_test!(
+        test_homebrew_31_test_64,
+        "roms/automated_tests/31_test_roms/31_test_64.nes",
+        "PASS"
+    );
+    setup_rom_console_test!(
+        test_homebrew_31_test_128,
+        "roms/automated_tests/31_test_roms/31_test_128.nes",
+        "PASS"
+    );
+    setup_rom_console_test!(
+        test_homebrew_31_test_256,
+        "roms/automated_tests/31_test_roms/31_test_256.nes",
+        "PASS"
+    );
+    setup_rom_console_test!(
+        test_homebrew_31_test_512,
+        "roms/automated_tests/31_test_roms/31_test_512.nes",
+        "PASS"
+    );
+    setup_rom_console_test!(
+        test_homebrew_31_test_1024,
+        "roms/automated_tests/31_test_roms/31_test_1024.nes",
+        "PASS"
+    );
+
+    // Mapper 28 (Action 53 / test28)
+    // Requires Start button press to begin automated tests, then a soft reset
+    // to complete the final bank-persistence check. Uses 16px font (non-ASCII
+    // tile encoding) so we verify by screen CRC instead of console text.
+    #[test]
+    fn test_homebrew_test28() {
+        let rom_path = "roms/automated_tests/test28-0.04/test28.nes";
+        let rom_data = fs::read(rom_path).expect("ROM should load");
+        let cartridge =
+            Cartridge::load_from_file(&rom_data, rom_path, crate::app_context::AppContext::new())
+                .expect("ROM should parse");
+
+        let config = Config {
+            ram_init_mode: RamInitMode::Zero,
+            ..Default::default()
+        };
+        let mut nes = Nes::new(crate::app_context::AppContext::new_with_config(config));
+        nes.insert_cartridge(cartridge);
+        nes.reset(false);
+
+        // Phase 1: Boot and wait for interactive mode to display
+        run_nes_for_frames(&mut nes, 120);
+
+        // Phase 2: Press Start to begin automated tests
+        nes.set_button(1, crate::input::Button::Start, true);
+        run_nes_for_frames(&mut nes, 2);
+        nes.set_button(1, crate::input::Button::Start, false);
+
+        // Phase 3: Run automated tests (~17s for 512K ROM = ~1020 frames)
+        // Wait 1500 frames (~25s) for generous margin
+        run_nes_for_frames(&mut nes, 1500);
+
+        // Phase 4: Trigger soft reset (preserves RAM, like pressing Reset button)
+        // test28 displays "One last thing: Please press the Reset Button"
+        // After reset, wrongbanks.s checks warm boot signature and bank persistence
+        nes.reset(true);
+
+        // Phase 5: Wait for result to display
+        run_nes_for_frames(&mut nes, 120);
+
+        // Phase 6: Verify the screen shows PASS (CRC of the pass screen)
+        let screen = nes.get_screen_buffer();
+        let crc = screen.crc32();
+        assert_eq!(
+            crc, 0x75C81870,
+            "test28 should show PASS screen after reset (actual CRC: 0x{:08X})",
+            crc
+        );
+    }
 
     // MMC3
     setup_rom_test!(

--- a/src/integration_tests/rom_test_runner.rs
+++ b/src/integration_tests/rom_test_runner.rs
@@ -268,10 +268,12 @@ pub(crate) mod tests {
                     }
                 } else if let RomTestVerification::Console { pass_string } = &self.verification {
                     let text = Self::read_console_text(&mut nes);
-                    if text.to_uppercase().ends_with(pass_string) {
+                    let uppercase_text = text.to_uppercase();
+
+                    if uppercase_text.ends_with(pass_string) {
                         return RomTestResult::Pass;
-                    } else if text.to_uppercase().contains("FAILED")
-                        || text.to_uppercase().contains("ERROR")
+                    } else if uppercase_text.contains("FAILED")
+                        || uppercase_text.contains("ERROR")
                         || (text.starts_with("0x") && text.chars().nth(2) != Some('0'))
                     {
                         println!("Test failed!");


### PR DESCRIPTION
## Summary

Adds automated integration tests for the homebrew mapper ROM test suites, replacing the `// TODO Homebrew Mappers` placeholder in `mapper_tests.rs`.

## Changes

### Mapper 31 (NSF / homebrew) - 7 tests
- Tests all 7 ROM sizes: 16K, 32K, 64K, 128K, 256K, 512K, 1024K
- Each ROM tests all 8 PRG banking registers ($5FF8-$5FFF) and their mirrors
- Uses console text verification (screen text ends with "PASS" when all register tests pass)
- All complete in under 1 second each

### Mapper 28 (Action 53 / test28) - 1 test
- Tests comprehensive PRG bank switching for all mode/outer-bank/inner-bank combinations (512K ROM)
- Custom test function because the ROM requires interactive steps:
  1. Press Start button to begin automated tests
  2. Wait for auto-tests to complete (~25s)
  3. Trigger soft reset (preserves RAM) to verify bank persistence
  4. Verify final PASS screen via CRC
- Uses CRC-based screen verification (ROM 16px font tiles do not map to ASCII, so console text decoding does not work)
- Completes in ~8 seconds

### rom_test_runner.rs
- Minor efficiency fix: cache text.to_uppercase() in local variable instead of computing it 3 times per frame in Console verification

## Validation

- cargo clippy --all-targets --all-features -- -D warnings: clean
- cargo fmt: clean
- cargo nextest run --all-features --lib: 5941 tests pass, 0 failures
- wasm-pack test --headless --chrome --no-default-features --features wasm: 48 tests pass
- // TODO Homebrew Mappers comment removed

Closes #1613
