### PR TITLE
fix: pass actual texture dimensions to shader instead of hardcoded 256×240

### DIFF
--- a/src/rendering/gl_backend.rs
+++ b/src/rendering/gl_backend.rs
@@ -588,10 +588,13 @@ impl GlBackend {
             let shader_out_w = (shader_out_w_f as u32).max(1);
             let shader_out_h = (shader_out_h_f as u32).max(1);
 
-            if let Err(e) =
-                self.shader_manager
-                    .apply_shader(self.nes_texture, shader_out_w, shader_out_h)
-            {
+            if let Err(e) = self.shader_manager.apply_shader(
+                self.nes_texture,
+                tex_w as u32,
+                tex_h as u32,
+                shader_out_w,
+                shader_out_h,
+            ) {
                 log_info(format!("Shader application error: {}", e));
             } else if let Some(tex) = self.shader_manager.output_texture() {
                 shader_output_texture_id = Some((tex as usize).into());

--- a/src/rendering/shader_manager.rs
+++ b/src/rendering/shader_manager.rs
@@ -146,10 +146,18 @@ impl ShaderManager {
         Ok(())
     }
 
-    /// Apply the loaded shader to transform input texture to output framebuffer.
+    /// Apply the loaded shader to transform `input_texture` into an internal
+    /// output texture (retrievable via [`output_texture`](Self::output_texture)).
+    ///
+    /// `input_width` × `input_height` must match the actual texture dimensions
+    /// (i.e. after overscan cropping). Shaders use these as `SourceSize` for
+    /// pixel-level calculations (CRT scanlines, NTSC encoding, etc.), so
+    /// passing incorrect dimensions causes visible artifacts (see bug #1851).
     pub fn apply_shader(
         &mut self,
         input_texture: gl::types::GLuint,
+        input_width: u32,
+        input_height: u32,
         viewport_width: u32,
         viewport_height: u32,
     ) -> Result<(), String> {
@@ -164,13 +172,15 @@ impl ShaderManager {
             .as_mut()
             .expect("filter_chain must be present");
 
+        let input_size = Size::new(input_width, input_height);
+
         // Create GLImage from input NES texture
         let image = GLImage {
             handle: Some(glow::NativeTexture(
                 std::num::NonZero::new(input_texture).ok_or("Invalid texture ID")?,
             )),
             format: gl::RGB8,
-            size: Size::new(256, 240),
+            size: input_size,
         };
 
         // Output image that will receive the final pass.


### PR DESCRIPTION
## Summary

Fixes #1851 — shader tearing artifacts in Legend of Zelda title screen vertical scroller.

## Root Cause

The default `vertical_overscan` is **8**, cropping the NES texture to **256×224**. But `ShaderManager::apply_shader()` hardcoded `Size::new(256, 240)` for the input `GLImage`. Shaders that use `SourceSize` for pixel-level calculations (CRT-Lottes, NTSC, xBRZ) computed incorrect pixel positions, causing visible tearing during vertical scrolling.

The stock shader was unaffected because it ignores `SourceSize` (simple passthrough).

## Fix

- `apply_shader()` now accepts `input_width` and `input_height` parameters
- The call site passes the actual cropped texture dimensions (`tex_w`, `tex_h`)
- Doc comment documents the contract and references the bug

## Changes

| File | Change |
|------|--------|
| `src/rendering/shader_manager.rs` | Added `input_width`/`input_height` params to `apply_shader`; documented the contract |
| `src/rendering/gl_backend.rs` | Pass `tex_w`/`tex_h` (cropped dimensions) to `apply_shader` |

## Validation

- All 6434 unit/integration tests pass
- Visually confirmed: no tearing with CRT-Lottes, NTSC, and xBRZ shaders on Zelda title screen
- Stock shader continues to render correctly (no regression)
- `cargo fmt --check` clean; pre-existing clippy warnings in `rom_db.rs` unchanged
