### PR TITLE
fix: alias and document invalid/misassigned mapper numbers (160, 161, 169, 179, 181, 182, 186, 248, 258)

### DIFF
--- a/src/nes/cartridge/mapper.rs
+++ b/src/nes/cartridge/mapper.rs
@@ -1048,17 +1048,27 @@ mapper_registry! {
     156 => Mapper156::new,
     157 => Mapper157::new,
     159 => Mapper159::new,
+    // 160: Alias of mapper 090 (J.Y. Company). NESdev notes mapper 090 fully covers mapper 160 behavior.
     160 => JyCompanyMapper::new,
+    // 161: Misassignment — 'Hanjuku Hero' was incorrectly assigned here before MMC1 behavior was understood. Alias of mapper 001 (MMC1).
+    161 => MMC1Mapper::new,
     162 => Mapper162::new,
     163 => Mapper163::new,
     165 => Mapper165::new,
     167 => Mapper167::new,
+    // 169: Yuxing board. 'Contra 168-in-1' was misassigned here; correct mapper is 015. Alias of mapper 015.
+    169 => Multicart15Mapper::new,
     171 => Mapper171::new,
     173 => Mapper173::new,
     174 => Mapper174::new,
     175 => Mapper175::new,
     177 => Mapper177::new,
     178 => Mapper178::new,
+    // 179: Nestopia misassignment — duplicates mapper 176. Alias of mapper 176 (not yet implemented; see issue #1108).
+    // 181: FCEUX patch-list heuristic entry only — no ROM actually uses this mapper number.
+    // 182: NESdev page for mapper 182 actually documents mapper 114 hardware. Alias of mapper 114.
+    182 => Mapper114::new,
+    // 186: Fukutake Study Box BIOS. Requires a headerless .BIN BIOS image, not an iNES ROM — not implementable here.
     180 => UxromInvertedMapper::new,
     184 => Sunsoft1Mapper::new,
     185 => CnromSecurityMapper::new,
@@ -1115,6 +1125,8 @@ mapper_registry! {
     244 => Mapper244::new,
     245 => Mapper245::new,
     246 => Mapper246::new,
+    // 248: Misassignment — NESdev notes mapper 115 handles these ROMs correctly. Alias of mapper 115.
+    248 => Mapper115::new,
     249 => Mapper249::new,
     250 => Mapper250::new,
     251 => Mapper251::new,
@@ -1122,6 +1134,7 @@ mapper_registry! {
     254 => Mapper254::new,
     255 => Mapper255::new,
     257 => Mapper257::new,
+    // 258: Tentatively reserved by FCEUX for UNIF MAPR 158B hardware — no proper iNES/NES 2.0 documentation.
     259 => Mapper259::new,
     260 => Mapper260::new,
     262 => Mapper262::new,

--- a/src/nes/cartridge/mapper.rs
+++ b/src/nes/cartridge/mapper.rs
@@ -1064,14 +1064,15 @@ mapper_registry! {
     175 => Mapper175::new,
     177 => Mapper177::new,
     178 => Mapper178::new,
-    // 179: Nestopia misassignment — duplicates mapper 176. Alias of mapper 176 (not yet implemented; see issue #1108).
+    // 179: Nestopia misassignment — intentionally unimplemented. Duplicates mapper 176 behavior;
+    //       implement via mapper 176 once that is added (see issue #1108).
     // 181: FCEUX patch-list heuristic entry only — no ROM actually uses this mapper number.
     // 182: NESdev page for mapper 182 actually documents mapper 114 hardware. Alias of mapper 114.
     182 => Mapper114::new,
-    // 186: Fukutake Study Box BIOS. Requires a headerless .BIN BIOS image, not an iNES ROM — not implementable here.
     180 => UxromInvertedMapper::new,
     184 => Sunsoft1Mapper::new,
     185 => CnromSecurityMapper::new,
+    // 186: Fukutake Study Box BIOS. Requires a headerless .BIN BIOS image, not an iNES ROM — not implementable here.
     188 => Mapper188::new,
     190 => Mapper190::new,
     191 => Mapper191::new,
@@ -1182,13 +1183,13 @@ const SUPPORTED_MAPPERS: &[u16] = &[
     50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
     74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96,
     100, 101, 102, 103, 104, 106, 108, 110, 114, 115, 117, 118, 120, 121, 122, 123, 124, 125, 126,
-    128, 129, 132, 133, 140, 141, 142, 143, 144, 145, 146, 147, 149, 154, 155, 156, 165, 173, 177,
-    180, 184, 185, 193, 205, 206, 207, 214, 216, 217, 218, 219, 222, 225, 226, 227, 228, 229, 230,
-    231, 232, 233, 234, 236, 237, 238, 241, 242, 243, 244, 245, 246, 249, 250, 251, 253, 254, 255,
-    257, 259, 260, 262, 263, 264, 267, 268, 269, 270, 271, 274, 281, 283, 285, 286, 287, 288, 289,
-    291, 292, 293, 294, 295, 296, 299, 300, 302, 303, 304, 305, 306, 307, 308, 310, 311, 313, 314,
-    315, 319, 320, 322, 323, 324, 326, 327, 328, 329, 330, 331, 332, 335, 337, 338, 339, 340, 342,
-    343, 344, 345, 346, 347, 348, 349, 350,
+    128, 129, 132, 133, 140, 141, 142, 143, 144, 145, 146, 147, 149, 154, 155, 156, 160, 161, 165,
+    169, 173, 177, 180, 182, 184, 185, 193, 205, 206, 207, 214, 216, 217, 218, 219, 222, 225, 226,
+    227, 228, 229, 230, 248, 231, 232, 233, 234, 236, 237, 238, 241, 242, 243, 244, 245, 246, 249,
+    250, 251, 253, 254, 255, 257, 259, 260, 262, 263, 264, 267, 268, 269, 270, 271, 274, 281, 283,
+    285, 286, 287, 288, 289, 291, 292, 293, 294, 295, 296, 299, 300, 302, 303, 304, 305, 306, 307,
+    308, 310, 311, 313, 314, 315, 319, 320, 322, 323, 324, 326, 327, 328, 329, 330, 331, 332, 335,
+    337, 338, 339, 340, 342, 343, 344, 345, 346, 347, 348, 349, 350,
 ];
 
 /// List of supported iNES mapper IDs handled by the factory.
@@ -1689,6 +1690,41 @@ mod tests {
         // Mapper 131 is an alternative assignment for the behavior of iNES Mapper 205.
         let m = make_mapper(131);
         assert_eq!(m.mapper_number(), 205);
+    }
+
+    #[test]
+    fn create_mapper_accepts_mapper_160_as_mapper_90_alias() {
+        // Mapper 160 is an alias of mapper 090 (J.Y. Company). NESdev notes mapper 090 fully covers it.
+        let m = make_mapper(160);
+        assert_eq!(m.mapper_number(), 160);
+    }
+
+    #[test]
+    fn create_mapper_accepts_mapper_161_as_mmc1_alias() {
+        // Mapper 161 was misassigned to 'Hanjuku Hero' before MMC1 behavior was understood. Alias of mapper 001.
+        let m = make_mapper(161);
+        assert_eq!(m.mapper_number(), 161);
+    }
+
+    #[test]
+    fn create_mapper_accepts_mapper_169_as_mapper_15_alias() {
+        // Mapper 169 was misassigned to 'Contra 168-in-1'; the correct mapper is 015.
+        let m = make_mapper(169);
+        assert_eq!(m.mapper_number(), 169);
+    }
+
+    #[test]
+    fn create_mapper_accepts_mapper_182_as_mapper_114_alias() {
+        // Mapper 182 NESdev page actually documents mapper 114 hardware. Reports mapper 114.
+        let m = make_mapper(182);
+        assert_eq!(m.mapper_number(), 114);
+    }
+
+    #[test]
+    fn create_mapper_accepts_mapper_248_as_mapper_115_alias() {
+        // Mapper 248 was misassigned; NESdev notes mapper 115 handles these ROMs. Reports mapper 115.
+        let m = make_mapper(248);
+        assert_eq!(m.mapper_number(), 115);
     }
 
     fn make_mapper(id: u16) -> Box<dyn Mapper> {


### PR DESCRIPTION
## Summary

Several open issues reference mapper numbers that are misassignments, duplicates, or otherwise not implementable as real hardware. This PR handles them by aliasing to the correct implementation or adding explanatory comments.

## Changes

| Mapper | Action | Reason |
|--------|--------|--------|
| 160 | Alias of mapper 090 (already correct) + comment | NESdev: mapper 090 fully covers 160 behavior |
| 161 | Alias → mapper 001 (MMC1) | NESdev: misassignment for *Hanjuku Hero* before MMC1 was understood |
| 169 | Alias → mapper 015 | NESdev: *Contra 168-in-1* was misassigned here; correct mapper is 015 |
| 179 | Comment only | Nestopia misassignment that duplicates mapper 176 (not yet implemented) |
| 181 | Comment only | FCEUX patch-list heuristic entry — no ROM actually uses this number |
| 182 | Alias → mapper 114 | NESdev page for 182 documents mapper 114 hardware |
| 186 | Comment only | Fukutake Study Box BIOS — requires headerless .BIN, not iNES |
| 248 | Alias → mapper 115 | NESdev: mapper 115 handles these ROMs correctly |
| 258 | Comment only | Tentatively reserved by FCEUX for UNIF MAPR 158B — no proper documentation |

## Closes

Closes #1075, #1077, #1094, #1114, #1072, #1120, #1126, #1234, #1248