### PR TITLE
fix(gb): correct LD (n16),SP byte order — fixes all Blargg cpu_instrs test 03 failures (closes #1979)

### DIFF
--- a/src/gb/cpu/sm83.rs
+++ b/src/gb/cpu/sm83.rs
@@ -647,7 +647,7 @@ impl<B: GbBus> Sm83<B> {
             // --- LD (n16), SP -------------------------------------------
             0x08 => {
                 let addr = self.fetch_u16();
-                let [hi, lo] = self.regs.sp.to_le_bytes();
+                let [lo, hi] = self.regs.sp.to_le_bytes();
                 self.write(addr, lo);
                 self.write(addr.wrapping_add(1), hi);
             }
@@ -1667,5 +1667,47 @@ mod tests {
         cpu.execute();
         assert!(!cpu.halted, "Pending interrupt should wake CPU from HALT");
         assert_eq!(cpu.regs.pc, 0x1000, "PC should not change if IME=false");
+    }
+
+    // -----------------------------------------------------------------------
+    // LD (n16), SP  (0x08)
+    // -----------------------------------------------------------------------
+
+    /// LD (n16),SP must store SP in little-endian order:
+    /// low byte at [addr], high byte at [addr+1].
+    ///
+    /// Per Pan Docs: https://gbdev.io/pandocs/CPU_Instruction_Set.html
+    #[test]
+    fn test_ld_nn_sp_stores_sp_little_endian() {
+        // Program: LD (0x8000), SP  →  0x08 0x00 0x80
+        let mut cpu = cpu_with(&[0x08, 0x00, 0x80]);
+        cpu.regs.sp = 0x1234;
+        cpu.execute();
+        assert_eq!(
+            cpu.bus.mem[0x8000], 0x34,
+            "low byte of SP should be stored at [addr]"
+        );
+        assert_eq!(
+            cpu.bus.mem[0x8001], 0x12,
+            "high byte of SP should be stored at [addr+1]"
+        );
+    }
+
+    /// LD (n16),SP with SP=0 stores 0x00 at both bytes.
+    #[test]
+    fn test_ld_nn_sp_stores_zero_sp() {
+        let mut cpu = cpu_with(&[0x08, 0x00, 0x80]);
+        cpu.regs.sp = 0x0000;
+        cpu.execute();
+        assert_eq!(cpu.bus.mem[0x8000], 0x00);
+        assert_eq!(cpu.bus.mem[0x8001], 0x00);
+    }
+
+    /// LD (n16),SP should take 5 M-cycles (fetch + fetch_u16 + write lo + write hi).
+    #[test]
+    fn test_ld_nn_sp_takes_5_m_cycles() {
+        let mut cpu = cpu_with(&[0x08, 0x00, 0x80]);
+        cpu.execute();
+        assert_eq!(cpu.cycles(), 5, "LD (n16),SP should take 5 M-cycles");
     }
 }

--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -56,7 +56,6 @@ fn test_cpu_instrs_02_interrupts() {
 }
 
 #[test]
-#[ignore = "failing: ADD SP,r8/LD HL,SP+r8 incorrect H/C flags — tracked in #1979"]
 fn test_cpu_instrs_03_op_sp_hl() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/cpu_instrs/individual/03-op sp,hl.gb");
     let output = run_blargg_rom(&mut gb);


### PR DESCRIPTION
## Summary

Fixes #1979 — all 8 instruction tests in Blargg cpu_instrs test 03 (`03-op sp,hl.gb`) now pass.

## Root cause (actual)

The issue title said "ADD SP,r8 / LD HL,SP+r8 incorrect H/C flags" but the real bug was in `LD (n16),SP` (opcode 0x08).

The `to_le_bytes()` destructuring was inverted:

```rust
// Before (WRONG) — [hi, lo] swaps the names, writing big-endian:
let [hi, lo] = self.regs.sp.to_le_bytes();
self.write(addr, lo);           // writes HIGH byte to addr
self.write(addr.wrapping_add(1), hi); // writes LOW byte to addr+1

// After (correct) — [lo, hi] matches to_le_bytes() semantics:
let [lo, hi] = self.regs.sp.to_le_bytes();
self.write(addr, lo);           // writes LOW byte to addr
self.write(addr.wrapping_add(1), hi); // writes HIGH byte to addr+1
```

The Blargg test 03 framework uses `ld (tempaddr),sp` to save SP before computing the CRC32 checksum of each instruction result. With bytes in the wrong order, every checksum mismatched the reference and all 8 instruction tests were reported as failing.

## Changes

- `src/gb/cpu/sm83.rs`: fix `[hi, lo]` -> `[lo, hi]` in opcode 0x08
- `src/gb/cpu/sm83.rs`: add 3 unit tests for `LD (n16),SP`
- `src/gb/integration_tests/blargg_tests.rs`: remove `#[ignore]` from `test_cpu_instrs_03_op_sp_hl`

## Test results

- `test_cpu_instrs_03_op_sp_hl` now passes
- All 47 SM83 unit tests pass
- 27 blargg tests pass, 6 ignored, 0 failed

Closes #1979
