### PR TITLE
Wire autorun recording/playback into native frontend

### DIFF
--- a/src/autorun/headless_playback.rs
+++ b/src/autorun/headless_playback.rs
@@ -159,7 +159,10 @@ where
 
 /// Emulate the NES until the PPU signals a completed frame, then clear the flag.
 #[allow(dead_code)]
-fn run_one_frame(nes: &mut Nes) {
+/// Run a single NES frame without audio, draining samples.
+///
+/// Used by headless playback and the native frontend's headless autorun loop.
+pub fn run_one_frame(nes: &mut Nes) {
     while !nes.is_ready_to_render() && !nes.cpu_ref().is_halted() {
         nes.run_cpu_tick();
         // Drain audio samples to avoid unbounded accumulation

--- a/src/main.rs
+++ b/src/main.rs
@@ -491,8 +491,9 @@ fn run_native_frontend(
         )
     };
 
-    // In headless autorun mode, skip audio
-    let headless = autorun_headless && autorun_mode != console::AutorunMode::None;
+    // Headless autorun is only supported in playback mode because
+    // record/extend have no guaranteed termination condition.
+    let headless = autorun_headless && autorun_mode == console::AutorunMode::Playback;
 
     // Create audio output (request 44.1 kHz) unless disabled or headless.
     let mut audio_sample_rate = None;

--- a/src/native_frontend/app_state.rs
+++ b/src/native_frontend/app_state.rs
@@ -304,4 +304,73 @@ mod tests {
             "cart-switch overlay should not show help text"
         );
     }
+
+    // ── overlay_text: autorun ─────────────────────────────────────────────────
+
+    fn make_recording_autorun_state() -> AutorunState {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let rom_path = dir.path().join("test.nes");
+        std::fs::write(&rom_path, b"dummy").expect("write dummy rom");
+        let (state, _) = AutorunState::new(
+            AutorunMode::Record,
+            rom_path.to_str().unwrap(),
+            true,
+            false,
+            None,
+            crate::autorun::AutorunFormat::Json,
+        )
+        .expect("create recording autorun state");
+        state
+    }
+
+    #[test]
+    fn test_overlay_text_shows_autorun_when_active() {
+        let state = NativeAppState::default();
+        let autorun = make_recording_autorun_state();
+        let text = state.overlay_text(&make_nes(), Some(&autorun));
+        assert!(text.is_some(), "overlay_text should be Some for autorun");
+        assert!(
+            text.unwrap().contains("Recording"),
+            "autorun overlay should show 'Recording'"
+        );
+    }
+
+    #[test]
+    fn test_overlay_text_autorun_takes_priority_over_help() {
+        let mut state = NativeAppState::default();
+        state.help_overlay_visible = true;
+        let autorun = make_recording_autorun_state();
+        let text = state.overlay_text(&make_nes(), Some(&autorun)).unwrap();
+        assert!(
+            text.contains("Recording"),
+            "autorun overlay should take priority over help"
+        );
+        assert!(
+            !text.contains("W/A/S/D"),
+            "help overlay should not appear when autorun is active"
+        );
+    }
+
+    #[test]
+    fn test_overlay_text_cart_switch_takes_priority_over_autorun() {
+        let mut state = NativeAppState::default();
+        state.cart_switch.open = true;
+        let autorun = make_recording_autorun_state();
+        let text = state.overlay_text(&make_nes(), Some(&autorun)).unwrap();
+        assert!(
+            text.contains("Cartridge Switch"),
+            "cart-switch should take priority over autorun"
+        );
+    }
+
+    // ── format helpers ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_format_mm_ss() {
+        assert_eq!(format_mm_ss(0), "00:00");
+        assert_eq!(format_mm_ss(59), "00:59");
+        assert_eq!(format_mm_ss(60), "01:00");
+        assert_eq!(format_mm_ss(125), "02:05");
+        assert_eq!(format_mm_ss(3661), "61:01");
+    }
 }

--- a/src/native_frontend/event_loop.rs
+++ b/src/native_frontend/event_loop.rs
@@ -410,14 +410,7 @@ impl NativeEventLoop {
 
             let checkpoint_due = self.handle_autorun_after_input();
 
-            // Emulate one frame without audio
-            while !self.nes.is_ready_to_render() && !self.nes.cpu_ref().is_halted() {
-                self.nes.run_cpu_tick();
-                while self.nes.sample_ready() {
-                    self.nes.get_sample();
-                }
-            }
-            self.nes.clear_ready_to_render();
+            crate::autorun::headless_playback::run_one_frame(&mut self.nes);
 
             self.handle_autorun_after_frame(checkpoint_due);
         }
@@ -455,7 +448,9 @@ impl ApplicationHandler for NativeEventLoop {
     ) {
         match event {
             WindowEvent::CloseRequested => {
-                let _ = self.finish_recording();
+                if let Err(e) = self.finish_recording() {
+                    eprintln!("Failed to finish recording on window close: {e}");
+                }
                 self.debugger_controller
                     .save_breakpoints_to_debug_file(&self.nes);
                 event_loop.exit();
@@ -510,7 +505,9 @@ impl ApplicationHandler for NativeEventLoop {
                     );
                     match outcome {
                         KeyOutcome::Quit => {
-                            let _ = self.finish_recording();
+                            if let Err(e) = self.finish_recording() {
+                                eprintln!("Failed to finish recording on quit: {e}");
+                            }
                             self.debugger_controller
                                 .save_breakpoints_to_debug_file(&self.nes);
                             event_loop.exit();


### PR DESCRIPTION
## Summary

Wire the shared `AutorunState` into the native frontend event loop for CI testing support — recording, playback, extend, and headless modes.

## Changes

### `src/native_frontend/event_loop.rs` (+242 lines)
- `init_autorun()` — initializes recording/playback/extend from config, restores checkpoint state
- `handle_autorun_before_frame()` — applies recorded input during playback
- `handle_autorun_after_input()` — captures button states during recording
- `handle_autorun_after_frame()` — captures/verifies checkpoint CRCs
- `finish_playback()` / `finish_recording()` — exit code handling and file saving
- `run_headless()` — tight frame loop without window/GL/audio for CI
- Updated `run_frame()`, `CloseRequested`, and `Quit` handlers with autorun hooks

### `src/native_frontend/app_state.rs` (+75 lines)
- `overlay_text()` now accepts `Option<&AutorunState>` and shows autorun progress
- Added `autorun_overlay_text()` with recording/playback/extend progress display

### `src/main.rs` (+57 lines)
- Read autorun config (mode, headless, overwrite, extend, from_checkpoint, format)
- Skip audio in headless mode
- Call `init_autorun()` after NES reset
- Handle `AUTORUN_EXIT:` exit codes (same pattern as SDL)

## Testing
- 124 native frontend tests pass
- 5911 full suite tests pass
- Shared `AutorunState` already has 22 unit tests

Closes #1777