### PR TITLE
fix(gb-apu): correct register reads when off, sweep overflow, and negate quirk

### DIFF
--- a/src/gb/apu/channel1.rs
+++ b/src/gb/apu/channel1.rs
@@ -30,8 +30,9 @@ pub struct Channel1 {
     sweep_timer: u8,    // sweep period countdown
     sweep_shadow: u16,  // shadow frequency register
     sweep_enabled: bool,
-    // Tracks whether a negate calculation has been done since last trigger
-    // (needed for the "disable-on-negate-recheck" quirk, omitted for simplicity)
+    /// Set when a negate-mode calculation is performed; cleared on trigger.
+    /// If NR10 clears the negate bit after this was set, the channel is disabled.
+    negate_used: bool,
 }
 
 impl Default for Channel1 {
@@ -63,11 +64,16 @@ impl Channel1 {
             sweep_timer: 0,
             sweep_shadow: 0,
             sweep_enabled: false,
+            negate_used: false,
         }
     }
 
     pub fn is_active(&self) -> bool {
         self.active
+    }
+
+    pub fn length_en(&self) -> bool {
+        self.length_en
     }
 
     /// Output sample in 0.0–1.0 range.
@@ -125,7 +131,12 @@ impl Channel1 {
             self.sweep_timer = self.sweep_timer_reload();
             if self.sweep_enabled && self.sweep_period > 0 {
                 let new_freq = self.compute_swept_frequency();
-                if new_freq <= 2047 && self.sweep_shift > 0 {
+                if self.sweep_negate {
+                    self.negate_used = true;
+                }
+                if new_freq > 2047 {
+                    self.active = false;
+                } else if self.sweep_shift > 0 {
                     self.sweep_shadow = new_freq;
                     self.freq = new_freq;
                     // Re-check overflow against the newly loaded frequency.
@@ -219,9 +230,15 @@ impl Channel1 {
     // ── Register writes ───────────────────────────────────────────────────
 
     pub fn write_nr10(&mut self, val: u8) {
+        let old_negate = self.sweep_negate;
         self.sweep_period = (val >> 4) & 0x07;
         self.sweep_negate = val & 0x08 != 0;
         self.sweep_shift = val & 0x07;
+        // Hardware quirk: if negate mode was used since last trigger and is now cleared,
+        // the channel is immediately disabled.
+        if old_negate && !self.sweep_negate && self.negate_used {
+            self.active = false;
+        }
     }
 
     pub fn write_nr11(&mut self, val: u8) {
@@ -273,6 +290,7 @@ impl Channel1 {
         self.sweep_shadow = self.freq;
         self.sweep_timer = self.sweep_timer_reload();
         self.sweep_enabled = self.sweep_period > 0 || self.sweep_shift > 0;
+        self.negate_used = false;
         // Trigger-time overflow check required by hardware even when sweep is otherwise idle.
         if self.sweep_shift > 0 {
             self.disable_if_sweep_overflows();
@@ -534,6 +552,57 @@ mod tests {
         assert_eq!(ch.read_nr14() & 0x40, 0x40);
         ch.write_nr14(0x00);
         assert_eq!(ch.read_nr14() & 0x40, 0x00);
+    }
+
+    // ── Sweep correctness (hardware quirks) ──────────────────────────────
+
+    #[test]
+    fn test_clock_sweep_disables_channel_on_overflow_when_shift_zero() {
+        // Given: sweep period=1, negate=false, shift=0 and freq=1400;
+        // When: clock_sweep fires;
+        // Then: new_freq = 1400+1400 = 2800 > 2047 → channel disabled even though shift=0.
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0); // DAC on
+        // NR10: period=1 (0x10>>4 & 0x07 = 1), negate=0, shift=0
+        ch.write_nr10(0x10);
+        // freq = 1400 = 0x578 → lo=0x78, hi=0x05
+        ch.write_nr13(0x78);
+        ch.write_nr14(0x85); // trigger + freq_hi=5
+        assert!(ch.is_active(), "channel must be active after trigger");
+        // sweep fires: timer 1→0, reload=1, enabled=true, period=1
+        // new_freq = 1400 + (1400>>0) = 2800 > 2047 → must disable
+        ch.clock_sweep();
+        assert!(
+            !ch.is_active(),
+            "channel must be disabled when sweep overflows even with shift=0"
+        );
+    }
+
+    #[test]
+    fn test_disabling_negate_after_calculation_disables_channel() {
+        // Given: CH1 with sweep period=1, negate=true, shift=1, freq=100;
+        //   After trigger and one sweep clock, a negate calculation is done (negate_used=true);
+        // When: NR10 is written clearing negate;
+        // Then: channel is disabled (hardware "negate-used" quirk).
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0); // DAC on
+        // NR10: period=1, negate=1, shift=1 → 0x19
+        ch.write_nr10(0x19);
+        ch.write_nr13(0x64); // freq = 100
+        ch.write_nr14(0x80); // trigger
+        assert!(ch.is_active(), "channel must be active after trigger");
+        // One sweep clock in negate mode → negate_used must be set
+        ch.clock_sweep();
+        assert!(
+            ch.is_active(),
+            "channel still active after negate calculation"
+        );
+        // Clear negate in NR10: period=1, negate=0, shift=1 → 0x11
+        ch.write_nr10(0x11);
+        assert!(
+            !ch.is_active(),
+            "channel must be disabled when negate is cleared after a negate calculation"
+        );
     }
 
     // ── Output level ──────────────────────────────────────────────────────

--- a/src/gb/apu/channel2.rs
+++ b/src/gb/apu/channel2.rs
@@ -50,6 +50,10 @@ impl Channel2 {
         self.active
     }
 
+    pub fn length_en(&self) -> bool {
+        self.length_en
+    }
+
     pub fn output(&self) -> f32 {
         if !self.active || !self.dac_on {
             return 0.0;

--- a/src/gb/apu/channel3.rs
+++ b/src/gb/apu/channel3.rs
@@ -54,6 +54,10 @@ impl Channel3 {
         self.active
     }
 
+    pub fn length_en(&self) -> bool {
+        self.length_en
+    }
+
     /// Output sample in 0.0–1.0 range.
     pub fn output(&self) -> f32 {
         if !self.active || !self.dac_on {

--- a/src/gb/apu/channel4.rs
+++ b/src/gb/apu/channel4.rs
@@ -55,6 +55,10 @@ impl Channel4 {
         self.active
     }
 
+    pub fn length_en(&self) -> bool {
+        self.length_en
+    }
+
     pub fn output(&self) -> f32 {
         if !self.active || !self.dac_on {
             return 0.0;

--- a/src/gb/apu/mod.rs
+++ b/src/gb/apu/mod.rs
@@ -209,15 +209,11 @@ impl Apu {
 
     /// Read an APU register.
     ///
-    /// Returns $FF for unimplemented or write-only bits / unused registers.
-    /// When powered off, all NR10–NR51 reads return $FF (consistent with
-    /// DMG/SameBoy behavior: registers are inaccessible while APU is off).
+    /// Returns $FF for write-only bits / unused registers.
+    /// When powered off, registers NR10–NR51 return their cleared values
+    /// (with unused bits set per the normal masking), consistent with DMG hardware.
     /// NR52 and wave RAM are always readable.
     pub fn read_register(&self, addr: u16) -> u8 {
-        // NR10–NR51: return $FF when APU is powered off.
-        if !self.powered && (0xFF10..=0xFF25).contains(&addr) {
-            return 0xFF;
-        }
         match addr {
             // CH1
             0xFF10 => self.ch1.read_nr10(),
@@ -499,6 +495,30 @@ mod tests {
             apu.tick(1);
         }
         assert_eq!(apu.fs_step, 0, "fs_step must wrap back to 0 after 8 steps");
+    }
+
+    // ── Register reads when powered off ──────────────────────────────────
+
+    #[test]
+    fn test_registers_return_cleared_values_when_powered_off() {
+        // Given: APU powered on then off;
+        // When: read NR10 (0xFF10) and NR12 (0xFF12);
+        // Then: they return the cleared register value (with unused bits set),
+        //   not 0xFF across the board.
+        let mut apu = powered_apu();
+        apu.write_register(0xFF26, 0x00); // power off
+        // ch1 cleared → read_nr10() = 0x80 (bit 7 always 1, all others 0)
+        assert_eq!(
+            apu.read_register(0xFF10),
+            0x80,
+            "NR10 must return cleared 0x80 when powered off (not 0xFF)"
+        );
+        // ch1 cleared → read_nr12() = 0x00 (all fields zero)
+        assert_eq!(
+            apu.read_register(0xFF12),
+            0x00,
+            "NR12 must return cleared 0x00 when powered off (not 0xFF)"
+        );
     }
 
     // ── NR52 channel-active status bits ───────────────────────────────────

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -893,23 +893,24 @@ mod tests {
     }
 
     #[test]
-    fn test_apu_registers_return_ff_when_powered_off() {
-        // When the APU is powered off, NR10–NR51 reads must return $FF.
+    fn test_apu_registers_return_cleared_values_when_powered_off() {
+        // When the APU is powered off, NR10–NR51 return their cleared values
+        // (writes are ignored; registers were cleared on power-off).
         let mut bus = make_bus();
         // APU starts powered off. Write a non-zero value to NR51 — should be ignored.
         bus.write(0xFF25, 0xAB);
-        // Read NR51: must return $FF because APU is off.
+        // Read NR51: must return 0x00 (cleared value) because APU is off.
         assert_eq!(
             bus.read(0xFF25),
-            0xFF,
-            "NR51 must read $FF when APU is powered off"
+            0x00,
+            "NR51 must read 0x00 (cleared) when APU is powered off"
         );
         // Same for NR50.
         bus.write(0xFF24, 0x77);
         assert_eq!(
             bus.read(0xFF24),
-            0xFF,
-            "NR50 must read $FF when APU is powered off"
+            0x00,
+            "NR50 must read 0x00 (cleared) when APU is powered off"
         );
     }
 

--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -332,7 +332,6 @@ fn test_mem_timing_2() {
 // ── dmg_sound single ROMs ────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "failing: APU off-state register read behaviour (NR52 bit 7) — tracked in #2034"]
 fn test_dmg_sound_01_registers() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/01-registers.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
@@ -364,7 +363,6 @@ fn test_dmg_sound_03_trigger() {
 }
 
 #[test]
-#[ignore = "failing: CH1 sweep calculation on trigger when shift=0 — tracked in #2034"]
 fn test_dmg_sound_04_sweep() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/04-sweep.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
@@ -397,7 +395,6 @@ fn test_dmg_sound_06_overflow_on_trigger() {
 }
 
 #[test]
-#[ignore = "failing: length/sweep period synchronisation (no output, likely hangs) — tracked in #2034"]
 fn test_dmg_sound_07_len_sweep_period_sync() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/07-len sweep period sync.gb");
@@ -469,7 +466,6 @@ fn test_dmg_sound_12_wave_write_while_on() {
 // ── cgb_sound single ROMs ─────────────────────────────────────────────────────
 
 #[test]
-#[ignore = "failing: APU off-state register read behaviour (NR52 bit 7) — tracked in #2034"]
 fn test_cgb_sound_01_registers() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/01-registers.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
@@ -501,7 +497,6 @@ fn test_cgb_sound_03_trigger() {
 }
 
 #[test]
-#[ignore = "failing: CH1 sweep calculation on trigger when shift=0 — tracked in #2034"]
 fn test_cgb_sound_04_sweep() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/04-sweep.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
@@ -534,7 +529,6 @@ fn test_cgb_sound_06_overflow_on_trigger() {
 }
 
 #[test]
-#[ignore = "failing: length/sweep period synchronisation (no output, likely hangs) — tracked in #2034"]
 fn test_cgb_sound_07_len_sweep_period_sync() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/07-len sweep period sync.gb");


### PR DESCRIPTION
## Summary

Fixes three APU emulation correctness bugs in the GB/DMG emulator. Six more Blargg sound integration tests now pass, with zero regressions.

### Tests gained (newly passing, `#[ignore]` removed)
| Test | Fix |
|---|---|
| `dmg_sound_01_registers` | Register reads when powered off |
| `cgb_sound_01_registers` | Register reads when powered off |
| `dmg_sound_04_sweep` | Sweep overflow with shift=0 |
| `cgb_sound_04_sweep` | Sweep overflow with shift=0 |
| `dmg_sound_07_len_sweep_period_sync` | Passes after sweep fix |
| `cgb_sound_07_len_sweep_period_sync` | Passes after sweep fix |

### Changes

**Fix 1 — Register reads when APU is powered off** (`mod.rs`)  
Previously `read_register` returned `0xFF` for every NR10–NR25 address when the APU was powered off. Hardware returns each register's cleared value with proper unused-bit masking instead (e.g. NR10 → `0x80`, NR12 → `0x00`).

**Fix 2 — Sweep overflow check when shift=0** (`channel1.rs`)  
`clock_sweep()` skipped the overflow check when `sweep_shift == 0`. Per hardware spec the overflow check must fire regardless of shift; only the frequency register update is gated on `shift > 0`.

**Fix 3 — Negate-used quirk** (`channel1.rs`)  
Added `negate_used: bool` to `Channel1`. It is set whenever a negate-mode sweep calculation fires and cleared on trigger. Writing NR10 to clear negate mode after a negate calculation immediately disables the channel.

### New unit tests (3)
- `test_registers_return_cleared_values_when_powered_off`
- `test_clock_sweep_disables_channel_on_overflow_when_shift_zero`
- `test_disabling_negate_after_calculation_disables_channel`

### Pre-existing issue
A clippy warning (`unused import: NametableLayout` in `mapper256.rs`) already exists on `main` and is unrelated to this PR.

Closes #2034
