### PR TITLE
feat: redesign web layout with DaisyUI drawer sidebar and neon theme

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -305,7 +305,7 @@ All Game Boy (DMG) hardware lives under `src/gb/`. The module is structured arou
 
 ### `web/` — Browser Frontend
 
-The web frontend is bundled with **Vite** (config at `vite.config.ts`, root: `web/`, build output: `dist/`). Styled with **Tailwind CSS v4** and **DaisyUI v5** (night theme with neon accent colors). Uses a DaisyUI drawer layout with a sidebar for ROM/emulation controls and a top bar for screen controls. JavaScript modules are organized into feature folders under `web/src/`.
+The web frontend is bundled with **Vite** (config at `vite.config.ts`, root: `web/`, build output: `dist/`). Styled with **Tailwind CSS v4** and **DaisyUI v5** (night theme with neon accent colors). Uses a DaisyUI drawer layout with a sidebar for ROM/emulation controls and a top bar for screen controls. TypeScript modules are organized into feature folders under `web/src/`.
 
 | Directory/File | Description |
 | -------------- | ------------- |
@@ -313,17 +313,17 @@ The web frontend is bundled with **Vite** (config at `vite.config.ts`, root: `we
 | `web/main.css` | Tailwind CSS entry point with DaisyUI plugin config, neon theme overrides, and custom component styles. |
 | `web/debugger.css` | Debugger panel styling (green-on-black terminal aesthetic). |
 | `web/src/app.ts` | Application bootstrapper — initializes the WASM module, sets up the render loop, and coordinates all subsystems. |
-| `web/src/audio/` | Audio resampling (`audio_resampler.js`), frame timing (`frame_limiter.js`, `frame_plan.js`). |
-| `web/src/input/` | Gamepad API (`gamepad.js`), keyboard/gamepad routing (`input_routing.js`), mouse input (`mouse_input.js`), pointer lock (`pointer_lock.js`). |
-| `web/src/display/` | Canvas sizing (`canvas_size.js`), zoom controls (`zoom_controls.js`), cursor visibility, crosshair overlay. |
-| `web/src/rom/` | ROM file listing (`rom_list.js`), selection UI (`rom_selection.js`), autorun context. |
-| `web/src/save-state/` | Save state persistence using IndexedDB (`save_state_storage.js`, `save_state_controller.js`, `save_state_context.js`). |
+| `web/src/audio/` | Audio resampling (`audio_resampler.ts`), frame timing (`frame_limiter.ts`, `frame_plan.ts`). |
+| `web/src/input/` | Gamepad API (`gamepad.ts`), keyboard/gamepad routing (`input_routing.ts`), mouse input (`mouse_input.ts`), pointer lock (`pointer_lock.ts`). |
+| `web/src/display/` | Canvas sizing (`canvas_size.ts`), zoom controls (`zoom_controls.ts`), cursor visibility, crosshair overlay. |
+| `web/src/rom/` | ROM file listing (`rom_list.ts`), selection UI (`rom_selection.ts`), autorun context. |
+| `web/src/save-state/` | Save state persistence using IndexedDB (`save_state_storage.ts`, `save_state_controller.ts`, `save_state_context.ts`). |
 | `web/src/debugger/` | Browser-based debugger panels — disassembly, OAM viewer, watch expressions, PPU viewer layout/scroll. |
 | `web/src/shortcuts/` | Keyboard shortcut actions and help overlay. |
-| `web/src/ui/` | Toast overlays (`toast_overlay.js`), gamepad init toast, sine scroller. |
+| `web/src/ui/` | Toast overlays (`toast_overlay.ts`), gamepad init toast, sine scroller. |
 | `web/integration/` | Playwright-based end-to-end integration tests for the web frontend. |
 
-Each JavaScript module has a corresponding `.test.mjs` unit test file (run with `vitest`).
+Each TypeScript module has a corresponding `.test.ts` unit test file (run with `vitest`).
 
 ### `shaders/` — Visual Filters
 

--- a/architecture.md
+++ b/architecture.md
@@ -305,13 +305,14 @@ All Game Boy (DMG) hardware lives under `src/gb/`. The module is structured arou
 
 ### `web/` — Browser Frontend
 
-The web frontend is bundled with **Vite** (config at `vite.config.js`, root: `web/`, build output: `dist/`). JavaScript modules are organized into feature folders under `web/src/`.
+The web frontend is bundled with **Vite** (config at `vite.config.ts`, root: `web/`, build output: `dist/`). Styled with **Tailwind CSS v4** and **DaisyUI v5** (night theme with neon accent colors). Uses a DaisyUI drawer layout with a sidebar for ROM/emulation controls and a top bar for screen controls. JavaScript modules are organized into feature folders under `web/src/`.
 
 | Directory/File | Description |
 | -------------- | ------------- |
-| `web/index.html` | Entry point — canvas element, ROM file picker, keyboard shortcuts overlay. Loads `./src/app.js` as the main module. |
-| `web/styles.css` | Application styling. |
-| `web/src/app.js` | Application bootstrapper — initializes the WASM module, sets up the render loop, and coordinates all subsystems. |
+| `web/index.html` | Entry point — DaisyUI drawer layout with sidebar, top bar, canvas area, footer, and autorun modal dialog. Loads `./src/app.ts` as the main module. |
+| `web/main.css` | Tailwind CSS entry point with DaisyUI plugin config, neon theme overrides, and custom component styles. |
+| `web/debugger.css` | Debugger panel styling (green-on-black terminal aesthetic). |
+| `web/src/app.ts` | Application bootstrapper — initializes the WASM module, sets up the render loop, and coordinates all subsystems. |
 | `web/src/audio/` | Audio resampling (`audio_resampler.js`), frame timing (`frame_limiter.js`, `frame_plan.js`). |
 | `web/src/input/` | Gamepad API (`gamepad.js`), keyboard/gamepad routing (`input_routing.js`), mouse input (`mouse_input.js`), pointer lock (`pointer_lock.js`). |
 | `web/src/display/` | Canvas sizing (`canvas_size.js`), zoom controls (`zoom_controls.js`), cursor visibility, crosshair overlay. |

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "node": ">=20"
     },
     "scripts": {
-        "dev": "vite web",
+        "dev": "vite",
         "build": "vite build",
         "preview": "vite preview",
         "test": "vitest run",

--- a/web/index.html
+++ b/web/index.html
@@ -8,102 +8,140 @@
     <link rel="stylesheet" href="./debugger.css" />
   </head>
   <body>
-    <div class="container py-4">
-      <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
-        <div>
-          <h1 class="h3 mb-1">NESER Web</h1>
-          <div class="text-body-secondary">Play classic ROMs with modern filters</div>
-        </div>
-        <div class="d-flex flex-wrap align-items-center gap-2">
-          <label for="rom" class="form-label mb-0">ROM file</label>
-          <div class="d-flex flex-nowrap align-items-center gap-2">
-            <input type="file" id="rom" accept=".nes" class="form-control form-control-sm" />
-            <select id="rom-select" class="form-select form-select-sm" aria-label="Select ROM from server">
+    <!-- DaisyUI drawer: sidebar + main content -->
+    <div class="drawer lg:drawer-open">
+      <input id="sidebar-toggle" type="checkbox" class="drawer-toggle" />
+
+      <!-- Main content area -->
+      <div class="drawer-content flex flex-col min-h-screen">
+        <!-- Top bar -->
+        <header class="flex items-center gap-2 px-4 py-2 bg-base-200 border-b border-base-300 flex-wrap">
+          <!-- Hamburger for mobile/tablet -->
+          <label for="sidebar-toggle" class="btn btn-ghost btn-sm lg:hidden" aria-label="Open sidebar">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+          </label>
+          <div class="flex flex-wrap items-center gap-2">
+            <button id="screen-minus" class="btn btn-outline btn-sm">Zoom -</button>
+            <button id="screen-plus" class="btn btn-outline btn-sm">Zoom +</button>
+            <button id="fullscreen" class="btn btn-outline btn-sm">Fullscreen</button>
+            <button id="filter-toggle" class="btn btn-outline btn-sm">Filter</button>
+            <button id="gamepad-toggle" class="btn btn-outline btn-sm" aria-pressed="true">Gamepad On</button>
+            <button id="mute" class="btn btn-outline btn-sm" aria-pressed="false">Mute</button>
+            <button id="save-state" class="btn btn-warning btn-outline btn-sm" disabled>Save State</button>
+            <button id="load-state" class="btn btn-warning btn-outline btn-sm" disabled>Load State</button>
+          </div>
+        </header>
+
+        <!-- Canvas area -->
+        <main class="flex-1 flex flex-col items-center justify-center p-4">
+          <div class="screen-wrap" id="screen-wrap">
+            <canvas id="screen" width="256" height="240" tabindex="0"></canvas>
+            <div id="shortcut-help-overlay" class="shortcut-help-overlay hidden" aria-hidden="true"></div>
+            <div id="debugger-panel" class="debugger-panel hidden" aria-label="Debugger panel"></div>
+          </div>
+          <div class="mt-3 flex items-center gap-2">
+            <span class="badge badge-neutral">Status</span>
+            <span id="status" class="status">Load a ROM to begin</span>
+          </div>
+        </main>
+
+        <!-- Footer -->
+        <footer class="px-4 py-3 bg-base-200 border-t border-base-300 text-center text-sm text-base-content/60">
+          <div id="controls">
+            <kbd class="kbd kbd-sm">W</kbd><kbd class="kbd kbd-sm">A</kbd><kbd class="kbd kbd-sm">S</kbd><kbd class="kbd kbd-sm">D</kbd> D-Pad
+            &nbsp;|&nbsp;
+            <kbd class="kbd kbd-sm">F</kbd> A
+            &nbsp;|&nbsp;
+            <kbd class="kbd kbd-sm">G</kbd> B
+            &nbsp;|&nbsp;
+            <kbd class="kbd kbd-sm">R</kbd> Select
+            &nbsp;|&nbsp;
+            <kbd class="kbd kbd-sm">T</kbd> Start
+            &nbsp;|&nbsp;
+            <kbd class="kbd kbd-sm">H</kbd> Help
+          </div>
+          <div id="shortcut-reference" class="mt-1"></div>
+        </footer>
+      </div>
+
+      <!-- Sidebar -->
+      <div class="drawer-side z-40">
+        <label for="sidebar-toggle" class="drawer-overlay" aria-label="Close sidebar"></label>
+        <aside class="w-60 min-h-screen bg-base-200 border-r border-base-300 flex flex-col p-4 gap-4">
+          <!-- NESER ASCII art logo -->
+          <div class="text-center select-none">
+            <pre class="font-mono text-xs leading-tight text-[#00f0ff]"> _   _ _____ ____  _____ ____
+| \ | | ____/ ___|| ____|  _ \
+|  \| |  _| \___ \|  _| | |_) |
+| |\  | |___ ___) | |___|  _ &lt;
+|_| \_|_____|____/|_____|_| \_\</pre>
+          </div>
+
+          <!-- ROM controls -->
+          <div class="flex flex-col gap-2">
+            <label for="rom" class="label text-xs">ROM file</label>
+            <input type="file" id="rom" accept=".nes" class="file-input file-input-bordered file-input-sm w-full" />
+            <select id="rom-select" class="select select-bordered select-sm w-full" aria-label="Select ROM from server">
               <option value="">Select bundled ROM…</option>
             </select>
-            <button id="start" class="btn btn-success btn-sm">Start</button>
-            <button id="reset" class="btn btn-outline-warning btn-sm" aria-label="Reset emulation">Reset</button>
-            <button id="pause" class="btn btn-outline-secondary btn-sm" aria-label="Pause or resume emulation">Pause/Resume</button>
-            <button id="stop" class="btn btn-outline-danger btn-sm" aria-label="Stop emulation">Stop</button>
           </div>
-          <div class="d-flex flex-nowrap align-items-center gap-3 mt-1">
-            <div class="form-check mb-0">
-              <input class="form-check-input" type="checkbox" id="autorun-create" />
-              <label class="form-check-label" for="autorun-create">Create autorun</label>
-            </div>
-            <button id="autorun-load" class="btn btn-outline-info btn-sm">Load autorun</button>
-            <span id="autorun-status" class="small"></span>
-            <button id="autorun-cancel" class="btn btn-outline-danger btn-sm hidden" aria-label="Cancel autorun">✕ Cancel</button>
-          </div>
-        </div>
-      </div>
 
-      <div class="card shadow-sm mb-3">
-        <div class="card-body">
-          <div class="row g-3 align-items-start">
-            <div class="col-12 col-lg-9">
-              <div class="screen-wrap">
-                <canvas id="screen" width="256" height="240" tabindex="0"></canvas>
-                <div id="shortcut-help-overlay" class="shortcut-help-overlay hidden" aria-hidden="true"></div>
-                <div id="debugger-panel" class="debugger-panel hidden" aria-label="Debugger panel"></div>
-              </div>
-              <div class="mt-3 d-flex flex-wrap align-items-center gap-2">
-                <span class="badge text-bg-dark">Status</span>
-                <span id="status" class="status">Load a ROM to begin</span>
-              </div>
+          <!-- Emulation controls -->
+          <div class="flex flex-col gap-2">
+            <button id="start" class="btn btn-success btn-sm w-full">Start</button>
+            <div class="flex gap-2">
+              <button id="pause" class="btn btn-outline btn-sm flex-1" aria-label="Pause or resume emulation">Pause</button>
+              <button id="reset" class="btn btn-warning btn-outline btn-sm flex-1" aria-label="Reset emulation">Reset</button>
             </div>
-            <div class="col-12 col-lg-2">
-              <div class="d-grid gap-2" id="screen-controls">
-                <button id="screen-minus" class="btn btn-outline-light rounded-pill btn-sm">Zoom -</button>
-                <button id="screen-plus" class="btn btn-outline-light rounded-pill btn-sm">Zoom +</button>
-                <button id="fullscreen" class="btn btn-outline-light rounded-pill btn-sm">Fullscreen</button>
-                <button id="filter-toggle" class="btn btn-outline-light rounded-pill btn-sm">Filter</button>
-                <button id="gamepad-toggle" class="btn btn-outline-light rounded-pill btn-sm" aria-pressed="true">Gamepad On</button>
-                <button id="mute" class="btn btn-outline-light rounded-pill btn-sm" aria-pressed="false">Mute</button>
-                <button id="save-state" class="btn btn-outline-warning rounded-pill btn-sm" disabled>Save State</button>
-                <button id="load-state" class="btn btn-outline-warning rounded-pill btn-sm" disabled>Load State</button>
-              </div>
-            </div>
+            <button id="stop" class="btn btn-error btn-outline btn-sm w-full" aria-label="Stop emulation">Stop</button>
           </div>
-        </div>
-      </div>
 
-      <div class="card bg-body-tertiary border-0">
-        <div class="card-body py-3">
-          <div id="controls">
-            <strong>Controls:</strong> W = Up | A = Left | S = Down | D = Right | F = A | G = B | R = Select | T = Start
+          <!-- Autorun controls -->
+          <div class="flex flex-col gap-2">
+            <label class="label cursor-pointer justify-start gap-2 p-0">
+              <input type="checkbox" id="autorun-create" class="checkbox checkbox-sm" />
+              <span class="label-text text-xs">Create autorun</span>
+            </label>
+            <button id="autorun-load" class="btn btn-info btn-outline btn-sm w-full">Load autorun</button>
+            <span id="autorun-status" class="text-xs text-info"></span>
+            <button id="autorun-cancel" class="btn btn-error btn-outline btn-sm w-full hidden" aria-label="Cancel autorun">✕ Cancel</button>
           </div>
-          <div id="shortcut-reference" class="mt-2"></div>
-        </div>
+
+          <!-- Spacer to push content up -->
+          <div class="flex-1"></div>
+        </aside>
       </div>
     </div>
 
     <!-- Autorun modal dialog (native dialog element) -->
-    <dialog id="autorun-modal" aria-labelledby="autorun-modal-label">
+    <dialog id="autorun-modal" class="modal" aria-labelledby="autorun-modal-label">
       <div class="modal-box">
-        <h5 id="autorun-modal-label">Configure Autorun</h5>
-        <div class="mb-3">
-          <label for="autorun-file-input">Autorun file (.autorun)</label>
-          <input type="file" id="autorun-file-input" accept=".autorun" />
-        </div>
-        <div id="autorun-file-info" class="hidden mb-3">
-          <div id="autorun-file-summary"></div>
-          <div class="mb-3">
-            <label for="autorun-checkpoint-select">Start from checkpoint</label>
-            <select id="autorun-checkpoint-select">
-              <option value="-1">From the beginning</option>
-            </select>
-          </div>
+        <h3 class="text-lg font-bold" id="autorun-modal-label">Configure Autorun</h3>
+        <div class="mt-4 flex flex-col gap-3">
           <div>
-            <input type="checkbox" id="autorun-extend-check" />
-            <label for="autorun-extend-check">Extend autorun (record after playback ends)</label>
+            <label for="autorun-file-input" class="label text-sm">Autorun file (.autorun)</label>
+            <input type="file" id="autorun-file-input" accept=".autorun" class="file-input file-input-bordered file-input-sm w-full" />
+          </div>
+          <div id="autorun-file-info" class="hidden">
+            <div class="alert alert-info text-sm" id="autorun-file-summary"></div>
+            <div class="mt-2">
+              <label for="autorun-checkpoint-select" class="label text-sm">Start from checkpoint</label>
+              <select id="autorun-checkpoint-select" class="select select-bordered select-sm w-full">
+                <option value="-1">From the beginning</option>
+              </select>
+            </div>
+            <label class="label cursor-pointer justify-start gap-2 mt-2">
+              <input type="checkbox" id="autorun-extend-check" class="checkbox checkbox-sm" />
+              <span class="label-text text-sm">Extend autorun (record after playback ends)</span>
+            </label>
           </div>
         </div>
         <div class="modal-action">
-          <button type="button" id="autorun-modal-cancel">Cancel</button>
-          <button type="button" id="autorun-use-btn" disabled>Use Autorun</button>
+          <button type="button" id="autorun-modal-cancel" class="btn btn-ghost">Cancel</button>
+          <button type="button" id="autorun-use-btn" class="btn btn-primary" disabled>Use Autorun</button>
         </div>
       </div>
+      <form method="dialog" class="modal-backdrop"><button>close</button></form>
     </dialog>
 
     <script type="module" src="./src/app.ts"></script>

--- a/web/main.css
+++ b/web/main.css
@@ -18,6 +18,16 @@ body {
   font-family: "Inter", system-ui, -apple-system, sans-serif;
 }
 
+/* ── Neon glow effects ───────────────────────────────────── */
+
+.btn:hover:not(:disabled) {
+  box-shadow: 0 0 12px #00f0ff40;
+}
+
+.btn:active:not(:disabled) {
+  box-shadow: 0 0 18px #00f0ff60;
+}
+
 /* ── Screen / canvas ─────────────────────────────────────── */
 
 .screen-wrap {
@@ -29,6 +39,7 @@ body {
   background: #0a0b0f;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 24px #00f0ff18;
 }
 
 .screen-wrap:fullscreen {
@@ -54,18 +65,19 @@ canvas {
   color: #9bc2ff;
 }
 
-#controls {
-  font-size: 0.9rem;
+#controls,
+#shortcut-reference {
   color: #c4c4c4;
   text-align: center;
   line-height: 1.4;
 }
 
+#controls {
+  font-size: 0.9rem;
+}
+
 #shortcut-reference {
   font-size: 0.85rem;
-  color: #c4c4c4;
-  text-align: center;
-  line-height: 1.4;
 }
 
 /* ── Overlays ────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Redesigns the web frontend layout using DaisyUI drawer sidebar and neon-themed styling, replacing the previous Bootstrap grid layout.

Closes #2021

## Changes

### Layout (index.html)
- **DaisyUI drawer**: responsive sidebar (`lg:drawer-open`) with hamburger toggle on mobile/tablet
- **Sidebar**: ASCII art NESER logo in cyan, ROM file input, bundled ROM dropdown, Start/Pause/Reset/Stop buttons, autorun controls
- **Top bar**: Zoom -/+, Fullscreen, Filter, Gamepad, Mute, Save/Load State buttons
- **Canvas area**: centered in main content with neon glow border
- **Footer**: compact keyboard reference using `<kbd>` elements
- **Autorun modal**: DaisyUI `modal` classes on native `<dialog>` with backdrop form

### Styling (main.css)
- Neon cyan (`#00f0ff`) glow on button hover/active via `box-shadow`
- Dark radial gradient body background
- Screen wrap with subtle cyan box-shadow
- Consolidated duplicate CSS selectors for `#controls` / `#shortcut-reference`

### Documentation
- Updated `architecture.md` to reflect new CSS file structure (main.css + debugger.css) and DaisyUI/Tailwind stack

## Pre-merge checks
- [x] cargo clippy (0 warnings)
- [x] cargo fmt
- [x] cargo test --no-default-features --lib (8272 passed, 1 pre-existing failure on main: test_mapper_3_autorun_gradius)
- [x] wasm-pack test (48 passed)
- [x] Python tests (201 passed)
- [x] npm test (185 passed)

## Testing
All element IDs preserved unchanged — Playwright integration tests remain compatible.
