### PR TITLE
fix(gb): remove #[ignore] from tests 07/08/instr_timing resolved by LD (n16),SP fix (closes #1980, #1981)

### DIFF
--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -96,7 +96,6 @@ fn test_cpu_instrs_06_ld_r_r() {
 }
 
 #[test]
-#[ignore = "failing: JR/JP/CALL/RET/RST all fail — tracked in #1980"]
 fn test_cpu_instrs_07_jr_jp_call_ret_rst() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/cpu_instrs/individual/07-jr,jp,call,ret,rst.gb");
@@ -108,7 +107,6 @@ fn test_cpu_instrs_07_jr_jp_call_ret_rst() {
 }
 
 #[test]
-#[ignore = "failing: loops indefinitely (STOP/HALT issue) — tracked in #1981"]
 fn test_cpu_instrs_08_misc_instrs() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/cpu_instrs/individual/08-misc instrs.gb");
     let output = run_blargg_rom(&mut gb);
@@ -151,7 +149,6 @@ fn test_cpu_instrs_11_op_a_hl() {
 // ── Other Blargg CPU ROMs ─────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "failing: instruction timing inaccuracies — tracked in #1983"]
 fn test_instr_timing() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/instr_timing/instr_timing.gb");
     let output = run_blargg_rom(&mut gb);


### PR DESCRIPTION
## Summary

Removes the `#[ignore]` annotations from three Blargg integration tests that
now pass as a side-effect of the LD (n16),SP byte-order fix in PR #1986.

No new code changes — this PR is purely an update to the test annotations.

## Root cause (already fixed)

The Blargg instr_test framework uses `LD (nn),SP` in every individual test to
save and restore SP for CRC checksumming. The byte-order bug in that instruction
(PR #1986 / issue #1979) caused every test that checksummed SP to produce a
wrong CRC — not just test 03.

## Tests now passing

| Test | Issue |
|------|-------|
| `test_cpu_instrs_07_jr_jp_call_ret_rst` | closes #1980 |
| `test_cpu_instrs_08_misc_instrs` | closes #1981 |
| `test_instr_timing` | partial progress on #1983 |

## Remaining ignored

| Test | Issue |
|------|-------|
| `test_halt_bug` | #1982 |
| `test_mem_timing` | #1983 |
| `test_mem_timing_2` | #1983 |

## Test results

test result: ok. 12 passed; 0 failed; 3 ignored

Closes #1980
Closes #1981
