### PR TITLE
feat(gb): implement DMG boot ROM sequence with LCD timing fixes

### DIFF
--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -897,16 +897,13 @@ impl ApplicationHandler for NativeEventLoop {
                 // elapsed since the last frame.
                 let using_manual_throttle =
                     should_use_manual_frame_throttle(self.vsync_enabled, self.state.window_focused);
-                let skip_emulation = if using_manual_throttle {
-                    let timing_mode = self
-                        .console
-                        .app_context()
-                        .borrow()
-                        .config()
-                        .nes
-                        .hardware_model
-                        .timing_mode();
-                    let target = target_frame_duration(timing_mode);
+                // The Game Boy has no audio output, so there is no ring-buffer
+                // back-pressure to limit the frame rate in vsync+focused mode.
+                // Apply the same elapsed-time guard as the manual throttle path.
+                let needs_frame_guard =
+                    using_manual_throttle || matches!(&self.console, Console::GameBoy(_));
+                let skip_emulation = if needs_frame_guard {
+                    let target = self.console.target_frame_duration();
                     // Allow a small tolerance (half a frame) to avoid skipping
                     // frames when the deadline fires slightly early.
                     self.last_frame_rendered.elapsed() < target / 2
@@ -1052,17 +1049,14 @@ impl ApplicationHandler for NativeEventLoop {
             } else if should_use_manual_frame_throttle(
                 self.vsync_enabled,
                 self.state.window_focused,
-            ) {
+            ) || matches!(&self.console, Console::GameBoy(_))
+            {
                 // Manual frame limiting: advance deadline by target interval.
-                let timing_mode = self
-                    .console
-                    .app_context()
-                    .borrow()
-                    .config()
-                    .nes
-                    .hardware_model
-                    .timing_mode();
-                let target = target_frame_duration(timing_mode);
+                // The GameBoy branch is included here because it has no audio
+                // back-pressure to naturally throttle the frame rate; without
+                // an explicit WaitUntil the event loop would Poll at the
+                // display's full refresh rate (e.g. 120 Hz on ProMotion Macs).
+                let target = self.console.target_frame_duration();
                 self.next_frame_deadline += target;
                 // Clamp to at least now to avoid spinning on past deadlines.
                 let now = Instant::now();

--- a/src/gb/boot_rom.rs
+++ b/src/gb/boot_rom.rs
@@ -27,8 +27,9 @@
 /// - APU is stubbed: NR50/NR51/NR52 are written with the correct post-boot
 ///   values but no actual audio is generated.
 /// - The ® trademark symbol tile is omitted to keep the ROM within budget.
-/// - LCDC is left at its hardware-reset default ($91); no explicit write is
-///   needed.
+/// - LCD starts off at power-on (DmgBus initialises LCDC=0x00); the boot ROM
+///   explicitly writes LCDC=0x91 to $FF40 just before the scroll animation
+///   begins, matching the sequence real hardware follows.
 /// - `WaitFrame` clobbers HL (safe because HL is not preserved after the tile
 ///   map is built).
 ///

--- a/src/gb/boot_rom.rs
+++ b/src/gb/boot_rom.rs
@@ -1,0 +1,234 @@
+/// Open-source DMG boot ROM replacement.
+///
+/// A hand-authored 256-byte SM83 machine code program that runs on the
+/// emulated CPU from reset ($0000) and implements the Game Boy DMG startup
+/// sequence:
+///
+/// 1. Initialise stack and clear VRAM.
+/// 2. Configure APU registers (NR50/NR51/NR52) and initial BG palette.
+/// 3. Read the Nintendo logo bitmap from the cartridge header ($0104–$0133),
+///    expand each nibble to a double-wide 8×8 tile, and write the tiles to
+///    VRAM starting at tile $01 ($8010).
+/// 4. Configure the BG tile map so the logo appears in rows 8–9 of the screen.
+/// 5. Set SCY=30 and animate the logo scrolling down over 15 VBlank frames.
+/// 6. After the scroll, darken the palette and wait ~1 second.
+/// 7. Re-read the cartridge logo and compare it byte-by-byte against the
+///    embedded 48-byte reference copy; hang if they differ (matching real DMG
+///    hardware behaviour that prevents non-licensed cartridges from booting).
+/// 8. Compute the header checksum over bytes $0134–$014C and compare it with
+///    the value stored at $014D; hang on mismatch.
+/// 9. Set the documented DMG post-boot CPU register state:
+///    A=$01, F=$B0, B=$00, C=$13, D=$00, E=$D8, H=$01, L=$4D, SP=$FFFE.
+/// 10. Write $FF50 (BOOT register) to unmap the boot ROM; the CPU immediately
+///     continues executing at $0100 in cartridge ROM.
+///
+/// ## Design notes
+///
+/// - APU is stubbed: NR50/NR51/NR52 are written with the correct post-boot
+///   values but no actual audio is generated.
+/// - The ® trademark symbol tile is omitted to keep the ROM within budget.
+/// - LCDC is left at its hardware-reset default ($91); no explicit write is
+///   needed.
+/// - `WaitFrame` clobbers HL (safe because HL is not preserved after the tile
+///   map is built).
+///
+/// ## Subroutine layout (placed backward from $00FE)
+///
+/// | Address | Routine                  | Size |
+/// |---------|--------------------------|------|
+/// | $00A6   | `DoubleBitsAndWriteRow`  | 21 B |
+/// | $00BB   | `WaitFrame`              | 10 B |
+/// | $00C5   | `WaitBFrames`            |  7 B |
+/// | $00CC   | `Lockup`                 |  2 B |
+/// | $00CE   | Nintendo logo reference  | 48 B |
+/// | $00FE   | `BootGame` (LDH [$FF50]) |  2 B |
+pub const DMG_BOOT_ROM: [u8; 256] = [
+    // ── $0000: LD SP, $FFFE ──────────────────────────────────────────────────
+    0x31, 0xFE, 0xFF,
+    // ── $0003: Clear VRAM ($8000–$9FFF) ─────────────────────────────────────
+    // LD HL, $8000; XOR A
+    // .loop: LD [HL+],A; BIT 5,H; JR Z,.loop
+    // Exit when H=$A0 (bit 5 of H set → HL has left VRAM range)
+    0x21, 0x00, 0x80, 0xAF, 0x22, 0xCB, 0x6C, 0x28, 0xFB,
+    // ── $000C: Init APU ──────────────────────────────────────────────────────
+    // NR52=$80 (audio power on), NR11=$80 (50% duty), NR12=$F3 (envelope),
+    // NR51=$F3 (routing), NR50=$77 (volume 7 both channels)
+    0x3E, 0x80, 0xE0, 0x26, // LD A,$80; LDH [$FF26]  NR52
+    0x3E, 0xF3, 0xE0, 0x12, // LD A,$F3; LDH [$FF12]  NR12
+    0xE0, 0x25, // LDH [$FF25]             NR51 (same A)
+    0x3E, 0x77, 0xE0, 0x24, // LD A,$77; LDH [$FF24]  NR50
+    // ── $001E: Init BG palette ───────────────────────────────────────────────
+    // BGP = $44 (%01_01_01_00) — medium grey for logo
+    0x3E, 0x44, 0xE0, 0x47,
+    // ── $0022: Load Nintendo logo tiles from cart → VRAM ────────────────────
+    // Source: cartridge $0104–$0133 (48 bytes).
+    // Destination: VRAM $8010 (tile slot 1).
+    // Each source byte → two 8-pixel rows via DoubleBitsAndWriteRow.
+    // Loop exits when E == LOW($0134) = $34 (i.e. DE has advanced to $0134).
+    0x11, 0x04, 0x01, // LD DE, $0104
+    0x21, 0x10, 0x80, // LD HL, $8010
+    // .logoLoop:
+    0x1A, 0x47, // LD A,[DE]; LD B,A
+    0xCD, 0xA6, 0x00, // CALL DoubleBitsAndWriteRow  ($00A6)
+    0xCD, 0xA6, 0x00, // CALL DoubleBitsAndWriteRow  ($00A6)
+    0x13, // INC DE
+    0x7B, 0xEE, 0x34, // LD A,E; XOR $34
+    0x20, 0xF2, // JR NZ, .logoLoop
+    // ── $0033: Build BG tile map ─────────────────────────────────────────────
+    // Logo tiles $01–$18 (24 tiles, 2 rows × 12 columns) placed at
+    // SCRN0 row 8 cols 4–15 and row 9 cols 4–15.
+    // Fill backwards: A starts at $19=25, DEC before write, stop at A=0.
+    // Bottom row: SCRN0+9*32+15 = $992F → $9924
+    // Top row:    SCRN0+8*32+15 = $990F → $9904
+    0x3E, 0x19, // LD A, $19
+    0x21, 0x2F, 0x99, // LD HL, $992F
+    0x0E, 0x0C, // LD C, 12
+    // .tmapLoop:
+    0x3D, // DEC A
+    0x28, 0x08, // JR Z, .tmapDone (+8 → $0047)
+    0x32, // LD [HL-], A
+    0x0D, // DEC C
+    0x20, 0xF9, // JR NZ, .tmapLoop
+    0x2E, 0x0F, // LD L, $0F  (→ $990F = top-row right edge)
+    0x18, 0xF5, // JR .tmapLoop
+    // .tmapDone:
+    // ── Enable LCD (LCDC=$91): LCD on, BG tile data $8000, BG map $9800 ─────
+    // The boot ROM runs with LCD *off* (LCDC=$00 at hardware power-on) so that
+    // VRAM writes during the logo tile load are never blocked by Mode 3.
+    // Enable here — after all tiles and the tile map are in place — so the
+    // PPU starts fresh at scanline 0 / Mode 2 just before the scroll animation.
+    0x3E, 0x91, 0xE0, 0x40, // LD A,$91; LDH [$FF40] (LCDC on)
+    // ── Set SCY=30 ────────────────────────────────────────────────────────────
+    0x3E, 0x1E, 0xE0, 0x42, // LD A,30; LDH [$FF42] (SCY)
+    // ── $004B: Scroll animation ──────────────────────────────────────────────
+    // Scroll the logo down from SCY≈30 to SCY=0 over 15 VBlank frames.
+    // D=$89 (=−119 signed, starting scroll value), C=15 (frame counter).
+    // SCY = D >> 2 each frame; D += C each frame.
+    // At C=8: darken palette to $AA (%10_10_10_00).
+    0x16, 0x89, // LD D, $89  (=-119 unsigned)
+    0x0E, 0x0F, // LD C, 15
+    // .animLoop ($004F):
+    0xCD, 0xBB, 0x00, // CALL WaitFrame ($00BB)
+    0x7A, 0xCB, 0x2F, 0xCB, 0x2F, // LD A,D; SRA A; SRA A
+    0xE0, 0x42, // LDH [$FF42] (SCY = D>>2)
+    0x7A, 0x81, 0x57, // LD A,D; ADD C; LD D,A  (D += C)
+    0x79, 0xFE, 0x08, // LD A,C; CP 8
+    0x20, 0x04, // JR NZ, .noPaletteChange (+4)
+    0x3E, 0xAA, 0xE0, 0x47, // LD A,$AA; LDH [$FF47] (BGP dark)
+    // .noPaletteChange:
+    0x0D, // DEC C
+    0x20, 0xE7, // JR NZ, .animLoop
+    // ── $006A: Final palette + wait ──────────────────────────────────────────
+    // BGP=$FC (%11_11_11_00) = all-dark.  Wait ~60 frames (~1 second).
+    0x3E, 0xFC, 0xE0, 0x47, // LD A,$FC; LDH [$FF47] (BGP)
+    0x06, 0x3C, // LD B, 60
+    0xCD, 0xC5, 0x00, // CALL WaitBFrames ($00C5)
+    // ── $0073: Verify Nintendo logo ──────────────────────────────────────────
+    // Re-read cart $0104–$0133; compare byte-by-byte against the 48-byte
+    // reference copy at $00CE.  Hang at Lockup ($00CC) on any mismatch.
+    0x11, 0x04, 0x01, // LD DE, $0104
+    0x21, 0xCE, 0x00, // LD HL, $00CE  (logo reference)
+    0x0E, 0x30, // LD C, 48
+    // .verifyLoop ($007C):
+    0x1A, 0x13, // LD A,[DE]; INC DE
+    0xBE, 0x23, // CP [HL]; INC HL
+    0x20, 0x4C, // JR NZ, Lockup ($00CC)
+    0x0D, // DEC C
+    0x20, 0xF7, // JR NZ, .verifyLoop
+    // ── $0084: Verify header checksum ────────────────────────────────────────
+    // Compute: A=0; for bytes $0134–$014C: A -= byte; A -= 1.
+    // Save in B; compare with stored checksum at $014D.
+    // Hang at Lockup on mismatch.
+    0x21, 0x34, 0x01, // LD HL, $0134
+    0x0E, 0x19, // LD C, 25
+    0xAF, // XOR A  (A=0)
+    // .csumLoop ($008B):
+    0x96, 0x3D, // SUB [HL]; DEC A
+    0x23, 0x0D, // INC HL; DEC C
+    0x20, 0xFA, // JR NZ, .csumLoop
+    0x47, // LD B, A  (save computed checksum)
+    // After csumLoop HL = $0134 + 25 = $014D → no need for a 3-byte absolute
+    // load; LD A,[HL] reads the stored checksum byte directly and saves 2 bytes.
+    0x7E, // LD A, [HL]  ($014D = stored header checksum)
+    0xB8, // CP B
+    0x20, 0x38, // JR NZ, Lockup ($00CC)
+    // ── $0096: Set post-boot register state ──────────────────────────────────
+    // A=$01, F=$B0 via PUSH HL; POP AF with HL=$01B0.
+    // HL=$014D (address of header checksum byte).
+    // BC=$0013, DE=$00D8 (per Pan Docs post-boot table).
+    0x21, 0xB0, 0x01, // LD HL, $01B0
+    0xE5, 0xF1, // PUSH HL; POP AF  → AF=$01B0
+    0x21, 0x4D, 0x01, // LD HL, $014D
+    0x01, 0x13, 0x00, // LD BC, $0013
+    0x11, 0xD8, 0x00, // LD DE, $00D8
+    // ── $00A3: JP BootGame ($00FE) ────────────────────────────────────────────
+    // After all registers are set up, jump to BootGame to unmap the boot ROM.
+    // This JP bridges the 4-byte gap between main code ($00A2) and subroutines
+    // ($00A6).  Execution flows: register setup → JP $00FE → LDH [$FF50],A
+    // → CPU fetches from cartridge at $0100.
+    0xC3, 0xFE, 0x00, // JP $00FE  (BootGame)
+    0x00, // NOP (1 padding byte)
+    // ════════════════════════════════════════════════════════════════════════
+    // ── $00A6: DoubleBitsAndWriteRow ─────────────────────────────────────────
+    // Expand the top 4 bits of B into an 8-pixel tile row (each bit → 2 pixels).
+    // Writes the result byte twice to VRAM at [HL] for 2× vertical scaling:
+    //   row-N low-plane  [HL+]  then  skip high-plane  [HL+]
+    //   row-N+1 same     [HL+]  then  skip high-plane [HL+]
+    // On entry: B contains the source byte (upper nibble processed first).
+    // On exit:  HL advanced by 4; B shifted left 4 positions.
+    // ─────────────────────────────────────────────────────────────────────────
+    0x3E, 0x04, // LD A, 4  (4 bits to expand)
+    0x0E, 0x00, // LD C, 0  (output accumulator)
+    // .dblLoop:
+    0xCB, 0x20, // SLA B        (next bit of B → carry)
+    0xF5, // PUSH AF       (save carry)
+    0xCB, 0x11, // RL C          (carry → C lsb)
+    0xF1, // POP AF        (restore carry)
+    0xCB, 0x11, // RL C          (carry → C lsb again = doubled bit)
+    0x3D, // DEC A
+    0x20, 0xF5, // JR NZ, .dblLoop
+    0x79, // LD A, C       (8-pixel row result)
+    0x22, 0x23, // LD [HL+],A; INC HL  (row 1 low-plane, skip high)
+    0x22, 0x23, // LD [HL+],A; INC HL  (row 2 low-plane, skip high)
+    0xC9, // RET
+    // ════════════════════════════════════════════════════════════════════════
+    // ── $00BB: WaitFrame ─────────────────────────────────────────────────────
+    // Clear VBlank flag in IF ($FF0F bit 0), then busy-wait until VBlank fires.
+    // Clobbers HL (safe; HL is not preserved across this call at runtime).
+    // ─────────────────────────────────────────────────────────────────────────
+    0x21, 0x0F, 0xFF, // LD HL, $FF0F  (IF register)
+    0xCB, 0x86, // RES 0, [HL]   (clear VBlank flag)
+    // .wfWait:
+    0xCB, 0x46, // BIT 0, [HL]   (test VBlank flag)
+    0x28, 0xFC, // JR Z, .wfWait (spin until VBlank fires)
+    0xC9, // RET
+    // ════════════════════════════════════════════════════════════════════════
+    // ── $00C5: WaitBFrames ───────────────────────────────────────────────────
+    // Call WaitFrame B times.
+    // ─────────────────────────────────────────────────────────────────────────
+    // .wbfLoop:
+    0xCD, 0xBB, 0x00, // CALL WaitFrame ($00BB)
+    0x05, // DEC B
+    0x20, 0xFA, // JR NZ, .wbfLoop
+    0xC9, // RET
+    // ════════════════════════════════════════════════════════════════════════
+    // ── $00CC: Lockup ────────────────────────────────────────────────────────
+    // Infinite loop — reached on logo or header checksum mismatch.
+    // Matches real DMG hardware: the console hangs and never boots the game.
+    // ─────────────────────────────────────────────────────────────────────────
+    0x18, 0xFE, // JR $-2  (jump to self forever)
+    // ════════════════════════════════════════════════════════════════════════
+    // ── $00CE: Nintendo logo reference data (48 bytes) ───────────────────────
+    // Canonical bitmap per Pan Docs §0104–0133.
+    // ─────────────────────────────────────────────────────────────────────────
+    0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B, 0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D,
+    0x00, 0x08, 0x11, 0x1F, 0x88, 0x89, 0x00, 0x0E, 0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99,
+    0xBB, 0xBB, 0x67, 0x63, 0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E,
+    // ════════════════════════════════════════════════════════════════════════
+    // ── $00FE: BootGame ──────────────────────────────────────────────────────
+    // Writing any value to $FF50 (BOOT register) unmaps the boot ROM.
+    // The CPU's next fetch ($0100) goes to cartridge ROM.
+    // This instruction must live at exactly $00FE (hardware constraint).
+    // ─────────────────────────────────────────────────────────────────────────
+    0xE0, 0x50, // LDH [$FF50], A  (unmap boot ROM → execute $0100)
+];

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -1,3 +1,4 @@
+use crate::gb::boot_rom::DMG_BOOT_ROM;
 use crate::gb::bus::GbBus;
 use crate::gb::cartridge::GbCartridge;
 use crate::gb::input::joypad::Joypad;
@@ -37,11 +38,17 @@ pub struct DmgBus {
     if_reg: u8,
     /// IE register ($FFFF): interrupt enable.
     ie_reg: u8,
+    /// Boot ROM contents (256 bytes).
+    boot_rom: [u8; 256],
+    /// When `true`, reads from $0000–$00FF are satisfied by `boot_rom`
+    /// instead of the cartridge.  Writing any value to $FF50 sets this
+    /// to `false` (mirrors real DMG hardware behaviour).
+    pub boot_rom_active: bool,
 }
 
 impl DmgBus {
     pub fn new(cart: Box<dyn GbCartridge>) -> Self {
-        Self {
+        let mut bus = Self {
             cart,
             ppu: Ppu::new(),
             wram: [0u8; 0x2000],
@@ -50,7 +57,15 @@ impl DmgBus {
             joypad: Joypad::new(),
             if_reg: 0,
             ie_reg: 0,
-        }
+            boot_rom: DMG_BOOT_ROM,
+            boot_rom_active: true,
+        };
+        // Real DMG hardware powers on with LCDC=$00 (LCD disabled).
+        // The boot ROM tile-loading runs while the LCD is off so VRAM writes
+        // are never blocked by Mode 3; our boot ROM explicitly re-enables the
+        // LCD (LCDC=$91) just before starting the scroll animation.
+        bus.ppu.write_register(0xFF40, 0x00);
+        bus
     }
 
     /// Reset all bus state to power-on defaults.
@@ -60,12 +75,14 @@ impl DmgBus {
     /// ROM, cartridge RAM, and any mapper state are preserved.
     pub fn reset(&mut self) {
         self.ppu = Ppu::new();
+        self.ppu.write_register(0xFF40, 0x00); // power-on: LCD disabled
         self.timer = Timer::new();
         self.joypad = Joypad::new();
         self.wram = [0u8; 0x2000];
         self.hram = [0u8; 0x7F];
         self.if_reg = 0;
         self.ie_reg = 0;
+        self.boot_rom_active = true;
     }
 
     /// Set a button state on the joypad and propagate any resulting interrupt.
@@ -95,6 +112,9 @@ impl DmgBus {
 
     /// Bypass PPU access-blocking for OAM DMA transfers.
     fn read_raw(&self, addr: u16) -> u8 {
+        if self.boot_rom_active && addr <= 0x00FF {
+            return self.boot_rom[addr as usize];
+        }
         match addr {
             0x0000..=0x7FFF => self.cart.read(addr),
             0x8000..=0x9FFF => self.ppu.vram[(addr - 0x8000) as usize],
@@ -116,6 +136,9 @@ impl DmgBus {
 
 impl GbBus for DmgBus {
     fn read(&mut self, addr: u16) -> u8 {
+        if self.boot_rom_active && addr <= 0x00FF {
+            return self.boot_rom[addr as usize];
+        }
         match addr {
             0x0000..=0x7FFF => self.cart.read(addr),
             0x8000..=0x9FFF => self.ppu.read_vram(addr),
@@ -148,6 +171,7 @@ impl GbBus for DmgBus {
             0xFF0F => self.if_reg = val & 0x1F,
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B => self.ppu.write_register(addr, val),
             0xFF46 => self.do_oam_dma(val),
+            0xFF50 => self.boot_rom_active = false,
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize] = val,
             0xFFFF => self.ie_reg = val,
             _ => {}
@@ -244,6 +268,10 @@ mod tests {
     /// Tick the bus enough M-cycles to reach VBlank (scanline 144).
     /// At that point the PPU enters Mode 1 and both OAM and VRAM are accessible.
     fn tick_to_vblank(bus: &mut DmgBus) {
+        // LCD is off at power-on; enable it so the PPU can advance to VBlank.
+        if bus.read(0xFF40) & 0x80 == 0 {
+            bus.write(0xFF40, 0x91);
+        }
         // VBlank starts at scanline 144 = 456*144 dots = 16416 M-cycles.
         // Tick in chunks to avoid overflow in the bus tick path.
         let mut remaining = 16_416u32;
@@ -276,13 +304,20 @@ mod tests {
 
     #[test]
     fn test_ppu_stat_register_reflects_mode() {
-        // At startup, PPU is in Mode 2 (OAM Scan); STAT bits 1:0 should be 0b10.
-        let bus = make_bus();
+        // At hardware power-on the LCD is disabled; STAT mode bits report 0.
+        let mut bus = make_bus();
+        assert_eq!(
+            bus.ppu.read_register(0xFF41) & 0x03,
+            0x00,
+            "STAT mode should be 0 while LCD is off"
+        );
+        // After enabling the LCD the PPU resets to OAM Scan (Mode 2).
+        bus.write(0xFF40, 0x91);
         let stat = bus.ppu.read_register(0xFF41);
         assert_eq!(
             stat & 0x03,
             0x02,
-            "initial STAT mode should be OAM Scan (2)"
+            "STAT mode should be OAM Scan (2) after LCD enable"
         );
     }
 

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -43,7 +43,7 @@ pub struct DmgBus {
     /// When `true`, reads from $0000–$00FF are satisfied by `boot_rom`
     /// instead of the cartridge.  Writing any value to $FF50 sets this
     /// to `false` (mirrors real DMG hardware behaviour).
-    pub boot_rom_active: bool,
+    boot_rom_active: bool,
 }
 
 impl DmgBus {
@@ -83,6 +83,11 @@ impl DmgBus {
         self.if_reg = 0;
         self.ie_reg = 0;
         self.boot_rom_active = true;
+    }
+
+    /// Returns `true` while the boot ROM is still mapped at $0000–$00FF.
+    pub fn is_boot_rom_active(&self) -> bool {
+        self.boot_rom_active
     }
 
     /// Set a button state on the joypad and propagate any resulting interrupt.

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -52,11 +52,12 @@ impl Gb<DmgBus> {
             // the cartridge entry point, preserving WRAM and bus state.
             self.cpu.reset_registers();
         } else {
-            // Hard reset: zero CPU state and reinitialise all bus hardware.
-            // The boot ROM is reactivated so the next instruction fetch
-            // (PC=$0000) runs the boot sequence from scratch.
-            // We call reset_registers() to clear all CPU state fields
-            // (including private ime_pending), then override PC to $0000.
+            // Hard reset: reinitialise all bus hardware and restart execution
+            // from the boot ROM entry point.
+            // reset_registers() restores the normal post-boot register defaults
+            // and clears internal CPU state (including ime_pending). We then
+            // override PC to $0000 so the reactivated boot ROM runs again from
+            // the start, establishing correct power-on behaviour.
             self.cpu.reset_registers();
             self.cpu.regs.pc = 0x0000;
             self.cpu.bus.reset();

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -47,8 +47,18 @@ impl Gb<DmgBus> {
     /// - `soft_reset = false`: resets CPU registers **and** all bus
     ///   state (WRAM zeroed, PPU/timer/joypad reinitialised).
     pub fn reset(&mut self, soft_reset: bool) {
-        self.cpu.reset_registers();
-        if !soft_reset {
+        if soft_reset {
+            // Soft reset: restore post-boot register state and continue from
+            // the cartridge entry point, preserving WRAM and bus state.
+            self.cpu.reset_registers();
+        } else {
+            // Hard reset: zero CPU state and reinitialise all bus hardware.
+            // The boot ROM is reactivated so the next instruction fetch
+            // (PC=$0000) runs the boot sequence from scratch.
+            // We call reset_registers() to clear all CPU state fields
+            // (including private ime_pending), then override PC to $0000.
+            self.cpu.reset_registers();
+            self.cpu.regs.pc = 0x0000;
             self.cpu.bus.reset();
         }
     }
@@ -170,11 +180,12 @@ mod tests {
 
     #[test]
     fn test_hard_reset_restores_pc_and_clears_wram() {
-        // Combined: PC is correct AND WRAM is zeroed after hard reset
+        // After a hard reset the CPU starts at $0000 so the boot ROM runs,
+        // matching real DMG power-on behaviour.  WRAM must still be zeroed.
         let mut gb = make_dmg();
         gb.cpu.bus.write(0xC000, 0xFF);
         gb.reset(false);
-        assert_eq!(gb.cpu.regs.pc, 0x0100);
+        assert_eq!(gb.cpu.regs.pc, 0x0000);
         assert_eq!(gb.cpu.bus.read(0xC000), 0x00);
     }
 

--- a/src/gb/integration_tests/boot_tests.rs
+++ b/src/gb/integration_tests/boot_tests.rs
@@ -1,0 +1,107 @@
+use crate::gb::bus::DmgBus;
+use crate::gb::cartridge::load_cartridge;
+use crate::gb::console::Gb;
+
+/// The expected Nintendo logo bitmap (48 bytes) at cartridge header $0104–$0133.
+///
+/// Per Pan Docs: <https://gbdev.io/pandocs/The_Cartridge_Header.html#0104-0133--nintendo-logo>
+const NINTENDO_LOGO: [u8; 48] = [
+    0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B, 0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D,
+    0x00, 0x08, 0x11, 0x1F, 0x88, 0x89, 0x00, 0x0E, 0xDC, 0xCC, 0x6E, 0xE6, 0xDD, 0xDD, 0xD9, 0x99,
+    0xBB, 0xBB, 0x67, 0x63, 0x6E, 0x0E, 0xEC, 0xCC, 0xDD, 0xDC, 0x99, 0x9F, 0xBB, 0xB9, 0x33, 0x3E,
+];
+
+/// Maximum M-cycles to allow for the boot sequence.
+///
+/// The full DMG boot sequence takes ~1.5 M M-cycles (~80 frames × 17 556 cycles/frame).
+/// 2.5 M gives ample headroom without running forever on a lock-up scenario.
+const BOOT_CYCLE_LIMIT: u64 = 2_500_000;
+
+/// Build a minimal 32 KiB ROM for boot tests.
+///
+/// Places `logo` at $0104–$0133 and a `JR $-2` infinite loop at $0100 so the
+/// running test can detect exactly when the boot ROM hands off to the cartridge.
+/// All other header bytes are zero (ROM-only, no RAM, no MBC).  The header
+/// checksum at $014D is recomputed from the header bytes $0134–$014C.
+fn build_test_rom(logo: &[u8; 48]) -> Vec<u8> {
+    let mut rom = vec![0u8; 0x8000];
+    // Entry point: `JR $-2` loops at $0100 (2 bytes, 8 T-cycles/2 M-cycles)
+    rom[0x0100] = 0x18; // JR opcode
+    rom[0x0101] = 0xFE; // offset -2 → jumps back to $0100
+    // Nintendo logo
+    rom[0x0104..=0x0133].copy_from_slice(logo);
+    // Cartridge type / ROM+RAM size
+    rom[0x0147] = 0x00; // ROM only
+    rom[0x0148] = 0x00; // 32 KiB
+    rom[0x0149] = 0x00; // no RAM
+    // Header checksum over $0134–$014C (all zero in this ROM)
+    let chk = rom[0x0134..=0x014C]
+        .iter()
+        .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+    rom[0x014D] = chk;
+    rom
+}
+
+/// Step `gb` until PC reaches $0100 or `BOOT_CYCLE_LIMIT` M-cycles have elapsed.
+///
+/// Returns `true` if $0100 was reached; `false` if the cycle budget was exhausted.
+fn run_until_cartridge_entry(gb: &mut Gb<DmgBus>) -> bool {
+    let start = gb.cycles();
+    loop {
+        if gb.cpu.regs.pc == 0x0100 {
+            return true;
+        }
+        if gb.cycles().saturating_sub(start) >= BOOT_CYCLE_LIMIT {
+            return false;
+        }
+        gb.step();
+    }
+}
+
+/// After the DMG boot ROM completes, the CPU registers must match the documented
+/// post-boot-ROM state.
+///
+/// Per Pan Docs: <https://gbdev.io/pandocs/Power_Up_Sequence.html#cpu-registers>
+#[test]
+fn test_dmg_boot_sets_correct_register_state() {
+    let rom = build_test_rom(&NINTENDO_LOGO);
+    let cart = load_cartridge(&rom).expect("valid ROM");
+    let mut gb = Gb::new(DmgBus::new(cart));
+
+    let reached = run_until_cartridge_entry(&mut gb);
+
+    assert!(
+        reached,
+        "Boot ROM never handed off to $0100 within the cycle limit"
+    );
+    assert_eq!(gb.cpu.regs.a, 0x01, "A register after boot");
+    assert_eq!(gb.cpu.regs.f, 0xB0, "F register after boot");
+    assert_eq!(gb.cpu.regs.b, 0x00, "B register after boot");
+    assert_eq!(gb.cpu.regs.c, 0x13, "C register after boot");
+    assert_eq!(gb.cpu.regs.d, 0x00, "D register after boot");
+    assert_eq!(gb.cpu.regs.e, 0xD8, "E register after boot");
+    assert_eq!(gb.cpu.regs.h, 0x01, "H register after boot");
+    assert_eq!(gb.cpu.regs.l, 0x4D, "L register after boot");
+    assert_eq!(gb.cpu.regs.sp, 0xFFFE, "SP after boot");
+    assert_eq!(gb.cpu.regs.pc, 0x0100, "PC after boot");
+}
+
+/// A cartridge with a corrupted Nintendo logo must cause the boot ROM to lock up,
+/// never handing off to $0100 — matching real DMG hardware behaviour.
+///
+/// Per Pan Docs: the boot ROM re-reads the logo after the scroll animation and
+/// compares it byte-by-byte against the reference copy.  Mismatch → infinite loop.
+#[test]
+fn test_dmg_boot_halts_on_corrupted_logo() {
+    let bad_logo = [0u8; 48]; // all-zero logo — definitely wrong
+    let rom = build_test_rom(&bad_logo);
+    let cart = load_cartridge(&rom).expect("valid ROM");
+    let mut gb = Gb::new(DmgBus::new(cart));
+
+    let reached = run_until_cartridge_entry(&mut gb);
+
+    assert!(
+        !reached,
+        "Boot ROM must lock up on a corrupted logo; it must not hand off to $0100"
+    );
+}

--- a/src/gb/integration_tests/mod.rs
+++ b/src/gb/integration_tests/mod.rs
@@ -1,1 +1,2 @@
+pub mod boot_tests;
 pub mod ppu_tests;

--- a/src/gb/mod.rs
+++ b/src/gb/mod.rs
@@ -1,3 +1,4 @@
+pub mod boot_rom;
 pub mod bus;
 pub mod cartridge;
 pub mod console;

--- a/src/gb/ppu/mod.rs
+++ b/src/gb/ppu/mod.rs
@@ -152,10 +152,10 @@ impl Ppu {
 
     /// Read from OAM address $FE00–$FE9F.
     ///
-    /// Returns 0xFF if the CPU is blocked (Mode 2 or 3).
+    /// Returns 0xFF if the CPU is blocked (Mode 2 or 3 while LCD on).
+    /// When LCD is disabled OAM is always accessible.
     pub fn read_oam(&self, addr: u16) -> u8 {
-        // LCD off: unrestricted access.
-        if self.registers.lcdc & 0x80 != 0
+        if self.registers.lcd_enabled()
             && matches!(
                 self.timing.mode(),
                 PpuMode::OamScan | PpuMode::PixelTransfer
@@ -168,10 +168,10 @@ impl Ppu {
 
     /// Write to OAM address $FE00–$FE9F.
     ///
-    /// Silently ignored if the CPU is blocked (Mode 2 or 3).
+    /// Silently ignored if the CPU is blocked (Mode 2 or 3 while LCD on).
+    /// When LCD is disabled OAM is always accessible.
     pub fn write_oam(&mut self, addr: u16, val: u8) {
-        // LCD off: unrestricted access.
-        if self.registers.lcdc & 0x80 != 0
+        if self.registers.lcd_enabled()
             && matches!(
                 self.timing.mode(),
                 PpuMode::OamScan | PpuMode::PixelTransfer
@@ -204,6 +204,8 @@ impl Ppu {
         self.registers.write(addr, val);
         if !was_enabled && self.registers.lcd_enabled() {
             self.timing = Timing::new();
+            self.window_line = 0;
+            self.prev_stat_irq_line = false;
         }
     }
 
@@ -522,10 +524,14 @@ mod tests {
 
     #[test]
     fn test_oam_write_succeeds_when_lcd_disabled() {
+        // Given: PPU in OAM Scan (Mode 2, startup); LCD turned off.
+        // Normally Mode 2 blocks OAM writes; LCD-off lifts that restriction.
         let mut ppu = Ppu::new();
         assert_eq!(ppu.timing.mode(), PpuMode::OamScan);
         ppu.write_register(0xFF40, 0x11); // LCD off
+        // When: write OAM
         ppu.write_oam(0xFE10, 0xBB);
+        // Then: write accepted
         assert_eq!(
             ppu.oam[0x10], 0xBB,
             "OAM write should succeed when LCD is off"
@@ -534,9 +540,12 @@ mod tests {
 
     #[test]
     fn test_oam_read_returns_actual_value_when_lcd_disabled() {
+        // Given: PPU in Mode 3 (PixelTransfer), LCD turned off.
         let mut ppu = ppu_in_mode3_then_lcd_off();
         ppu.oam[0x05] = 0xCC;
+        // When: read OAM
         let val = ppu.read_oam(0xFE05);
+        // Then: actual value returned (not 0xFF)
         assert_eq!(
             val, 0xCC,
             "OAM read should return actual value when LCD is off"

--- a/src/gb/ppu/mod.rs
+++ b/src/gb/ppu/mod.rs
@@ -47,7 +47,11 @@ impl Ppu {
     /// Advance the PPU by `n` dots (T-cycles).
     ///
     /// Call from `DmgBus::tick(m_cycles)` with `n = m_cycles * 4`.
+    /// No-op when the LCD is disabled (LCDC bit 7 = 0).
     pub fn tick_dots(&mut self, n: u32) {
+        if !self.registers.lcd_enabled() {
+            return;
+        }
         for _ in 0..n {
             self.tick_one_dot();
         }
@@ -91,6 +95,10 @@ impl Ppu {
     // ── STAT IRQ line ─────────────────────────────────────────────────────────
 
     fn compose_stat_byte(&self) -> u8 {
+        // When LCD is off, mode bits report 0 (H-Blank) and LYC=LY is 0.
+        if !self.registers.lcd_enabled() {
+            return self.registers.stat_irq_enables & 0x78;
+        }
         let mode_bits = self.timing.mode() as u8;
         let lyc_bit = if self.timing.ly() == self.registers.lyc {
             0x04
@@ -122,10 +130,10 @@ impl Ppu {
 
     /// Read from VRAM address $8000–$9FFF.
     ///
-    /// Returns 0xFF if the CPU is blocked (Mode 3 — Pixel Transfer).
+    /// Returns 0xFF if the CPU is blocked (Mode 3 — Pixel Transfer while LCD on).
+    /// When LCD is disabled VRAM is always accessible.
     pub fn read_vram(&self, addr: u16) -> u8 {
-        // LCD off: unrestricted access.
-        if self.registers.lcdc & 0x80 != 0 && self.timing.mode() == PpuMode::PixelTransfer {
+        if self.registers.lcd_enabled() && self.timing.mode() == PpuMode::PixelTransfer {
             return 0xFF;
         }
         self.vram[(addr - 0x8000) as usize]
@@ -133,10 +141,10 @@ impl Ppu {
 
     /// Write to VRAM address $8000–$9FFF.
     ///
-    /// Silently ignored if the CPU is blocked (Mode 3 — Pixel Transfer).
+    /// Silently ignored if the CPU is blocked (Mode 3 — Pixel Transfer while LCD on).
+    /// When LCD is disabled VRAM is always accessible.
     pub fn write_vram(&mut self, addr: u16, val: u8) {
-        // LCD off: unrestricted access.
-        if self.registers.lcdc & 0x80 != 0 && self.timing.mode() == PpuMode::PixelTransfer {
+        if self.registers.lcd_enabled() && self.timing.mode() == PpuMode::PixelTransfer {
             return;
         }
         self.vram[(addr - 0x8000) as usize] = val;
@@ -175,29 +183,28 @@ impl Ppu {
     }
 
     /// Read a PPU I/O register ($FF40–$FF4B).
+    ///
+    /// When LCD is disabled, LY always reads as 0 and STAT mode bits are 0.
     pub fn read_register(&self, addr: u16) -> u8 {
-        let lcd_off = self.registers.lcdc & 0x80 == 0;
-        // LY reads as 0 and mode bits read as 0 (HBlank) when LCD is off.
-        let stat = if lcd_off {
-            0x80
+        let stat = self.compose_stat_byte();
+        let ly = if self.registers.lcd_enabled() {
+            self.timing.ly()
         } else {
-            self.compose_stat_byte()
+            0
         };
-        let ly = if lcd_off { 0 } else { self.timing.ly() };
         self.registers.read(addr, ly, stat).unwrap_or(0xFF)
     }
 
     /// Write a PPU I/O register ($FF40–$FF4B).
+    ///
+    /// Detects LCD 0→1 enable transition (LCDC bit 7) and resets PPU timing
+    /// to scanline 0 / Mode 2, as the hardware does.
     pub fn write_register(&mut self, addr: u16, val: u8) {
-        // Reset PPU timing when LCD transitions from off → on.
-        if addr == 0xFF40 {
-            let was_off = self.registers.lcdc & 0x80 == 0;
-            let turning_on = val & 0x80 != 0;
-            if was_off && turning_on {
-                self.timing = Timing::new();
-            }
-        }
+        let was_enabled = self.registers.lcd_enabled();
         self.registers.write(addr, val);
+        if !was_enabled && self.registers.lcd_enabled() {
+            self.timing = Timing::new();
+        }
     }
 
     // ── Interrupt interface ───────────────────────────────────────────────────
@@ -426,82 +433,113 @@ mod tests {
         assert_eq!(ppu.read_register(0xFF44), 10);
     }
 
-    // ── LCD-off behaviour ─────────────────────────────────────────────────────
+    // ── LCD disabled (LCDC bit 7 = 0) ─────────────────────────────────────────
+    //
+    // Per Pan Docs: when LCDC bit 7 is cleared the LCD stops, LY is fixed at 0,
+    // the STAT mode bits report Mode 0, and VRAM/OAM become freely accessible.
 
-    /// When the LCD is off (LCDC bit 7 = 0) the PPU timing must freeze: no
-    /// VBlank interrupt fires even after a full frame's worth of dots.
-    #[test]
-    fn test_ppu_does_not_advance_when_lcd_is_off() {
+    /// Helper: advance PPU into Mode 3 then disable the LCD.
+    fn ppu_in_mode3_then_lcd_off() -> Ppu {
         let mut ppu = Ppu::new();
-        ppu.write_register(0xFF40, 0x11); // LCD off (bit 7 = 0)
-        tick_dots(&mut ppu, 456 * 154); // full frame worth of dots
-        assert_eq!(
-            ppu.take_pending_interrupts() & 0x01,
-            0,
-            "no VBlank interrupt when LCD is off"
-        );
-    }
-
-    /// LY ($FF44) must read as 0 while the LCD is off.
-    #[test]
-    fn test_ly_returns_0_when_lcd_is_off() {
-        let mut ppu = Ppu::new();
-        tick_dots(&mut ppu, 456 * 10); // advance to scanline 10
-        assert_eq!(ppu.read_register(0xFF44), 10);
-        ppu.write_register(0xFF40, 0x11); // LCD off
-        assert_eq!(
-            ppu.read_register(0xFF44),
-            0,
-            "LY must read 0 when LCD is off"
-        );
-    }
-
-    /// VRAM writes must succeed even when Mode 3 is active, as long as the LCD is off.
-    /// This is the core bug: games turn off the LCD to safely fill VRAM.
-    #[test]
-    fn test_vram_write_accepted_when_lcd_is_off() {
-        let mut ppu = Ppu::new();
-        tick_dots(&mut ppu, 80); // → PixelTransfer (Mode 3)
+        tick_dots(&mut ppu, 80); // dot 80 → Mode 3
         assert_eq!(ppu.timing.mode(), PpuMode::PixelTransfer);
-        // Turn LCD off while in Mode 3
-        ppu.write_register(0xFF40, 0x11); // LCDC bit 7 = 0
-        // Write to VRAM — should NOT be dropped
-        ppu.write_vram(0x8050, 0xAB);
-        // Verify the write was accepted
+        ppu.write_register(0xFF40, 0x11); // clear bit 7 (LCD off), keep rest
+        ppu
+    }
+
+    #[test]
+    fn test_vram_write_succeeds_when_lcd_disabled() {
+        let mut ppu = ppu_in_mode3_then_lcd_off();
+        ppu.write_vram(0x8000, 0x42);
         assert_eq!(
-            ppu.vram[0x0050], 0xAB,
-            "VRAM write must succeed when LCD is off"
+            ppu.vram[0], 0x42,
+            "VRAM write should succeed when LCD is off"
         );
     }
 
-    /// VRAM reads must return real data (not 0xFF) when the LCD is off.
     #[test]
-    fn test_vram_read_returns_real_value_when_lcd_is_off() {
-        let mut ppu = Ppu::new();
-        ppu.vram[0x0010] = 0xAB; // seed value directly
-        tick_dots(&mut ppu, 80); // → PixelTransfer
-        assert_eq!(ppu.timing.mode(), PpuMode::PixelTransfer);
-        ppu.write_register(0xFF40, 0x11); // LCD off
+    fn test_vram_read_returns_actual_value_when_lcd_disabled() {
+        let mut ppu = ppu_in_mode3_then_lcd_off();
+        ppu.vram[0x10] = 0xAB;
+        let val = ppu.read_vram(0x8010);
         assert_eq!(
-            ppu.read_vram(0x8010),
-            0xAB,
-            "VRAM read must return real value when LCD is off"
+            val, 0xAB,
+            "VRAM read should return actual value when LCD is off"
         );
     }
 
-    /// PPU timing must restart from dot 0 / scanline 0 when the LCD is re-enabled.
     #[test]
-    fn test_ppu_timing_resets_when_lcd_is_re_enabled() {
+    fn test_ppu_does_not_advance_when_lcd_disabled() {
+        let mut ppu = ppu_in_mode3_then_lcd_off();
+        let ly_before = ppu.read_register(0xFF44);
+        ppu.tick_dots(456 * 10);
+        let ly_after = ppu.read_register(0xFF44);
+        assert_eq!(
+            ly_before, ly_after,
+            "PPU should not advance when LCD is off"
+        );
+    }
+
+    #[test]
+    fn test_ly_reads_zero_when_lcd_disabled() {
         let mut ppu = Ppu::new();
-        tick_dots(&mut ppu, 456 * 50); // advance to scanline 50
+        tick_dots(&mut ppu, 456 * 50);
+        assert_eq!(ppu.timing.ly(), 50);
         ppu.write_register(0xFF40, 0x11); // LCD off
-        tick_dots(&mut ppu, 100); // should be a no-op
-        // Re-enable LCD
+        let ly = ppu.read_register(0xFF44);
+        assert_eq!(ly, 0, "LY must read as 0 when LCD is disabled");
+    }
+
+    #[test]
+    fn test_ppu_timing_resets_when_lcd_enabled_after_off() {
+        let mut ppu = Ppu::new();
+        tick_dots(&mut ppu, 456 * 50);
+        ppu.write_register(0xFF40, 0x11); // LCD off
+        ppu.tick_dots(456 * 20); // no-op
         ppu.write_register(0xFF40, 0x91); // LCD on
         assert_eq!(
-            ppu.read_register(0xFF44),
+            ppu.timing.ly(),
             0,
-            "LY must be 0 after LCD re-enable"
+            "LY should reset to 0 when LCD is re-enabled"
+        );
+        assert_eq!(
+            ppu.timing.mode(),
+            PpuMode::OamScan,
+            "PPU should start in OAM scan mode when re-enabled"
+        );
+    }
+
+    #[test]
+    fn test_stat_mode_bits_report_mode0_when_lcd_disabled() {
+        let mut ppu = ppu_in_mode3_then_lcd_off();
+        let stat = ppu.read_register(0xFF41);
+        assert_eq!(
+            stat & 0x03,
+            0,
+            "STAT mode bits must be 0 (Mode 0) when LCD is disabled"
+        );
+    }
+
+    #[test]
+    fn test_oam_write_succeeds_when_lcd_disabled() {
+        let mut ppu = Ppu::new();
+        assert_eq!(ppu.timing.mode(), PpuMode::OamScan);
+        ppu.write_register(0xFF40, 0x11); // LCD off
+        ppu.write_oam(0xFE10, 0xBB);
+        assert_eq!(
+            ppu.oam[0x10], 0xBB,
+            "OAM write should succeed when LCD is off"
+        );
+    }
+
+    #[test]
+    fn test_oam_read_returns_actual_value_when_lcd_disabled() {
+        let mut ppu = ppu_in_mode3_then_lcd_off();
+        ppu.oam[0x05] = 0xCC;
+        let val = ppu.read_oam(0xFE05);
+        assert_eq!(
+            val, 0xCC,
+            "OAM read should return actual value when LCD is off"
         );
     }
 }

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -263,6 +263,36 @@ impl Console {
             Console::GameBoy(_) => {}
         }
     }
+
+    /// Target wall-clock duration between rendered frames for this system.
+    ///
+    /// Frontends use this to pace emulation correctly regardless of display
+    /// refresh rate.  The NES value is derived from the hardware timing mode
+    /// (NTSC ≈ 60.10 fps, PAL ≈ 50.01 fps).  The DMG Game Boy always runs at
+    /// 4,194,304 Hz / 70,224 cycles per frame ≈ 59.73 fps.
+    ///
+    /// Unlike the NES, the Game Boy currently has no audio output, so there is
+    /// no ring-buffer back-pressure to naturally throttle the frame rate when
+    /// vsync is enabled.  Frontends must use this value to gate emulation.
+    pub fn target_frame_duration(&self) -> std::time::Duration {
+        match self {
+            Console::GameBoy(_) => {
+                // DMG: 4,194,304 Hz clock / 70,224 cycles per frame ≈ 59.7275 fps
+                std::time::Duration::from_secs_f64(70_224.0 / 4_194_304.0)
+            }
+            Console::Nes(_) => {
+                let hz = self
+                    .app_context()
+                    .borrow()
+                    .config()
+                    .nes
+                    .hardware_model
+                    .timing_mode()
+                    .frame_rate_hz();
+                std::time::Duration::from_secs_f64(1.0 / hz)
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1945

## Summary

Implements the full DMG boot ROM sequence — Nintendo logo tile loading, scroll animation, logo/checksum verification, and correct post-boot CPU register state.

Four commits ship together:

### 1. `fix(gb/ppu)`: Respect LCD disable (LCDC bit 7)

When LCDC bit 7 is cleared the PPU must stop ticking, report LY=0 and Mode=0, and allow unrestricted VRAM/OAM access. The PPU previously ignored this bit, blocking VRAM writes during Mode 3 even with the LCD off.

- `tick_dots()` is a no-op when LCD is disabled  
- `read_vram`/`write_vram` only enforce Mode-3 blocking when LCD is on  
- `read_register` returns LY=0 and STAT mode=0 when LCD is off  
- `write_register` resets `Timing` to scanline 0 / Mode 2 on LCD 0→1 transition  
- 6 new unit tests (RED→GREEN)

### 2. `fix(gb/boot)`: Start LCD off at power-on; boot ROM enables LCD before display

Real DMG hardware powers on with LCDC=0x00. The boot ROM loads tile data while the LCD is off so VRAM writes are never blocked by Mode 3. Our boot ROM then explicitly re-enables the LCD (LCDC=0x91) just before the scroll animation.

- `DmgBus::new()` / `reset()` initialise LCDC=0x00  
- Boot ROM gains `LD A,$91; LDH [$FF40]` after the tile-map build  
- Space reclaimed without growing the 256-byte ROM: NR11 stub removed (−2 B), `LD A,[HL]` replaces `LD A,[$014D]` (−2 B)

### 3. `feat(gb/boot)`: Wire boot ROM into emulator and add integration tests

- `gb/mod.rs` exposes the `boot_rom` module  
- Hard reset sets PC=0x0000 and re-activates the boot ROM  
- Integration tests: `test_dmg_boot_sets_correct_register_state` and `test_dmg_boot_halts_on_corrupted_logo`

### 4. `fix(gb)`: Throttle GameBoy frame rate to ~59.73 fps

With vsync enabled on a 120 Hz ProMotion display the event loop used `ControlFlow::Poll`, running the GB at 120 fps (the NES avoids this via audio back-pressure, but the GB has no audio yet).

- `Console::target_frame_duration()` returns the hardware-accurate frame interval  
- `RedrawRequested`: skip-emulation guard extended to Game Boy  
- `AboutToWait`: Game Boy uses `WaitUntil` (≈16.74 ms) instead of `Poll`

## Test plan

- All 22 PPU unit tests pass (including 6 new LCD-disable tests)  
- All 216 GB unit/integration tests pass  
- Full suite passes (2 pre-existing NES failures unrelated to this PR)  
- Nintendo logo visible and scrolling before game starts  
- Game Boy runs at correct speed (~59.73 fps)
