### PR TITLE
Add VS System arcade input (coin, DIP, service) — #1834

### DIFF
--- a/src/bus/bus.rs
+++ b/src/bus/bus.rs
@@ -1,5 +1,7 @@
 use super::apu_device::ApuDevice;
-use super::controller_device::ControllerDevice;
+use super::controller_device::{
+    ControllerDevice, VS_INPUT_COIN_SLOT1, VS_INPUT_COIN_SLOT2, VS_INPUT_SERVICE,
+};
 use super::mapper_device::MapperDevice;
 use super::oam_dma_device::OamDmaDevice;
 use super::ppu_device::PpuDevice;
@@ -16,7 +18,7 @@ use crate::input::{
 };
 use crate::ppu::{self, SharedPpu};
 use serde::{Deserialize, Serialize};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::io;
 use std::ops::RangeInclusive;
 
@@ -56,20 +58,25 @@ pub struct MapperState {
 use std::path::PathBuf;
 use std::rc::Rc;
 
+/// Configuration passed to [`BusDevice::sync_controller_modes`] when the
+/// emulator config changes (e.g. expansion-port auto-detection from ROM DB).
+#[derive(Debug, Clone, Default)]
+pub struct ControllerModes {
+    pub four_score_enabled: bool,
+    pub famicom_four_players_enabled: bool,
+    pub famicom_mode: bool,
+    pub arkanoid_famicom_enabled: bool,
+    pub zapper_famicom_enabled: bool,
+    pub power_pad_famicom_enabled: bool,
+    pub vs_system_enabled: bool,
+    pub vs_dip_switches: u8,
+}
+
 pub trait BusDevice {
     fn read(&mut self, addr: u16, open_bus: u8, is_dummy_read: bool) -> Option<u8>;
     fn write(&mut self, addr: u16, value: u8, is_dummy_write: bool) -> bool;
     fn address_range(&self) -> RangeInclusive<u16>;
-    fn sync_controller_modes(
-        &mut self,
-        _four_score_enabled: bool,
-        _famicom_four_players_enabled: bool,
-        _famicom_mode: bool,
-        _arkanoid_famicom_enabled: bool,
-        _zapper_famicom_enabled: bool,
-        _power_pad_famicom_enabled: bool,
-    ) {
-    }
+    fn sync_controller_modes(&mut self, _modes: &ControllerModes) {}
 }
 
 pub type SharedBus = Rc<RefCell<Bus>>;
@@ -88,6 +95,7 @@ pub struct Bus {
     expansion_arkanoid: Rc<RefCell<ArkanoidController>>, // Famicom expansion Arkanoid controller
     expansion_zapper: Rc<RefCell<Zapper>>,              // Famicom expansion Zapper controller
     expansion_power_pad: Rc<RefCell<PowerPad>>,         // Famicom expansion Power Pad controller
+    vs_arcade_input: Rc<Cell<u8>>,                      // VS System coin/service input state
     open_bus: u8, // Last value on the data bus for open bus behavior
     devices: Vec<Box<dyn BusDevice>>,
 }
@@ -136,6 +144,7 @@ impl Bus {
         let expansion_arkanoid = Rc::new(RefCell::new(ArkanoidController::new()));
         let expansion_zapper = Rc::new(RefCell::new(Zapper::new(ppu.clone(), app_context.clone())));
         let expansion_power_pad = Rc::new(RefCell::new(PowerPad::new()));
+        let vs_arcade_input = Rc::new(Cell::new(0u8));
 
         let mut controller = Self {
             cpu_ram: Rc::new(RefCell::new(cpu_ram)),
@@ -150,6 +159,7 @@ impl Bus {
             expansion_arkanoid,
             expansion_zapper,
             expansion_power_pad,
+            vs_arcade_input,
             open_bus: 0xFF, // Initialize to 0xFF (common power-on state)
             devices: Vec::new(),
         };
@@ -175,6 +185,7 @@ impl Bus {
         controller_device.set_zapper_famicom_expansion(Some(controller.expansion_zapper.clone()));
         controller_device
             .set_power_pad_famicom_expansion(Some(controller.expansion_power_pad.clone()));
+        controller_device.set_vs_arcade_input(controller.vs_arcade_input.clone());
         controller.register_device(Box::new(controller_device));
         controller.register_device(Box::new(ApuDevice::new(controller.apu.clone())));
         controller.register_device(Box::new(OamDmaDevice::new(
@@ -193,23 +204,21 @@ impl Bus {
 
     pub fn sync_controller_modes_from_config(&mut self) {
         let app_context = self.app_context.borrow();
-        let four_score_enabled = app_context.config().four_score_enabled;
-        let famicom_four_players_enabled = Self::is_famicom_four_players(app_context.config());
-        let famicom_mode = app_context.config().hardware_mode == HardwareMode::Famicom;
-        let arkanoid_famicom_enabled = Self::is_arkanoid_famicom(app_context.config());
-        let zapper_famicom_enabled = Self::is_zapper_famicom(app_context.config());
-        let power_pad_famicom_enabled = Self::is_power_pad_famicom(app_context.config());
+        let config = app_context.config();
+        let modes = ControllerModes {
+            four_score_enabled: config.four_score_enabled,
+            famicom_four_players_enabled: Self::is_famicom_four_players(config),
+            famicom_mode: config.hardware_mode == HardwareMode::Famicom,
+            arkanoid_famicom_enabled: Self::is_arkanoid_famicom(config),
+            zapper_famicom_enabled: Self::is_zapper_famicom(config),
+            power_pad_famicom_enabled: Self::is_power_pad_famicom(config),
+            vs_system_enabled: Self::is_vs_system(config),
+            vs_dip_switches: config.vs_dip_switches,
+        };
         drop(app_context);
 
         for device in self.devices.iter_mut() {
-            device.sync_controller_modes(
-                four_score_enabled,
-                famicom_four_players_enabled,
-                famicom_mode,
-                arkanoid_famicom_enabled,
-                zapper_famicom_enabled,
-                power_pad_famicom_enabled,
-            );
+            device.sync_controller_modes(&modes);
         }
     }
 
@@ -235,6 +244,10 @@ impl Bus {
     fn is_power_pad_famicom(config: &crate::console::Config) -> bool {
         config.hardware_mode == HardwareMode::Famicom
             && config.expansion_port == ExpansionPort::PowerPadFamicom
+    }
+
+    fn is_vs_system(config: &crate::console::Config) -> bool {
+        config.expansion_port == ExpansionPort::VsSystem
     }
 
     fn has_player34_serial_enabled(&self) -> bool {
@@ -608,6 +621,31 @@ impl Bus {
             states[player_index] |= 1 << bit;
         } else {
             states[player_index] &= !(1 << bit);
+        }
+    }
+
+    /// Set VS System coin insert state for a specific slot (0 or 1).
+    pub fn set_vs_coin_insert(&self, slot: u8, pressed: bool) {
+        let bit = if slot == 0 {
+            VS_INPUT_COIN_SLOT1
+        } else {
+            VS_INPUT_COIN_SLOT2
+        };
+        let current = self.vs_arcade_input.get();
+        if pressed {
+            self.vs_arcade_input.set(current | bit);
+        } else {
+            self.vs_arcade_input.set(current & !bit);
+        }
+    }
+
+    /// Set VS System service button state.
+    pub fn set_vs_service_button(&self, pressed: bool) {
+        let current = self.vs_arcade_input.get();
+        if pressed {
+            self.vs_arcade_input.set(current | VS_INPUT_SERVICE);
+        } else {
+            self.vs_arcade_input.set(current & !VS_INPUT_SERVICE);
         }
     }
 

--- a/src/bus/controller_device.rs
+++ b/src/bus/controller_device.rs
@@ -1,11 +1,17 @@
-use crate::bus::bus::BusDevice;
+use crate::bus::bus::{BusDevice, ControllerModes};
 use crate::input::ArkanoidController;
 use crate::input::Controller;
 use crate::input::PowerPad;
 use crate::input::Zapper;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::ops::RangeInclusive;
 use std::rc::Rc;
+
+/// Packed bit flags for VS System arcade input, shared between Bus and
+/// ControllerDevice via `Rc<Cell<u8>>`.
+pub(crate) const VS_INPUT_COIN_SLOT1: u8 = 0x01;
+pub(crate) const VS_INPUT_COIN_SLOT2: u8 = 0x02;
+pub(crate) const VS_INPUT_SERVICE: u8 = 0x04;
 
 pub(crate) struct ControllerDevice {
     controllers: [Rc<RefCell<Box<dyn Controller>>>; 2],
@@ -23,6 +29,9 @@ pub(crate) struct ControllerDevice {
     zapper_famicom_enabled: bool,
     power_pad_expansion: Option<Rc<RefCell<PowerPad>>>,
     power_pad_famicom_enabled: bool,
+    vs_system_enabled: bool,
+    vs_arcade_input: Rc<Cell<u8>>,
+    vs_dip_switches: u8,
 }
 
 impl ControllerDevice {
@@ -63,6 +72,9 @@ impl ControllerDevice {
             zapper_famicom_enabled: false,
             power_pad_expansion: None,
             power_pad_famicom_enabled: false,
+            vs_system_enabled: false,
+            vs_arcade_input: Rc::new(Cell::new(0)),
+            vs_dip_switches: 0,
         }
     }
 
@@ -106,6 +118,62 @@ impl ControllerDevice {
 
     pub(crate) fn set_power_pad_famicom_enabled(&mut self, enabled: bool) {
         self.power_pad_famicom_enabled = enabled;
+    }
+
+    pub(crate) fn set_vs_system_enabled(&mut self, enabled: bool) {
+        self.vs_system_enabled = enabled;
+    }
+
+    pub(crate) fn set_vs_arcade_input(&mut self, input: Rc<Cell<u8>>) {
+        self.vs_arcade_input = input;
+    }
+
+    pub(crate) fn set_vs_dip_switches(&mut self, value: u8) {
+        self.vs_dip_switches = value;
+    }
+
+    /// Read VS System controller register.
+    ///
+    /// In VS System mode all 8 bits of $4016/$4017 are hardware-defined
+    /// (no open-bus bits).
+    ///
+    /// $4016 read: `PCCD DS0B`
+    ///   bit 0: right stick serial data
+    ///   bit 1: always 0
+    ///   bit 2: service button
+    ///   bits 3-4: DIP switches 1-2
+    ///   bits 5-6: coin inserted (slot 1, slot 2)
+    ///   bit 7: 0 = primary CPU (UniSystem)
+    ///
+    /// $4017 read: `DDDD DD0B`
+    ///   bit 0: left stick serial data
+    ///   bit 1: always 0
+    ///   bits 2-7: DIP switches 3-8
+    fn read_vs_system_bit(&mut self, port_index: usize, is_dummy_read: bool) -> u8 {
+        let controller_bit = self.controllers[port_index]
+            .borrow_mut()
+            .read(is_dummy_read)
+            & 0x01;
+
+        if port_index == 0 {
+            let arcade = self.vs_arcade_input.get();
+            let mut value = controller_bit;
+            if arcade & VS_INPUT_SERVICE != 0 {
+                value |= 0x04;
+            }
+            value |= (self.vs_dip_switches & 0x03) << 3;
+            if arcade & VS_INPUT_COIN_SLOT1 != 0 {
+                value |= 0x20;
+            }
+            if arcade & VS_INPUT_COIN_SLOT2 != 0 {
+                value |= 0x40;
+            }
+            value
+        } else {
+            let mut value = controller_bit;
+            value |= self.vs_dip_switches & 0xFC;
+            value
+        }
     }
 
     fn read_arkanoid_famicom_bit(&mut self, port_index: usize, is_dummy_read: bool) -> u8 {
@@ -229,6 +297,11 @@ impl BusDevice for ControllerDevice {
     fn read(&mut self, addr: u16, open_bus: u8, is_dummy_read: bool) -> Option<u8> {
         let index = (addr - 0x4016) as usize;
 
+        // VS System: all 8 bits are hardware-defined, no open bus
+        if self.vs_system_enabled {
+            return Some(self.read_vs_system_bit(index, is_dummy_read));
+        }
+
         let mut controller_state = if self.four_score_enabled {
             self.read_four_score_bit(index, is_dummy_read)
         } else if self.famicom_four_players_enabled {
@@ -302,21 +375,15 @@ impl BusDevice for ControllerDevice {
         0x4016..=0x4017
     }
 
-    fn sync_controller_modes(
-        &mut self,
-        four_score_enabled: bool,
-        famicom_four_players_enabled: bool,
-        famicom_mode: bool,
-        arkanoid_famicom_enabled: bool,
-        zapper_famicom_enabled: bool,
-        power_pad_famicom_enabled: bool,
-    ) {
-        self.set_four_score_enabled(four_score_enabled);
-        self.set_famicom_four_players_enabled(famicom_four_players_enabled);
-        self.famicom_mode = famicom_mode;
-        self.set_arkanoid_famicom_enabled(arkanoid_famicom_enabled);
-        self.set_zapper_famicom_enabled(zapper_famicom_enabled);
-        self.set_power_pad_famicom_enabled(power_pad_famicom_enabled);
+    fn sync_controller_modes(&mut self, modes: &ControllerModes) {
+        self.set_four_score_enabled(modes.four_score_enabled);
+        self.set_famicom_four_players_enabled(modes.famicom_four_players_enabled);
+        self.famicom_mode = modes.famicom_mode;
+        self.set_arkanoid_famicom_enabled(modes.arkanoid_famicom_enabled);
+        self.set_zapper_famicom_enabled(modes.zapper_famicom_enabled);
+        self.set_power_pad_famicom_enabled(modes.power_pad_famicom_enabled);
+        self.set_vs_system_enabled(modes.vs_system_enabled);
+        self.set_vs_dip_switches(modes.vs_dip_switches);
     }
 }
 
@@ -896,6 +963,195 @@ mod tests {
             0xF8,
             "$4016 bits 3-7 should be open bus (mask 0xF8) even with Zapper expansion. Got ${:02X}",
             value
+        );
+    }
+
+    // ── VS System tests ──────────────────────────────────────────────────────
+
+    /// Create a VS System-enabled controller device with a shared arcade input cell.
+    fn create_vs_controller_device() -> (ControllerDevice, Rc<Cell<u8>>) {
+        let mut device = create_test_controller_device();
+        let arcade_input = Rc::new(Cell::new(0u8));
+        device.set_vs_arcade_input(arcade_input.clone());
+        device.set_vs_system_enabled(true);
+        (device, arcade_input)
+    }
+
+    #[test]
+    fn test_vs_system_4016_read_has_zero_on_bit_1() {
+        let (mut device, _) = create_vs_controller_device();
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(result & 0x02, 0x00, "VS $4016 bit 1 should always be 0");
+    }
+
+    #[test]
+    fn test_vs_system_4016_read_service_button_on_bit_2() {
+        let (mut device, arcade_input) = create_vs_controller_device();
+
+        // Service button not pressed
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0x04,
+            0x00,
+            "Service button should be 0 when not pressed"
+        );
+
+        // Service button pressed
+        arcade_input.set(VS_INPUT_SERVICE);
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0x04,
+            0x04,
+            "Service button should set bit 2 of $4016"
+        );
+    }
+
+    #[test]
+    fn test_vs_system_4016_read_dip_switches_on_bits_3_4() {
+        let (mut device, _) = create_vs_controller_device();
+
+        // DIP 1 on (bit 0 of dip_switches) → $4016 bit 3
+        device.set_vs_dip_switches(0x01);
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0x18,
+            0x08,
+            "DIP switch 1 should map to $4016 bit 3"
+        );
+
+        // DIP 2 on (bit 1 of dip_switches) → $4016 bit 4
+        device.set_vs_dip_switches(0x02);
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0x18,
+            0x10,
+            "DIP switch 2 should map to $4016 bit 4"
+        );
+
+        // Both DIP 1 and 2 on
+        device.set_vs_dip_switches(0x03);
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(result & 0x18, 0x18, "DIP switches 1+2 should set bits 3-4");
+    }
+
+    #[test]
+    fn test_vs_system_4016_read_coin_on_bits_5_6() {
+        let (mut device, arcade_input) = create_vs_controller_device();
+
+        // No coin
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(result & 0x60, 0x00, "No coin bits when nothing inserted");
+
+        // Coin slot 1
+        arcade_input.set(VS_INPUT_COIN_SLOT1);
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(result & 0x60, 0x20, "Coin slot 1 should set $4016 bit 5");
+
+        // Coin slot 2
+        arcade_input.set(VS_INPUT_COIN_SLOT2);
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(result & 0x60, 0x40, "Coin slot 2 should set $4016 bit 6");
+
+        // Both coin slots
+        arcade_input.set(VS_INPUT_COIN_SLOT1 | VS_INPUT_COIN_SLOT2);
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(result & 0x60, 0x60, "Both coin slots should set bits 5-6");
+    }
+
+    #[test]
+    fn test_vs_system_4016_read_primary_cpu_bit_7_is_zero() {
+        let (mut device, _) = create_vs_controller_device();
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0x80,
+            0x00,
+            "VS $4016 bit 7 should be 0 (primary CPU)"
+        );
+    }
+
+    #[test]
+    fn test_vs_system_4017_read_has_zero_on_bit_1() {
+        let (mut device, _) = create_vs_controller_device();
+        let result = device.read(0x4017, 0xFF, false).unwrap();
+        assert_eq!(result & 0x02, 0x00, "VS $4017 bit 1 should always be 0");
+    }
+
+    #[test]
+    fn test_vs_system_4017_read_dip_switches_on_bits_2_7() {
+        let (mut device, _) = create_vs_controller_device();
+
+        // DIP 3 (bit 2 of dip_switches) → $4017 bit 2
+        device.set_vs_dip_switches(0x04);
+        let result = device.read(0x4017, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0xFC,
+            0x04,
+            "DIP switch 3 should map to $4017 bit 2"
+        );
+
+        // DIP 8 (bit 7 of dip_switches) → $4017 bit 7
+        device.set_vs_dip_switches(0x80);
+        let result = device.read(0x4017, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0xFC,
+            0x80,
+            "DIP switch 8 should map to $4017 bit 7"
+        );
+
+        // All DIP 3-8 on
+        device.set_vs_dip_switches(0xFC);
+        let result = device.read(0x4017, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0xFC,
+            0xFC,
+            "DIP switches 3-8 should set $4017 bits 2-7"
+        );
+    }
+
+    #[test]
+    fn test_vs_system_all_bits_defined_no_open_bus() {
+        let (mut device, _) = create_vs_controller_device();
+        // Open bus should be ignored — all 8 bits are hardware-defined in VS mode
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(
+            result, 0x00,
+            "VS $4016 with no inputs should be 0x00 regardless of open bus"
+        );
+
+        let result = device.read(0x4017, 0xFF, false).unwrap();
+        assert_eq!(
+            result, 0x00,
+            "VS $4017 with no inputs should be 0x00 regardless of open bus"
+        );
+    }
+
+    #[test]
+    fn test_vs_system_does_not_affect_non_vs_reads() {
+        let mut device = create_test_controller_device();
+        // VS mode NOT enabled — normal NES open bus behavior
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        assert_eq!(
+            result & 0xE0,
+            0xE0,
+            "Non-VS mode should apply NES open bus (bits 5-7)"
+        );
+    }
+
+    #[test]
+    fn test_vs_system_4016_combined_bits() {
+        let (mut device, arcade_input) = create_vs_controller_device();
+
+        // Set DIP 1+2, coin slot 1, and service button
+        device.set_vs_dip_switches(0x03);
+        arcade_input.set(VS_INPUT_COIN_SLOT1 | VS_INPUT_SERVICE);
+
+        let result = device.read(0x4016, 0xFF, false).unwrap();
+        // Expected: bit 0 = 0 (controller), bit 1 = 0, bit 2 = 1 (service),
+        //           bits 3-4 = 11 (DIP 1+2), bit 5 = 1 (coin), bits 6-7 = 0
+        assert_eq!(
+            result, 0x3C,
+            "VS $4016 combined: service + DIP 1,2 + coin1 = $3C, got ${:02X}",
+            result
         );
     }
 }

--- a/src/cartridge/unlicensed/mapper226.rs
+++ b/src/cartridge/unlicensed/mapper226.rs
@@ -179,8 +179,13 @@ mod tests {
 
     fn make_mapper(prg_rom: Vec<u8>) -> Mapper226 {
         Mapper226::new(
-            MapperContext::new_for_test(MAPPER_NUMBER, prg_rom, vec![], NametableLayout::Horizontal)
-                .with_prg_ram_banks(0),
+            MapperContext::new_for_test(
+                MAPPER_NUMBER,
+                prg_rom,
+                vec![],
+                NametableLayout::Horizontal,
+            )
+            .with_prg_ram_banks(0),
         )
     }
 

--- a/src/console/config.rs
+++ b/src/console/config.rs
@@ -496,6 +496,7 @@ pub enum ExpansionPort {
     ArkanoidFamicom,
     ZapperFamicom,
     PowerPadFamicom,
+    VsSystem,
 }
 
 impl ExpansionPort {
@@ -511,6 +512,9 @@ impl ExpansionPort {
         } else if value.eq_ignore_ascii_case("power-pad") || value.eq_ignore_ascii_case("powerpad")
         {
             Some(Self::PowerPadFamicom)
+        } else if value.eq_ignore_ascii_case("vs-system") || value.eq_ignore_ascii_case("vssystem")
+        {
+            Some(Self::VsSystem)
         } else {
             None
         }
@@ -538,6 +542,8 @@ pub struct Config {
     pub expansion_port: ExpansionPort,
     /// Whether expansion port type was explicitly configured.
     pub expansion_port_explicit: bool,
+    /// VS System DIP switch value (8-bit, one bit per switch).
+    pub vs_dip_switches: u8,
     /// Emulated hardware model.
     pub hardware_model: HardwareModel,
     /// Whether the hardware model was explicitly configured.
@@ -732,6 +738,7 @@ impl Default for Config {
             hardware_mode_explicit: false,
             expansion_port: ExpansionPort::None,
             expansion_port_explicit: false,
+            vs_dip_switches: 0x00,
             hardware_model: HardwareModel::NesNtsc,
             hardware_model_explicit: false,
             audio_enabled: true,
@@ -813,7 +820,7 @@ impl Config {
         if let Some(expansion_port) = Self::parse_string_arg(args, "--expansion-port") {
             let parsed = ExpansionPort::parse(&expansion_port).ok_or_else(|| {
                 format!(
-                    "Invalid --expansion-port value: '{}'. Valid options are: none, famicom-four-players, arkanoid, zapper, power-pad",
+                    "Invalid --expansion-port value: '{}'. Valid options are: none, famicom-four-players, arkanoid, zapper, power-pad, vs-system",
                     expansion_port
                 )
             })?;
@@ -1763,6 +1770,14 @@ impl Config {
         match key {
             "hardware" => self.apply_hardware_value(value)?,
             "expansion_port" => self.apply_expansion_port_value(value)?,
+            "vs_dip_switches" => {
+                self.vs_dip_switches = Self::parse_hex_u8(value).map_err(|_| {
+                    format!(
+                        "Invalid vs_dip_switches value: '{}'. Expected hex (0x00-0xFF) or decimal (0-255)",
+                        value
+                    )
+                })?;
+            }
             "audio" => {
                 if let Ok(b) = Self::parse_bool(value) {
                     self.audio_enabled = b;
@@ -2092,6 +2107,19 @@ impl Config {
         false
     }
 
+    pub fn apply_rom_db_vs_system_hint(&mut self, is_vs: bool) -> bool {
+        if !is_vs {
+            return false;
+        }
+
+        if !self.expansion_port_explicit && self.expansion_port != ExpansionPort::VsSystem {
+            self.expansion_port = ExpansionPort::VsSystem;
+            return true;
+        }
+
+        false
+    }
+
     /// Parse a boolean value from config file.
     /// Accepts: true, false, yes, no, 1, 0 (case-insensitive)
     fn parse_bool(value: &str) -> Result<bool, ()> {
@@ -2099,6 +2127,19 @@ impl Config {
             "true" | "yes" | "1" => Ok(true),
             "false" | "no" | "0" => Ok(false),
             _ => Err(()),
+        }
+    }
+
+    /// Parse a u8 from hex (0x..) or decimal string.
+    fn parse_hex_u8(value: &str) -> Result<u8, ()> {
+        let trimmed = value.trim();
+        if let Some(hex) = trimmed
+            .strip_prefix("0x")
+            .or_else(|| trimmed.strip_prefix("0X"))
+        {
+            u8::from_str_radix(hex, 16).map_err(|_| ())
+        } else {
+            trimmed.parse::<u8>().map_err(|_| ())
         }
     }
 
@@ -5293,6 +5334,90 @@ filter=invalid-shader
         assert!(
             !config.tui_mode,
             "tui_mode should remain false without --tui"
+        );
+    }
+
+    // ── VS System config tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_config_expansion_port_parse_vs_system() {
+        assert_eq!(
+            ExpansionPort::parse("vs-system"),
+            Some(ExpansionPort::VsSystem)
+        );
+        assert_eq!(
+            ExpansionPort::parse("vssystem"),
+            Some(ExpansionPort::VsSystem)
+        );
+    }
+
+    #[test]
+    fn test_config_vs_dip_switches_default() {
+        let config = Config::default();
+        assert_eq!(config.vs_dip_switches, 0x00);
+    }
+
+    #[test]
+    fn test_config_vs_dip_switches_hex_parse() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("vs_dip_switches", "0xFF")
+            .unwrap();
+        assert_eq!(config.vs_dip_switches, 0xFF);
+    }
+
+    #[test]
+    fn test_config_vs_dip_switches_decimal_parse() {
+        let mut config = Config::default();
+        config.apply_config_value("vs_dip_switches", "42").unwrap();
+        assert_eq!(config.vs_dip_switches, 42);
+    }
+
+    #[test]
+    fn test_config_vs_dip_switches_invalid_parse() {
+        let mut config = Config::default();
+        assert!(config.apply_config_value("vs_dip_switches", "xyz").is_err());
+    }
+
+    #[test]
+    fn test_config_apply_rom_db_vs_system_hint_sets_expansion_port() {
+        let mut config = Config::default();
+
+        let changed = config.apply_rom_db_vs_system_hint(true);
+
+        assert!(changed);
+        assert_eq!(config.expansion_port, ExpansionPort::VsSystem);
+    }
+
+    #[test]
+    fn test_config_apply_rom_db_vs_system_hint_respects_explicit_expansion() {
+        let mut config = Config {
+            expansion_port: ExpansionPort::None,
+            expansion_port_explicit: true,
+            ..Default::default()
+        };
+
+        let changed = config.apply_rom_db_vs_system_hint(true);
+
+        assert!(!changed);
+        assert_eq!(config.expansion_port, ExpansionPort::None);
+    }
+
+    #[test]
+    fn test_config_apply_rom_db_vs_system_hint_false_is_noop() {
+        let mut config = Config::default();
+
+        let changed = config.apply_rom_db_vs_system_hint(false);
+
+        assert!(!changed);
+        assert_eq!(config.expansion_port, ExpansionPort::None);
+    }
+
+    #[test]
+    fn test_config_vs_system_not_famicom_only() {
+        assert!(
+            !ExpansionPort::VsSystem.is_famicom_only(),
+            "VS System should not be classified as Famicom-only"
         );
     }
 }

--- a/src/console/nes.rs
+++ b/src/console/nes.rs
@@ -204,6 +204,14 @@ impl Nes {
             .config_mut()
             .apply_rom_db_zapper_famicom_hint(has_zapper_famicom_expansion);
 
+        // Auto-detect VS System mode from cartridge VS metadata
+        let is_vs_system =
+            cartridge.vs_ppu_type().is_some() || cartridge.vs_hardware_type().is_some();
+        self.app_context
+            .borrow_mut()
+            .config_mut()
+            .apply_rom_db_vs_system_hint(is_vs_system);
+
         // Propagate any hardware-mode change from ROM DB hint to the live PPU
         let is_famicom = self.app_context.borrow().config().hardware_mode
             == crate::console::HardwareMode::Famicom;
@@ -544,6 +552,16 @@ impl Nes {
         self.bus
             .borrow_mut()
             .set_expansion_power_pad_button(button, pressed)
+    }
+
+    /// Set VS System coin insert state for a specific slot (0 or 1).
+    pub fn set_vs_coin_insert(&self, slot: u8, pressed: bool) {
+        self.bus.borrow().set_vs_coin_insert(slot, pressed);
+    }
+
+    /// Set VS System service button state.
+    pub fn set_vs_service_button(&self, pressed: bool) {
+        self.bus.borrow().set_vs_service_button(pressed);
     }
 
     /// Set all joypad button states from a u8 bitmask (for autorun playback).

--- a/src/frontend_toasts.rs
+++ b/src/frontend_toasts.rs
@@ -43,6 +43,7 @@ pub fn hardware_mode_toast_message(
             ExpansionPort::ArkanoidFamicom => "Hardware: Famicom (Arkanoid expansion)".to_string(),
             ExpansionPort::ZapperFamicom => "Hardware: Famicom (Zapper expansion)".to_string(),
             ExpansionPort::PowerPadFamicom => "Hardware: Famicom (Power Pad expansion)".to_string(),
+            ExpansionPort::VsSystem => "Hardware: VS System".to_string(),
             ExpansionPort::None => "Hardware: Famicom".to_string(),
         },
     }

--- a/src/native_frontend/keyboard.rs
+++ b/src/native_frontend/keyboard.rs
@@ -204,6 +204,10 @@ fn handle_controller_key(nes: &mut Nes, key_code: KeyCode, pressed: bool) {
         KeyCode::Period => pp_p2(nes, PowerPadButton::Twelve, pressed),
         KeyCode::KeyP => nes.set_button(2, Button::B, pressed),
 
+        // ── VS System: coin insert / service button ──────────────────────
+        KeyCode::Digit6 => nes.set_vs_coin_insert(0, pressed),
+        KeyCode::Minus => nes.set_vs_service_button(pressed),
+
         _ => {}
     }
 }

--- a/src/web_frontend/wasm.rs
+++ b/src/web_frontend/wasm.rs
@@ -562,6 +562,7 @@ impl WasmNes {
             crate::console::ExpansionPort::ArkanoidFamicom => "arkanoid".to_string(),
             crate::console::ExpansionPort::ZapperFamicom => "zapper".to_string(),
             crate::console::ExpansionPort::PowerPadFamicom => "power-pad".to_string(),
+            crate::console::ExpansionPort::VsSystem => "vs-system".to_string(),
         }
     }
 


### PR DESCRIPTION
## Summary

Implements VS System arcade I/O for $4016/$4017 per [NESdev specification](https://nesdev-wiki.nes.science/wikipages/Vs__System.xhtml).

### VS System $4016 read layout
```
PCCD DS0B
|||| ||||
|||| |||+- Right stick serial data (bit 0)
|||| ||+-- Always 0
|||| |+--- Service button
|||+-+---- DIP switches 1-2
|++------- Coin inserted (slot 1, slot 2)
+--------- 0 = primary CPU (UniSystem)
```

### VS System $4017 read layout
```
DDDD DD0B
|||| ||||
|||| |||+- Left stick serial data (bit 0)
|||| ||+-- Always 0
++++-++--- DIP switches 3-8
```

### Changes

**`src/bus/controller_device.rs`** — VS System read mode with shared `Rc<Cell<u8>>` arcade input state
**`src/console/config.rs`** — `ExpansionPort::VsSystem` variant, `vs_dip_switches` config field, `apply_rom_db_vs_system_hint()`
**`src/bus/bus.rs`** — `ControllerModes` struct (replaces 8 params), `set_vs_coin_insert()`/`set_vs_service_button()` methods
**`src/console/nes.rs`** — Auto-detection in `insert_cartridge()`, forwarding methods
**`src/native_frontend/keyboard.rs`** — Key 6 = coin insert, Minus = service button
**`src/frontend_toasts.rs`** — VS System toast label

### Testing

21 new tests (10 controller device + 11 config). All 6174 tests pass.

Closes #1834
Sub-issue of #1466