### PR TITLE
feat(gb): GB joypad input and Console::GameBoy integration

### DIFF
--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -205,7 +205,7 @@ impl NativeEventLoop {
         let audio = self.audio.take();
         let audio_cell = std::cell::RefCell::new(audio);
         let Console::Nes(nes) = &mut self.console else {
-            return;
+            panic!("NES-only event loop: unexpected non-NES console in run_frame");
         };
         self.debugger_controller
             .run_frame(nes, &self.tracing, &mut |nes| {
@@ -577,7 +577,7 @@ impl ApplicationHandler for NativeEventLoop {
                     self.initialize_audio();
                     self.sync_audio_state();
                     let Console::Nes(nes) = &self.console else {
-                        return;
+                        panic!("NES-only event loop: unexpected non-NES console in resumed");
                     };
                     let watches = self.debugger_controller.load_debug_state_from_file(nes);
                     if let Some(ref mut gl) = self.gl_wrapper {
@@ -610,7 +610,7 @@ impl ApplicationHandler for NativeEventLoop {
                     .map(|gl| gl.watch_addresses())
                     .unwrap_or_default();
                 let Console::Nes(nes) = &self.console else {
-                    return;
+                    panic!("NES-only event loop: unexpected non-NES console in CloseRequested");
                 };
                 self.debugger_controller
                     .save_debug_state_to_file(nes, &watches);
@@ -681,7 +681,7 @@ impl ApplicationHandler for NativeEventLoop {
                     let audio_ref: Option<&dyn EmulatorAudio> =
                         self.audio.as_ref().map(|a| a as &dyn EmulatorAudio);
                     let Console::Nes(nes) = &mut self.console else {
-                        return;
+                        panic!("NES-only event loop: unexpected non-NES console in KeyInput");
                     };
                     let outcome =
                         keyboard::handle_key_pressed(nes, key_code, &mut self.state, audio_ref);
@@ -696,7 +696,7 @@ impl ApplicationHandler for NativeEventLoop {
                                 .map(|gl| gl.watch_addresses())
                                 .unwrap_or_default();
                             let Console::Nes(nes) = &self.console else {
-                                return;
+                                panic!("NES-only event loop: unexpected non-NES console in Quit");
                             };
                             self.debugger_controller
                                 .save_debug_state_to_file(nes, &watches);
@@ -717,21 +717,27 @@ impl ApplicationHandler for NativeEventLoop {
                         }
                         KeyOutcome::ToggleDebugger => {
                             let Console::Nes(nes) = &self.console else {
-                                return;
+                                panic!(
+                                    "NES-only event loop: unexpected non-NES console in ToggleDebugger"
+                                );
                             };
                             self.debugger_controller.toggle_debugger(nes);
                             self.sync_from_controller();
                         }
                         KeyOutcome::StepOver => {
                             let Console::Nes(nes) = &mut self.console else {
-                                return;
+                                panic!(
+                                    "NES-only event loop: unexpected non-NES console in StepOver"
+                                );
                             };
                             self.debugger_controller.step_over(nes);
                             self.sync_from_controller();
                         }
                         KeyOutcome::StepInto => {
                             let Console::Nes(nes) = &mut self.console else {
-                                return;
+                                panic!(
+                                    "NES-only event loop: unexpected non-NES console in StepInto"
+                                );
                             };
                             self.debugger_controller.step_into(nes);
                             self.sync_from_controller();
@@ -756,7 +762,9 @@ impl ApplicationHandler for NativeEventLoop {
                     }
                 } else {
                     let Console::Nes(nes) = &mut self.console else {
-                        return;
+                        panic!(
+                            "NES-only event loop: unexpected non-NES console in KeyInput released"
+                        );
                     };
                     keyboard::handle_key_released(
                         nes,
@@ -910,7 +918,7 @@ impl ApplicationHandler for NativeEventLoop {
                 let action = if let Some(ref mut gl) = self.gl_wrapper {
                     gl.update_breakpoints(self.debugger_controller.breakpoints());
                     let Console::Nes(nes) = &self.console else {
-                        return;
+                        panic!("NES-only event loop: unexpected non-NES console in render");
                     };
                     let overlay = self.state.overlay_text(nes, self.autorun_state.as_ref());
                     let crosshair = mouse::zapper_crosshair(nes, self.state.last_zapper_position);
@@ -926,7 +934,9 @@ impl ApplicationHandler for NativeEventLoop {
                 };
                 {
                     let Console::Nes(nes) = &mut self.console else {
-                        return;
+                        panic!(
+                            "NES-only event loop: unexpected non-NES console in apply_ui_action"
+                        );
                     };
                     self.debugger_controller.apply_ui_action(nes, action);
                 }
@@ -986,7 +996,7 @@ impl ApplicationHandler for NativeEventLoop {
         // Poll gamepad events before requesting redraw.
         if let Some(ref mut gp) = self.gamepad {
             let Console::Nes(nes) = &mut self.console else {
-                return;
+                panic!("NES-only event loop: unexpected non-NES console in about_to_wait");
             };
             let changes = gp.process_events(nes);
             self.state.gamepad_count = gp.connected_count();

--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -143,13 +143,17 @@ impl NativeEventLoop {
 
     /// Extract the inner NES emulator for NES-specific operations.
     fn nes(&self) -> &Nes {
-        let Console::Nes(nes) = &self.console;
+        let Console::Nes(nes) = &self.console else {
+            panic!("expected NES console")
+        };
         nes
     }
 
     /// Extract the inner NES emulator mutably for NES-specific operations.
     fn nes_mut(&mut self) -> &mut Nes {
-        let Console::Nes(nes) = &mut self.console;
+        let Console::Nes(nes) = &mut self.console else {
+            panic!("expected NES console")
+        };
         nes
     }
 
@@ -200,7 +204,9 @@ impl NativeEventLoop {
 
         let audio = self.audio.take();
         let audio_cell = std::cell::RefCell::new(audio);
-        let Console::Nes(nes) = &mut self.console;
+        let Console::Nes(nes) = &mut self.console else {
+            return;
+        };
         self.debugger_controller
             .run_frame(nes, &self.tracing, &mut |nes| {
                 if let Some(ref mut audio) = *audio_cell.borrow_mut() {
@@ -570,7 +576,9 @@ impl ApplicationHandler for NativeEventLoop {
                 if !self.initialized {
                     self.initialize_audio();
                     self.sync_audio_state();
-                    let Console::Nes(nes) = &self.console;
+                    let Console::Nes(nes) = &self.console else {
+                        return;
+                    };
                     let watches = self.debugger_controller.load_debug_state_from_file(nes);
                     if let Some(ref mut gl) = self.gl_wrapper {
                         gl.set_watch_addresses(watches);
@@ -601,7 +609,9 @@ impl ApplicationHandler for NativeEventLoop {
                     .as_ref()
                     .map(|gl| gl.watch_addresses())
                     .unwrap_or_default();
-                let Console::Nes(nes) = &self.console;
+                let Console::Nes(nes) = &self.console else {
+                    return;
+                };
                 self.debugger_controller
                     .save_debug_state_to_file(nes, &watches);
                 if let Err(e) = self.console.save_ram() {
@@ -670,7 +680,9 @@ impl ApplicationHandler for NativeEventLoop {
                     let fullscreen_before = self.state.fullscreen;
                     let audio_ref: Option<&dyn EmulatorAudio> =
                         self.audio.as_ref().map(|a| a as &dyn EmulatorAudio);
-                    let Console::Nes(nes) = &mut self.console;
+                    let Console::Nes(nes) = &mut self.console else {
+                        return;
+                    };
                     let outcome =
                         keyboard::handle_key_pressed(nes, key_code, &mut self.state, audio_ref);
                     match outcome {
@@ -683,7 +695,9 @@ impl ApplicationHandler for NativeEventLoop {
                                 .as_ref()
                                 .map(|gl| gl.watch_addresses())
                                 .unwrap_or_default();
-                            let Console::Nes(nes) = &self.console;
+                            let Console::Nes(nes) = &self.console else {
+                                return;
+                            };
                             self.debugger_controller
                                 .save_debug_state_to_file(nes, &watches);
                             if let Err(e) = self.console.save_ram() {
@@ -702,17 +716,23 @@ impl ApplicationHandler for NativeEventLoop {
                             }
                         }
                         KeyOutcome::ToggleDebugger => {
-                            let Console::Nes(nes) = &self.console;
+                            let Console::Nes(nes) = &self.console else {
+                                return;
+                            };
                             self.debugger_controller.toggle_debugger(nes);
                             self.sync_from_controller();
                         }
                         KeyOutcome::StepOver => {
-                            let Console::Nes(nes) = &mut self.console;
+                            let Console::Nes(nes) = &mut self.console else {
+                                return;
+                            };
                             self.debugger_controller.step_over(nes);
                             self.sync_from_controller();
                         }
                         KeyOutcome::StepInto => {
-                            let Console::Nes(nes) = &mut self.console;
+                            let Console::Nes(nes) = &mut self.console else {
+                                return;
+                            };
                             self.debugger_controller.step_into(nes);
                             self.sync_from_controller();
                         }
@@ -735,7 +755,9 @@ impl ApplicationHandler for NativeEventLoop {
                         }
                     }
                 } else {
-                    let Console::Nes(nes) = &mut self.console;
+                    let Console::Nes(nes) = &mut self.console else {
+                        return;
+                    };
                     keyboard::handle_key_released(
                         nes,
                         key_code,
@@ -887,7 +909,9 @@ impl ApplicationHandler for NativeEventLoop {
                 // Render and apply debugger UI actions
                 let action = if let Some(ref mut gl) = self.gl_wrapper {
                     gl.update_breakpoints(self.debugger_controller.breakpoints());
-                    let Console::Nes(nes) = &self.console;
+                    let Console::Nes(nes) = &self.console else {
+                        return;
+                    };
                     let overlay = self.state.overlay_text(nes, self.autorun_state.as_ref());
                     let crosshair = mouse::zapper_crosshair(nes, self.state.last_zapper_position);
                     gl.render(
@@ -901,7 +925,9 @@ impl ApplicationHandler for NativeEventLoop {
                     Default::default()
                 };
                 {
-                    let Console::Nes(nes) = &mut self.console;
+                    let Console::Nes(nes) = &mut self.console else {
+                        return;
+                    };
                     self.debugger_controller.apply_ui_action(nes, action);
                 }
                 self.sync_from_controller();
@@ -959,7 +985,9 @@ impl ApplicationHandler for NativeEventLoop {
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         // Poll gamepad events before requesting redraw.
         if let Some(ref mut gp) = self.gamepad {
-            let Console::Nes(nes) = &mut self.console;
+            let Console::Nes(nes) = &mut self.console else {
+                return;
+            };
             let changes = gp.process_events(nes);
             self.state.gamepad_count = gp.connected_count();
 

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -56,8 +56,8 @@ impl DmgBus {
     /// Reset all bus state to power-on defaults.
     ///
     /// Reinitialises the PPU, timer, and joypad; zeroes WRAM and HRAM;
-    /// clears IF and IE. The cartridge is NOT reset (ROM contents are
-    /// preserved; RAM is cleared by the cart's own reset if needed).
+    /// clears IF and IE. The cartridge is not touched by this reset, so
+    /// ROM, cartridge RAM, and any mapper state are preserved.
     pub fn reset(&mut self) {
         self.ppu = Ppu::new();
         self.timer = Timer::new();

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -53,6 +53,21 @@ impl DmgBus {
         }
     }
 
+    /// Reset all bus state to power-on defaults.
+    ///
+    /// Reinitialises the PPU, timer, and joypad; zeroes WRAM and HRAM;
+    /// clears IF and IE. The cartridge is NOT reset (ROM contents are
+    /// preserved; RAM is cleared by the cart's own reset if needed).
+    pub fn reset(&mut self) {
+        self.ppu = Ppu::new();
+        self.timer = Timer::new();
+        self.joypad = Joypad::new();
+        self.wram = [0u8; 0x2000];
+        self.hram = [0u8; 0x7F];
+        self.if_reg = 0;
+        self.ie_reg = 0;
+    }
+
     /// Set a button state on the joypad and propagate any resulting interrupt.
     ///
     /// Sets IF bit 4 (joypad interrupt) when pressing a button in the

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -1,5 +1,6 @@
 use crate::gb::bus::GbBus;
 use crate::gb::cartridge::GbCartridge;
+use crate::gb::input::joypad::Joypad;
 use crate::gb::ppu::Ppu;
 use crate::gb::timer::Timer;
 
@@ -23,13 +24,15 @@ use crate::gb::timer::Timer;
 /// - $FF46:       OAM DMA (write-only trigger)
 /// - $FF80–$FFFE: HRAM
 /// - $FFFF:       IE register
-/// - Everything else in $FF00–$FF7F: I/O stubs (reads return 0xFF)
+/// - $FF00:       Joypad (P1 register)
+/// - Everything else in $FF01–$FF7F: I/O stubs (reads return 0xFF)
 pub struct DmgBus {
     cart: Box<dyn GbCartridge>,
     pub ppu: Ppu,
     wram: [u8; 0x2000],
     hram: [u8; 0x7F],
     timer: Timer,
+    pub joypad: Joypad,
     /// IF register ($FF0F): interrupt flag.
     if_reg: u8,
     /// IE register ($FFFF): interrupt enable.
@@ -44,8 +47,20 @@ impl DmgBus {
             wram: [0u8; 0x2000],
             hram: [0u8; 0x7F],
             timer: Timer::new(),
+            joypad: Joypad::new(),
             if_reg: 0,
             ie_reg: 0,
+        }
+    }
+
+    /// Set a button state on the joypad and propagate any resulting interrupt.
+    ///
+    /// Sets IF bit 4 (joypad interrupt) when pressing a button in the
+    /// currently selected group causes the effective nibble to transition
+    /// from all-ones to any-zero.
+    pub fn set_joypad_button(&mut self, id: u8, pressed: bool) {
+        if self.joypad.set_button(id, pressed) {
+            self.if_reg |= 0x10;
         }
     }
 
@@ -94,6 +109,7 @@ impl GbBus for DmgBus {
             0xE000..=0xFDFF => self.wram[(addr - 0xE000) as usize],
             0xFE00..=0xFE9F => self.ppu.read_oam(addr),
             0xFEA0..=0xFEFF => 0xFF,
+            0xFF00 => self.joypad.read(),
             0xFF04..=0xFF07 => self.timer.read(addr),
             0xFF0F => self.if_reg | 0xE0,
             0xFF40..=0xFF4B => self.ppu.read_register(addr),
@@ -112,6 +128,7 @@ impl GbBus for DmgBus {
             0xE000..=0xFDFF => self.wram[(addr - 0xE000) as usize] = val,
             0xFE00..=0xFE9F => self.ppu.write_oam(addr, val),
             0xFEA0..=0xFEFF => {}
+            0xFF00 => self.joypad.write(val),
             0xFF04..=0xFF07 => self.timer.write(addr, val),
             0xFF0F => self.if_reg = val & 0x1F,
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B => self.ppu.write_register(addr, val),
@@ -323,10 +340,63 @@ mod tests {
     #[test]
     fn test_unmapped_io_reads_return_0xff() {
         let mut bus = make_bus();
-        // $FF00 (joypad stub), $FF01 (serial), $FF08 (unmapped)
-        assert_eq!(bus.read(0xFF00), 0xFF);
+        // $FF01 (serial), $FF08 (unmapped) — $FF00 is now the joypad register
         assert_eq!(bus.read(0xFF01), 0xFF);
         assert_eq!(bus.read(0xFF08), 0xFF);
+    }
+
+    // ── Joypad ($FF00) ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_ff00_read_reflects_joypad_state_no_buttons_pressed() {
+        // Given: fresh bus (neither group selected = default after new)
+        let mut bus = make_bus();
+        // When: write 0x10 to $FF00 (select P15 / action group)
+        bus.write(0xFF00, 0x10);
+        // Then: read reflects select bits and all-released nibble = 0xDF
+        // 0xC0 | 0x10 | 0x0F = 0xDF
+        assert_eq!(bus.read(0xFF00), 0xDF);
+    }
+
+    #[test]
+    fn test_ff00_write_updates_select_and_read_reflects_it() {
+        // Given: select P14 (direction group)
+        let mut bus = make_bus();
+        bus.write(0xFF00, 0x20);
+        // Then: bits 5-4 of read = 0x20
+        assert_eq!(bus.read(0xFF00) & 0x30, 0x20);
+    }
+
+    #[test]
+    fn test_set_joypad_button_affects_ff00_read() {
+        // Given: P15 selected
+        let mut bus = make_bus();
+        bus.write(0xFF00, 0x10); // select P15 (action buttons)
+        // When: press A (id=0)
+        bus.set_joypad_button(0, true);
+        // Then: bit0 of lower nibble is 0 (active-low) → read = 0xDE
+        assert_eq!(bus.read(0xFF00), 0xDE);
+    }
+
+    #[test]
+    fn test_set_joypad_button_sets_if_bit4_on_first_press() {
+        // Given: P15 selected
+        let mut bus = make_bus();
+        bus.write(0xFF00, 0x10); // select P15
+        // When: press A (first button — nibble transitions 0xF → non-0xF)
+        bus.set_joypad_button(0, true);
+        // Then: IF bit 4 (joypad interrupt) is set
+        assert_eq!(bus.read(0xFF0F) & 0x10, 0x10, "IF bit 4 should be set");
+    }
+
+    #[test]
+    fn test_set_joypad_button_no_if_when_group_not_selected() {
+        // Given: neither group selected (default)
+        let mut bus = make_bus();
+        // When: press A — action group not selected, no IRQ
+        bus.set_joypad_button(0, true);
+        // Then: IF bit 4 not set
+        assert_eq!(bus.read(0xFF0F) & 0x10, 0x00, "IF bit 4 should NOT be set");
     }
 
     // ── IF register ──────────────────────────────────────────────────────────

--- a/src/gb/bus/mod.rs
+++ b/src/gb/bus/mod.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 pub use bus::{GbBus, StubBus};
 pub use dmg_bus::DmgBus;
 

--- a/src/gb/console.rs
+++ b/src/gb/console.rs
@@ -31,6 +31,22 @@ impl<B: GbBus> Gb<B> {
     }
 }
 
+/// Reset support for Gb<DmgBus>.
+impl Gb<DmgBus> {
+    /// Reset the console.
+    ///
+    /// - `soft_reset = true`: resets only the CPU registers to the
+    ///   post-boot-ROM state (WRAM and other bus state are preserved).
+    /// - `soft_reset = false`: resets CPU registers **and** all bus
+    ///   state (WRAM zeroed, PPU/timer/joypad reinitialised).
+    pub fn reset(&mut self, soft_reset: bool) {
+        self.cpu.reset_registers();
+        if !soft_reset {
+            self.cpu.bus.reset();
+        }
+    }
+}
+
 /// DMG-specific screen and frame API.
 impl Gb<DmgBus> {
     /// Snapshot the current rendered screen as a 160×144 RGB byte vector.
@@ -52,6 +68,111 @@ impl Gb<DmgBus> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gb::cartridge::load_cartridge;
+
+    // ── DMG reset helpers ─────────────────────────────────────────────────
+
+    /// Build a minimal valid ROM-only cartridge for reset tests.
+    fn minimal_cart() -> Box<dyn crate::gb::cartridge::GbCartridge> {
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0147] = 0x00; // ROM only
+        rom[0x0148] = 0x00; // 32 KB
+        rom[0x0149] = 0x00; // no RAM
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+        load_cartridge(&rom).expect("valid ROM")
+    }
+
+    fn make_dmg() -> Gb<DmgBus> {
+        Gb::new(DmgBus::new(minimal_cart()))
+    }
+
+    // ── reset: CPU registers ──────────────────────────────────────────────
+
+    #[test]
+    fn test_reset_registers_restores_pc_to_0100() {
+        // Given: a fresh DMG console
+        let mut gb = make_dmg();
+        // PC starts at 0 before any code runs
+        assert_eq!(gb.cpu.regs.pc, 0x0000);
+        // When: reset registers
+        gb.cpu.reset_registers();
+        // Then: PC = $0100 (post-boot-ROM entry)
+        assert_eq!(gb.cpu.regs.pc, 0x0100);
+    }
+
+    #[test]
+    fn test_reset_registers_sets_dmg_af() {
+        // Given/When: reset CPU registers
+        let mut gb = make_dmg();
+        gb.cpu.reset_registers();
+        // Then: AF = $01B0 (DMG post-boot value per Pan Docs)
+        assert_eq!(gb.cpu.regs.af(), 0x01B0);
+    }
+
+    #[test]
+    fn test_reset_registers_sets_dmg_bc_de_hl_sp() {
+        let mut gb = make_dmg();
+        gb.cpu.reset_registers();
+        assert_eq!(gb.cpu.regs.bc(), 0x0013);
+        assert_eq!(gb.cpu.regs.de(), 0x00D8);
+        assert_eq!(gb.cpu.regs.hl(), 0x014D);
+        assert_eq!(gb.cpu.regs.sp, 0xFFFE);
+    }
+
+    #[test]
+    fn test_reset_registers_clears_ime_and_halted() {
+        let mut gb = make_dmg();
+        gb.cpu.ime = true;
+        gb.cpu.halted = true;
+        gb.cpu.reset_registers();
+        assert!(!gb.cpu.ime);
+        assert!(!gb.cpu.halted);
+    }
+
+    // ── reset: soft vs hard ───────────────────────────────────────────────
+
+    #[test]
+    fn test_soft_reset_preserves_wram() {
+        // Given: write a known value to WRAM
+        let mut gb = make_dmg();
+        gb.cpu.bus.write(0xC100, 0xAB);
+        // When: soft reset
+        gb.reset(true);
+        // Then: WRAM is unchanged
+        assert_eq!(gb.cpu.bus.read(0xC100), 0xAB);
+    }
+
+    #[test]
+    fn test_hard_reset_clears_wram() {
+        // Given: write a known value to WRAM
+        let mut gb = make_dmg();
+        gb.cpu.bus.write(0xC100, 0xAB);
+        // When: hard reset
+        gb.reset(false);
+        // Then: WRAM is zeroed
+        assert_eq!(gb.cpu.bus.read(0xC100), 0x00);
+    }
+
+    #[test]
+    fn test_hard_reset_restores_pc_and_clears_wram() {
+        // Combined: PC is correct AND WRAM is zeroed after hard reset
+        let mut gb = make_dmg();
+        gb.cpu.bus.write(0xC000, 0xFF);
+        gb.reset(false);
+        assert_eq!(gb.cpu.regs.pc, 0x0100);
+        assert_eq!(gb.cpu.bus.read(0xC000), 0x00);
+    }
+
+    #[test]
+    fn test_soft_reset_restores_pc() {
+        // Soft reset must still reset CPU registers (including PC)
+        let mut gb = make_dmg();
+        gb.reset(true);
+        assert_eq!(gb.cpu.regs.pc, 0x0100);
+    }
 
     /// A bus that counts the total M-cycles passed to `tick()`.
     struct TrackingBus {

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -1,0 +1,253 @@
+//! Platform-facing Game Boy wrapper for the `Console` enum.
+//!
+//! `GameBoy` owns a [`Gb<DmgBus>`] (created lazily on [`load_rom`]) and a
+//! [`SharedAppContext`], providing the same interface that the NES side
+//! exposes so that frontends can drive both systems through `Console`.
+
+use crate::gb::bus::DmgBus;
+use crate::gb::cartridge::load_cartridge;
+use crate::gb::console::Gb;
+use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
+
+/// Platform-facing Game Boy (DMG) console wrapper.
+pub struct GameBoy {
+    gb: Option<Gb<DmgBus>>,
+    app_context: SharedAppContext,
+}
+
+impl GameBoy {
+    /// Screen width in pixels.
+    pub const SCREEN_WIDTH: u32 = 160;
+    /// Screen height in pixels.
+    pub const SCREEN_HEIGHT: u32 = 144;
+
+    /// Create a new Game Boy instance (no ROM loaded yet).
+    pub fn new(app_context: impl IntoSharedAppContext) -> Self {
+        Self {
+            gb: None,
+            app_context: app_context.into_shared(),
+        }
+    }
+
+    /// Load a `.gb` ROM image. Replaces any previously loaded ROM.
+    pub fn load_rom(&mut self, bytes: &[u8], _name: &str) -> Result<(), String> {
+        let cart = load_cartridge(bytes).map_err(|e| format!("{e:?}"))?;
+        self.gb = Some(Gb::new(DmgBus::new(cart)));
+        Ok(())
+    }
+
+    /// Advance one CPU instruction. Returns the number of M-cycles consumed.
+    pub fn run_tick(&mut self) -> u8 {
+        match &mut self.gb {
+            Some(gb) => gb.step(),
+            None => 0,
+        }
+    }
+
+    /// Returns `true` when the PPU has completed a full frame.
+    pub fn is_frame_ready(&self) -> bool {
+        self.gb.as_ref().is_some_and(|gb| gb.is_frame_ready())
+    }
+
+    /// Clear the frame-ready flag after the frontend has consumed the frame.
+    pub fn clear_frame_ready(&mut self) {
+        if let Some(gb) = &mut self.gb {
+            gb.clear_frame_ready();
+        }
+    }
+
+    /// Snapshot the current frame as a 160×144 RGB888 byte vector.
+    pub fn screen_snapshot(&self) -> Vec<u8> {
+        self.gb.as_ref().map_or_else(
+            || vec![0u8; (Self::SCREEN_WIDTH * Self::SCREEN_HEIGHT * 3) as usize],
+            |gb| gb.screen_snapshot(),
+        )
+    }
+
+    /// CRC32 of the current screen buffer.
+    pub fn screen_crc32(&self) -> u32 {
+        self.gb.as_ref().map_or(0, |gb| gb.screen_crc32())
+    }
+
+    /// Snapshot with no overscan (Game Boy has no overscan).
+    pub fn cropped_screen_snapshot(&self) -> Vec<u8> {
+        self.screen_snapshot()
+    }
+
+    /// Set a single button state.
+    ///
+    /// Uses NES-convention IDs: A=0, B=1, Select=2, Start=3, Up=4, Down=5,
+    /// Left=6, Right=7.
+    pub fn set_button(&mut self, id: u8, pressed: bool) {
+        if let Some(gb) = &mut self.gb {
+            gb.cpu.bus.set_joypad_button(id, pressed);
+        }
+    }
+
+    /// Set all button states from a NES-convention bitmask.
+    pub fn set_joypad_button_states(&mut self, state: u8) {
+        for id in 0u8..8 {
+            let pressed = state & (1 << id) != 0;
+            self.set_button(id, pressed);
+        }
+    }
+
+    /// Get all button states as a NES-convention bitmask.
+    pub fn get_joypad_button_states(&self) -> u8 {
+        self.gb
+            .as_ref()
+            .map_or(0, |gb| gb.cpu.bus.joypad.get_states())
+    }
+
+    /// Serialize emulator state (not supported for MVP — returns `Err`).
+    pub fn save_state_bytes(&self) -> Result<Vec<u8>, String> {
+        Err("Game Boy save states are not supported in MVP".into())
+    }
+
+    /// Restore emulator state (not supported for MVP — returns `Err`).
+    pub fn load_state_bytes(&mut self, _data: &[u8]) -> Result<(), String> {
+        Err("Game Boy save states are not supported in MVP".into())
+    }
+
+    /// Reset the console.
+    ///
+    /// - `soft_reset = true`: CPU registers only.
+    /// - `soft_reset = false`: CPU registers + full bus state.
+    pub fn reset(&mut self, soft_reset: bool) {
+        if let Some(gb) = &mut self.gb {
+            gb.reset(soft_reset);
+        }
+    }
+
+    /// Access the shared application context.
+    pub fn app_context(&self) -> &SharedAppContext {
+        &self.app_context
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::app_context::AppContext;
+    use crate::platform::config::Config;
+
+    fn make_gameboy() -> GameBoy {
+        let config = Config::default();
+        let app_context = AppContext::new_with_config(config).into_shared();
+        GameBoy::new(app_context)
+    }
+
+    fn minimal_rom() -> Vec<u8> {
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0147] = 0x00; // ROM only
+        rom[0x0148] = 0x00; // 32 KB
+        rom[0x0149] = 0x00; // no RAM
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+        rom
+    }
+
+    // ── safety before ROM load ──────────────────────────────────────────────
+
+    #[test]
+    fn test_no_rom_run_tick_returns_zero() {
+        let mut gb = make_gameboy();
+        assert_eq!(gb.run_tick(), 0);
+    }
+
+    #[test]
+    fn test_no_rom_is_frame_ready_returns_false() {
+        let gb = make_gameboy();
+        assert!(!gb.is_frame_ready());
+    }
+
+    #[test]
+    fn test_no_rom_screen_snapshot_returns_correct_size() {
+        let gb = make_gameboy();
+        let snap = gb.screen_snapshot();
+        assert_eq!(snap.len(), 160 * 144 * 3);
+    }
+
+    #[test]
+    fn test_no_rom_get_joypad_button_states_returns_zero() {
+        let gb = make_gameboy();
+        assert_eq!(gb.get_joypad_button_states(), 0);
+    }
+
+    #[test]
+    fn test_no_rom_set_button_does_not_panic() {
+        let mut gb = make_gameboy();
+        gb.set_button(0, true); // should not panic
+    }
+
+    #[test]
+    fn test_no_rom_save_state_returns_err() {
+        let gb = make_gameboy();
+        assert!(gb.save_state_bytes().is_err());
+    }
+
+    #[test]
+    fn test_no_rom_load_state_returns_err() {
+        let mut gb = make_gameboy();
+        assert!(gb.load_state_bytes(&[0u8; 4]).is_err());
+    }
+
+    // ── after ROM load ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_valid_rom_succeeds() {
+        let mut gb = make_gameboy();
+        assert!(gb.load_rom(&minimal_rom(), "test.gb").is_ok());
+    }
+
+    #[test]
+    fn test_load_invalid_rom_returns_err() {
+        let mut gb = make_gameboy();
+        assert!(gb.load_rom(&[0u8; 16], "bad.gb").is_err());
+    }
+
+    #[test]
+    fn test_run_tick_after_load_returns_nonzero_cycles() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+        let cycles = gb.run_tick();
+        assert!(cycles > 0, "expected non-zero cycles, got {cycles}");
+    }
+
+    #[test]
+    fn test_set_get_joypad_button_states_roundtrip() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+        let mask: u8 = 0b0000_1001; // A + Start pressed
+        gb.set_joypad_button_states(mask);
+        assert_eq!(gb.get_joypad_button_states(), mask);
+    }
+
+    #[test]
+    fn test_screen_constants() {
+        assert_eq!(GameBoy::SCREEN_WIDTH, 160);
+        assert_eq!(GameBoy::SCREEN_HEIGHT, 144);
+    }
+
+    #[test]
+    fn test_reset_soft_after_load_does_not_panic() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+        gb.reset(true); // should not panic
+    }
+
+    #[test]
+    fn test_reset_hard_after_load_does_not_panic() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+        gb.reset(false); // should not panic
+    }
+
+    #[test]
+    fn test_app_context_returns_reference() {
+        let gb = make_gameboy();
+        let _ = gb.app_context(); // should not panic
+    }
+}

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -4,10 +4,14 @@ use crate::gb::cpu::Sm83;
 
 pub mod gameboy;
 
-/// Game Boy (DMG) console stub.
+/// Game Boy (DMG) console wrapper.
 ///
-/// Wraps the SM83 CPU and a bus. This is a minimal integration shell;
-/// rendering, audio, and input are out of scope for the initial CPU sub-issue.
+/// Wraps the SM83 CPU and a bus, providing the core console integration
+/// needed to execute instructions and advance the attached hardware.
+///
+/// The generic `Gb<B>` interface exposes CPU stepping and cycle tracking.
+/// DMG-specific integrations on `Gb<DmgBus>` additionally provide reset
+/// behavior, screen/framebuffer access, and input handling through the bus.
 pub struct Gb<B: GbBus> {
     pub cpu: Sm83<B>,
 }

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -2,6 +2,8 @@ use crate::gb::bus::DmgBus;
 use crate::gb::bus::GbBus;
 use crate::gb::cpu::Sm83;
 
+pub mod gameboy;
+
 /// Game Boy (DMG) console stub.
 ///
 /// Wraps the SM83 CPU and a bus. This is a minimal integration shell;
@@ -17,12 +19,13 @@ impl<B: GbBus> Gb<B> {
         }
     }
 
-    /// Step one CPU instruction.
-    pub fn step(&mut self) {
+    /// Step one CPU instruction. Returns the number of M-cycles consumed.
+    pub fn step(&mut self) -> u8 {
         let before = self.cpu.cycles();
         self.cpu.execute();
         let delta = (self.cpu.cycles() - before) as u8;
         self.cpu.bus.tick(delta);
+        delta
     }
 
     /// Total M-cycles elapsed.
@@ -62,6 +65,11 @@ impl Gb<DmgBus> {
     /// Clear the frame-ready flag.
     pub fn clear_frame_ready(&mut self) {
         self.cpu.bus.ppu.clear_frame_ready();
+    }
+
+    /// CRC32 of the current screen buffer.
+    pub fn screen_crc32(&self) -> u32 {
+        self.cpu.bus.ppu.screen_buffer().crc32()
     }
 }
 

--- a/src/gb/cpu/mod.rs
+++ b/src/gb/cpu/mod.rs
@@ -1,3 +1,4 @@
+#[allow(unused_imports)]
 pub use sm83::{Registers, Sm83};
 
 mod opcode;

--- a/src/gb/cpu/sm83.rs
+++ b/src/gb/cpu/sm83.rs
@@ -149,6 +149,25 @@ impl<B: GbBus> Sm83<B> {
         self.cycles
     }
 
+    /// Reset the CPU registers to the post-boot-ROM (DMG) state.
+    ///
+    /// This matches the register values a DMG has after the boot ROM finishes
+    /// and jumps to the cartridge entry point at $0100.
+    /// Clears IME, halted, halt_bug, and ime_pending; the cycle counter is
+    /// intentionally NOT reset (it tracks wall-clock ticks, not game time).
+    pub fn reset_registers(&mut self) {
+        self.regs.set_af(0x01B0);
+        self.regs.set_bc(0x0013);
+        self.regs.set_de(0x00D8);
+        self.regs.set_hl(0x014D);
+        self.regs.sp = 0xFFFE;
+        self.regs.pc = 0x0100;
+        self.ime = false;
+        self.halted = false;
+        self.halt_bug = false;
+        self.ime_pending = false;
+    }
+
     /// Read a byte from the bus and advance the cycle counter by 1 M-cycle.
     fn read(&mut self, addr: u16) -> u8 {
         self.cycles += 1;

--- a/src/gb/input/joypad.rs
+++ b/src/gb/input/joypad.rs
@@ -54,9 +54,10 @@ impl Joypad {
 
     /// Update a button state. Returns `true` if a joypad interrupt should fire.
     ///
-    /// An interrupt fires when the effective lower nibble transitions from
-    /// all-ones (`0xF`) to any-zero, i.e. the first button in the active
-    /// group is pressed.
+    /// An interrupt fires on any **1→0 falling edge** of a selected output
+    /// line, i.e. whenever a button in the active group transitions from
+    /// released to pressed. Multiple simultaneous presses each generate a
+    /// separate falling edge.
     ///
     /// `id` uses the NES platform convention:
     /// A=0, B=1, Select=2, Start=3, Up=4, Down=5, Left=6, Right=7.
@@ -79,7 +80,7 @@ impl Joypad {
             *state &= !mask;
         }
         let new_nibble = self.effective_nibble();
-        let irq = self.prev_nibble == 0xF && new_nibble != 0xF;
+        let irq = (self.prev_nibble & !new_nibble) != 0;
         self.prev_nibble = new_nibble;
         irq
     }
@@ -103,13 +104,16 @@ impl Joypad {
 
     /// Set all button states from a NES-convention bitmask (bulk update).
     ///
-    /// Does not update the IRQ edge baseline (`prev_nibble`).
+    /// Updates the IRQ edge baseline (`prev_nibble`) to the new effective
+    /// nibble without firing an interrupt, so subsequent `set_button()` calls
+    /// compare against the current bulk-updated state.
     pub fn set_states(&mut self, state: u8) {
         self.p15_state = state & 0x0F;
         self.p14_state = ((state & 0x10) >> 2)  // Up   (bit4) → p14 bit2
             | ((state & 0x20) >> 2)              // Down (bit5) → p14 bit3
             | ((state & 0x40) >> 5)              // Left (bit6) → p14 bit1
             | ((state & 0x80) >> 7); // Right(bit7) → p14 bit0
+        self.prev_nibble = self.effective_nibble();
     }
 
     /// Compute the effective lower nibble for the currently selected group(s).
@@ -288,13 +292,31 @@ mod tests {
         assert!(!irq, "expected no IRQ when button's group not selected");
     }
 
-    /// Second button press in the same group does NOT re-fire the interrupt.
+    /// Re-pressing an already-held button does not fire a second IRQ (no new falling edge).
     #[test]
-    fn test_interrupt_no_fire_on_second_press() {
+    fn test_interrupt_no_fire_on_repeated_press_of_same_button() {
         let mut j = make_p15_selected();
-        j.set_button(0, true); // first press → IRQ (consume it)
-        let irq = j.set_button(1, true); // second press → no IRQ
-        assert!(!irq, "expected no IRQ on second button press");
+        j.set_button(0, true); // press A → IRQ fires
+        let irq = j.set_button(0, true); // press A again while held → no new falling edge
+        assert!(
+            !irq,
+            "expected no IRQ on repeated press of already-held button"
+        );
+    }
+
+    /// Each new button press creates a new falling edge and fires IRQ independently.
+    ///
+    /// Per Pan Docs: the joypad IRQ fires on every 1→0 transition of a selected
+    /// output line, not just the first press from the all-released state.
+    #[test]
+    fn test_interrupt_fires_for_each_new_button_press() {
+        let mut j = make_p15_selected();
+        j.set_button(0, true); // press A → IRQ fires
+        let irq = j.set_button(1, true); // press B while A held → new falling edge → IRQ
+        assert!(
+            irq,
+            "expected IRQ for B press while A held (new falling edge)"
+        );
     }
 
     /// After fully releasing all buttons in the group, the next press fires
@@ -308,21 +330,24 @@ mod tests {
         assert!(irq, "expected IRQ to re-fire after full release");
     }
 
-    /// Changing the select group does not spuriously fire an interrupt on the
-    /// next button press if a button was already pressed before the switch.
+    /// After a group switch and switch back, re-pressing an already-held button
+    /// does not fire a spurious IRQ (write() resets prev_nibble to current state).
     #[test]
     fn test_no_spurious_irq_after_group_switch_with_held_button() {
         let mut j = Joypad::new();
         // Press A while P15 is selected
         j.write(0x10);
-        j.set_button(0, true); // IRQ fires here, nibble → non-0xF
-        // Switch group away — A is still held but P15 is now deselected
-        j.write(0x20); // P14 selected only; effective nibble recomputed
-        // Switch back to P15 — A is still held
+        j.set_button(0, true); // IRQ fires; prev_nibble = 0xE
+        // Switch group away — A still held; prev_nibble reset to current P14 nibble (0xF)
+        j.write(0x20); // P14 selected
+        // Switch back to P15 — A still held; prev_nibble reset to 0xE
         j.write(0x10);
-        // No new button *press* occurred; no interrupt should fire
-        let irq = j.set_button(1, true); // press B while A held → nibble still non-0xF before press
-        assert!(!irq, "expected no IRQ since nibble was already non-0xF");
+        // Re-pressing A (already held): bit0 already low, no falling edge → no IRQ
+        let irq = j.set_button(0, true);
+        assert!(
+            !irq,
+            "re-pressing held button after group switch must not fire IRQ"
+        );
     }
 
     // ── get_states / set_states ────────────────────────────────────────────
@@ -363,5 +388,17 @@ mod tests {
         j.set_button(0, true);
         j.set_button(0, false);
         assert_eq!(j.get_states() & 0x01, 0x00);
+    }
+
+    /// set_states updates prev_nibble so that a subsequent set_button does not
+    /// fire a spurious IRQ for a button that was already set by set_states.
+    #[test]
+    fn test_set_states_updates_prev_nibble() {
+        let mut j = make_p15_selected();
+        // Bulk-set A as pressed via set_states
+        j.set_states(0x01); // A pressed (bit0)
+        // A is already "pressed"; pressing it again is not a new falling edge
+        let irq = j.set_button(0, true);
+        assert!(!irq, "expected no IRQ: A was already in the bulk-set state");
     }
 }

--- a/src/gb/input/joypad.rs
+++ b/src/gb/input/joypad.rs
@@ -1,0 +1,367 @@
+//! Game Boy joypad input register ($FF00 / P1).
+//!
+//! Implements the P1 register per Pan Docs:
+//! <https://gbdev.io/pandocs/Joypad_Input.html>
+//!
+//! The register uses two selection groups:
+//! - **P14** (bit4=0): direction buttons — Right, Left, Up, Down
+//! - **P15** (bit5=0): action buttons   — A, B, Select, Start
+//!
+//! Button IDs follow the NES convention used throughout the platform API:
+//! A=0, B=1, Select=2, Start=3, Up=4, Down=5, Left=6, Right=7.
+
+/// Game Boy joypad ($FF00 / P1 register).
+pub struct Joypad {
+    /// Bits 4-5 written by the game (`val & 0x30`); bit=0 means group is selected.
+    select_bits: u8,
+    /// Button state for P14 (direction): 1=pressed.
+    /// bit0=Right, bit1=Left, bit2=Up, bit3=Down.
+    p14_state: u8,
+    /// Button state for P15 (action): 1=pressed.
+    /// bit0=A, bit1=B, bit2=Select, bit3=Start.
+    p15_state: u8,
+    /// Last computed effective lower nibble; used for joypad IRQ edge detection.
+    prev_nibble: u8,
+}
+
+impl Joypad {
+    pub fn new() -> Self {
+        Self {
+            select_bits: 0x30, // neither group selected by default
+            p14_state: 0,
+            p15_state: 0,
+            prev_nibble: 0xF,
+        }
+    }
+
+    /// Read the P1 register.
+    ///
+    /// Returns `0xC0 | select_bits | effective_nibble()`.
+    /// Bits 7-6 are always 1 (open-bus); bits 5-4 reflect the select lines;
+    /// bits 3-0 are the inverted active button states (0 = pressed).
+    pub fn read(&self) -> u8 {
+        0xC0 | self.select_bits | self.effective_nibble()
+    }
+
+    /// Write the P1 register.
+    ///
+    /// Only bits 4-5 are writable (select lines). Resets the IRQ edge baseline
+    /// so that a group change does not spuriously re-fire the interrupt.
+    pub fn write(&mut self, val: u8) {
+        self.select_bits = val & 0x30;
+        self.prev_nibble = self.effective_nibble();
+    }
+
+    /// Update a button state. Returns `true` if a joypad interrupt should fire.
+    ///
+    /// An interrupt fires when the effective lower nibble transitions from
+    /// all-ones (`0xF`) to any-zero, i.e. the first button in the active
+    /// group is pressed.
+    ///
+    /// `id` uses the NES platform convention:
+    /// A=0, B=1, Select=2, Start=3, Up=4, Down=5, Left=6, Right=7.
+    /// Unknown IDs are silently ignored and never trigger an interrupt.
+    pub fn set_button(&mut self, id: u8, pressed: bool) -> bool {
+        let (state, mask) = match id {
+            0 => (&mut self.p15_state, 0x01u8), // A      → P15 bit0
+            1 => (&mut self.p15_state, 0x02),   // B      → P15 bit1
+            2 => (&mut self.p15_state, 0x04),   // Select → P15 bit2
+            3 => (&mut self.p15_state, 0x08),   // Start  → P15 bit3
+            4 => (&mut self.p14_state, 0x04),   // Up     → P14 bit2
+            5 => (&mut self.p14_state, 0x08),   // Down   → P14 bit3
+            6 => (&mut self.p14_state, 0x02),   // Left   → P14 bit1
+            7 => (&mut self.p14_state, 0x01),   // Right  → P14 bit0
+            _ => return false,
+        };
+        if pressed {
+            *state |= mask;
+        } else {
+            *state &= !mask;
+        }
+        let new_nibble = self.effective_nibble();
+        let irq = self.prev_nibble == 0xF && new_nibble != 0xF;
+        self.prev_nibble = new_nibble;
+        irq
+    }
+
+    /// Return all eight button states as a NES-convention bitmask.
+    ///
+    /// Each bit N is 1 when the button with ID N is pressed.
+    pub fn get_states(&self) -> u8 {
+        // bits 0-3: P15 action buttons (A, B, Select, Start)
+        let actions = self.p15_state & 0x0F;
+        // bit4 (Up)    = p14 bit2
+        let up = (self.p14_state & 0x04) << 2;
+        // bit5 (Down)  = p14 bit3
+        let down = (self.p14_state & 0x08) << 2;
+        // bit6 (Left)  = p14 bit1
+        let left = (self.p14_state & 0x02) << 5;
+        // bit7 (Right) = p14 bit0
+        let right = (self.p14_state & 0x01) << 7;
+        actions | up | down | left | right
+    }
+
+    /// Set all button states from a NES-convention bitmask (bulk update).
+    ///
+    /// Does not update the IRQ edge baseline (`prev_nibble`).
+    pub fn set_states(&mut self, state: u8) {
+        self.p15_state = state & 0x0F;
+        self.p14_state = ((state & 0x10) >> 2)  // Up   (bit4) → p14 bit2
+            | ((state & 0x20) >> 2)              // Down (bit5) → p14 bit3
+            | ((state & 0x40) >> 5)              // Left (bit6) → p14 bit1
+            | ((state & 0x80) >> 7); // Right(bit7) → p14 bit0
+    }
+
+    /// Compute the effective lower nibble for the currently selected group(s).
+    ///
+    /// Returns `0xF` when no group is selected. Otherwise ANDs together the
+    /// inverted states of every selected group, so that a pressed button (1)
+    /// pulls its corresponding output bit low (0), as the hardware does.
+    fn effective_nibble(&self) -> u8 {
+        let mut nibble = 0x0Fu8;
+        if self.select_bits & 0x10 == 0 {
+            // P14 selected (direction buttons)
+            nibble &= !self.p14_state & 0x0F;
+        }
+        if self.select_bits & 0x20 == 0 {
+            // P15 selected (action buttons)
+            nibble &= !self.p15_state & 0x0F;
+        }
+        nibble
+    }
+}
+
+impl Default for Joypad {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    /// Fresh joypad with both groups selected (write 0x00).
+    fn make_both_selected() -> Joypad {
+        let mut j = Joypad::new();
+        j.write(0x00);
+        j
+    }
+
+    /// Fresh joypad with only P15 (action buttons) selected (write 0x10).
+    fn make_p15_selected() -> Joypad {
+        let mut j = Joypad::new();
+        j.write(0x10);
+        j
+    }
+
+    /// Fresh joypad with only P14 (direction buttons) selected (write 0x20).
+    fn make_p14_selected() -> Joypad {
+        let mut j = Joypad::new();
+        j.write(0x20);
+        j
+    }
+
+    // ── read/write ─────────────────────────────────────────────────────────
+
+    /// After construction and selecting both groups, no buttons pressed →
+    /// lower nibble must be 0xF (all output lines high = released).
+    #[test]
+    fn test_read_with_both_groups_selected_no_buttons_pressed() {
+        // Given: both groups selected, no buttons pressed
+        let j = make_both_selected();
+        // When: read P1
+        let val = j.read();
+        // Then: lower nibble is 0xF (0xCF)
+        assert_eq!(val, 0xCF, "expected 0xCF, got {val:#04x}");
+    }
+
+    /// Bits 7-6 are always 1 regardless of state.
+    #[test]
+    fn test_upper_bits_always_set_in_read() {
+        let j = Joypad::new();
+        assert_eq!(j.read() & 0xC0, 0xC0);
+    }
+
+    /// Write 0x10 (P15 selected) — bits 5-4 of read must reflect that.
+    #[test]
+    fn test_select_bits_reflected_in_read() {
+        let j = make_p15_selected();
+        // bit4=1 (P14 not selected), bit5=0 (P15 selected) → 0x10 in bits 5-4
+        assert_eq!(j.read() & 0x30, 0x10);
+    }
+
+    // ── P15 (action buttons) ───────────────────────────────────────────────
+
+    /// P15 selected; pressing A (id=0) pulls bit0 of read low.
+    #[test]
+    fn test_p15_select_a_button_pressed() {
+        // Given: P15 selected only
+        let mut j = make_p15_selected();
+        // When: press A
+        j.set_button(0, true);
+        // Then: read = 0xC0 | 0x10 | 0x0E = 0xDE (bit0 clear)
+        assert_eq!(j.read(), 0xDE, "expected 0xDE, got {:#04x}", j.read());
+    }
+
+    /// P15 selected; pressing all four action buttons clears the lower nibble.
+    #[test]
+    fn test_p15_all_action_buttons_pressed() {
+        let mut j = make_p15_selected();
+        for id in 0..=3u8 {
+            j.set_button(id, true);
+        }
+        // All four P15 bits pressed → lower nibble = 0x0
+        assert_eq!(j.read() & 0x0F, 0x00);
+    }
+
+    // ── P14 (direction buttons) ────────────────────────────────────────────
+
+    /// P14 selected; pressing Right (id=7) pulls bit0 of read low.
+    #[test]
+    fn test_p14_select_right_pressed() {
+        // Given: P14 selected only
+        let mut j = make_p14_selected();
+        // When: press Right
+        j.set_button(7, true);
+        // Then: read = 0xC0 | 0x20 | 0x0E = 0xEE (bit0 clear)
+        assert_eq!(j.read(), 0xEE, "expected 0xEE, got {:#04x}", j.read());
+    }
+
+    /// P14 selected; Up (id=4) maps to p14 bit2; pressing it clears bit2.
+    #[test]
+    fn test_p14_select_up_pressed() {
+        let mut j = make_p14_selected();
+        j.set_button(4, true); // Up → p14 bit2
+        // effective_nibble = !0x04 & 0x0F = 0x0B
+        assert_eq!(j.read() & 0x0F, 0x0B);
+    }
+
+    // ── neither / both groups ──────────────────────────────────────────────
+
+    /// Neither group selected (default after new): pressing a button does not
+    /// change the lower nibble (all output lines float high).
+    #[test]
+    fn test_neither_group_selected_lower_nibble_stays_f() {
+        // Given: neither group selected (select_bits=0x30 after new)
+        let mut j = Joypad::new();
+        // When: press A
+        j.set_button(0, true);
+        // Then: lower nibble is still 0xF
+        assert_eq!(j.read() & 0x0F, 0x0F);
+    }
+
+    /// Both groups selected; A (P15 bit0) and Right (P14 bit0) both map to
+    /// output bit0 — pressing either clears that bit.
+    #[test]
+    fn test_both_groups_selected_combines_bit0() {
+        let mut j = make_both_selected();
+        j.set_button(0, true); // A → P15 bit0
+        j.set_button(7, true); // Right → P14 bit0
+        // Both drive output bit0 low
+        assert_eq!(j.read() & 0x01, 0x00);
+    }
+
+    // ── joypad interrupt ───────────────────────────────────────────────────
+
+    /// First button press in selected group fires an interrupt (0xF → non-0xF).
+    #[test]
+    fn test_interrupt_fires_on_first_press_in_selected_group() {
+        // Given: P15 selected
+        let mut j = make_p15_selected();
+        // When: press A (first button, nibble transitions from 0xF)
+        let irq = j.set_button(0, true);
+        // Then: interrupt fires
+        assert!(irq, "expected joypad IRQ on first press");
+    }
+
+    /// Pressing a button whose group is *not* selected does not fire interrupt.
+    #[test]
+    fn test_interrupt_no_fire_when_group_not_selected() {
+        // Given: P14 selected only
+        let mut j = make_p14_selected();
+        // When: press A (action button, P15 not selected)
+        let irq = j.set_button(0, true);
+        // Then: no interrupt (effective nibble unchanged — P15 not active)
+        assert!(!irq, "expected no IRQ when button's group not selected");
+    }
+
+    /// Second button press in the same group does NOT re-fire the interrupt.
+    #[test]
+    fn test_interrupt_no_fire_on_second_press() {
+        let mut j = make_p15_selected();
+        j.set_button(0, true); // first press → IRQ (consume it)
+        let irq = j.set_button(1, true); // second press → no IRQ
+        assert!(!irq, "expected no IRQ on second button press");
+    }
+
+    /// After fully releasing all buttons in the group, the next press fires
+    /// the interrupt again.
+    #[test]
+    fn test_interrupt_refires_after_full_release() {
+        let mut j = make_p15_selected();
+        j.set_button(0, true); // press A → IRQ fires
+        j.set_button(0, false); // release A → nibble back to 0xF
+        let irq = j.set_button(0, true); // press A again → IRQ should fire
+        assert!(irq, "expected IRQ to re-fire after full release");
+    }
+
+    /// Changing the select group does not spuriously fire an interrupt on the
+    /// next button press if a button was already pressed before the switch.
+    #[test]
+    fn test_no_spurious_irq_after_group_switch_with_held_button() {
+        let mut j = Joypad::new();
+        // Press A while P15 is selected
+        j.write(0x10);
+        j.set_button(0, true); // IRQ fires here, nibble → non-0xF
+        // Switch group away — A is still held but P15 is now deselected
+        j.write(0x20); // P14 selected only; effective nibble recomputed
+        // Switch back to P15 — A is still held
+        j.write(0x10);
+        // No new button *press* occurred; no interrupt should fire
+        let irq = j.set_button(1, true); // press B while A held → nibble still non-0xF before press
+        assert!(!irq, "expected no IRQ since nibble was already non-0xF");
+    }
+
+    // ── get_states / set_states ────────────────────────────────────────────
+
+    /// Each button id (0..=7): press it, verify its bit is set in get_states().
+    #[test]
+    fn test_get_states_roundtrip_each_button() {
+        for id in 0u8..=7 {
+            let mut j = Joypad::new();
+            j.set_button(id, true);
+            let states = j.get_states();
+            assert_ne!(
+                states & (1 << id),
+                0,
+                "button id={id} not set in get_states()={states:#010b}"
+            );
+        }
+    }
+
+    /// set_states + get_states round-trip with a mixed bitmask.
+    #[test]
+    fn test_set_states_get_states_roundtrip() {
+        let mut j = Joypad::new();
+        let mask: u8 = 0b1011_0101; // A, Sel, Up, Down, Right pressed
+        j.set_states(mask);
+        assert_eq!(
+            j.get_states(),
+            mask,
+            "round-trip failed: got {:#010b}",
+            j.get_states()
+        );
+    }
+
+    /// Releasing a button clears its bit in get_states.
+    #[test]
+    fn test_release_button_clears_state() {
+        let mut j = Joypad::new();
+        j.set_button(0, true);
+        j.set_button(0, false);
+        assert_eq!(j.get_states() & 0x01, 0x00);
+    }
+}

--- a/src/gb/input/mod.rs
+++ b/src/gb/input/mod.rs
@@ -1,0 +1,1 @@
+pub mod joypad;

--- a/src/gb/mod.rs
+++ b/src/gb/mod.rs
@@ -2,6 +2,7 @@ pub mod bus;
 pub mod cartridge;
 pub mod console;
 pub mod cpu;
+pub mod input;
 pub mod ppu;
 pub mod timer;
 

--- a/src/gb/mod.rs
+++ b/src/gb/mod.rs
@@ -6,5 +6,7 @@ pub mod input;
 pub mod ppu;
 pub mod timer;
 
+pub use console::gameboy::GameBoy;
+
 #[cfg(test)]
 pub mod integration_tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 mod nes;
 
 mod frontends;
+mod gb;
 mod platform;
 
 use nes::console::{
@@ -330,7 +331,9 @@ fn run_native_frontend(
 
     let mut console = platform::emulator::Console::new_nes(app_context.clone());
     {
-        let platform::emulator::Console::Nes(nes) = &mut console;
+        let platform::emulator::Console::Nes(nes) = &mut console else {
+            panic!("expected NES console")
+        };
         nes.insert_cartridge(cart);
     }
 

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -27,16 +27,15 @@ pub enum SystemType {
 ///     // NES-specific: debugger, PPU viewer, Zapper, etc.
 /// }
 /// ```
-#[allow(clippy::large_enum_variant)]
 pub enum Console {
-    Nes(Nes),
+    Nes(Box<Nes>),
     GameBoy(Box<GameBoy>),
 }
 
 impl Console {
     /// Create a new NES emulator instance.
     pub fn new_nes(app_context: impl IntoSharedAppContext) -> Self {
-        Console::Nes(Nes::new(app_context))
+        Console::Nes(Box::new(Nes::new(app_context)))
     }
 
     /// Create a new Game Boy (DMG) emulator instance.
@@ -166,6 +165,7 @@ impl Console {
     ///
     /// `button_id` is system-specific: for NES, it maps to [`crate::nes::input::Button`]
     /// discriminant values (A=0, B=1, Select=2, Start=3, Up=4, Down=5, Left=6, Right=7).
+    /// For Game Boy, only `port == 0` is meaningful; calls for other ports are ignored.
     pub fn set_button(&mut self, port: u8, button_id: u8, pressed: bool) {
         match self {
             Console::Nes(nes) => {
@@ -174,25 +174,42 @@ impl Console {
                     eprintln!("warning: invalid NES button_id: {button_id}");
                 }
             }
-            Console::GameBoy(gb) => gb.set_button(button_id, pressed),
+            Console::GameBoy(gb) => {
+                if port == 0 {
+                    gb.set_button(button_id, pressed);
+                }
+            }
         }
     }
 
     /// Set all button states from a bitmask (for autorun playback).
     ///
     /// Each bit corresponds to a button by its system-specific ID.
+    /// For Game Boy, only `port == 0` is applied; other ports are ignored.
     pub fn set_joypad_button_states(&mut self, port: u8, state: u8) {
         match self {
             Console::Nes(nes) => nes.set_joypad_button_states(port, state),
-            Console::GameBoy(gb) => gb.set_joypad_button_states(state),
+            Console::GameBoy(gb) => {
+                if port == 0 {
+                    gb.set_joypad_button_states(state);
+                }
+            }
         }
     }
 
     /// Get all button states as a bitmask (for autorun recording).
+    ///
+    /// For Game Boy, only `port == 0` returns button states; other ports return 0.
     pub fn get_joypad_button_states(&self, port: u8) -> u8 {
         match self {
             Console::Nes(nes) => nes.get_joypad_button_states(port),
-            Console::GameBoy(gb) => gb.get_joypad_button_states(),
+            Console::GameBoy(gb) => {
+                if port == 0 {
+                    gb.get_joypad_button_states()
+                } else {
+                    0
+                }
+            }
         }
     }
 

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -5,6 +5,7 @@
 //! NES-specific features (debugging, PPU viewer, etc.) are accessed by
 //! matching on the [`Console::Nes`] variant directly.
 
+use crate::gb::GameBoy;
 use crate::nes::console::Nes;
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
 
@@ -12,6 +13,7 @@ use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SystemType {
     Nes,
+    GameBoy,
 }
 
 /// Hardware-agnostic wrapper around system-specific emulators.
@@ -25,8 +27,10 @@ pub enum SystemType {
 ///     // NES-specific: debugger, PPU viewer, Zapper, etc.
 /// }
 /// ```
+#[allow(clippy::large_enum_variant)]
 pub enum Console {
     Nes(Nes),
+    GameBoy(Box<GameBoy>),
 }
 
 impl Console {
@@ -35,10 +39,16 @@ impl Console {
         Console::Nes(Nes::new(app_context))
     }
 
+    /// Create a new Game Boy (DMG) emulator instance.
+    pub fn new_gameboy(app_context: impl IntoSharedAppContext) -> Self {
+        Console::GameBoy(Box::new(GameBoy::new(app_context)))
+    }
+
     /// Which system this console is emulating.
     pub fn system_type(&self) -> SystemType {
         match self {
             Console::Nes(_) => SystemType::Nes,
+            Console::GameBoy(_) => SystemType::GameBoy,
         }
     }
 
@@ -54,6 +64,7 @@ impl Console {
     pub fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String> {
         match self {
             Console::Nes(nes) => nes.load_rom(bytes, name),
+            Console::GameBoy(gb) => gb.load_rom(bytes, name),
         }
     }
 
@@ -63,6 +74,7 @@ impl Console {
     pub fn run_tick(&mut self) -> u8 {
         match self {
             Console::Nes(nes) => nes.run_cpu_tick(),
+            Console::GameBoy(gb) => gb.run_tick(),
         }
     }
 
@@ -71,6 +83,7 @@ impl Console {
     pub fn is_ready_to_render(&self) -> bool {
         match self {
             Console::Nes(nes) => nes.is_ready_to_render(),
+            Console::GameBoy(gb) => gb.is_frame_ready(),
         }
     }
 
@@ -78,6 +91,7 @@ impl Console {
     pub fn clear_ready_to_render(&mut self) {
         match self {
             Console::Nes(nes) => nes.clear_ready_to_render(),
+            Console::GameBoy(gb) => gb.clear_frame_ready(),
         }
     }
 
@@ -85,6 +99,7 @@ impl Console {
     pub fn screen_width(&self) -> u32 {
         match self {
             Console::Nes(_) => Nes::SCREEN_WIDTH,
+            Console::GameBoy(_) => GameBoy::SCREEN_WIDTH,
         }
     }
 
@@ -92,6 +107,7 @@ impl Console {
     pub fn screen_height(&self) -> u32 {
         match self {
             Console::Nes(_) => Nes::SCREEN_HEIGHT,
+            Console::GameBoy(_) => GameBoy::SCREEN_HEIGHT,
         }
     }
 
@@ -102,6 +118,7 @@ impl Console {
     pub fn screen_snapshot(&self) -> Vec<u8> {
         match self {
             Console::Nes(nes) => nes.get_screen_buffer().snapshot(),
+            Console::GameBoy(gb) => gb.screen_snapshot(),
         }
     }
 
@@ -114,6 +131,7 @@ impl Console {
             Console::Nes(nes) => nes
                 .get_screen_buffer()
                 .cropped_snapshot(h_overscan, v_overscan),
+            Console::GameBoy(gb) => gb.cropped_screen_snapshot(),
         }
     }
 
@@ -121,6 +139,7 @@ impl Console {
     pub fn screen_crc32(&self) -> u32 {
         match self {
             Console::Nes(nes) => nes.get_screen_buffer().crc32(),
+            Console::GameBoy(gb) => gb.screen_crc32(),
         }
     }
 
@@ -128,6 +147,7 @@ impl Console {
     pub fn sample_ready(&self) -> bool {
         match self {
             Console::Nes(nes) => nes.sample_ready(),
+            Console::GameBoy(_) => false,
         }
     }
 
@@ -138,6 +158,7 @@ impl Console {
     pub fn get_sample(&mut self) -> Option<f32> {
         match self {
             Console::Nes(nes) => nes.get_sample(),
+            Console::GameBoy(_) => None,
         }
     }
 
@@ -153,6 +174,7 @@ impl Console {
                     eprintln!("warning: invalid NES button_id: {button_id}");
                 }
             }
+            Console::GameBoy(gb) => gb.set_button(button_id, pressed),
         }
     }
 
@@ -162,6 +184,7 @@ impl Console {
     pub fn set_joypad_button_states(&mut self, port: u8, state: u8) {
         match self {
             Console::Nes(nes) => nes.set_joypad_button_states(port, state),
+            Console::GameBoy(gb) => gb.set_joypad_button_states(state),
         }
     }
 
@@ -169,6 +192,7 @@ impl Console {
     pub fn get_joypad_button_states(&self, port: u8) -> u8 {
         match self {
             Console::Nes(nes) => nes.get_joypad_button_states(port),
+            Console::GameBoy(gb) => gb.get_joypad_button_states(),
         }
     }
 
@@ -176,6 +200,7 @@ impl Console {
     pub fn save_state_bytes(&self) -> Result<Vec<u8>, String> {
         match self {
             Console::Nes(nes) => nes.save_state_bytes(),
+            Console::GameBoy(gb) => gb.save_state_bytes(),
         }
     }
 
@@ -183,6 +208,7 @@ impl Console {
     pub fn load_state_bytes(&mut self, data: &[u8]) -> Result<(), String> {
         match self {
             Console::Nes(nes) => nes.load_state_bytes(data),
+            Console::GameBoy(gb) => gb.load_state_bytes(data),
         }
     }
 
@@ -193,6 +219,7 @@ impl Console {
     pub fn reset(&mut self, soft_reset: bool) {
         match self {
             Console::Nes(nes) => nes.reset(soft_reset),
+            Console::GameBoy(gb) => gb.reset(soft_reset),
         }
     }
 
@@ -200,6 +227,7 @@ impl Console {
     pub fn app_context(&self) -> &SharedAppContext {
         match self {
             Console::Nes(nes) => nes.app_context(),
+            Console::GameBoy(gb) => gb.app_context(),
         }
     }
 
@@ -207,6 +235,7 @@ impl Console {
     pub fn save_ram(&self) -> Result<(), String> {
         match self {
             Console::Nes(nes) => nes.save_ram().map_err(|e| e.to_string()),
+            Console::GameBoy(_) => Ok(()),
         }
     }
 
@@ -214,6 +243,7 @@ impl Console {
     pub fn set_audio_sample_rate(&mut self, rate: f32) {
         match self {
             Console::Nes(nes) => nes.set_audio_sample_rate(rate),
+            Console::GameBoy(_) => {}
         }
     }
 }
@@ -332,8 +362,11 @@ mod tests {
     #[test]
     fn test_nes_variant_is_accessible() {
         let mut console = make_console();
-        let Console::Nes(nes) = &mut console;
-        assert!(!nes.is_ready_to_render());
+        if let Console::Nes(nes) = &mut console {
+            assert!(!nes.is_ready_to_render());
+        } else {
+            panic!("expected Console::Nes");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements GB joypad input ($FF00/P1 register) and `Console::GameBoy` integration per issue #1908.

## Changes

### Phase 1 — Joypad module (`src/gb/input/joypad.rs`)
- `Joypad` struct with P14 (actions) and P15 (d-pad) groups
- `read()` / `write()` for $FF00 register
- `set_button(id, pressed) -> bool` — returns `true` when joypad IRQ should fire
- Spec-accurate IRQ: fires only when effective nibble transitions from `0xF` to non-`0xF`
- Spurious-IRQ guard on group switch

### Phase 2 — DmgBus wiring (`src/gb/bus/dmg_bus.rs`)
- `$FF00` routed to `joypad.read()` / `joypad.write()`
- `set_joypad_button()` sets `IF` bit 4 when IRQ fires
- `DmgBus::reset()` — reinitialises PPU, Timer, Joypad, clears WRAM/HRAM/IF/IE

### Phase 3 — Reset methods
- `Sm83::reset_registers()` — DMG post-boot register values
- `Gb<DmgBus>::reset(soft_reset)` — soft resets CPU registers only; hard also resets bus

### Phase 4 — GameBoy wrapper + Console enum
- `src/gb/console.rs` → `src/gb/console/mod.rs` (module directory)
- `src/gb/console/gameboy.rs`: `GameBoy` platform wrapper struct
  - `load_rom`, `run_tick`, `is_frame_ready`, `screen_snapshot`, `screen_crc32`
  - `set_button`, `set_joypad_button_states`, `get_joypad_button_states`
  - `save_state_bytes` / `load_state_bytes` (unimplemented stubs)
  - `reset`, `app_context`
- `src/platform/emulator.rs`: `Console::GameBoy(Box<GameBoy>)` + `SystemType::GameBoy`
  - `new_gameboy()` constructor
  - All 16 match arms extended with `Console::GameBoy` arms
- Fixed refutable `let Console::Nes` patterns in `event_loop.rs` and `main.rs` using `let-else`
- Added `mod gb;` to `main.rs` so `crate::gb` resolves in binary target

## Tests

- 17 unit tests for joypad module (P14/P15 groups, IRQ edge detection)
- 5 new tests in dmg_bus ($FF00 read/write, IRQ flag behaviour)
- 8 reset tests in console (soft/hard reset, register state)
- 15 unit tests for `GameBoy` wrapper (load ROM, run tick, screen, input, reset)
- 5 new tests for `Console::GameBoy` in emulator module

All tests pass. Pre-existing failures in `test_mapper_1_autorun_startropics` and `test_mapper_3_autorun_gradius` are unrelated NES integration tests that also fail on `main`.

Closes #1908
