### PR TITLE
feat(platform): introduce Emulator trait for system-agnostic dispatch

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -14,14 +14,15 @@ The codebase is roughly 183,000 lines of Rust, with additional JavaScript for th
 ┌───────────────────────────────────────────────────────┐
 │                     Frontends                         │
 │  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐   │
-│  │Native Frntend│ │ TUI Frontend │ │ WASM Frontend│   │
+│  │Native Frontend│ │ TUI Frontend │ │ WASM Frontend│   │
 │  │(Desktop, GL) │ │ (Terminal)   │ │ (Browser)    │   │
 │  └──────┬───────┘ └──────┬───────┘ └──────┬───────┘   │
 │         │                │                │           │
 │         └────────────────┼────────────────┘           │
 │                          ▼                            │
 │  ┌─────────────────────────────────────────────────┐  │
-│  │  Console enum + Emulator trait (src/emulator.rs)│  │
+│  │  Console enum + Emulator trait                  │  │
+│  │  (src/platform/emulator.rs)                      │  │
 │  │  Hardware-agnostic interface: run_tick, render, │  │
 │  │  audio, input, save/load state, reset           │  │
 │  │  Variants: Console::Nes(Nes), Console::GameBoy  │  │
@@ -65,9 +66,9 @@ The codebase is roughly 183,000 lines of Rust, with additional JavaScript for th
 
 The emulator is designed around a **multi-layer architecture**:
 
-- **Emulator trait + Console enum** (`src/emulator.rs`): The `Emulator` trait defines the common interface that every emulated system must implement (run, render, audio, input, save/load state, reset — 22 methods total). `Nes` and `GameBoy` implement the trait in their respective modules. The `Console` enum wraps both systems and delegates common methods through `as_core()`/`as_core_mut()` (which return `&dyn Emulator`), keeping a single pair of match arms instead of one per method. System-specific features (NES debugging, PPU viewer, Zapper) are still accessed by matching on `Console::Nes`.
+- **Emulator trait + Console enum** (`src/platform/emulator.rs`): The `Emulator` trait defines the common interface that every emulated system must implement (run, render, audio, input, save/load state, reset — 22 methods total). `Nes` and `GameBoy` implement the trait in their respective modules. The `Console` enum wraps both systems and delegates common methods through `as_core()`/`as_core_mut()` (which return `&dyn Emulator`), keeping a single pair of match arms instead of one per method. System-specific features (NES debugging, PPU viewer, Zapper) are still accessed by matching on `Console::Nes`.
 - **NES emulator** (`src/nes/`): All NES-specific hardware lives under this namespace. The `Nes` struct in `src/nes/console/nes.rs` orchestrates the per-cycle stepping of CPU, PPU, APU, and Bus.
-- **Shared platform** (`src/`): `FrontendConfig` (src/config.rs), `AppContext` (src/app_context.rs), audio infrastructure, and rendering backends are shared across all emulated systems.
+- **Shared platform** (`src/platform/`): `FrontendConfig` (src/platform/config.rs), `AppContext` (src/platform/app_context.rs), audio infrastructure, and rendering backends are shared across all emulated systems.
 - **Bus-centric hardware**: Within the NES, the `Bus` struct routes memory reads and writes between the CPU, PPU registers, APU registers, RAM, OAM DMA, controller ports, and the cartridge mapper.
 
 ## Binaries and Scripts
@@ -107,9 +108,9 @@ The `src/bin/roms.rs` file is a library binary (accessed via `cargo run --bin ro
 
 | File | Description |
 | ------ | ------------- |
-| `src/emulator.rs` | `Emulator` trait — defines the common interface (22 methods) for all emulated systems: `run_tick`, `is_ready_to_render`, `screen_snapshot`, `get_sample`, `set_button`, `save_state_bytes`/`load_state_bytes`, `reset`, etc. `Console` enum wraps `Box<Nes>` and `Box<GameBoy>`, delegating common methods through `as_core()`/`as_core_mut()`. System-specific features accessed via variant matching (`Console::Nes`). |
-| `src/config.rs` | `FrontendConfig` struct — generic frontend settings (audio, video, autorun, debugger, window) shared across all emulated systems. |
-| `src/app_context.rs` | `AppContext` — shared application state including configuration, ROM database, and toast notification manager. Wrapped in `Rc<RefCell<>>` for interior mutability. |
+| `src/platform/emulator.rs` | `Emulator` trait — defines the common interface (22 methods) for all emulated systems: `run_tick`, `is_ready_to_render`, `screen_snapshot`, `get_sample`, `set_button`, `save_state_bytes`/`load_state_bytes`, `reset`, etc. `Console` enum wraps `Box<Nes>` and `Box<GameBoy>`, delegating common methods through `as_core()`/`as_core_mut()`. System-specific features accessed via variant matching (`Console::Nes`). |
+| `src/platform/config.rs` | `FrontendConfig` struct — generic frontend settings (audio, video, autorun, debugger, window) shared across all emulated systems. |
+| `src/platform/app_context.rs` | `AppContext` — shared application state including configuration, ROM database, and toast notification manager. Wrapped in `Rc<RefCell<>>` for interior mutability. |
 
 #### NES Emulation (`src/nes/`)
 

--- a/architecture.md
+++ b/architecture.md
@@ -14,18 +14,18 @@ The codebase is roughly 183,000 lines of Rust, with additional JavaScript for th
 ┌───────────────────────────────────────────────────────┐
 │                     Frontends                         │
 │  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐   │
-│  │Native Frontend│ │ TUI Frontend │ │ WASM Frontend│   │
+│  │Native Frntend│ │ TUI Frontend │ │ WASM Frontend│   │
 │  │(Desktop, GL) │ │ (Terminal)   │ │ (Browser)    │   │
 │  └──────┬───────┘ └──────┬───────┘ └──────┬───────┘   │
 │         │                │                │           │
 │         └────────────────┼────────────────┘           │
 │                          ▼                            │
 │  ┌─────────────────────────────────────────────────┐  │
-│  │  Console enum (src/emulator.rs)                 │  │
-│  │  Hardware-agnostic interface: run_tick, render,  │  │
+│  │  Console enum + Emulator trait (src/emulator.rs)│  │
+│  │  Hardware-agnostic interface: run_tick, render, │  │
 │  │  audio, input, save/load state, reset           │  │
-│  │  Variants: Console::Nes(Nes)                    │  │
-│  └──────────────────────┬─────────────────────────┘  │
+│  │  Variants: Console::Nes(Nes), Console::GameBoy  │  │
+│  └──────────────────────┬─────────────────────────┘   │
 │                          │                            │
 │                          ▼                            │
 │  ┌─────────────────────────────────────────────────┐  │
@@ -58,14 +58,14 @@ The codebase is roughly 183,000 lines of Rust, with additional JavaScript for th
 │                                                       │
 │  ┌─────────────────────────────────────────────────┐  │
 │  │  Shared Platform (src/)                         │  │
-│  │  AppContext · FrontendConfig · Audio · Rendering │  │
+│  │  AppContext · FrontendConfig · Audio · Rendering│  │
 │  └─────────────────────────────────────────────────┘  │
 └───────────────────────────────────────────────────────┘
 ```
 
 The emulator is designed around a **multi-layer architecture**:
 
-- **Console enum** (`src/emulator.rs`): Hardware-agnostic dispatch layer. Frontends program against `Console` for common operations (run, render, audio, input, save/load state, reset). System-specific features (NES debugging, PPU viewer, Zapper) are accessed by matching on the `Console::Nes` variant.
+- **Emulator trait + Console enum** (`src/emulator.rs`): The `Emulator` trait defines the common interface that every emulated system must implement (run, render, audio, input, save/load state, reset — 22 methods total). `Nes` and `GameBoy` implement the trait in their respective modules. The `Console` enum wraps both systems and delegates common methods through `as_core()`/`as_core_mut()` (which return `&dyn Emulator`), keeping a single pair of match arms instead of one per method. System-specific features (NES debugging, PPU viewer, Zapper) are still accessed by matching on `Console::Nes`.
 - **NES emulator** (`src/nes/`): All NES-specific hardware lives under this namespace. The `Nes` struct in `src/nes/console/nes.rs` orchestrates the per-cycle stepping of CPU, PPU, APU, and Bus.
 - **Shared platform** (`src/`): `FrontendConfig` (src/config.rs), `AppContext` (src/app_context.rs), audio infrastructure, and rendering backends are shared across all emulated systems.
 - **Bus-centric hardware**: Within the NES, the `Bus` struct routes memory reads and writes between the CPU, PPU registers, APU registers, RAM, OAM DMA, controller ports, and the cartridge mapper.
@@ -107,7 +107,7 @@ The `src/bin/roms.rs` file is a library binary (accessed via `cargo run --bin ro
 
 | File | Description |
 | ------ | ------------- |
-| `src/emulator.rs` | `Console` enum — hardware-agnostic wrapper around system-specific emulators. Provides common interface: `run_tick`, `is_ready_to_render`, `screen_snapshot`, `get_sample`, `set_button`, `save_state_bytes`/`load_state_bytes`, `reset`. System-specific features accessed via variant matching (`Console::Nes`). |
+| `src/emulator.rs` | `Emulator` trait — defines the common interface (22 methods) for all emulated systems: `run_tick`, `is_ready_to_render`, `screen_snapshot`, `get_sample`, `set_button`, `save_state_bytes`/`load_state_bytes`, `reset`, etc. `Console` enum wraps `Box<Nes>` and `Box<GameBoy>`, delegating common methods through `as_core()`/`as_core_mut()`. System-specific features accessed via variant matching (`Console::Nes`). |
 | `src/config.rs` | `FrontendConfig` struct — generic frontend settings (audio, video, autorun, debugger, window) shared across all emulated systems. |
 | `src/app_context.rs` | `AppContext` — shared application state including configuration, ROM database, and toast notification manager. Wrapped in `Rc<RefCell<>>` for interior mutability. |
 
@@ -119,7 +119,7 @@ All NES-specific hardware and supporting code lives under `src/nes/`.
 | ---------------- | ------------- |
 | `src/nes/mod.rs` | Module declarations for all NES sub-modules. |
 | `src/nes/console/` | Top-level NES orchestration. |
-| `src/nes/console/nes.rs` | The `Nes` struct — creates and owns CPU, PPU, APU, and Bus. Runs the master clock cycle loop. Handles save state capture/restore, cartridge insertion, and reset logic. |
+| `src/nes/console/nes.rs` | The `Nes` struct — creates and owns CPU, PPU, APU, and Bus. Runs the master clock cycle loop. Handles save state capture/restore, cartridge insertion, and reset logic. Implements the `Emulator` trait for system-agnostic dispatch. |
 | `src/nes/console/config.rs` | `Config` struct (composition of `FrontendConfig` + `NesConfig`), `NesConfig` struct (NES-specific hardware settings), and CLI argument parser. Defines all command-line flags, config file loading, and hardware/timing/input settings. |
 | `src/nes/console/cartridge_catalog.rs` | Scans directories for NES ROMs and builds/caches a CSV catalog of discovered cartridges for the TUI launcher. |
 | `src/nes/console/ram_init.rs` | RAM initialization modes: `Zero`, `Random`, and `SeededRandom` for deterministic test setups. |
@@ -212,7 +212,8 @@ All Game Boy (DMG) hardware lives under `src/gb/`. The module is structured arou
 | Directory/File | Description |
 | ---------------- | ------------- |
 | `src/gb/mod.rs` | Module declarations for all GB sub-modules. |
-| `src/gb/console.rs` | `Gb<B: GbBus>` — thin console shell that owns the CPU. `step()` executes one instruction and ticks the bus by the elapsed M-cycles. |
+| `src/gb/console/mod.rs` | `Gb<B: GbBus>` — thin console shell that owns the CPU. `step()` executes one instruction and ticks the bus by the elapsed M-cycles. DMG-specific impls for screen, frame-ready, and reset. |
+| `src/gb/console/gameboy.rs` | `GameBoy` — platform-facing wrapper that owns a `Gb<DmgBus>` (created lazily on `load_rom`). Implements the `Emulator` trait for system-agnostic dispatch. |
 | `src/gb/bus/bus.rs` | `GbBus` trait — `read(&mut self, addr: u16) -> u8`, `write(&mut self, addr: u16, val: u8)`, and a default no-op `tick(&mut self, m_cycles: u8)`. `StubBus` implements the trait for unit tests. |
 | `src/gb/bus/dmg_bus.rs` | `DmgBus` — full DMG memory map. Routes all 16-bit addresses to cartridge ROM/RAM, VRAM, WRAM, echo RAM, OAM, HRAM, Timer registers ($FF04–$FF07), APU registers ($FF10–$FF3F), IF ($FF0F), IE ($FFFF), and I/O stubs. Owns the cartridge, Timer, and APU. Overrides `tick()` to advance the Timer, APU, and propagate timer interrupts to IF. Exposes `sample_ready()`/`take_sample()`/`set_audio_sample_rate()` for the platform audio layer. |
 | `src/gb/apu/mod.rs` | `Apu` — DMG Audio Processing Unit. 8-step frame sequencer (512 Hz), NR50/NR51/NR52 power/volume/panning control, mixer (NR51 L/R routing, NR50 master volume), sample output pipeline (fractional M-cycle accumulator). |

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -8,6 +8,7 @@ use crate::gb::bus::DmgBus;
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
+use crate::platform::emulator::{Emulator, SystemType};
 
 /// Platform-facing Game Boy (DMG) console wrapper.
 pub struct GameBoy {
@@ -139,6 +140,105 @@ impl GameBoy {
     /// Access the shared application context.
     pub fn app_context(&self) -> &SharedAppContext {
         &self.app_context
+    }
+}
+
+impl Emulator for GameBoy {
+    fn system_type(&self) -> SystemType {
+        SystemType::GameBoy
+    }
+
+    fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String> {
+        GameBoy::load_rom(self, bytes, name)
+    }
+
+    fn run_tick(&mut self) -> u8 {
+        GameBoy::run_tick(self)
+    }
+
+    fn is_ready_to_render(&self) -> bool {
+        self.is_frame_ready()
+    }
+
+    fn clear_ready_to_render(&mut self) {
+        self.clear_frame_ready()
+    }
+
+    fn screen_width(&self) -> u32 {
+        GameBoy::SCREEN_WIDTH
+    }
+
+    fn screen_height(&self) -> u32 {
+        GameBoy::SCREEN_HEIGHT
+    }
+
+    fn screen_snapshot(&self) -> Vec<u8> {
+        GameBoy::screen_snapshot(self)
+    }
+
+    fn cropped_screen_snapshot(&self, _h_overscan: u32, _v_overscan: u32) -> Vec<u8> {
+        GameBoy::cropped_screen_snapshot(self)
+    }
+
+    fn screen_crc32(&self) -> u32 {
+        GameBoy::screen_crc32(self)
+    }
+
+    fn sample_ready(&self) -> bool {
+        GameBoy::sample_ready(self)
+    }
+
+    fn get_sample(&mut self) -> Option<f32> {
+        GameBoy::get_sample(self)
+    }
+
+    fn set_audio_sample_rate(&mut self, rate: f32) {
+        GameBoy::set_audio_sample_rate(self, rate)
+    }
+
+    fn set_button(&mut self, port: u8, button_id: u8, pressed: bool) {
+        if port == 0 {
+            GameBoy::set_button(self, button_id, pressed);
+        }
+    }
+
+    fn set_joypad_button_states(&mut self, port: u8, state: u8) {
+        if port == 0 {
+            GameBoy::set_joypad_button_states(self, state);
+        }
+    }
+
+    fn get_joypad_button_states(&self, port: u8) -> u8 {
+        if port == 0 {
+            GameBoy::get_joypad_button_states(self)
+        } else {
+            0
+        }
+    }
+
+    fn save_state_bytes(&self) -> Result<Vec<u8>, String> {
+        GameBoy::save_state_bytes(self)
+    }
+
+    fn load_state_bytes(&mut self, data: &[u8]) -> Result<(), String> {
+        GameBoy::load_state_bytes(self, data)
+    }
+
+    fn reset(&mut self, soft_reset: bool) {
+        GameBoy::reset(self, soft_reset)
+    }
+
+    fn save_ram(&self) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn app_context(&self) -> &SharedAppContext {
+        GameBoy::app_context(self)
+    }
+
+    fn target_frame_duration(&self) -> std::time::Duration {
+        // DMG: 4,194,304 Hz clock / 70,224 cycles per frame ≈ 59.7275 fps
+        std::time::Duration::from_secs_f64(70_224.0 / 4_194_304.0)
     }
 }
 

--- a/src/nes/console/nes.rs
+++ b/src/nes/console/nes.rs
@@ -13,6 +13,7 @@ use crate::nes::input::ControllerType;
 use crate::nes::ppu::{Ppu, PpuState, SharedPpu};
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
 use crate::platform::debugging::{Tracing, log_info};
+use crate::platform::emulator::{Emulator, SystemType};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -1174,6 +1175,108 @@ impl Nes {
         } else {
             false
         }
+    }
+}
+
+impl Emulator for Nes {
+    fn system_type(&self) -> SystemType {
+        SystemType::Nes
+    }
+
+    fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String> {
+        Nes::load_rom(self, bytes, name)
+    }
+
+    fn run_tick(&mut self) -> u8 {
+        self.run_cpu_tick()
+    }
+
+    fn is_ready_to_render(&self) -> bool {
+        Nes::is_ready_to_render(self)
+    }
+
+    fn clear_ready_to_render(&mut self) {
+        Nes::clear_ready_to_render(self)
+    }
+
+    fn screen_width(&self) -> u32 {
+        Nes::SCREEN_WIDTH
+    }
+
+    fn screen_height(&self) -> u32 {
+        Nes::SCREEN_HEIGHT
+    }
+
+    fn screen_snapshot(&self) -> Vec<u8> {
+        self.get_screen_buffer().snapshot()
+    }
+
+    fn cropped_screen_snapshot(&self, h_overscan: u32, v_overscan: u32) -> Vec<u8> {
+        self.get_screen_buffer()
+            .cropped_snapshot(h_overscan, v_overscan)
+    }
+
+    fn screen_crc32(&self) -> u32 {
+        self.get_screen_buffer().crc32()
+    }
+
+    fn sample_ready(&self) -> bool {
+        Nes::sample_ready(self)
+    }
+
+    fn get_sample(&mut self) -> Option<f32> {
+        Nes::get_sample(self)
+    }
+
+    fn set_audio_sample_rate(&mut self, rate: f32) {
+        Nes::set_audio_sample_rate(self, rate)
+    }
+
+    fn set_button(&mut self, port: u8, button_id: u8, pressed: bool) {
+        if !self.set_button_by_id(port, button_id, pressed) {
+            #[cfg(debug_assertions)]
+            eprintln!("warning: invalid NES button_id: {button_id}");
+        }
+    }
+
+    fn set_joypad_button_states(&mut self, port: u8, state: u8) {
+        Nes::set_joypad_button_states(self, port, state)
+    }
+
+    fn get_joypad_button_states(&self, port: u8) -> u8 {
+        Nes::get_joypad_button_states(self, port)
+    }
+
+    fn save_state_bytes(&self) -> Result<Vec<u8>, String> {
+        Nes::save_state_bytes(self)
+    }
+
+    fn load_state_bytes(&mut self, data: &[u8]) -> Result<(), String> {
+        Nes::load_state_bytes(self, data)
+    }
+
+    fn reset(&mut self, soft_reset: bool) {
+        Nes::reset(self, soft_reset)
+    }
+
+    fn save_ram(&self) -> Result<(), String> {
+        Nes::save_ram(self).map_err(|e| e.to_string())
+    }
+
+    fn app_context(&self) -> &SharedAppContext {
+        Nes::app_context(self)
+    }
+
+    fn target_frame_duration(&self) -> std::time::Duration {
+        let hz = self
+            .app_context()
+            .borrow()
+            .config()
+            .nes
+            .hardware_model
+            .timing_mode()
+            .frame_rate_hz();
+        std::time::Duration::from_secs_f64(1.0 / hz)
     }
 }
 

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -4,10 +4,46 @@
 //! and provides a common interface that frontends can program against.
 //! NES-specific features (debugging, PPU viewer, etc.) are accessed by
 //! matching on the [`Console::Nes`] variant directly.
+//!
+//! The [`Emulator`] trait defines the common operations every emulated system
+//! must support.  `Console` delegates its common methods through
+//! [`as_core()`](Console::as_core) / [`as_core_mut()`](Console::as_core_mut),
+//! keeping a single pair of match arms instead of one pair per method.
 
 use crate::gb::GameBoy;
 use crate::nes::console::Nes;
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
+
+/// Common operations that every emulated system must support.
+///
+/// Frontends program against this trait (via [`Console`]) for system-agnostic
+/// functionality: execution, rendering, audio, input, state management, and
+/// configuration.  System-specific features are accessed by downcasting the
+/// [`Console`] variant.
+pub trait Emulator {
+    fn system_type(&self) -> SystemType;
+    fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String>;
+    fn run_tick(&mut self) -> u8;
+    fn is_ready_to_render(&self) -> bool;
+    fn clear_ready_to_render(&mut self);
+    fn screen_width(&self) -> u32;
+    fn screen_height(&self) -> u32;
+    fn screen_snapshot(&self) -> Vec<u8>;
+    fn cropped_screen_snapshot(&self, h_overscan: u32, v_overscan: u32) -> Vec<u8>;
+    fn screen_crc32(&self) -> u32;
+    fn sample_ready(&self) -> bool;
+    fn get_sample(&mut self) -> Option<f32>;
+    fn set_audio_sample_rate(&mut self, rate: f32);
+    fn set_button(&mut self, port: u8, button_id: u8, pressed: bool);
+    fn set_joypad_button_states(&mut self, port: u8, state: u8);
+    fn get_joypad_button_states(&self, port: u8) -> u8;
+    fn save_state_bytes(&self) -> Result<Vec<u8>, String>;
+    fn load_state_bytes(&mut self, data: &[u8]) -> Result<(), String>;
+    fn reset(&mut self, soft_reset: bool);
+    fn save_ram(&self) -> Result<(), String>;
+    fn app_context(&self) -> &SharedAppContext;
+    fn target_frame_duration(&self) -> std::time::Duration;
+}
 
 /// Identifies which emulated system a [`Console`] instance is running.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,12 +79,25 @@ impl Console {
         Console::GameBoy(Box::new(GameBoy::new(app_context)))
     }
 
+    /// Access the common emulator interface (immutable).
+    pub fn as_core(&self) -> &dyn Emulator {
+        match self {
+            Console::Nes(nes) => nes.as_ref(),
+            Console::GameBoy(gb) => gb.as_ref(),
+        }
+    }
+
+    /// Access the common emulator interface (mutable).
+    pub fn as_core_mut(&mut self) -> &mut dyn Emulator {
+        match self {
+            Console::Nes(nes) => nes.as_mut(),
+            Console::GameBoy(gb) => gb.as_mut(),
+        }
+    }
+
     /// Which system this console is emulating.
     pub fn system_type(&self) -> SystemType {
-        match self {
-            Console::Nes(_) => SystemType::Nes,
-            Console::GameBoy(_) => SystemType::GameBoy,
-        }
+        self.as_core().system_type()
     }
 
     /// Load a ROM into the emulator.
@@ -61,53 +110,35 @@ impl Console {
     /// to inspect the cartridge before insertion (timing mode, toasts),
     /// destructure the Console variant and use `insert_cartridge` directly.
     pub fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String> {
-        match self {
-            Console::Nes(nes) => nes.load_rom(bytes, name),
-            Console::GameBoy(gb) => gb.load_rom(bytes, name),
-        }
+        self.as_core_mut().load_rom(bytes, name)
     }
 
     /// Execute one CPU tick (instruction) and advance all subsystems.
     ///
     /// Returns the number of CPU cycles consumed.
     pub fn run_tick(&mut self) -> u8 {
-        match self {
-            Console::Nes(nes) => nes.run_cpu_tick(),
-            Console::GameBoy(gb) => gb.run_tick(),
-        }
+        self.as_core_mut().run_tick()
     }
 
     /// Returns `true` when a complete frame has been rendered and is ready
     /// for display.
     pub fn is_ready_to_render(&self) -> bool {
-        match self {
-            Console::Nes(nes) => nes.is_ready_to_render(),
-            Console::GameBoy(gb) => gb.is_frame_ready(),
-        }
+        self.as_core().is_ready_to_render()
     }
 
     /// Clear the frame-ready flag after the frontend has consumed the frame.
     pub fn clear_ready_to_render(&mut self) {
-        match self {
-            Console::Nes(nes) => nes.clear_ready_to_render(),
-            Console::GameBoy(gb) => gb.clear_frame_ready(),
-        }
+        self.as_core_mut().clear_ready_to_render()
     }
 
     /// Width of the emulated display in pixels.
     pub fn screen_width(&self) -> u32 {
-        match self {
-            Console::Nes(_) => Nes::SCREEN_WIDTH,
-            Console::GameBoy(_) => GameBoy::SCREEN_WIDTH,
-        }
+        self.as_core().screen_width()
     }
 
     /// Height of the emulated display in pixels.
     pub fn screen_height(&self) -> u32 {
-        match self {
-            Console::Nes(_) => Nes::SCREEN_HEIGHT,
-            Console::GameBoy(_) => GameBoy::SCREEN_HEIGHT,
-        }
+        self.as_core().screen_height()
     }
 
     /// Returns a snapshot of the current frame as RGB888 bytes.
@@ -115,10 +146,7 @@ impl Console {
     /// The returned buffer has `screen_width() * screen_height() * 3` bytes,
     /// ordered row-major with 3 bytes per pixel (R, G, B).
     pub fn screen_snapshot(&self) -> Vec<u8> {
-        match self {
-            Console::Nes(nes) => nes.get_screen_buffer().snapshot(),
-            Console::GameBoy(gb) => gb.screen_snapshot(),
-        }
+        self.as_core().screen_snapshot()
     }
 
     /// Returns a cropped snapshot with overscan removed.
@@ -126,28 +154,18 @@ impl Console {
     /// `h_overscan` pixels are removed from left and right edges.
     /// `v_overscan` pixels are removed from top and bottom edges.
     pub fn cropped_screen_snapshot(&self, h_overscan: u32, v_overscan: u32) -> Vec<u8> {
-        match self {
-            Console::Nes(nes) => nes
-                .get_screen_buffer()
-                .cropped_snapshot(h_overscan, v_overscan),
-            Console::GameBoy(gb) => gb.cropped_screen_snapshot(),
-        }
+        self.as_core()
+            .cropped_screen_snapshot(h_overscan, v_overscan)
     }
 
     /// CRC32 of the current screen buffer (for autorun verification).
     pub fn screen_crc32(&self) -> u32 {
-        match self {
-            Console::Nes(nes) => nes.get_screen_buffer().crc32(),
-            Console::GameBoy(gb) => gb.screen_crc32(),
-        }
+        self.as_core().screen_crc32()
     }
 
     /// Returns `true` when an audio sample is ready for retrieval.
     pub fn sample_ready(&self) -> bool {
-        match self {
-            Console::Nes(nes) => nes.sample_ready(),
-            Console::GameBoy(gb) => gb.sample_ready(),
-        }
+        self.as_core().sample_ready()
     }
 
     /// Retrieve the next audio sample, if one is ready.
@@ -155,10 +173,7 @@ impl Console {
     /// Returns a sample in the range `0.0..=1.0`, or `None` if no sample
     /// is pending.
     pub fn get_sample(&mut self) -> Option<f32> {
-        match self {
-            Console::Nes(nes) => nes.get_sample(),
-            Console::GameBoy(gb) => gb.get_sample(),
-        }
+        self.as_core_mut().get_sample()
     }
 
     /// Set a button state on a controller port.
@@ -167,19 +182,7 @@ impl Console {
     /// discriminant values (A=0, B=1, Select=2, Start=3, Up=4, Down=5, Left=6, Right=7).
     /// For Game Boy, only `port == 0` is meaningful; calls for other ports are ignored.
     pub fn set_button(&mut self, port: u8, button_id: u8, pressed: bool) {
-        match self {
-            Console::Nes(nes) => {
-                if !nes.set_button_by_id(port, button_id, pressed) {
-                    #[cfg(debug_assertions)]
-                    eprintln!("warning: invalid NES button_id: {button_id}");
-                }
-            }
-            Console::GameBoy(gb) => {
-                if port == 0 {
-                    gb.set_button(button_id, pressed);
-                }
-            }
-        }
+        self.as_core_mut().set_button(port, button_id, pressed)
     }
 
     /// Set all button states from a bitmask (for autorun playback).
@@ -187,46 +190,24 @@ impl Console {
     /// Each bit corresponds to a button by its system-specific ID.
     /// For Game Boy, only `port == 0` is applied; other ports are ignored.
     pub fn set_joypad_button_states(&mut self, port: u8, state: u8) {
-        match self {
-            Console::Nes(nes) => nes.set_joypad_button_states(port, state),
-            Console::GameBoy(gb) => {
-                if port == 0 {
-                    gb.set_joypad_button_states(state);
-                }
-            }
-        }
+        self.as_core_mut().set_joypad_button_states(port, state)
     }
 
     /// Get all button states as a bitmask (for autorun recording).
     ///
     /// For Game Boy, only `port == 0` returns button states; other ports return 0.
     pub fn get_joypad_button_states(&self, port: u8) -> u8 {
-        match self {
-            Console::Nes(nes) => nes.get_joypad_button_states(port),
-            Console::GameBoy(gb) => {
-                if port == 0 {
-                    gb.get_joypad_button_states()
-                } else {
-                    0
-                }
-            }
-        }
+        self.as_core().get_joypad_button_states(port)
     }
 
     /// Serialize the complete emulator state to bytes.
     pub fn save_state_bytes(&self) -> Result<Vec<u8>, String> {
-        match self {
-            Console::Nes(nes) => nes.save_state_bytes(),
-            Console::GameBoy(gb) => gb.save_state_bytes(),
-        }
+        self.as_core().save_state_bytes()
     }
 
     /// Restore emulator state from previously serialized bytes.
     pub fn load_state_bytes(&mut self, data: &[u8]) -> Result<(), String> {
-        match self {
-            Console::Nes(nes) => nes.load_state_bytes(data),
-            Console::GameBoy(gb) => gb.load_state_bytes(data),
-        }
+        self.as_core_mut().load_state_bytes(data)
     }
 
     /// Reset the emulator.
@@ -234,34 +215,22 @@ impl Console {
     /// `soft_reset` = true simulates pressing the reset button.
     /// `soft_reset` = false simulates a power cycle.
     pub fn reset(&mut self, soft_reset: bool) {
-        match self {
-            Console::Nes(nes) => nes.reset(soft_reset),
-            Console::GameBoy(gb) => gb.reset(soft_reset),
-        }
+        self.as_core_mut().reset(soft_reset)
     }
 
     /// Access the shared application context (config, ROM database, toasts).
     pub fn app_context(&self) -> &SharedAppContext {
-        match self {
-            Console::Nes(nes) => nes.app_context(),
-            Console::GameBoy(gb) => gb.app_context(),
-        }
+        self.as_core().app_context()
     }
 
     /// Save battery-backed RAM to disk (if applicable).
     pub fn save_ram(&self) -> Result<(), String> {
-        match self {
-            Console::Nes(nes) => nes.save_ram().map_err(|e| e.to_string()),
-            Console::GameBoy(_) => Ok(()),
-        }
+        self.as_core().save_ram()
     }
 
     /// Set the audio output sample rate (Hz) for the emulator's APU.
     pub fn set_audio_sample_rate(&mut self, rate: f32) {
-        match self {
-            Console::Nes(nes) => nes.set_audio_sample_rate(rate),
-            Console::GameBoy(gb) => gb.set_audio_sample_rate(rate),
-        }
+        self.as_core_mut().set_audio_sample_rate(rate)
     }
 
     /// Target wall-clock duration between rendered frames for this system.
@@ -271,23 +240,7 @@ impl Console {
     /// (NTSC ≈ 60.10 fps, PAL ≈ 50.01 fps).  The DMG Game Boy always runs at
     /// 4,194,304 Hz / 70,224 cycles per frame ≈ 59.73 fps.
     pub fn target_frame_duration(&self) -> std::time::Duration {
-        match self {
-            Console::GameBoy(_) => {
-                // DMG: 4,194,304 Hz clock / 70,224 cycles per frame ≈ 59.7275 fps
-                std::time::Duration::from_secs_f64(70_224.0 / 4_194_304.0)
-            }
-            Console::Nes(_) => {
-                let hz = self
-                    .app_context()
-                    .borrow()
-                    .config()
-                    .nes
-                    .hardware_model
-                    .timing_mode()
-                    .frame_rate_hz();
-                std::time::Duration::from_secs_f64(1.0 / hz)
-            }
-        }
+        self.as_core().target_frame_duration()
     }
 }
 
@@ -320,15 +273,24 @@ mod tests {
         rom
     }
 
+    fn make_shared_context() -> SharedAppContext {
+        AppContext::new_with_config(Config::default()).into_shared()
+    }
+
     fn make_console() -> Console {
-        let config = Config::default();
-        let app_context = AppContext::new_with_config(config);
-        Console::new_nes(app_context)
+        Console::new_nes(make_shared_context())
+    }
+
+    fn make_nes() -> Nes {
+        Nes::new(make_shared_context())
+    }
+
+    fn make_gameboy() -> GameBoy {
+        GameBoy::new(make_shared_context())
     }
 
     fn make_console_with_rom() -> (Console, SharedAppContext) {
-        let config = Config::default();
-        let app_context: SharedAppContext = AppContext::new_with_config(config).into_shared();
+        let app_context = make_shared_context();
         let mut console = Console::new_nes(app_context.clone());
         let rom = create_minimal_rom();
         console.load_rom(&rom, "test.nes").expect("load ROM");
@@ -429,7 +391,7 @@ mod tests {
 
     #[test]
     fn test_load_rom_with_invalid_data_returns_error() {
-        let mut console = Console::new_nes(AppContext::new_with_config(Config::default()));
+        let mut console = make_console();
         let result = console.load_rom(b"not a valid ROM", "bad.nes");
         assert!(result.is_err());
     }
@@ -450,111 +412,129 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // Trait-based extensibility proof — shows the Console interface
-    // can support multiple hardware targets via a common trait.
-    // Covers the core subset of Console's public methods. When adding
-    // a new generic method to Console, also add it here so that
-    // GameBoyStub must implement it, catching gaps at compile time.
+    // Emulator-trait tests — verifies that Nes and GameBoy both
+    // implement the production Emulator trait and that Console
+    // delegates through as_core()/as_core_mut().
     // ---------------------------------------------------------------
 
-    /// Common operations that every emulated system must support.
-    trait SystemOps {
-        fn run_tick(&mut self) -> u8;
-        fn is_ready_to_render(&self) -> bool;
-        fn screen_width(&self) -> u32;
-        fn screen_height(&self) -> u32;
-        fn screen_snapshot(&self) -> Vec<u8>;
-    }
-
-    impl SystemOps for Console {
-        fn run_tick(&mut self) -> u8 {
-            Console::run_tick(self)
-        }
-        fn is_ready_to_render(&self) -> bool {
-            Console::is_ready_to_render(self)
-        }
-        fn screen_width(&self) -> u32 {
-            Console::screen_width(self)
-        }
-        fn screen_height(&self) -> u32 {
-            Console::screen_height(self)
-        }
-        fn screen_snapshot(&self) -> Vec<u8> {
-            Console::screen_snapshot(self)
-        }
-    }
-
-    /// Minimal stub proving a second system can implement the same trait.
-    struct GameBoyStub {
-        frame_ready: bool,
-        cycles_in_frame: u32,
-        screen: Vec<u8>,
-    }
-
-    impl GameBoyStub {
-        const WIDTH: u32 = 160;
-        const HEIGHT: u32 = 144;
-        const CYCLES_PER_FRAME: u32 = 70224; // ~4.19 MHz / ~59.73 Hz
-
-        fn new() -> Self {
-            Self {
-                frame_ready: false,
-                cycles_in_frame: 0,
-                screen: vec![0; (Self::WIDTH * Self::HEIGHT * 3) as usize],
-            }
-        }
-    }
-
-    impl SystemOps for GameBoyStub {
-        fn run_tick(&mut self) -> u8 {
-            let cycles = 4; // GB instructions are 4-cycle minimum
-            self.cycles_in_frame += cycles as u32;
-            if self.cycles_in_frame >= Self::CYCLES_PER_FRAME {
-                self.cycles_in_frame -= Self::CYCLES_PER_FRAME;
-                self.frame_ready = true;
-            }
-            cycles
-        }
-        fn is_ready_to_render(&self) -> bool {
-            self.frame_ready
-        }
-        fn screen_width(&self) -> u32 {
-            Self::WIDTH
-        }
-        fn screen_height(&self) -> u32 {
-            Self::HEIGHT
-        }
-        fn screen_snapshot(&self) -> Vec<u8> {
-            self.screen.clone()
-        }
-    }
-
-    fn run_system_to_frame(system: &mut dyn SystemOps) -> u64 {
+    fn run_emulator_to_frame(emu: &mut dyn Emulator) -> u64 {
         let mut total = 0u64;
-        while !system.is_ready_to_render() && total < 200_000 {
-            total += system.run_tick() as u64;
+        while !emu.is_ready_to_render() && total < 200_000 {
+            total += emu.run_tick() as u64;
         }
         total
     }
 
     #[test]
-    fn test_gameboy_stub_via_trait() {
-        let mut gb = GameBoyStub::new();
-        assert_eq!(gb.screen_width(), 160);
-        assert_eq!(gb.screen_height(), 144);
+    fn test_nes_implements_emulator_trait() {
+        let mut nes = make_nes();
+        let rom = create_minimal_rom();
+        nes.load_rom(&rom, "test.nes").unwrap();
+        nes.reset(false);
 
-        run_system_to_frame(&mut gb);
-        assert!(gb.is_ready_to_render());
-        assert_eq!(gb.screen_snapshot().len(), (160 * 144 * 3) as usize);
+        let emu: &mut dyn Emulator = &mut nes;
+        assert_eq!(emu.system_type(), SystemType::Nes);
+        assert_eq!(emu.screen_width(), 256);
+        assert_eq!(emu.screen_height(), 240);
+        assert!(!emu.is_ready_to_render());
+
+        run_emulator_to_frame(emu);
+        assert!(emu.is_ready_to_render());
+        emu.clear_ready_to_render();
+        assert!(!emu.is_ready_to_render());
     }
 
     #[test]
-    fn test_console_via_trait() {
-        let (mut console, _) = make_console_with_rom();
-        assert_eq!(console.screen_width(), 256);
-        assert_eq!(console.screen_height(), 240);
+    fn test_gameboy_implements_emulator_trait() {
+        let mut gb = make_gameboy();
 
-        run_system_to_frame(&mut console);
-        assert!(console.is_ready_to_render());
+        let emu: &dyn Emulator = &gb;
+        assert_eq!(emu.system_type(), SystemType::GameBoy);
+        assert_eq!(emu.screen_width(), 160);
+        assert_eq!(emu.screen_height(), 144);
+
+        // No ROM loaded — safe default behaviour
+        let emu: &mut dyn Emulator = &mut gb;
+        assert_eq!(emu.run_tick(), 0);
+        assert!(!emu.is_ready_to_render());
+    }
+
+    #[test]
+    fn test_console_as_core_delegates_to_nes() {
+        let (mut console, _) = make_console_with_rom();
+
+        let emu = console.as_core();
+        assert_eq!(emu.system_type(), SystemType::Nes);
+        assert_eq!(emu.screen_width(), 256);
+        assert_eq!(emu.screen_height(), 240);
+
+        let emu = console.as_core_mut();
+        run_emulator_to_frame(emu);
+        assert!(console.as_core().is_ready_to_render());
+    }
+
+    #[test]
+    fn test_console_as_core_delegates_to_gameboy() {
+        let console = Console::new_gameboy(make_shared_context());
+
+        let emu = console.as_core();
+        assert_eq!(emu.system_type(), SystemType::GameBoy);
+        assert_eq!(emu.screen_width(), 160);
+        assert_eq!(emu.screen_height(), 144);
+    }
+
+    #[test]
+    fn test_nes_trait_screen_snapshot_has_correct_size() {
+        let nes = make_nes();
+        let emu: &dyn Emulator = &nes;
+        assert_eq!(emu.screen_snapshot().len(), 256 * 240 * 3);
+    }
+
+    #[test]
+    fn test_gameboy_trait_screen_snapshot_has_correct_size() {
+        let gb = make_gameboy();
+        let emu: &dyn Emulator = &gb;
+        assert_eq!(emu.screen_snapshot().len(), 160 * 144 * 3);
+    }
+
+    #[test]
+    fn test_nes_trait_target_frame_duration() {
+        let nes = make_nes();
+        let emu: &dyn Emulator = &nes;
+        let dur = emu.target_frame_duration();
+        // NTSC ≈ 60.10 fps → ~16.6 ms
+        assert!(dur.as_millis() > 15 && dur.as_millis() < 20);
+    }
+
+    #[test]
+    fn test_gameboy_trait_target_frame_duration() {
+        let gb = make_gameboy();
+        let emu: &dyn Emulator = &gb;
+        let dur = emu.target_frame_duration();
+        // DMG ≈ 59.73 fps → ~16.7 ms
+        assert!(dur.as_millis() > 15 && dur.as_millis() < 20);
+    }
+
+    #[test]
+    fn test_nes_trait_save_ram_without_cart_returns_ok() {
+        let nes = make_nes();
+        let emu: &dyn Emulator = &nes;
+        // Without a battery-backed cartridge, save_ram should succeed (no-op)
+        assert!(emu.save_ram().is_ok());
+    }
+
+    #[test]
+    fn test_gameboy_trait_save_ram_returns_ok() {
+        let gb = make_gameboy();
+        let emu: &dyn Emulator = &gb;
+        assert!(emu.save_ram().is_ok());
+    }
+
+    #[test]
+    fn test_nes_trait_joypad_roundtrip() {
+        let mut nes = make_nes();
+        let emu: &mut dyn Emulator = &mut nes;
+        emu.set_joypad_button_states(1, 0b1010_0101);
+        assert_eq!(emu.get_joypad_button_states(1), 0b1010_0101);
     }
 }

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -420,7 +420,11 @@ mod tests {
     fn run_emulator_to_frame(emu: &mut dyn Emulator) -> u64 {
         let mut total = 0u64;
         while !emu.is_ready_to_render() && total < 200_000 {
-            total += emu.run_tick() as u64;
+            let ticks = emu.run_tick() as u64;
+            if ticks == 0 {
+                break;
+            }
+            total += ticks;
         }
         total
     }


### PR DESCRIPTION
## Summary

Introduces an `Emulator` trait that both `Nes` and `GameBoy` implement, replacing per-emulator match arms in `Console` with trait dispatch via `as_core()` / `as_core_mut()`.

Closes #2030

## Changes

### New: `Emulator` trait (22 methods)
Defined in `src/platform/emulator.rs` with methods covering the full lifecycle: `load_rom`, `reset`, `run_tick`, screen access, audio, input, save/load state, debugging, and configuration.

### `Console` delegation
`Console::as_core()` and `Console::as_core_mut()` return `&dyn Emulator` / `&mut dyn Emulator`. All 22 existing `Console` methods now delegate through these instead of matching on the enum variant directly.

### `impl Emulator for Nes`
Added in `src/nes/console/nes.rs`. Adapts existing Nes methods to the trait interface (e.g., `set_button_by_id` for u8 button IDs, `save_ram` returning `Result<(), String>`).

### `impl Emulator for GameBoy`
Added in `src/gb/console/gameboy.rs`. Adapts existing GameBoy methods with port-0-only guards for single-controller hardware.

### Tests
11 new trait-level tests in `src/platform/emulator.rs` with DRY helpers (`make_shared_context()`, `make_nes()`, `make_gameboy()`). All existing tests continue to pass.

### Documentation
Updated `architecture.md` with Emulator trait documentation, updated file table entries, and corrected GB console path.

## Verification

- `cargo fmt` - clean
- `cargo clippy --all-targets --all-features -- -D warnings` - clean
- `cargo test --no-default-features --lib` - 8290 passed, 1 failed (pre-existing: `test_mapper_3_autorun_gradius`)
- `wasm-pack test --headless --chrome --no-default-features --features wasm` - 48 passed
- Python tests - 201 passed
- `npm test` - 185 passed
## Summary

Replace Bootstrap 5.3.2 with Tailwind CSS v4 + DaisyUI v5 as the web frontend styling foundation.

Closes #2020

## Changes

### Library swap
- Installed `tailwindcss`, `@tailwindcss/vite`, and `daisyui` as npm dependencies
- Added `@tailwindcss/vite` plugin to `vite.config.ts`
- Removed Bootstrap CDN `<link>` and `<script>` tags from `index.html`

### CSS restructure
- Created `web/main.css`: Tailwind imports, DaisyUI night theme config, neon color overrides (cyan `#00f0ff`, magenta `#ff00e6`), and non-debugger custom styles
- Created `web/debugger.css`: all debugger panel custom styles (extracted from old styles.css)
- Deleted `web/styles.css` (replaced by `main.css` + `debugger.css`)
- Added `data-theme="night"` to `<html>` element

### Modal migration
- Converted `#autorun-modal` from Bootstrap `.modal` to native `<dialog>` element
- Replaced `bootstrap.Modal` JS API with `dialog.showModal()`/`dialog.close()`
- Added `#autorun-modal-cancel` button with close handler
- Removed `BootstrapModal` interface and `window.bootstrap` global declaration from `app.ts`

### CSS class migration
- Replaced all `d-none` (Bootstrap utility) usage with `hidden` (Tailwind utility) in HTML, TypeScript, and tests

### Incidental fix
- Fixed pre-existing unused import `NametableLayout` warning in `mapper256.rs` (gated behind `#[cfg(test)]`)

## Pre-merge checks

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt` clean
- [x] `cargo test --no-default-features --lib` 8144 passed, 1 pre-existing failure (`test_mapper_3_autorun_gradius`, also fails on main)
- [x] `npm test` 185/185 tests pass
- [x] `wasm-pack test --headless --chrome --no-default-features --features wasm` 48/48 pass
- [x] `python -m unittest discover` 201/201 pass
- [x] `npx vite build` succeeds

## Note

The HTML markup still uses some Bootstrap utility classes (e.g. `d-flex`, `btn-success`). These will be replaced with DaisyUI/Tailwind equivalents in sub-issue #2021 (layout redesign). The page loads and all JS functionality works, but visual styling may be incomplete until the layout sub-issue is addressed.
