### PR TITLE
Pause audio on focus loss in native frontend (#1811)

### DIFF
--- a/src/native_frontend/event_loop.rs
+++ b/src/native_frontend/event_loop.rs
@@ -547,7 +547,14 @@ impl ApplicationHandler for NativeEventLoop {
 
             WindowEvent::Focused(focused) => {
                 self.state.window_focused = focused;
-                if !focused {
+                if focused {
+                    if let Some(ref audio) = self.audio {
+                        audio.resume();
+                    }
+                } else {
+                    if let Some(ref audio) = self.audio {
+                        audio.pause();
+                    }
                     // Release grab on focus loss, but do NOT set
                     // mouse_released_by_escape — that flag is only for
                     // explicit Escape key presses. Keeping it clear means


### PR DESCRIPTION
## Summary

Pauses audio output when the native frontend window loses focus and resumes it when focus returns. Prevents the emulator from blaring audio when the user switches to another application.

Closes #1811

## Changes

- Call `audio.pause()` on `WindowEvent::Focused(false)`
- Call `audio.resume()` on `WindowEvent::Focused(true)`
- Mouse grab release on focus loss (unchanged behavior)

Minimal change — the `NesAudio` trait already had `pause()`/`resume()` methods.

## Testing

178 native frontend tests pass (no new tests needed — audio pause/resume already tested in audio.rs).