### PR TITLE
Complete cartridge switching dialog in native frontend (#1805)

### DIFF
--- a/src/native_frontend/app_state.rs
+++ b/src/native_frontend/app_state.rs
@@ -38,9 +38,20 @@ impl CartridgeSwitchState {
         self.filtered_indices.clear();
     }
 
+    /// Returns true when a non-empty filter is active and
+    /// `filtered_indices` is populated.
+    pub fn has_active_filter(&self) -> bool {
+        !self.filter.is_empty()
+    }
+
     /// Recomputes `filtered_indices` from the current filter text.
     /// Clamps `selection` so it stays within the visible range.
     pub fn refresh_filtered(&mut self) {
+        if self.filter.is_empty() {
+            self.filtered_indices.clear();
+            return;
+        }
+
         let needle = self.filter.to_ascii_lowercase();
         self.filtered_indices = self
             .entries
@@ -660,6 +671,18 @@ mod tests {
         assert!(!cs.open);
         assert!(cs.filter.is_empty());
         assert_eq!(cs.selection, 0);
+    }
+
+    #[test]
+    fn test_refresh_filtered_empty_filter_does_not_populate_indices() {
+        let mut cs = make_cart_switch(&["a.nes", "b.nes", "c.nes"]);
+        cs.filter.clear();
+        cs.refresh_filtered();
+        assert!(
+            !cs.has_active_filter(),
+            "empty filter should not populate filtered_indices"
+        );
+        assert_eq!(cs.visible_count(), 3, "all entries visible without filter");
     }
 
     // ── overlay text: cartridge switch ────────────────────────────────────────

--- a/src/native_frontend/event_loop.rs
+++ b/src/native_frontend/event_loop.rs
@@ -36,6 +36,8 @@ pub struct NativeEventLoop {
     /// Whether the user had manually paused before the debugger opened,
     /// so we can restore pause state when the debugger closes.
     paused_before_debugger: bool,
+    /// Whether the user had manually paused before the cart-switch dialog opened.
+    paused_before_cart_switch: bool,
     gamepad: Option<GamepadManager>,
     gamepads_enabled: bool,
     gamepad_toast_shown: bool,
@@ -96,6 +98,7 @@ impl NativeEventLoop {
             },
             debugger_controller,
             paused_before_debugger: false,
+            paused_before_cart_switch: false,
             gamepad,
             gamepads_enabled,
             gamepad_toast_shown: false,
@@ -244,6 +247,7 @@ impl NativeEventLoop {
 
     /// Opens the cartridge-switch dialog, loading the catalog CSV first.
     fn open_cartridge_switch_dialog(&mut self) {
+        self.paused_before_cart_switch = self.state.paused;
         self.state.cart_switch.open = true;
         self.state.cart_switch.filter.clear();
         self.state.cart_switch.selection = 0;
@@ -253,6 +257,12 @@ impl NativeEventLoop {
         }
 
         self.state.paused = true;
+    }
+
+    /// Restores the pause state that was active before the dialog opened.
+    fn restore_pause_after_cart_switch(&mut self) {
+        self.state.paused = self.state.debugger_open || self.paused_before_cart_switch;
+        self.paused_before_cart_switch = false;
     }
 
     /// Loads cartridge catalog entries from the default CSV path.
@@ -599,9 +609,13 @@ impl ApplicationHandler for NativeEventLoop {
                         }
                         KeyOutcome::SwitchCartridge(path) => {
                             self.switch_to_cartridge(&path);
+                            self.restore_pause_after_cart_switch();
                         }
                         KeyOutcome::OpenCartridgeSwitch => {
                             self.open_cartridge_switch_dialog();
+                        }
+                        KeyOutcome::CloseCartridgeSwitch => {
+                            self.restore_pause_after_cart_switch();
                         }
                         KeyOutcome::Continue => {
                             if self.state.fullscreen != fullscreen_before {

--- a/src/native_frontend/keyboard.rs
+++ b/src/native_frontend/keyboard.rs
@@ -29,6 +29,8 @@ pub enum KeyOutcome {
     SwitchCartridge(String),
     /// The user requested the cartridge-switch dialog (Ctrl+O).
     OpenCartridgeSwitch,
+    /// The user closed the cartridge-switch dialog (Escape).
+    CloseCartridgeSwitch,
 }
 
 /// Handles a key-press event.
@@ -275,7 +277,7 @@ fn handle_cartridge_switch_key(key_code: KeyCode, app_state: &mut NativeAppState
     match key_code {
         KeyCode::Escape => {
             app_state.cart_switch.close();
-            KeyOutcome::Continue
+            KeyOutcome::CloseCartridgeSwitch
         }
         KeyCode::ArrowDown => {
             app_state.cart_switch.move_selection_next();
@@ -299,7 +301,7 @@ fn handle_cartridge_switch_key(key_code: KeyCode, app_state: &mut NativeAppState
             }
         }
         _ => {
-            if let Some(ch) = key_code_to_filter_char(key_code) {
+            if let Some(ch) = key_code_to_filter_char(key_code, app_state.modifiers.shift_key()) {
                 app_state.cart_switch.filter.push(ch);
                 app_state.cart_switch.refresh_filtered();
             }
@@ -309,7 +311,7 @@ fn handle_cartridge_switch_key(key_code: KeyCode, app_state: &mut NativeAppState
 }
 
 /// Maps a physical key code to its lowercase character for the filter field.
-fn key_code_to_filter_char(key_code: KeyCode) -> Option<char> {
+fn key_code_to_filter_char(key_code: KeyCode, shift: bool) -> Option<char> {
     match key_code {
         KeyCode::KeyA => Some('a'),
         KeyCode::KeyB => Some('b'),
@@ -348,7 +350,7 @@ fn key_code_to_filter_char(key_code: KeyCode) -> Option<char> {
         KeyCode::Digit8 => Some('8'),
         KeyCode::Digit9 => Some('9'),
         KeyCode::Space => Some(' '),
-        KeyCode::Minus => Some('-'),
+        KeyCode::Minus => Some(if shift { '_' } else { '-' }),
         KeyCode::Period => Some('.'),
         KeyCode::Slash => Some('/'),
         _ => None,
@@ -936,6 +938,45 @@ mod tests {
             buttons(&nes, 1) & BIT_UP,
             0,
             "W should not control NES when dialog is open"
+        );
+    }
+
+    // ── Review fix: Escape returns CloseCartridgeSwitch ───────────────────────
+
+    #[test]
+    fn test_cart_switch_escape_returns_close_outcome() {
+        let mut nes = make_nes();
+        let mut state = make_cart_switch_state(&["a.nes"]);
+        let outcome = handle_key_pressed(&mut nes, KeyCode::Escape, &mut state, None);
+        assert_eq!(
+            outcome,
+            KeyOutcome::CloseCartridgeSwitch,
+            "Escape should return CloseCartridgeSwitch so event loop can restore pause"
+        );
+    }
+
+    // ── Review fix: underscore via Shift+Minus ────────────────────────────────
+
+    #[test]
+    fn test_cart_switch_shift_minus_types_underscore() {
+        let mut nes = make_nes();
+        let mut state = make_cart_switch_state(&["a_b.nes"]);
+        state.modifiers = ModifiersState::SHIFT;
+        handle_key_pressed(&mut nes, KeyCode::Minus, &mut state, None);
+        assert_eq!(
+            state.cart_switch.filter, "_",
+            "Shift+Minus should type underscore"
+        );
+    }
+
+    #[test]
+    fn test_cart_switch_minus_without_shift_types_dash() {
+        let mut nes = make_nes();
+        let mut state = make_cart_switch_state(&["a-b.nes"]);
+        handle_key_pressed(&mut nes, KeyCode::Minus, &mut state, None);
+        assert_eq!(
+            state.cart_switch.filter, "-",
+            "Minus without Shift should type dash"
         );
     }
 }


### PR DESCRIPTION
## Summary

Completes the cartridge-switch dialog in the native frontend with full text input, fuzzy search, cartridge loading, and catalog integration — matching SDL2 frontend behavior.

Closes #1805

## Changes

### CartridgeSwitchState enhancements (`app_state.rs`)
- Added `filtered_indices` field for tracking visible entries after filtering
- `refresh_filtered()` — recomputes filtered indices and clamps selection
- `visible_count()` — returns filtered or total count
- `move_selection_next/prev()` — wrapping navigation
- `selected_entry()` / `visible_entry_at()` — entry lookup by visible index
- `fuzzy_matches()` — subsequence matching (chars in order, not consecutive)
- `entry_matches_filter()` — fuzzy on filename, substring on directory
- Updated overlay text to match SDL: filter label, match count, scrolling window (12 max), selection markers

### Keyboard handler (`keyboard.rs`)
- New `KeyOutcome::SwitchCartridge(String)` — carries selected ROM path
- New `KeyOutcome::OpenCartridgeSwitch` — signals event loop to load catalog
- `handle_cartridge_switch_key()` now returns `KeyOutcome`
- Added text input (a-z, 0-9, space, dash, period, slash), Backspace, Enter handling
- `key_code_to_filter_char()` — maps physical keys to filter characters

### Event loop wiring (`event_loop.rs`)
- `open_cartridge_switch_dialog()` — opens dialog, loads catalog, pauses
- `load_catalog_entries()` — reads `~/.neser/cartridges.csv`
- `switch_to_cartridge()` — reads ROM, loads cartridge, applies timing mode, hard resets
- Dispatches `SwitchCartridge` and `OpenCartridgeSwitch` outcomes

## Testing

36 new unit tests:
- 10 fuzzy matching tests
- 12 CartridgeSwitchState model tests
- 6 overlay text tests
- 10 keyboard interaction tests (typing, backspace, enter, escape, arrows, controller isolation)

**164 native frontend tests pass** (was 128).
