### PR TITLE
feat: native frontend uses DebuggerController (#1795)

### DIFF
--- a/src/native_frontend/event_loop.rs
+++ b/src/native_frontend/event_loop.rs
@@ -32,6 +32,9 @@ pub struct NativeEventLoop {
     tracing: Tracing,
     state: NativeAppState,
     debugger_controller: DebuggerController,
+    /// Whether the user had manually paused before the debugger opened,
+    /// so we can restore pause state when the debugger closes.
+    paused_before_debugger: bool,
     gamepad: Option<GamepadManager>,
     gamepads_enabled: bool,
     gamepad_toast_shown: bool,
@@ -84,6 +87,7 @@ impl NativeEventLoop {
                 ..NativeAppState::default()
             },
             debugger_controller,
+            paused_before_debugger: false,
             gamepad,
             gamepads_enabled,
             gamepad_toast_shown: false,
@@ -148,10 +152,15 @@ impl NativeEventLoop {
     /// Sync frontend state from the debugger controller.
     fn sync_from_controller(&mut self) {
         if self.debugger_controller.is_debugger_open() {
+            if !self.state.debugger_open {
+                // Debugger just opened — remember manual pause state.
+                self.paused_before_debugger = self.state.paused;
+            }
             self.state.paused = true;
             self.state.debugger_open = true;
         } else if self.state.debugger_open {
-            self.state.paused = false;
+            // Debugger just closed — restore manual pause state.
+            self.state.paused = self.paused_before_debugger;
             self.state.debugger_open = false;
         }
     }
@@ -279,7 +288,11 @@ impl ApplicationHandler for NativeEventLoop {
                         audio_ref,
                     );
                     match outcome {
-                        KeyOutcome::Quit => event_loop.exit(),
+                        KeyOutcome::Quit => {
+                            self.debugger_controller
+                                .save_breakpoints_to_debug_file(&self.nes);
+                            event_loop.exit();
+                        }
                         KeyOutcome::CycleShader => {
                             if let Some(ref mut gl) = self.gl_wrapper {
                                 gl.cycle_shader();

--- a/src/native_frontend/keyboard.rs
+++ b/src/native_frontend/keyboard.rs
@@ -517,23 +517,33 @@ mod tests {
     }
 
     #[test]
-    fn test_f5_opens_debugger_when_closed() {
+    fn test_f5_returns_toggle_debugger() {
         let mut nes = make_nes();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::F5, &mut state, None);
-        assert!(state.debugger_open);
-        assert!(state.paused, "Opening debugger should pause emulation");
+        assert_eq!(
+            handle_key_pressed(&mut nes, KeyCode::F5, &mut state, None),
+            KeyOutcome::ToggleDebugger
+        );
     }
 
     #[test]
-    fn test_f5_closes_debugger_when_open() {
+    fn test_f10_returns_step_over() {
         let mut nes = make_nes();
         let mut state = make_state();
-        state.debugger_open = true;
-        state.paused = true;
-        handle_key_pressed(&mut nes, KeyCode::F5, &mut state, None);
-        assert!(!state.debugger_open);
-        assert!(!state.paused, "Closing debugger should resume emulation");
+        assert_eq!(
+            handle_key_pressed(&mut nes, KeyCode::F10, &mut state, None),
+            KeyOutcome::StepOver
+        );
+    }
+
+    #[test]
+    fn test_f11_returns_step_into() {
+        let mut nes = make_nes();
+        let mut state = make_state();
+        assert_eq!(
+            handle_key_pressed(&mut nes, KeyCode::F11, &mut state, None),
+            KeyOutcome::StepInto
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wires the native frontend (winit/glutin) to use the shared `DebuggerController` from #1793, replacing the previous minimal/broken debugger support.

Closes #1795

## What was broken before

- `DebuggerUiAction` returned from `gl.render()` was **discarded** — debugger UI buttons (step, continue, breakpoints) did nothing
- F10/F11 used a blocking `run_cpu_tick()` loop that ignored breakpoints
- No breakpoint evaluation in the emulation loop
- No breakpoint loading/saving from `.debug` files

## Changes

### `src/native_frontend/event_loop.rs` (+55, -14 lines)

- **Added** `debugger_controller: DebuggerController` field
- **Replaced** `run_frame()` — now uses `controller.run_frame()` with breakpoint evaluation every instruction and audio drain callback
- **Added** `sync_from_controller()` — syncs `state.paused`/`state.debugger_open` from controller
- **Captures** `DebuggerUiAction` from render and applies via `controller.apply_ui_action()`
- **Syncs** breakpoints to GlBackend via `update_breakpoints()` before each render
- **Loads** breakpoints from `.debug` file on init (Resumed event)
- **Saves** breakpoints on `CloseRequested`
- **Handles** new `KeyOutcome` variants: `ToggleDebugger`, `StepOver`, `StepInto`

### `src/native_frontend/keyboard.rs` (+14, -47 lines)

- **Added** `KeyOutcome::ToggleDebugger`, `StepOver`, `StepInto` variants
- **F5/F10/F11** now return outcome variants instead of inline logic
- **Removed** `toggle_debugger()`, `step_into()`, `step_over()`, `enter_debugger_paused()` — replaced by `DebuggerController` methods

## Testing

- ✅ `cargo check --features native --no-default-features` compiles
- ✅ `cargo check --all-features` compiles (5 pre-existing native_frontend clippy warnings)
- ✅ Full test suite: 5896 passed, 0 failed
- ✅ `cargo fmt --check` clean

## Design Notes

- Same `sync_from_controller()` pattern as SDL frontend (PR #1798)
- Audio drain uses `RefCell` to split borrows between controller and audio
- Breakpoint-based stepping for JSR step-over now works correctly (was a blocking loop before)
- Manual pause (Space key) still works independently of debugger pause
