### PR TITLE
Add Blargg dmg_sound and cgb_sound integration tests (#2031)

### DIFF
--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -329,6 +329,279 @@ fn test_mem_timing_2() {
     );
 }
 
+// ── dmg_sound single ROMs ────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "failing: APU off-state register read behaviour (NR52 bit 7) — tracked in #2034"]
+fn test_dmg_sound_01_registers() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/01-registers.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_dmg_sound_02_len_ctr() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/02-len ctr.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: length counter clocking on trigger in first half of period — tracked in #2034"]
+fn test_dmg_sound_03_trigger() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/03-trigger.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: CH1 sweep calculation on trigger when shift=0 — tracked in #2034"]
+fn test_dmg_sound_04_sweep() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/04-sweep.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: sweep negate-mode exit disables channel — tracked in #2034"]
+fn test_dmg_sound_05_sweep_details() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/05-sweep details.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_dmg_sound_06_overflow_on_trigger() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/06-overflow on trigger.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: length/sweep period synchronisation (no output, likely hangs) — tracked in #2034"]
+fn test_dmg_sound_07_len_sweep_period_sync() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/07-len sweep period sync.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_dmg_sound_08_len_ctr_during_power() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/08-len ctr during power.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: wave channel read-while-on behaviour — tracked in #2034"]
+fn test_dmg_sound_09_wave_read_while_on() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/09-wave read while on.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: wave channel trigger-while-on behaviour — tracked in #2034"]
+fn test_dmg_sound_10_wave_trigger_while_on() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/10-wave trigger while on.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_dmg_sound_11_regs_after_power() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/11-regs after power.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: wave channel write-while-on behaviour — tracked in #2034"]
+fn test_dmg_sound_12_wave_write_while_on() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/12-wave write while on.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+// ── cgb_sound single ROMs ─────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "failing: APU off-state register read behaviour (NR52 bit 7) — tracked in #2034"]
+fn test_cgb_sound_01_registers() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/01-registers.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_cgb_sound_02_len_ctr() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/02-len ctr.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: length counter clocking on trigger in first half of period — tracked in #2034"]
+fn test_cgb_sound_03_trigger() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/03-trigger.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: CH1 sweep calculation on trigger when shift=0 — tracked in #2034"]
+fn test_cgb_sound_04_sweep() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/04-sweep.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: sweep negate-mode exit disables channel — tracked in #2034"]
+fn test_cgb_sound_05_sweep_details() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/05-sweep details.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_cgb_sound_06_overflow_on_trigger() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/06-overflow on trigger.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: length/sweep period synchronisation (no output, likely hangs) — tracked in #2034"]
+fn test_cgb_sound_07_len_sweep_period_sync() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/07-len sweep period sync.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: length counter behaviour during APU power cycle (CGB variant) — tracked in #2034"]
+fn test_cgb_sound_08_len_ctr_during_power() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/08-len ctr during power.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: wave channel read-while-on behaviour — tracked in #2034"]
+fn test_cgb_sound_09_wave_read_while_on() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/09-wave read while on.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_cgb_sound_10_wave_trigger_while_on() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/10-wave trigger while on.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+#[ignore = "failing: APU power-off should clear NR41 length counter (CGB variant) — tracked in #2034"]
+fn test_cgb_sound_11_regs_after_power() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/11-regs after power.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_cgb_sound_12_wave() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/12-wave.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
 // ── OAM bug single ROMs ───────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #2031.

Adds 24 integration tests (12 `dmg_sound` + 12 `cgb_sound`) to `src/gb/integration_tests/blargg_tests.rs`, one per Blargg audio ROM single, using the existing `run_blargg_rom_cart_ram()` helper.

## Pass / Fail matrix

| # | dmg_sound | cgb_sound |
|---|---|---|
| 01-registers | ⛔ ignored | ⛔ ignored |
| 02-len ctr | ✅ passes | ✅ passes |
| 03-trigger | ⛔ ignored | ⛔ ignored |
| 04-sweep | ⛔ ignored | ⛔ ignored |
| 05-sweep details | ⛔ ignored | ⛔ ignored |
| 06-overflow on trigger | ✅ passes | ✅ passes |
| 07-len sweep period sync | ⛔ ignored | ⛔ ignored |
| 08-len ctr during power | ✅ passes | ⛔ ignored |
| 09-wave read while on | ⛔ ignored | ⛔ ignored |
| 10-wave trigger while on | ⛔ ignored | ✅ passes |
| 11-regs after power | ✅ passes | ⛔ ignored |
| 12-wave / wave write while on | ⛔ ignored | ✅ passes |

**8 passing, 16 ignored** — all ignored tests link to #2034 (APU correctness gaps).

## Test results

```
cargo test gb::integration_tests::blargg_tests
test result: ok. 30 passed; 0 failed; 17 ignored
```

(17 ignored = 16 new + 1 pre-existing oam_bug test)

## Notes

- cgb_sound ROMs load successfully on `DmgBus` (MBC1+RAM, loader accepts MBC 0x02; no CGB-mode check). Tests that fail do so due to APU behaviour gaps, not loader issues.
- No new test infrastructure added — reuses `run_blargg_rom_cart_ram()` and `BLARGG_CYCLE_LIMIT`.
- The one pre-existing unrelated failure (`test_convert_autorun_for_rom_converts_v2_file_to_v3`) is present on `main` before this PR.