### PR TITLE
feat: native frontend support for Game Boy ROMs (#1909)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ target
 
 # ROMs that should not be comitted
 roms/games
+roms/gb/games
 
 .github/ISSUE_TEMPLATE
 *.log

--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -204,19 +204,26 @@ impl NativeEventLoop {
 
         let audio = self.audio.take();
         let audio_cell = std::cell::RefCell::new(audio);
-        let Console::Nes(nes) = &mut self.console else {
-            panic!("NES-only event loop: unexpected non-NES console in run_frame");
-        };
-        self.debugger_controller
-            .run_frame(nes, &self.tracing, &mut |nes| {
-                if let Some(ref mut audio) = *audio_cell.borrow_mut() {
-                    while nes.sample_ready() {
-                        if let Some(sample) = nes.get_sample() {
-                            audio.queue_sample(sample);
+        match &mut self.console {
+            Console::Nes(nes) => {
+                self.debugger_controller
+                    .run_frame(nes, &self.tracing, &mut |nes| {
+                        if let Some(ref mut audio) = *audio_cell.borrow_mut() {
+                            while nes.sample_ready() {
+                                if let Some(sample) = nes.get_sample() {
+                                    audio.queue_sample(sample);
+                                }
+                            }
                         }
-                    }
+                    });
+            }
+            Console::GameBoy(gb) => {
+                // Run ticks until a full frame is ready.
+                while !gb.is_frame_ready() {
+                    gb.run_tick();
                 }
-            });
+            }
+        }
         self.audio = audio_cell.into_inner();
         self.sync_from_controller();
         self.console.clear_ready_to_render();
@@ -275,6 +282,10 @@ impl NativeEventLoop {
     /// Called once per frame to ensure grab/visibility stay in sync after
     /// cartridge switches, focus changes, or controller hot-swaps.
     fn sync_mouse_grab_state(&mut self) {
+        // Mouse grab is only relevant for NES (Zapper / SNES Mouse controllers).
+        let Console::Nes(_) = &self.console else {
+            return;
+        };
         let has_mouse = mouse::has_any_mouse_controller(self.nes());
         let should_grab = crate::nes::input::mouse_mapping::should_grab_mouse_input(
             has_mouse,
@@ -557,7 +568,9 @@ impl NativeEventLoop {
 
             let checkpoint_due = self.handle_autorun_after_input();
 
-            crate::nes::autorun::headless_playback::run_one_frame(self.nes_mut());
+            if let Console::Nes(nes) = &mut self.console {
+                crate::nes::autorun::headless_playback::run_one_frame(nes);
+            }
 
             self.handle_autorun_after_frame(checkpoint_due);
         }
@@ -576,12 +589,11 @@ impl ApplicationHandler for NativeEventLoop {
                 if !self.initialized {
                     self.initialize_audio();
                     self.sync_audio_state();
-                    let Console::Nes(nes) = &self.console else {
-                        panic!("NES-only event loop: unexpected non-NES console in resumed");
-                    };
-                    let watches = self.debugger_controller.load_debug_state_from_file(nes);
-                    if let Some(ref mut gl) = self.gl_wrapper {
-                        gl.set_watch_addresses(watches);
+                    if let Console::Nes(nes) = &self.console {
+                        let watches = self.debugger_controller.load_debug_state_from_file(nes);
+                        if let Some(ref mut gl) = self.gl_wrapper {
+                            gl.set_watch_addresses(watches);
+                        }
                     }
                     self.initialized = true;
                 }
@@ -604,16 +616,15 @@ impl ApplicationHandler for NativeEventLoop {
                 if let Err(e) = self.finish_recording() {
                     eprintln!("Failed to finish recording on window close: {e}");
                 }
-                let watches = self
-                    .gl_wrapper
-                    .as_ref()
-                    .map(|gl| gl.watch_addresses())
-                    .unwrap_or_default();
-                let Console::Nes(nes) = &self.console else {
-                    panic!("NES-only event loop: unexpected non-NES console in CloseRequested");
-                };
-                self.debugger_controller
-                    .save_debug_state_to_file(nes, &watches);
+                if let Console::Nes(nes) = &self.console {
+                    let watches = self
+                        .gl_wrapper
+                        .as_ref()
+                        .map(|gl| gl.watch_addresses())
+                        .unwrap_or_default();
+                    self.debugger_controller
+                        .save_debug_state_to_file(nes, &watches);
+                }
                 if let Err(e) = self.console.save_ram() {
                     eprintln!("Failed to save battery-backed RAM on exit: {e}");
                 }
@@ -680,26 +691,26 @@ impl ApplicationHandler for NativeEventLoop {
                     let fullscreen_before = self.state.fullscreen;
                     let audio_ref: Option<&dyn EmulatorAudio> =
                         self.audio.as_ref().map(|a| a as &dyn EmulatorAudio);
-                    let Console::Nes(nes) = &mut self.console else {
-                        panic!("NES-only event loop: unexpected non-NES console in KeyInput");
-                    };
-                    let outcome =
-                        keyboard::handle_key_pressed(nes, key_code, &mut self.state, audio_ref);
+                    let outcome = keyboard::handle_key_pressed(
+                        &mut self.console,
+                        key_code,
+                        &mut self.state,
+                        audio_ref,
+                    );
                     match outcome {
                         KeyOutcome::Quit => {
                             if let Err(e) = self.finish_recording() {
                                 eprintln!("Failed to finish recording on quit: {e}");
                             }
-                            let watches = self
-                                .gl_wrapper
-                                .as_ref()
-                                .map(|gl| gl.watch_addresses())
-                                .unwrap_or_default();
-                            let Console::Nes(nes) = &self.console else {
-                                panic!("NES-only event loop: unexpected non-NES console in Quit");
-                            };
-                            self.debugger_controller
-                                .save_debug_state_to_file(nes, &watches);
+                            if let Console::Nes(nes) = &self.console {
+                                let watches = self
+                                    .gl_wrapper
+                                    .as_ref()
+                                    .map(|gl| gl.watch_addresses())
+                                    .unwrap_or_default();
+                                self.debugger_controller
+                                    .save_debug_state_to_file(nes, &watches);
+                            }
                             if let Err(e) = self.console.save_ram() {
                                 eprintln!("Failed to save battery-backed RAM on quit: {e}");
                             }
@@ -761,13 +772,8 @@ impl ApplicationHandler for NativeEventLoop {
                         }
                     }
                 } else {
-                    let Console::Nes(nes) = &mut self.console else {
-                        panic!(
-                            "NES-only event loop: unexpected non-NES console in KeyInput released"
-                        );
-                    };
                     keyboard::handle_key_released(
-                        nes,
+                        &mut self.console,
                         key_code,
                         self.state.gamepad_count,
                         self.state.four_score_enabled,
@@ -799,6 +805,11 @@ impl ApplicationHandler for NativeEventLoop {
                 if let Some(ref mut gl) = self.gl_wrapper {
                     gl.handle_mouse_button(button, state);
                 }
+
+                // Mouse controller logic is NES-only.
+                let Console::Nes(_) = &self.console else {
+                    return;
+                };
 
                 let has_mouse = mouse::has_any_mouse_controller(self.nes());
 
@@ -917,13 +928,16 @@ impl ApplicationHandler for NativeEventLoop {
                 // Render and apply debugger UI actions
                 let action = if let Some(ref mut gl) = self.gl_wrapper {
                     gl.update_breakpoints(self.debugger_controller.breakpoints());
-                    let Console::Nes(nes) = &self.console else {
-                        panic!("NES-only event loop: unexpected non-NES console in render");
+                    let (overlay, crosshair) = if let Console::Nes(nes) = &self.console {
+                        (
+                            self.state.overlay_text(nes, self.autorun_state.as_ref()),
+                            mouse::zapper_crosshair(nes, self.state.last_zapper_position),
+                        )
+                    } else {
+                        (None, None)
                     };
-                    let overlay = self.state.overlay_text(nes, self.autorun_state.as_ref());
-                    let crosshair = mouse::zapper_crosshair(nes, self.state.last_zapper_position);
                     gl.render(
-                        nes,
+                        &self.console,
                         self.state.debugger_open,
                         overlay.as_deref(),
                         false,
@@ -932,12 +946,7 @@ impl ApplicationHandler for NativeEventLoop {
                 } else {
                     Default::default()
                 };
-                {
-                    let Console::Nes(nes) = &mut self.console else {
-                        panic!(
-                            "NES-only event loop: unexpected non-NES console in apply_ui_action"
-                        );
-                    };
+                if let Console::Nes(nes) = &mut self.console {
                     self.debugger_controller.apply_ui_action(nes, action);
                 }
                 self.sync_from_controller();
@@ -960,6 +969,11 @@ impl ApplicationHandler for NativeEventLoop {
             if !self.state.mouse_grabbed {
                 return;
             }
+
+            // Mouse motion routing is NES-only.
+            let Console::Nes(_) = &self.console else {
+                return;
+            };
 
             let (w, h) = self
                 .gl_wrapper
@@ -995,10 +1009,7 @@ impl ApplicationHandler for NativeEventLoop {
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
         // Poll gamepad events before requesting redraw.
         if let Some(ref mut gp) = self.gamepad {
-            let Console::Nes(nes) = &mut self.console else {
-                panic!("NES-only event loop: unexpected non-NES console in about_to_wait");
-            };
-            let changes = gp.process_events(nes);
+            let changes = gp.process_events(&mut self.console);
             self.state.gamepad_count = gp.connected_count();
 
             if self.gamepad_init_toast_shown {

--- a/src/frontends/native/gamepad.rs
+++ b/src/frontends/native/gamepad.rs
@@ -6,6 +6,7 @@
 
 use crate::nes::console::Nes;
 use crate::nes::input::{Button, ControllerInput, SnesButton};
+use crate::platform::emulator::Console;
 
 use gilrs::{Axis, EventType, GamepadId, Gilrs, GilrsBuilder};
 
@@ -214,38 +215,79 @@ impl GamepadManager {
         self.player_map.len()
     }
 
-    /// Polls all pending gilrs events, applies them to `nes`, and returns
+    /// Polls all pending gilrs events, applies them to `console`, and returns
     /// any hot-plug connect/disconnect events that occurred.
-    pub fn process_events(&mut self, nes: &mut Nes) -> Vec<GamepadChange> {
+    pub fn process_events(&mut self, console: &mut Console) -> Vec<GamepadChange> {
         let mut changes = Vec::new();
-        while let Some(event) = self.gilrs.next_event() {
-            match event.event {
-                EventType::ButtonPressed(button, _) => {
-                    self.handle_button(nes, event.id, button, true);
-                }
-                EventType::ButtonReleased(button, _) => {
-                    self.handle_button(nes, event.id, button, false);
-                }
-                // ButtonChanged is intentionally NOT handled here.
-                // gilrs generates ButtonPressed/ButtonReleased for digital
-                // state transitions (including from analog thresholds via the
-                // default filter). Handling ButtonChanged causes the button
-                // to be released immediately when val=0 arrives in the same
-                // event batch as ButtonPressed, before the NES frame runs.
-                EventType::AxisChanged(axis, value, _) => {
-                    self.handle_axis(nes, event.id, axis, value);
-                }
-                EventType::Connected => {
-                    if let Some(change) = self.handle_connected(event.id) {
-                        changes.push(change);
+        match console {
+            Console::Nes(nes) => {
+                while let Some(event) = self.gilrs.next_event() {
+                    match event.event {
+                        EventType::ButtonPressed(button, _) => {
+                            self.handle_button(nes, event.id, button, true);
+                        }
+                        EventType::ButtonReleased(button, _) => {
+                            self.handle_button(nes, event.id, button, false);
+                        }
+                        EventType::AxisChanged(axis, value, _) => {
+                            self.handle_axis(nes, event.id, axis, value);
+                        }
+                        EventType::Connected => {
+                            if let Some(change) = self.handle_connected(event.id) {
+                                changes.push(change);
+                            }
+                        }
+                        EventType::Disconnected => {
+                            if let Some(change) = self.handle_disconnected(nes, event.id) {
+                                changes.push(change);
+                            }
+                        }
+                        _ => {}
                     }
                 }
-                EventType::Disconnected => {
-                    if let Some(change) = self.handle_disconnected(nes, event.id) {
-                        changes.push(change);
+            }
+            Console::GameBoy(_) => {
+                while let Some(event) = self.gilrs.next_event() {
+                    match event.event {
+                        EventType::ButtonPressed(button, _) => {
+                            if let Some(nes_btn) = map_button_to_nes(button) {
+                                console.set_button(0, nes_btn as u8, true);
+                            }
+                        }
+                        EventType::ButtonReleased(button, _) => {
+                            if let Some(nes_btn) = map_button_to_nes(button) {
+                                console.set_button(0, nes_btn as u8, false);
+                            }
+                        }
+                        EventType::AxisChanged(axis, value, _) => {
+                            let state = self.gamepad_states.entry(event.id).or_default();
+                            let axis_changes = match axis {
+                                Axis::LeftStickX => state.axis.update_x(value),
+                                Axis::LeftStickY => state.axis.update_y(value),
+                                _ => vec![],
+                            };
+                            for (btn, pressed) in axis_changes {
+                                console.set_button(0, btn as u8, pressed);
+                            }
+                        }
+                        EventType::Connected => {
+                            if let Some(change) = self.handle_connected(event.id) {
+                                changes.push(change);
+                            }
+                        }
+                        EventType::Disconnected => {
+                            // Release all GB buttons on disconnect.
+                            console.set_joypad_button_states(0, 0);
+                            if let Some(player_num) = self.player_map.get(&event.id).copied() {
+                                self.player_map.remove(&event.id);
+                                self.gamepad_states.remove(&event.id);
+                                self.reassign_players();
+                                changes.push(GamepadChange::Disconnected(player_num));
+                            }
+                        }
+                        _ => {}
                     }
                 }
-                _ => {}
             }
         }
         changes

--- a/src/frontends/native/gamepad.rs
+++ b/src/frontends/native/gamepad.rs
@@ -276,12 +276,14 @@ impl GamepadManager {
                             }
                         }
                         EventType::Disconnected => {
-                            // Release all GB buttons on disconnect.
-                            console.set_joypad_button_states(0, 0);
                             if let Some(player_num) = self.player_map.get(&event.id).copied() {
                                 self.player_map.remove(&event.id);
                                 self.gamepad_states.remove(&event.id);
                                 self.reassign_players();
+                                if self.player_map.is_empty() {
+                                    // Release all GB buttons only when the last gamepad disconnects.
+                                    console.set_joypad_button_states(0, 0);
+                                }
                                 changes.push(GamepadChange::Disconnected(player_num));
                             }
                         }

--- a/src/frontends/native/gl_wrapper.rs
+++ b/src/frontends/native/gl_wrapper.rs
@@ -184,14 +184,14 @@ impl NativeGlWrapper {
     /// Renders a frame and optional debugger overlay.
     pub fn render(
         &mut self,
-        nes: &crate::nes::console::Nes,
+        console: &crate::platform::emulator::Console,
         show_debugger: bool,
         overlay_text: Option<&str>,
         overlay_blink_red: bool,
         crosshair: Option<Crosshair>,
     ) -> DebuggerUiAction {
         self.gl_backend.render(
-            nes,
+            console,
             show_debugger,
             overlay_text,
             overlay_blink_red,

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -147,6 +147,46 @@ fn gameboy_key_to_button_id(key_code: KeyCode) -> Option<u8> {
     }
 }
 
+/// Attempts to handle a key press that is identical for all console types.
+///
+/// Returns `Some(KeyOutcome::Continue)` for Escape and Space (which mutate
+/// `app_state` / `audio`), `Some(KeyOutcome::CycleShader)` for F4, and
+/// `None` for keys that need system-specific handling.
+fn handle_common_hotkey(
+    key_code: KeyCode,
+    app_state: &mut NativeAppState,
+    audio: Option<&dyn EmulatorAudio>,
+) -> Option<KeyOutcome> {
+    match key_code {
+        KeyCode::Escape => {
+            app_state.mouse_grabbed = false;
+            app_state.mouse_released_by_escape = true;
+            Some(KeyOutcome::Continue)
+        }
+        KeyCode::Space => {
+            app_state.paused = !app_state.paused;
+            if let Some(audio) = audio {
+                if app_state.paused {
+                    audio.pause();
+                } else {
+                    audio.resume();
+                }
+            }
+            Some(KeyOutcome::Continue)
+        }
+        KeyCode::F4 => Some(KeyOutcome::CycleShader),
+        KeyCode::F2 => {
+            adjust_volume(audio, 0.1);
+            Some(KeyOutcome::Continue)
+        }
+        KeyCode::F3 => {
+            adjust_volume(audio, -0.1);
+            Some(KeyOutcome::Continue)
+        }
+        _ => None,
+    }
+}
+
 /// Handles a key-press event for a [`Console::GameBoy`].
 ///
 /// Dispatches generic hotkeys (pause, fullscreen, Ctrl+Q, shader cycling) and
@@ -169,29 +209,12 @@ fn handle_gameboy_key_pressed(
         };
     }
 
-    match key_code {
-        KeyCode::Escape => {
-            app_state.mouse_grabbed = false;
-            app_state.mouse_released_by_escape = true;
-        }
-        KeyCode::Space => {
-            app_state.paused = !app_state.paused;
-            if let Some(audio) = audio {
-                if app_state.paused {
-                    audio.pause();
-                } else {
-                    audio.resume();
-                }
-            }
-        }
-        KeyCode::F4 => return KeyOutcome::CycleShader,
-        KeyCode::F2 => adjust_volume(audio, 0.1),
-        KeyCode::F3 => adjust_volume(audio, -0.1),
-        _ => {
-            if let Some(btn_id) = gameboy_key_to_button_id(key_code) {
-                console.set_button(0, btn_id, true);
-            }
-        }
+    if let Some(outcome) = handle_common_hotkey(key_code, app_state, audio) {
+        return outcome;
+    }
+
+    if let Some(btn_id) = gameboy_key_to_button_id(key_code) {
+        console.set_button(0, btn_id, true);
     }
 
     KeyOutcome::Continue
@@ -223,25 +246,12 @@ fn handle_unmodified_key(
     app_state: &mut NativeAppState,
     audio: Option<&dyn EmulatorAudio>,
 ) -> KeyOutcome {
+    if let Some(outcome) = handle_common_hotkey(key_code, app_state, audio) {
+        return outcome;
+    }
+
     match key_code {
-        KeyCode::Escape => {
-            app_state.mouse_grabbed = false;
-            app_state.mouse_released_by_escape = true;
-        }
-        KeyCode::Space => {
-            app_state.paused = !app_state.paused;
-            if let Some(audio) = audio {
-                if app_state.paused {
-                    audio.pause();
-                } else {
-                    audio.resume();
-                }
-            }
-        }
         KeyCode::KeyH => app_state.help_overlay_visible = !app_state.help_overlay_visible,
-        KeyCode::F2 => adjust_volume(audio, 0.1),
-        KeyCode::F3 => adjust_volume(audio, -0.1),
-        KeyCode::F4 => return KeyOutcome::CycleShader,
         KeyCode::F5 => return KeyOutcome::ToggleDebugger,
         KeyCode::F6 => {
             crate::nes::console::save_state_io::save_state_to_disk(nes);

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -8,6 +8,7 @@ use crate::frontends::native::app_state::NativeAppState;
 use crate::nes::console::Nes;
 use crate::nes::input::{Button, PowerPadButton, SnesButton};
 use crate::platform::audio::EmulatorAudio;
+use crate::platform::emulator::Console;
 use winit::keyboard::KeyCode;
 
 /// The result of processing a key-press event.
@@ -35,25 +36,32 @@ pub enum KeyOutcome {
 
 /// Handles a key-press event.
 ///
-/// Updates `nes` and `app_state` as appropriate, and optionally adjusts
+/// Updates `console` and `app_state` as appropriate, and optionally adjusts
 /// audio volume via `audio`.  Returns a [`KeyOutcome`] so the caller can act
 /// on actions that require access to the GL wrapper (e.g. shader cycling,
 /// fullscreen toggle).
+///
+/// For [`Console::GameBoy`], only generic actions (pause, fullscreen toggle,
+/// directional/A/B/Start/Select keys) are dispatched; NES-specific features
+/// such as the debugger, save states, SNES buttons, and Power Pad are ignored.
 pub fn handle_key_pressed(
-    nes: &mut Nes,
+    console: &mut Console,
     key_code: KeyCode,
     app_state: &mut NativeAppState,
     audio: Option<&dyn EmulatorAudio>,
 ) -> KeyOutcome {
-    if app_state.cart_switch.open {
-        return handle_cartridge_switch_key(key_code, app_state);
+    match console {
+        Console::Nes(nes) => {
+            if app_state.cart_switch.open {
+                return handle_cartridge_switch_key(key_code, app_state);
+            }
+            if app_state.modifiers.control_key() {
+                return handle_ctrl_hotkey(nes, key_code, app_state);
+            }
+            handle_unmodified_key(nes, key_code, app_state, audio)
+        }
+        Console::GameBoy(_) => handle_gameboy_key_pressed(console, key_code, app_state, audio),
     }
-
-    if app_state.modifiers.control_key() {
-        return handle_ctrl_hotkey(nes, key_code, app_state);
-    }
-
-    handle_unmodified_key(nes, key_code, app_state, audio)
 }
 
 /// Handles a key-release event.
@@ -61,14 +69,26 @@ pub fn handle_key_pressed(
 /// Releases the NES / SNES / Power Pad button corresponding to the given key.
 /// `gamepad_count` and `four_score` determine which ports keyboard input is
 /// routed to.
+///
+/// For [`Console::GameBoy`], only generic directional/A/B/Start/Select
+/// releases are dispatched; NES-specific keys are ignored.
 pub fn handle_key_released(
-    nes: &mut Nes,
+    console: &mut Console,
     key_code: KeyCode,
     gamepad_count: usize,
     four_score: bool,
 ) {
-    let ports = keyboard_target_ports(gamepad_count, four_score);
-    handle_controller_key(nes, key_code, false, ports);
+    match console {
+        Console::Nes(nes) => {
+            let ports = keyboard_target_ports(gamepad_count, four_score);
+            handle_controller_key(nes, key_code, false, ports);
+        }
+        Console::GameBoy(_) => {
+            if let Some(btn_id) = gameboy_key_to_button_id(key_code) {
+                console.set_button(0, btn_id, false);
+            }
+        }
+    }
 }
 
 /// Returns the NES ports that keyboard input should be routed to, based on
@@ -104,6 +124,78 @@ pub fn keyboard_target_ports(gamepad_count: usize, four_score: bool) -> &'static
 }
 
 // ── Hotkey dispatch ───────────────────────────────────────────────────────────
+
+// ── Game Boy keyboard dispatch ────────────────────────────────────────────────
+
+/// Maps a key code to a Game Boy button ID (0=A,1=B,2=Select,3=Start,4=Up,5=Down,6=Left,7=Right).
+///
+/// Uses the same physical-position layout as the NES P1 keys so that
+/// players feel at home: WASD for D-pad, R=A, T=B, 4=Select, 5=Start.
+/// Arrow keys are also mapped to the D-pad for convenience.
+fn gameboy_key_to_button_id(key_code: KeyCode) -> Option<u8> {
+    use Button::{A, B, Down, Left, Right, Select, Start, Up};
+    match key_code {
+        KeyCode::KeyR => Some(A as u8),
+        KeyCode::KeyT => Some(B as u8),
+        KeyCode::Digit4 => Some(Select as u8),
+        KeyCode::Digit5 => Some(Start as u8),
+        KeyCode::KeyW | KeyCode::ArrowUp => Some(Up as u8),
+        KeyCode::KeyS | KeyCode::ArrowDown => Some(Down as u8),
+        KeyCode::KeyA | KeyCode::ArrowLeft => Some(Left as u8),
+        KeyCode::KeyD | KeyCode::ArrowRight => Some(Right as u8),
+        _ => None,
+    }
+}
+
+/// Handles a key-press event for a [`Console::GameBoy`].
+///
+/// Dispatches generic hotkeys (pause, fullscreen, Ctrl+Q, shader cycling) and
+/// maps standard button keys to Game Boy buttons on port 0.
+fn handle_gameboy_key_pressed(
+    console: &mut Console,
+    key_code: KeyCode,
+    app_state: &mut NativeAppState,
+    audio: Option<&dyn EmulatorAudio>,
+) -> KeyOutcome {
+    // Generic hotkeys that work for any system.
+    if app_state.modifiers.control_key() {
+        return match key_code {
+            KeyCode::KeyQ => KeyOutcome::Quit,
+            KeyCode::KeyF => {
+                app_state.fullscreen = !app_state.fullscreen;
+                KeyOutcome::Continue
+            }
+            _ => KeyOutcome::Continue,
+        };
+    }
+
+    match key_code {
+        KeyCode::Escape => {
+            app_state.mouse_grabbed = false;
+            app_state.mouse_released_by_escape = true;
+        }
+        KeyCode::Space => {
+            app_state.paused = !app_state.paused;
+            if let Some(audio) = audio {
+                if app_state.paused {
+                    audio.pause();
+                } else {
+                    audio.resume();
+                }
+            }
+        }
+        KeyCode::F4 => return KeyOutcome::CycleShader,
+        KeyCode::F2 => adjust_volume(audio, 0.1),
+        KeyCode::F3 => adjust_volume(audio, -0.1),
+        _ => {
+            if let Some(btn_id) = gameboy_key_to_button_id(key_code) {
+                console.set_button(0, btn_id, true);
+            }
+        }
+    }
+
+    KeyOutcome::Continue
+}
 
 fn handle_ctrl_hotkey(
     nes: &mut Nes,
@@ -433,6 +525,7 @@ mod tests {
     use super::*;
     use crate::nes::console::{Config, NesConfig};
     use crate::platform::app_context::AppContext;
+    use crate::platform::emulator::Console;
     use winit::keyboard::ModifiersState;
 
     // ── Test helpers ──────────────────────────────────────────────────────────
@@ -469,6 +562,18 @@ mod tests {
         nes
     }
 
+    fn make_nes_console() -> Console {
+        Console::Nes(Box::new(make_nes()))
+    }
+
+    fn make_nes_console_with_cart() -> Console {
+        Console::Nes(Box::new(make_nes_with_cartridge()))
+    }
+
+    fn make_nes_console_four_score() -> Console {
+        Console::Nes(Box::new(make_nes_four_score()))
+    }
+
     fn make_state() -> NativeAppState {
         NativeAppState::default()
     }
@@ -481,6 +586,7 @@ mod tests {
         state.modifiers = ModifiersState::CONTROL | ModifiersState::SHIFT;
     }
 
+    #[allow(dead_code)]
     fn buttons(nes: &Nes, port: u8) -> u8 {
         nes.get_joypad_button_states(port)
     }
@@ -580,32 +686,32 @@ mod tests {
 
     #[test]
     fn test_ctrl_q_returns_quit() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         with_ctrl(&mut state);
         assert_eq!(
-            handle_key_pressed(&mut nes, KeyCode::KeyQ, &mut state, None),
+            handle_key_pressed(&mut console, KeyCode::KeyQ, &mut state, None),
             KeyOutcome::Quit
         );
     }
 
     #[test]
     fn test_escape_returns_continue_when_mouse_not_grabbed() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         state.mouse_grabbed = false;
         assert_eq!(
-            handle_key_pressed(&mut nes, KeyCode::Escape, &mut state, None),
+            handle_key_pressed(&mut console, KeyCode::Escape, &mut state, None),
             KeyOutcome::Continue
         );
     }
 
     #[test]
     fn test_escape_releases_mouse_when_grabbed() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         state.mouse_grabbed = true;
-        handle_key_pressed(&mut nes, KeyCode::Escape, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Escape, &mut state, None);
         assert!(!state.mouse_grabbed, "Escape should release mouse grab");
         assert!(
             state.mouse_released_by_escape,
@@ -615,29 +721,29 @@ mod tests {
 
     #[test]
     fn test_space_toggles_pause_on() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::Space, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Space, &mut state, None);
         assert!(state.paused, "Space should pause when unpaused");
     }
 
     #[test]
     fn test_space_toggles_pause_off() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         state.paused = true;
-        handle_key_pressed(&mut nes, KeyCode::Space, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Space, &mut state, None);
         assert!(!state.paused, "Space should unpause when paused");
     }
 
     #[test]
     fn test_space_calls_audio_pause_when_pausing() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         state.paused = false;
         let (audio, pause_called, _resume_called, _drain_buffer_called) = TrackingMockAudio::new();
         handle_key_pressed(
-            &mut nes,
+            &mut console,
             KeyCode::Space,
             &mut state,
             Some(&audio as &dyn EmulatorAudio),
@@ -650,12 +756,12 @@ mod tests {
 
     #[test]
     fn test_space_calls_audio_resume_when_resuming() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         state.paused = true;
         let (audio, _pause_called, resume_called, _drain_buffer_called) = TrackingMockAudio::new();
         handle_key_pressed(
-            &mut nes,
+            &mut console,
             KeyCode::Space,
             &mut state,
             Some(&audio as &dyn EmulatorAudio),
@@ -668,65 +774,65 @@ mod tests {
 
     #[test]
     fn test_h_toggles_help_overlay_on() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyH, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyH, &mut state, None);
         assert!(state.help_overlay_visible);
     }
 
     #[test]
     fn test_h_toggles_help_overlay_off() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         state.help_overlay_visible = true;
-        handle_key_pressed(&mut nes, KeyCode::KeyH, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyH, &mut state, None);
         assert!(!state.help_overlay_visible);
     }
 
     #[test]
     fn test_ctrl_f_toggles_fullscreen_on() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         with_ctrl(&mut state);
-        handle_key_pressed(&mut nes, KeyCode::KeyF, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyF, &mut state, None);
         assert!(state.fullscreen);
     }
 
     #[test]
     fn test_ctrl_f_toggles_fullscreen_off() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         state.fullscreen = true;
         with_ctrl(&mut state);
-        handle_key_pressed(&mut nes, KeyCode::KeyF, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyF, &mut state, None);
         assert!(!state.fullscreen);
     }
 
     #[test]
     fn test_alt_f_does_not_toggle_fullscreen() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         state.modifiers = ModifiersState::ALT;
-        handle_key_pressed(&mut nes, KeyCode::KeyF, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyF, &mut state, None);
         assert!(!state.fullscreen, "Alt+F should not toggle fullscreen");
     }
 
     #[test]
     fn test_f4_returns_cycle_shader() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         assert_eq!(
-            handle_key_pressed(&mut nes, KeyCode::F4, &mut state, None),
+            handle_key_pressed(&mut console, KeyCode::F4, &mut state, None),
             KeyOutcome::CycleShader
         );
     }
 
     #[test]
     fn test_f2_increases_volume() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         let audio = MockAudio::new_with_volume(0.5);
-        handle_key_pressed(&mut nes, KeyCode::F2, &mut state, Some(&audio));
+        handle_key_pressed(&mut console, KeyCode::F2, &mut state, Some(&audio));
         let vol = audio.get_volume();
         assert!(
             (vol - 0.6).abs() < 1e-5,
@@ -736,10 +842,10 @@ mod tests {
 
     #[test]
     fn test_f3_decreases_volume() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         let audio = MockAudio::new_with_volume(0.5);
-        handle_key_pressed(&mut nes, KeyCode::F3, &mut state, Some(&audio));
+        handle_key_pressed(&mut console, KeyCode::F3, &mut state, Some(&audio));
         let vol = audio.get_volume();
         assert!(
             (vol - 0.4).abs() < 1e-5,
@@ -749,52 +855,52 @@ mod tests {
 
     #[test]
     fn test_f5_returns_toggle_debugger() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         assert_eq!(
-            handle_key_pressed(&mut nes, KeyCode::F5, &mut state, None),
+            handle_key_pressed(&mut console, KeyCode::F5, &mut state, None),
             KeyOutcome::ToggleDebugger
         );
     }
 
     #[test]
     fn test_f10_returns_step_over() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         assert_eq!(
-            handle_key_pressed(&mut nes, KeyCode::F10, &mut state, None),
+            handle_key_pressed(&mut console, KeyCode::F10, &mut state, None),
             KeyOutcome::StepOver
         );
     }
 
     #[test]
     fn test_f11_returns_step_into() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         assert_eq!(
-            handle_key_pressed(&mut nes, KeyCode::F11, &mut state, None),
+            handle_key_pressed(&mut console, KeyCode::F11, &mut state, None),
             KeyOutcome::StepInto
         );
     }
 
     #[test]
     fn test_ctrl_r_soft_resets() {
-        let mut nes = make_nes_with_cartridge();
+        let mut console = make_nes_console_with_cart();
         let mut state = make_state();
         with_ctrl(&mut state);
         assert_eq!(
-            handle_key_pressed(&mut nes, KeyCode::KeyR, &mut state, None),
+            handle_key_pressed(&mut console, KeyCode::KeyR, &mut state, None),
             KeyOutcome::Continue
         );
     }
 
     #[test]
     fn test_ctrl_shift_r_hard_resets() {
-        let mut nes = make_nes_with_cartridge();
+        let mut console = make_nes_console_with_cart();
         let mut state = make_state();
         with_ctrl_shift(&mut state);
         assert_eq!(
-            handle_key_pressed(&mut nes, KeyCode::KeyR, &mut state, None),
+            handle_key_pressed(&mut console, KeyCode::KeyR, &mut state, None),
             KeyOutcome::Continue
         );
     }
@@ -803,59 +909,83 @@ mod tests {
 
     #[test]
     fn test_p1_w_sets_up() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyW, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_UP, 0, "W should set Up on P1");
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_UP,
+            0,
+            "W should set Up on P1"
+        );
     }
 
     #[test]
     fn test_p1_a_sets_left() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyA, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_LEFT, 0, "A should set Left on P1");
+        handle_key_pressed(&mut console, KeyCode::KeyA, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_LEFT,
+            0,
+            "A should set Left on P1"
+        );
     }
 
     #[test]
     fn test_p1_s_sets_down() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyS, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_DOWN, 0, "S should set Down on P1");
+        handle_key_pressed(&mut console, KeyCode::KeyS, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_DOWN,
+            0,
+            "S should set Down on P1"
+        );
     }
 
     #[test]
     fn test_p1_d_sets_right() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyD, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_RIGHT, 0, "D should set Right on P1");
+        handle_key_pressed(&mut console, KeyCode::KeyD, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_RIGHT,
+            0,
+            "D should set Right on P1"
+        );
     }
 
     #[test]
     fn test_p1_r_sets_a() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyR, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_A, 0, "R should set A on P1");
+        handle_key_pressed(&mut console, KeyCode::KeyR, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_A,
+            0,
+            "R should set A on P1"
+        );
     }
 
     #[test]
     fn test_p1_t_sets_b() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyT, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_B, 0, "T should set B on P1");
+        handle_key_pressed(&mut console, KeyCode::KeyT, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_B,
+            0,
+            "T should set B on P1"
+        );
     }
 
     #[test]
     fn test_p1_num4_sets_select() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::Digit4, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Digit4, &mut state, None);
         assert_ne!(
-            buttons(&nes, 1) & BIT_SELECT,
+            console.get_joypad_button_states(1) & BIT_SELECT,
             0,
             "4 should set Select on P1"
         );
@@ -863,91 +993,131 @@ mod tests {
 
     #[test]
     fn test_p1_num5_sets_start() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::Digit5, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_START, 0, "5 should set Start on P1");
+        handle_key_pressed(&mut console, KeyCode::Digit5, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_START,
+            0,
+            "5 should set Start on P1"
+        );
     }
 
     // ── Player 1 — key release clears button ──────────────────────────────────
 
     #[test]
     fn test_p1_w_released_clears_up() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyW, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_UP, 0);
-        handle_key_released(&mut nes, KeyCode::KeyW, 0, false);
-        assert_eq!(buttons(&nes, 1) & BIT_UP, 0, "Releasing W should clear Up");
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
+        assert_ne!(console.get_joypad_button_states(1) & BIT_UP, 0);
+        handle_key_released(&mut console, KeyCode::KeyW, 0, false);
+        assert_eq!(
+            console.get_joypad_button_states(1) & BIT_UP,
+            0,
+            "Releasing W should clear Up"
+        );
     }
 
     #[test]
     fn test_p1_r_released_clears_a() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyR, &mut state, None);
-        handle_key_released(&mut nes, KeyCode::KeyR, 0, false);
-        assert_eq!(buttons(&nes, 1) & BIT_A, 0, "Releasing R should clear A");
+        handle_key_pressed(&mut console, KeyCode::KeyR, &mut state, None);
+        handle_key_released(&mut console, KeyCode::KeyR, 0, false);
+        assert_eq!(
+            console.get_joypad_button_states(1) & BIT_A,
+            0,
+            "Releasing R should clear A"
+        );
     }
 
     // ── Player 2 standard button mapping ──────────────────────────────────────
 
     #[test]
     fn test_p2_i_sets_up() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyI, &mut state, None);
-        assert_ne!(buttons(&nes, 2) & BIT_UP, 0, "I should set Up on P2");
-        assert_eq!(buttons(&nes, 1) & BIT_UP, 0, "I should not affect P1");
+        handle_key_pressed(&mut console, KeyCode::KeyI, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(2) & BIT_UP,
+            0,
+            "I should set Up on P2"
+        );
+        assert_eq!(
+            console.get_joypad_button_states(1) & BIT_UP,
+            0,
+            "I should not affect P1"
+        );
     }
 
     #[test]
     fn test_p2_j_sets_left() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyJ, &mut state, None);
-        assert_ne!(buttons(&nes, 2) & BIT_LEFT, 0, "J should set Left on P2");
+        handle_key_pressed(&mut console, KeyCode::KeyJ, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(2) & BIT_LEFT,
+            0,
+            "J should set Left on P2"
+        );
     }
 
     #[test]
     fn test_p2_k_sets_down() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyK, &mut state, None);
-        assert_ne!(buttons(&nes, 2) & BIT_DOWN, 0, "K should set Down on P2");
+        handle_key_pressed(&mut console, KeyCode::KeyK, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(2) & BIT_DOWN,
+            0,
+            "K should set Down on P2"
+        );
     }
 
     #[test]
     fn test_p2_l_sets_right() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyL, &mut state, None);
-        assert_ne!(buttons(&nes, 2) & BIT_RIGHT, 0, "L should set Right on P2");
+        handle_key_pressed(&mut console, KeyCode::KeyL, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(2) & BIT_RIGHT,
+            0,
+            "L should set Right on P2"
+        );
     }
 
     #[test]
     fn test_p2_o_sets_a() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyO, &mut state, None);
-        assert_ne!(buttons(&nes, 2) & BIT_A, 0, "O should set A on P2");
+        handle_key_pressed(&mut console, KeyCode::KeyO, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(2) & BIT_A,
+            0,
+            "O should set A on P2"
+        );
     }
 
     #[test]
     fn test_p2_p_sets_b() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyP, &mut state, None);
-        assert_ne!(buttons(&nes, 2) & BIT_B, 0, "P should set B on P2");
+        handle_key_pressed(&mut console, KeyCode::KeyP, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(2) & BIT_B,
+            0,
+            "P should set B on P2"
+        );
     }
 
     #[test]
     fn test_p2_num9_sets_select() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::Digit9, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Digit9, &mut state, None);
         assert_ne!(
-            buttons(&nes, 2) & BIT_SELECT,
+            console.get_joypad_button_states(2) & BIT_SELECT,
             0,
             "9 should set Select on P2"
         );
@@ -955,22 +1125,30 @@ mod tests {
 
     #[test]
     fn test_p2_num0_sets_start() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::Digit0, &mut state, None);
-        assert_ne!(buttons(&nes, 2) & BIT_START, 0, "0 should set Start on P2");
+        handle_key_pressed(&mut console, KeyCode::Digit0, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(2) & BIT_START,
+            0,
+            "0 should set Start on P2"
+        );
     }
 
     // ── P1 keys target port 1 only (not port 2) when no gamepad ─────────────
 
     #[test]
     fn test_w_targets_port1_only_when_no_gamepad() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state(); // gamepad_count = 0
-        handle_key_pressed(&mut nes, KeyCode::KeyW, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_UP, 0, "W should set Up on P1");
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_UP,
+            0,
+            "W should set Up on P1"
+        );
         assert_eq!(
-            buttons(&nes, 2) & BIT_UP,
+            console.get_joypad_button_states(2) & BIT_UP,
             0,
             "W should NOT set Up on P2 (port 2 has dedicated IJKL keys)"
         );
@@ -978,12 +1156,16 @@ mod tests {
 
     #[test]
     fn test_s_targets_port1_only_when_no_gamepad() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyS, &mut state, None);
-        assert_ne!(buttons(&nes, 1) & BIT_DOWN, 0, "S should set Down on P1");
+        handle_key_pressed(&mut console, KeyCode::KeyS, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(1) & BIT_DOWN,
+            0,
+            "S should set Down on P1"
+        );
         assert_eq!(
-            buttons(&nes, 2) & BIT_DOWN,
+            console.get_joypad_button_states(2) & BIT_DOWN,
             0,
             "S should NOT set Down on P2"
         );
@@ -993,12 +1175,12 @@ mod tests {
 
     #[test]
     fn test_p2_i_released_clears_up() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
-        handle_key_pressed(&mut nes, KeyCode::KeyI, &mut state, None);
-        handle_key_released(&mut nes, KeyCode::KeyI, 0, false);
+        handle_key_pressed(&mut console, KeyCode::KeyI, &mut state, None);
+        handle_key_released(&mut console, KeyCode::KeyI, 0, false);
         assert_eq!(
-            buttons(&nes, 2) & BIT_UP,
+            console.get_joypad_button_states(2) & BIT_UP,
             0,
             "Releasing I should clear Up on P2"
         );
@@ -1015,95 +1197,95 @@ mod tests {
 
     #[test]
     fn test_cart_switch_typing_adds_to_filter() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["alpha.nes", "beta.nes"]);
-        handle_key_pressed(&mut nes, KeyCode::KeyA, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyA, &mut state, None);
         assert_eq!(state.cart_switch.filter, "a");
-        handle_key_pressed(&mut nes, KeyCode::KeyB, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyB, &mut state, None);
         assert_eq!(state.cart_switch.filter, "ab");
     }
 
     #[test]
     fn test_cart_switch_backspace_removes_char() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["a.nes"]);
         state.cart_switch.filter = "abc".to_string();
-        let outcome = handle_key_pressed(&mut nes, KeyCode::Backspace, &mut state, None);
+        let outcome = handle_key_pressed(&mut console, KeyCode::Backspace, &mut state, None);
         assert_eq!(state.cart_switch.filter, "ab");
         assert_eq!(outcome, KeyOutcome::Continue);
     }
 
     #[test]
     fn test_cart_switch_backspace_on_empty_filter() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["a.nes"]);
-        let outcome = handle_key_pressed(&mut nes, KeyCode::Backspace, &mut state, None);
+        let outcome = handle_key_pressed(&mut console, KeyCode::Backspace, &mut state, None);
         assert!(state.cart_switch.filter.is_empty());
         assert_eq!(outcome, KeyOutcome::Continue);
     }
 
     #[test]
     fn test_cart_switch_enter_returns_switch_cartridge() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["game.nes", "other.nes"]);
         state.cart_switch.selection = 0;
-        let outcome = handle_key_pressed(&mut nes, KeyCode::Enter, &mut state, None);
+        let outcome = handle_key_pressed(&mut console, KeyCode::Enter, &mut state, None);
         assert_eq!(outcome, KeyOutcome::SwitchCartridge("game.nes".to_string()));
         assert!(!state.cart_switch.open, "dialog should close after Enter");
     }
 
     #[test]
     fn test_cart_switch_enter_with_no_entries_returns_continue() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&[]);
-        let outcome = handle_key_pressed(&mut nes, KeyCode::Enter, &mut state, None);
+        let outcome = handle_key_pressed(&mut console, KeyCode::Enter, &mut state, None);
         assert_eq!(outcome, KeyOutcome::Continue);
     }
 
     #[test]
     fn test_cart_switch_escape_closes_dialog() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["a.nes"]);
-        handle_key_pressed(&mut nes, KeyCode::Escape, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Escape, &mut state, None);
         assert!(!state.cart_switch.open);
     }
 
     #[test]
     fn test_cart_switch_arrow_down_wraps() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["a.nes", "b.nes"]);
         state.cart_switch.selection = 1;
-        handle_key_pressed(&mut nes, KeyCode::ArrowDown, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::ArrowDown, &mut state, None);
         assert_eq!(state.cart_switch.selection, 0, "should wrap to first");
     }
 
     #[test]
     fn test_cart_switch_arrow_up_wraps() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["a.nes", "b.nes"]);
         state.cart_switch.selection = 0;
-        handle_key_pressed(&mut nes, KeyCode::ArrowUp, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::ArrowUp, &mut state, None);
         assert_eq!(state.cart_switch.selection, 1, "should wrap to last");
     }
 
     #[test]
     fn test_cart_switch_typing_filters_entries() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["alpha.nes", "beta.nes", "gamma.nes"]);
         // Type 'b' — only "beta.nes" matches (fuzzy on filename)
-        handle_key_pressed(&mut nes, KeyCode::KeyB, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyB, &mut state, None);
         assert_eq!(state.cart_switch.visible_count(), 1);
         assert_eq!(state.cart_switch.selected_entry(), Some("beta.nes"));
     }
 
     #[test]
     fn test_cart_switch_keys_dont_trigger_controller() {
-        let mut nes = make_nes_with_cartridge();
+        let mut console = make_nes_console_with_cart();
         let mut state = make_cart_switch_state(&["a.nes"]);
         // Pressing W while cart switch is open should NOT set Up on P1
-        handle_key_pressed(&mut nes, KeyCode::KeyW, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
         assert_eq!(
-            buttons(&nes, 1) & BIT_UP,
+            console.get_joypad_button_states(1) & BIT_UP,
             0,
             "W should not control NES when dialog is open"
         );
@@ -1113,9 +1295,9 @@ mod tests {
 
     #[test]
     fn test_cart_switch_escape_returns_close_outcome() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["a.nes"]);
-        let outcome = handle_key_pressed(&mut nes, KeyCode::Escape, &mut state, None);
+        let outcome = handle_key_pressed(&mut console, KeyCode::Escape, &mut state, None);
         assert_eq!(
             outcome,
             KeyOutcome::CloseCartridgeSwitch,
@@ -1127,10 +1309,10 @@ mod tests {
 
     #[test]
     fn test_cart_switch_shift_minus_types_underscore() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["a_b.nes"]);
         state.modifiers = ModifiersState::SHIFT;
-        handle_key_pressed(&mut nes, KeyCode::Minus, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Minus, &mut state, None);
         assert_eq!(
             state.cart_switch.filter, "_",
             "Shift+Minus should type underscore"
@@ -1139,9 +1321,9 @@ mod tests {
 
     #[test]
     fn test_cart_switch_minus_without_shift_types_dash() {
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_cart_switch_state(&["a-b.nes"]);
-        handle_key_pressed(&mut nes, KeyCode::Minus, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Minus, &mut state, None);
         assert_eq!(
             state.cart_switch.filter, "-",
             "Minus without Shift should type dash"
@@ -1153,11 +1335,11 @@ mod tests {
         // When F7 (load state) is pressed, any pre-restore samples still buffered
         // in the audio ring buffer must be discarded silently so they do not
         // bleed into the post-restore playback.
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = make_state();
         let (audio, _pause_called, _resume_called, drain_buffer_called) = TrackingMockAudio::new();
         handle_key_pressed(
-            &mut nes,
+            &mut console,
             KeyCode::F7,
             &mut state,
             Some(&audio as &dyn EmulatorAudio),
@@ -1173,21 +1355,21 @@ mod tests {
     #[test]
     fn test_wasd_routes_to_port2_only_when_one_gamepad() {
         // Given: one gamepad connected (port 1 owned by gamepad)
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = NativeAppState {
             gamepad_count: 1,
             ..NativeAppState::default()
         };
         // When: W (Up) is pressed
-        handle_key_pressed(&mut nes, KeyCode::KeyW, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
         // Then: port 2 gets Up; port 1 does NOT (gamepad owns port 1)
         assert_ne!(
-            buttons(&nes, 2) & BIT_UP,
+            console.get_joypad_button_states(2) & BIT_UP,
             0,
             "W should set port 2 Up when one gamepad is connected"
         );
         assert_eq!(
-            buttons(&nes, 1) & BIT_UP,
+            console.get_joypad_button_states(1) & BIT_UP,
             0,
             "W should NOT set port 1 Up when one gamepad is connected"
         );
@@ -1196,21 +1378,21 @@ mod tests {
     #[test]
     fn test_wasd_disabled_when_two_gamepads() {
         // Given: two gamepads connected (both ports owned by gamepads)
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = NativeAppState {
             gamepad_count: 2,
             ..NativeAppState::default()
         };
         // When: W (Up) is pressed
-        handle_key_pressed(&mut nes, KeyCode::KeyW, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
         // Then: neither port gets input
         assert_eq!(
-            buttons(&nes, 1) & BIT_UP,
+            console.get_joypad_button_states(1) & BIT_UP,
             0,
             "W should NOT set port 1 Up when two gamepads are connected"
         );
         assert_eq!(
-            buttons(&nes, 2) & BIT_UP,
+            console.get_joypad_button_states(2) & BIT_UP,
             0,
             "W should NOT set port 2 Up when two gamepads are connected"
         );
@@ -1219,16 +1401,16 @@ mod tests {
     #[test]
     fn test_ijkl_disabled_when_two_gamepads() {
         // Given: two gamepads connected
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = NativeAppState {
             gamepad_count: 2,
             ..NativeAppState::default()
         };
         // When: I (P2 Up) is pressed
-        handle_key_pressed(&mut nes, KeyCode::KeyI, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyI, &mut state, None);
         // Then: port 2 gets no input
         assert_eq!(
-            buttons(&nes, 2) & BIT_UP,
+            console.get_joypad_button_states(2) & BIT_UP,
             0,
             "I (P2 Up) should be disabled when two gamepads are connected"
         );
@@ -1240,14 +1422,14 @@ mod tests {
         // on port 2 should use WASD (the P1 key set, which shifts to track
         // ports.first()).  The P2-specific IJKL keys should be disabled because
         // there is no dedicated keyboard "player 2" slot.
-        let mut nes = make_nes();
+        let mut console = make_nes_console();
         let mut state = NativeAppState {
             gamepad_count: 1,
             ..NativeAppState::default()
         };
-        handle_key_pressed(&mut nes, KeyCode::KeyI, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyI, &mut state, None);
         assert_eq!(
-            buttons(&nes, 2) & BIT_UP,
+            console.get_joypad_button_states(2) & BIT_UP,
             0,
             "I (P2 Up) should be disabled when one gamepad is connected; use WASD instead"
         );
@@ -1323,25 +1505,25 @@ mod tests {
 
     #[test]
     fn test_wasd_routes_to_port3_with_four_score_and_2_gamepads() {
-        let mut nes = make_nes_four_score();
+        let mut console = make_nes_console_four_score();
         let mut state = NativeAppState {
             gamepad_count: 2,
             four_score_enabled: true,
             ..NativeAppState::default()
         };
-        handle_key_pressed(&mut nes, KeyCode::KeyW, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
         assert_ne!(
-            buttons(&nes, 3) & BIT_UP,
+            console.get_joypad_button_states(3) & BIT_UP,
             0,
             "W should set Up on port 3 with four-score and 2 gamepads"
         );
         assert_eq!(
-            buttons(&nes, 1) & BIT_UP,
+            console.get_joypad_button_states(1) & BIT_UP,
             0,
             "W should NOT affect port 1 (owned by gamepad)"
         );
         assert_eq!(
-            buttons(&nes, 2) & BIT_UP,
+            console.get_joypad_button_states(2) & BIT_UP,
             0,
             "W should NOT affect port 2 (owned by gamepad)"
         );
@@ -1349,15 +1531,15 @@ mod tests {
 
     #[test]
     fn test_ijkl_routes_to_port4_with_four_score_and_2_gamepads() {
-        let mut nes = make_nes_four_score();
+        let mut console = make_nes_console_four_score();
         let mut state = NativeAppState {
             gamepad_count: 2,
             four_score_enabled: true,
             ..NativeAppState::default()
         };
-        handle_key_pressed(&mut nes, KeyCode::KeyI, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyI, &mut state, None);
         assert_ne!(
-            buttons(&nes, 4) & BIT_UP,
+            console.get_joypad_button_states(4) & BIT_UP,
             0,
             "I should set Up on port 4 with four-score and 2 gamepads"
         );
@@ -1365,15 +1547,15 @@ mod tests {
 
     #[test]
     fn test_p2_start_routes_to_port4_with_four_score_and_2_gamepads() {
-        let mut nes = make_nes_four_score();
+        let mut console = make_nes_console_four_score();
         let mut state = NativeAppState {
             gamepad_count: 2,
             four_score_enabled: true,
             ..NativeAppState::default()
         };
-        handle_key_pressed(&mut nes, KeyCode::Digit0, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::Digit0, &mut state, None);
         assert_ne!(
-            buttons(&nes, 4) & BIT_START,
+            console.get_joypad_button_states(4) & BIT_START,
             0,
             "0 should set Start on port 4 with four-score and 2 gamepads"
         );
@@ -1381,19 +1563,100 @@ mod tests {
 
     #[test]
     fn test_key_release_works_on_port3_with_four_score() {
-        let mut nes = make_nes_four_score();
+        let mut console = make_nes_console_four_score();
         let mut state = NativeAppState {
             gamepad_count: 2,
             four_score_enabled: true,
             ..NativeAppState::default()
         };
-        handle_key_pressed(&mut nes, KeyCode::KeyW, &mut state, None);
-        assert_ne!(buttons(&nes, 3) & BIT_UP, 0);
-        handle_key_released(&mut nes, KeyCode::KeyW, 2, true);
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
+        assert_ne!(console.get_joypad_button_states(3) & BIT_UP, 0);
+        handle_key_released(&mut console, KeyCode::KeyW, 2, true);
         assert_eq!(
-            buttons(&nes, 3) & BIT_UP,
+            console.get_joypad_button_states(3) & BIT_UP,
             0,
             "Releasing W should clear Up on port 3"
+        );
+    }
+
+    // ── Game Boy keyboard dispatch ────────────────────────────────────────────
+
+    /// Creates a minimal valid GB ROM for testing (ROM-only, 32 KB, correct checksum).
+    fn minimal_gb_rom() -> Vec<u8> {
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0147] = 0x00; // ROM only
+        rom[0x0148] = 0x00; // 32 KB
+        rom[0x0149] = 0x00; // no RAM
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+        rom
+    }
+
+    fn make_gameboy_console() -> Console {
+        let mut console = Console::new_gameboy(AppContext::new_with_config(Config::default()));
+        console
+            .load_rom(&minimal_gb_rom(), "test.gb")
+            .expect("minimal GB ROM should load");
+        console
+    }
+
+    #[test]
+    fn gameboy_d_key_sets_right_button() {
+        // Given a Game Boy console and default state (no gamepads)
+        let mut console = make_gameboy_console();
+        let mut state = make_state();
+        // When the 'D' key (Right) is pressed
+        handle_key_pressed(&mut console, KeyCode::KeyD, &mut state, None);
+        // Then the Right button (bit 7) should be set on port 0
+        assert_ne!(
+            console.get_joypad_button_states(0) & BIT_RIGHT,
+            0,
+            "D key should set GB Right button"
+        );
+    }
+
+    #[test]
+    fn gameboy_w_key_sets_up_button() {
+        let mut console = make_gameboy_console();
+        let mut state = make_state();
+        handle_key_pressed(&mut console, KeyCode::KeyW, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(0) & BIT_UP,
+            0,
+            "W key should set GB Up button"
+        );
+    }
+
+    #[test]
+    fn gameboy_r_key_sets_a_button() {
+        let mut console = make_gameboy_console();
+        let mut state = make_state();
+        handle_key_pressed(&mut console, KeyCode::KeyR, &mut state, None);
+        assert_ne!(
+            console.get_joypad_button_states(0) & BIT_A,
+            0,
+            "R key should set GB A button"
+        );
+    }
+
+    #[test]
+    fn gameboy_d_key_released_clears_right_button() {
+        let mut console = make_gameboy_console();
+        let mut state = make_state();
+        handle_key_pressed(&mut console, KeyCode::KeyD, &mut state, None);
+        // Pressing D must set the button first; if not, the release test is meaningless.
+        assert_ne!(
+            console.get_joypad_button_states(0) & BIT_RIGHT,
+            0,
+            "D key must set GB Right button before testing release"
+        );
+        handle_key_released(&mut console, KeyCode::KeyD, 0, false);
+        assert_eq!(
+            console.get_joypad_button_states(0) & BIT_RIGHT,
+            0,
+            "Releasing D should clear GB Right button"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,36 +306,64 @@ fn run_native_frontend(
         }
     };
 
-    let rom_db = nes::cartridge::load_rom_db();
-    let cart = match nes::cartridge::Cartridge::load_from_file(&rom_bytes, &rom_path, Some(&rom_db))
-    {
-        Ok(cartridge) => {
+    let rom_name = std::path::Path::new(&rom_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&rom_path)
+        .to_string();
+
+    let console = match detect_system_type(&rom_path) {
+        platform::emulator::SystemType::Nes => {
+            let rom_db = nes::cartridge::load_rom_db();
+            let cart = match nes::cartridge::Cartridge::load_from_file(
+                &rom_bytes,
+                &rom_path,
+                Some(&rom_db),
+            ) {
+                Ok(cartridge) => {
+                    app_context
+                        .borrow_mut()
+                        .add_toast(cartridge_load_toast_message(&rom_path, true));
+                    cartridge
+                }
+                Err(err) => {
+                    app_context
+                        .borrow_mut()
+                        .add_toast(cartridge_load_toast_message(&rom_path, false));
+                    return Err(err.into());
+                }
+            };
+
+            let rom_timing_mode = cart.rom_timing_mode();
+            app_context
+                .borrow_mut()
+                .config_mut()
+                .apply_rom_timing_mode(rom_timing_mode);
+
+            let mut console = platform::emulator::Console::new_nes(app_context.clone());
+            {
+                let platform::emulator::Console::Nes(nes) = &mut console else {
+                    panic!("expected NES console")
+                };
+                nes.insert_cartridge(cart);
+            }
+            console
+        }
+        platform::emulator::SystemType::GameBoy => {
+            let mut console = platform::emulator::Console::new_gameboy(app_context.clone());
+            if let Err(err) = console.load_rom(&rom_bytes, &rom_name) {
+                app_context
+                    .borrow_mut()
+                    .add_toast(cartridge_load_toast_message(&rom_path, false));
+                return Err(err.into());
+            }
             app_context
                 .borrow_mut()
                 .add_toast(cartridge_load_toast_message(&rom_path, true));
-            cartridge
-        }
-        Err(err) => {
-            app_context
-                .borrow_mut()
-                .add_toast(cartridge_load_toast_message(&rom_path, false));
-            return Err(err.into());
+            console
         }
     };
-
-    let rom_timing_mode = cart.rom_timing_mode();
-    app_context
-        .borrow_mut()
-        .config_mut()
-        .apply_rom_timing_mode(rom_timing_mode);
-
-    let mut console = platform::emulator::Console::new_nes(app_context.clone());
-    {
-        let platform::emulator::Console::Nes(nes) = &mut console else {
-            panic!("expected NES console")
-        };
-        nes.insert_cartridge(cart);
-    }
+    let mut console = console;
 
     if let Some(actual_rate) = audio_sample_rate {
         console.set_audio_sample_rate(actual_rate);
@@ -373,11 +401,55 @@ fn run_native_frontend(
     run_result.map_err(|e| e.into())
 }
 
+/// Detect the emulated system type from the file extension of a ROM path.
+///
+/// Returns [`platform::emulator::SystemType::GameBoy`] for `.gb` files
+/// (case-insensitive) and [`platform::emulator::SystemType::Nes`] for all
+/// other extensions (including `.nes` and unknown types).
+fn detect_system_type(path: &str) -> platform::emulator::SystemType {
+    use std::path::Path;
+    let ext = Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    if ext.eq_ignore_ascii_case("gb") {
+        platform::emulator::SystemType::GameBoy
+    } else {
+        platform::emulator::SystemType::Nes
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::platform::autorun::AUTORUN_VERSION;
+    use crate::platform::emulator::SystemType;
     use tempfile::TempDir;
+
+    #[test]
+    fn detect_system_type_gb_extension_returns_gameboy() {
+        assert_eq!(detect_system_type("tetris.gb"), SystemType::GameBoy);
+    }
+
+    #[test]
+    fn detect_system_type_nes_extension_returns_nes() {
+        assert_eq!(detect_system_type("cpu.nes"), SystemType::Nes);
+    }
+
+    #[test]
+    fn detect_system_type_uppercase_gb_returns_gameboy() {
+        assert_eq!(detect_system_type("TETRIS.GB"), SystemType::GameBoy);
+    }
+
+    #[test]
+    fn detect_system_type_unknown_extension_falls_back_to_nes() {
+        assert_eq!(detect_system_type("rom.unknown"), SystemType::Nes);
+    }
+
+    #[test]
+    fn detect_system_type_no_extension_falls_back_to_nes() {
+        assert_eq!(detect_system_type("noext"), SystemType::Nes);
+    }
 
     #[test]
     fn test_convert_autorun_for_rom_fails_when_autorun_file_missing() {

--- a/src/platform/rendering/gl_backend.rs
+++ b/src/platform/rendering/gl_backend.rs
@@ -520,7 +520,10 @@ impl GlBackend {
         }
     }
 
-    /// Renders the current NES frame and optional debugger overlay.
+    /// Renders the current frame and optional debugger overlay.
+    ///
+    /// Accepts a `&Console` so it works for both NES and Game Boy. The debugger
+    /// overlay is only drawn when `console` is a `Console::Nes` variant.
     pub fn render(
         &mut self,
         console: &Console,

--- a/src/platform/rendering/gl_backend.rs
+++ b/src/platform/rendering/gl_backend.rs
@@ -9,6 +9,7 @@ use crate::nes::debugging::ui::{
 use crate::platform::app_context::SharedAppContext;
 use crate::platform::debugging::breakpoints::BreakpointList;
 use crate::platform::debugging::log_info;
+use crate::platform::emulator::Console;
 use crate::platform::rendering::input::{InputEvent, apply_input};
 use crate::platform::rendering::shader_manager::ShaderManager;
 use std::ffi::c_void;
@@ -82,6 +83,10 @@ pub struct GlBackend {
     h_overscan: u32,
     /// Vertical overscan in pixels (removed from top and bottom).
     v_overscan: u32,
+    /// Current GL texture width (updated when console type changes).
+    tex_w: u32,
+    /// Current GL texture height (updated when console type changes).
+    tex_h: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -275,13 +280,13 @@ impl GlBackend {
     #[cfg(test)]
     const NTSC_ASPECT: f32 = 8.0 / 7.0 * 16.0 / 15.0;
 
-    /// Returns the aspect ratio used for rendering the NES output.
+    /// Returns the aspect ratio used for rendering the current frame.
     fn target_aspect(&self) -> f32 {
-        // NES pixel aspect ratio (8:7 NTSC) applied to the cropped pixel dimensions.
-        let w = self.cropped_width() as f32;
-        let h = self.cropped_height() as f32;
-        // pixel_ar = 8/7; display_ar = (w / h) * pixel_ar
-        (w / h) * (8.0 / 7.0)
+        let w = self.tex_w as f32;
+        let h = self.tex_h as f32;
+        // NES: 8:7 NTSC pixel AR.  GB: square pixels (1:1).
+        let is_nes = self.tex_w == self.cropped_width() && self.tex_h == self.cropped_height();
+        if is_nes { (w / h) * (8.0 / 7.0) } else { w / h }
     }
 
     fn cropped_width(&self) -> u32 {
@@ -474,6 +479,8 @@ impl GlBackend {
             shader_manager,
             h_overscan,
             v_overscan,
+            tex_w,
+            tex_h,
         })
     }
 
@@ -516,7 +523,7 @@ impl GlBackend {
     /// Renders the current NES frame and optional debugger overlay.
     pub fn render(
         &mut self,
-        nes: &Nes,
+        console: &Console,
         show_debugger: bool,
         overlay_text: Option<&str>,
         overlay_blink_red: bool,
@@ -555,18 +562,44 @@ impl GlBackend {
             io.display_framebuffer_scale = [scale_x, scale_y];
         }
 
-        // Update NES texture (keep the PPU borrow short-lived so we can snapshot later).
+        // Compute pixel dimensions from the console type.
+        let (frame_w, frame_h) = match console {
+            Console::Nes(_) => (self.cropped_width(), self.cropped_height()),
+            Console::GameBoy(_) => (console.screen_width(), console.screen_height()),
+        };
+
+        // Update texture (keep the borrow short-lived).
         {
-            let screen_buffer = nes.get_screen_buffer();
-            let cropped = screen_buffer.cropped_snapshot(self.h_overscan, self.v_overscan);
+            let cropped = console.cropped_screen_snapshot(self.h_overscan, self.v_overscan);
+            // Resize framebuffer if dimensions changed (e.g. NES → GB switch).
+            let required = (frame_w * frame_h * 3) as usize;
+            if self.framebuffer.len() != required {
+                self.framebuffer.resize(required, 0);
+            }
             self.framebuffer.copy_from_slice(&cropped);
         }
 
-        let tex_w = self.cropped_width() as i32;
-        let tex_h = self.cropped_height() as i32;
+        let tex_w = frame_w as i32;
+        let tex_h = frame_h as i32;
 
         unsafe {
             gl::BindTexture(gl::TEXTURE_2D, self.nes_texture);
+            // Reallocate texture storage if dimensions changed.
+            if self.tex_w != frame_w || self.tex_h != frame_h {
+                gl::TexImage2D(
+                    gl::TEXTURE_2D,
+                    0,
+                    gl::RGB8 as i32,
+                    tex_w,
+                    tex_h,
+                    0,
+                    gl::RGB,
+                    gl::UNSIGNED_BYTE,
+                    std::ptr::null(),
+                );
+                self.tex_w = frame_w;
+                self.tex_h = frame_h;
+            }
             gl::PixelStorei(gl::UNPACK_ALIGNMENT, 1);
             gl::TexSubImage2D(
                 gl::TEXTURE_2D,
@@ -618,8 +651,8 @@ impl GlBackend {
         }
 
         let visible_toasts = self.app_context.borrow_mut().visible_toasts(now);
-        let cropped_w = self.cropped_width();
-        let cropped_h = self.cropped_height();
+        let cropped_w = self.tex_w;
+        let cropped_h = self.tex_h;
         // Start ImGui frame
         {
             let ui = self.imgui.frame();
@@ -675,7 +708,7 @@ impl GlBackend {
                 );
             }
 
-            if show_debugger {
+            if show_debugger && let Console::Nes(nes) = console {
                 let snapshot = self.debugger_view_state.snapshot(nes);
                 action = debugger_ui::render(
                     ui,


### PR DESCRIPTION
## Summary

Implements native frontend support for Game Boy ROM files, resolving #1909.

When the user passes a `.gb` or `.GB` file to the `neser` binary, the emulator now:
1. Detects the file extension and creates a `Console::GameBoy` instead of `Console::Nes`
2. Loads the ROM via `console.load_rom()`
3. Runs the GB tick loop each frame (`while !is_frame_ready() { run_tick(); }`)
4. Renders the 160×144 GB framebuffer through the existing GL pipeline
5. Routes keyboard/gamepad input to GB buttons

All NES functionality is unchanged.

## Changes

### `src/main.rs`
- Added `detect_system_type(path)` → `SystemType` (checks `.gb` extension case-insensitively, falls back to NES)
- Branched ROM loading: NES path unchanged; GB path calls `Console::new_gameboy()` + `console.load_rom()`

### `src/frontends/native/keyboard.rs`
- `handle_key_pressed/released` now accept `&mut Console` instead of `&mut Nes`
- Added `gameboy_key_to_button_id()` (R→A, T→B, 4→Select, 5→Start, WASD/Arrows→D-pad)
- Added `handle_gameboy_key_pressed()` for GB key dispatch
- Extracted `handle_common_hotkey()` to eliminate Escape/Space/F4/F2/F3 duplication between NES and GB paths

### `src/frontends/native/gamepad.rs`
- `process_events` now accepts `&mut Console`; NES branch unchanged; GB branch dispatches buttons to port 0

### `src/frontends/native/event_loop.rs`
- All NES-only panics replaced with `if let Console::Nes` guards
- `run_frame()` splits on console type: NES uses debugger path; GB runs tick loop
- Mouse grab/device events skip early for non-NES consoles (GB has no Zapper/SNES Mouse)
- Debugger save/load guarded with `if let Console::Nes`

### `src/frontends/native/gl_wrapper.rs`
- `render()` signature changed from `&Nes` to `&Console`

### `src/platform/rendering/gl_backend.rs`
- `render()` accepts `&Console`; screen data via `console.cropped_screen_snapshot()`
- Dynamic GL texture resizing: reallocates on dimension change (NES=cropped 256×240, GB=160×144)
- Aspect ratio logic uses stored `tex_w/tex_h`; GB uses square pixels (1:1), NES uses 8:7 NTSC
- NES debugger / PPU viewer guarded with `if let Console::Nes`

## Tests

- 5 new `detect_system_type` tests in `main.rs`
- 4 new GB keyboard tests in `keyboard.rs`
- All 74 keyboard tests pass (70 NES + 4 GB)
- All 233 native frontend tests pass
- All 48 WASM tests pass
- Full lib test suite: 7,201 pass (2 pre-existing autorun failures unrelated to this change)

## Acceptance Criteria

- [x] `.gb` files are detected and routed to `Console::GameBoy`
- [x] GB ROM loads and frame loop runs
- [x] Keyboard input (WASD/arrows, R/T/4/5) maps to GB buttons
- [x] Gamepad input dispatches to GB buttons on port 0
- [x] GL renderer handles 160×144 GB framebuffer
- [x] All common hotkeys (pause, fullscreen, quit, shader cycle) work for GB
- [x] NES behavior unchanged (all existing tests pass)

Closes #1909
