### PR TITLE
Add automated regression test for fadeout_and_triangle_tests ROM suite

### DIFF
--- a/src/integration_tests/apu_audio_tests.rs
+++ b/src/integration_tests/apu_audio_tests.rs
@@ -968,7 +968,13 @@ mod tests {
             .copied()
             .filter(|&p| (p - median_period).abs() / median_period < 0.1)
             .collect();
-        let avg_period: f32 = filtered.iter().sum::<f32>() / filtered.len().max(1) as f32;
+        assert!(
+            !filtered.is_empty(),
+            "expected at least one triangle period within ±10% of median ({:.1}), got 0 out of {} periods",
+            median_period,
+            periods.len()
+        );
+        let avg_period: f32 = filtered.iter().sum::<f32>() / filtered.len() as f32;
         let freq = SAMPLE_RATE_HZ / avg_period;
 
         // Triangle frequency should be within ±10% of expected ~196 Hz.


### PR DESCRIPTION
## Summary

Implements the automated regression test requested in #1603. Replaces the `// TODO fadeout_and_triangle_tests` comment with a `test_fadeout_and_triangle` test function.

## Test approach

The test uses **analytical assertions** (no reference WAV file) with two sample collections:

1. **Mixed output** (all channels): Verifies the fadeout envelope — the ROM plays multiple channels that fade out over ~1.5s, leaving only the triangle.
2. **Triangle-only** (isolated via `collect_forced_channel_samples`): Verifies frequency stability (~196 Hz) and that the triangle channel is active (non-silent).

## Assertions

| # | What | How | Catches |
|---|------|-----|---------|
| 1 | Fadeout envelope | Peak/trough RMS ratio > 1.5; first quarter avg > second quarter avg | Broken channel envelope/decay |
| 2 | Triangle active | Triangle-only avg RMS > 0.05; post-fade mixed RMS > 0.05 | Triangle output silenced or linear counter stuck at 0 |
| 3 | Frequency stability | Median period ≈ 225 samples (196 Hz ±10%); >90% periods within ±10% of median | Wrong timer programming |

## Validation

- ✅ `cargo test --no-default-features test_fadeout_and_triangle` passes
- ✅ Silencing triangle output → test fails with: *"expected non-silent triangle output (avg RMS > 0.05), got 0.0000"*
- ✅ Forcing timer to 0x7FF → test fails with: *"expected triangle frequency ~196 Hz (±10%), got 109.2 Hz"*
- ✅ Full library test suite passes (6666 tests, 0 failures)

Closes #1603