### PR TITLE
fix(gb-apu): pass all 10 remaining Blargg dmg/cgb_sound tests

### DIFF
--- a/src/gb/apu/channel1.rs
+++ b/src/gb/apu/channel1.rs
@@ -21,14 +21,14 @@ pub struct Channel1 {
 
     // Internal state
     active: bool,
-    dac_on: bool,       // NR12 bits 7-3 != 0
-    duty_pos: u8,       // 0-7
-    freq_timer: u16,    // countdown; reloads to (2048 - freq) * 4
-    length_counter: u8, // 0-64; silences when reaches 0
-    volume: u8,         // current volume 0-15
-    env_timer: u8,      // envelope period countdown
-    sweep_timer: u8,    // sweep period countdown
-    sweep_shadow: u16,  // shadow frequency register
+    dac_on: bool,                  // NR12 bits 7-3 != 0
+    duty_pos: u8,                  // 0-7
+    freq_timer: u16,               // countdown; reloads to (2048 - freq) * 4
+    pub(crate) length_counter: u8, // 0-64; silences when reaches 0
+    volume: u8,                    // current volume 0-15
+    env_timer: u8,                 // envelope period countdown
+    sweep_timer: u8,               // sweep period countdown
+    sweep_shadow: u16,             // shadow frequency register
     sweep_enabled: bool,
     /// Set when a negate-mode calculation is performed; cleared on trigger.
     /// If NR10 clears the negate bit after this was set, the channel is disabled.
@@ -261,11 +261,27 @@ impl Channel1 {
         self.freq = (self.freq & 0x0700) | u16::from(val);
     }
 
-    pub fn write_nr14(&mut self, val: u8) {
+    pub fn write_nr14(&mut self, val: u8, extra_clk: bool) {
+        let old_length_en = self.length_en;
         self.length_en = val & 0x40 != 0;
         self.freq = (self.freq & 0x00FF) | (u16::from(val & 0x07) << 8);
+
+        // Extra length clocking: when length_en transitions 0→1 while the FS
+        // next step does NOT clock length, the counter is immediately clocked.
+        if extra_clk && !old_length_en && self.length_en && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.active = false;
+            }
+        }
+
         if val & 0x80 != 0 {
             self.trigger();
+            // If trigger reloaded counter to max AND length_en AND extra-clock
+            // window, decrement the freshly-loaded counter by 1.
+            if extra_clk && self.length_en && self.length_counter == 64 {
+                self.length_counter = 63;
+            }
         }
     }
 
@@ -293,6 +309,9 @@ impl Channel1 {
         self.negate_used = false;
         // Trigger-time overflow check required by hardware even when sweep is otherwise idle.
         if self.sweep_shift > 0 {
+            if self.sweep_negate {
+                self.negate_used = true;
+            }
             self.disable_if_sweep_overflows();
         }
     }
@@ -311,7 +330,7 @@ mod tests {
         // NR11: 50% duty, length = 0 (max)
         ch.write_nr11(0x80);
         // NR14: trigger, no length enable, freq high = 0
-        ch.write_nr14(0x80);
+        ch.write_nr14(0x80, false);
         ch
     }
 
@@ -329,7 +348,7 @@ mod tests {
         // Given: NR12 = 0x00 (DAC off); When: trigger; Then: channel stays inactive
         let mut ch = Channel1::new();
         ch.write_nr12(0x00); // no volume, no envelope → DAC off
-        ch.write_nr14(0x80); // trigger
+        ch.write_nr14(0x80, false); // trigger
         assert!(!ch.is_active());
     }
 
@@ -359,7 +378,7 @@ mod tests {
         let mut ch = Channel1::new();
         ch.write_nr12(0xF0); // DAC on
         ch.write_nr11(0xFF); // length = 63 → counter = 1
-        ch.write_nr14(0xC0); // trigger + length enable
+        ch.write_nr14(0xC0, false); // trigger + length enable
         assert!(ch.is_active());
         ch.clock_length();
         assert!(
@@ -375,7 +394,7 @@ mod tests {
         let mut ch = Channel1::new();
         ch.write_nr12(0xF0);
         ch.write_nr11(0xFF); // counter = 1
-        ch.write_nr14(0x80); // trigger, no length enable
+        ch.write_nr14(0x80, false); // trigger, no length enable
         ch.clock_length();
         assert!(
             ch.is_active(),
@@ -389,13 +408,64 @@ mod tests {
         let mut ch = Channel1::new();
         ch.write_nr12(0xF0);
         ch.write_nr11(0x3F); // length = 63 → counter = 1
-        ch.write_nr14(0x40); // length enable, NO trigger → counter = 1
+        ch.write_nr14(0x40, false); // length enable, NO trigger → counter = 1
         ch.clock_length(); // expires to 0, channel inactive
         assert!(!ch.is_active());
         // Trigger again – counter should reload to 64.
-        ch.write_nr14(0x80); // trigger (no length enable)
+        ch.write_nr14(0x80, false); // trigger (no length enable)
         assert!(ch.is_active());
         assert_eq!(ch.length_counter, 64);
+    }
+
+    // ── Extra length clocking on NRx4 write ──────────────────────────────
+
+    #[test]
+    fn test_enabling_length_in_first_half_clocks_length() {
+        // Blargg 03-trigger sub-test 3: enabling length_en when the FS next
+        // step does NOT clock length must extra-clock the length counter.
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0); // DAC on
+        ch.write_nr11(0xBE); // length_load=62 → counter = 64-62 = 2
+        ch.write_nr14(0x80, false); // trigger, no length enable
+        assert_eq!(ch.length_counter, 2);
+        // Enable length with extra_clk=true (FS in first half).
+        ch.write_nr14(0x40, true); // length enable, no trigger, extra clock
+        assert_eq!(
+            ch.length_counter, 1,
+            "enabling length in first half must extra-clock (2 → 1)"
+        );
+    }
+
+    #[test]
+    fn test_enabling_length_in_second_half_does_not_clock() {
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0);
+        ch.write_nr11(0xBE); // counter = 2
+        ch.write_nr14(0x80, false); // trigger, no length enable
+        // Enable length with extra_clk=false (FS in second half).
+        ch.write_nr14(0x40, false); // no extra clock
+        assert_eq!(
+            ch.length_counter, 2,
+            "enabling length in second half must NOT extra-clock"
+        );
+    }
+
+    #[test]
+    fn test_trigger_unfreezes_and_extra_clocks_when_enabled() {
+        // Blargg 03-trigger sub-test 8: trigger reloads length to max,
+        // and if length_en is set and FS extra-clocks, decrement by 1.
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0);
+        ch.write_nr11(0x3F); // counter = 1
+        ch.write_nr14(0x40, true); // enable → extra clock → counter 1→0, channel disabled
+        assert!(!ch.is_active());
+        // Trigger + length enable with extra clock: counter was 0, reloads to 64,
+        // then extra-clock decrements to 63.
+        ch.write_nr14(0xC0, true); // trigger + length enable
+        assert_eq!(
+            ch.length_counter, 63,
+            "trigger reload + extra clock: 64 → 63"
+        );
     }
 
     // ── Volume envelope ───────────────────────────────────────────────────
@@ -405,7 +475,7 @@ mod tests {
         // NR12: vol=7, dir=subtract, period=1
         let mut ch = Channel1::new();
         ch.write_nr12(0x71); // vol=7, add=0, period=1
-        ch.write_nr14(0x80); // trigger
+        ch.write_nr14(0x80, false); // trigger
         assert_eq!(ch.volume, 7);
         ch.clock_envelope();
         assert_eq!(ch.volume, 6);
@@ -416,7 +486,7 @@ mod tests {
         // NR12: vol=7, dir=add, period=1
         let mut ch = Channel1::new();
         ch.write_nr12(0x79); // vol=7, add=1, period=1
-        ch.write_nr14(0x80);
+        ch.write_nr14(0x80, false);
         ch.clock_envelope();
         assert_eq!(ch.volume, 8);
     }
@@ -425,7 +495,7 @@ mod tests {
     fn test_envelope_does_not_go_below_zero() {
         let mut ch = Channel1::new();
         ch.write_nr12(0x01); // vol=0, add=0, period=1
-        ch.write_nr14(0x80);
+        ch.write_nr14(0x80, false);
         ch.clock_envelope();
         assert_eq!(ch.volume, 0);
     }
@@ -434,7 +504,7 @@ mod tests {
     fn test_envelope_does_not_exceed_15() {
         let mut ch = Channel1::new();
         ch.write_nr12(0xF9); // vol=15, add=1, period=1
-        ch.write_nr14(0x80);
+        ch.write_nr14(0x80, false);
         ch.clock_envelope();
         assert_eq!(ch.volume, 15);
     }
@@ -443,7 +513,7 @@ mod tests {
     fn test_envelope_frozen_when_period_zero() {
         let mut ch = Channel1::new();
         ch.write_nr12(0x70); // vol=7, period=0
-        ch.write_nr14(0x80);
+        ch.write_nr14(0x80, false);
         ch.clock_envelope();
         assert_eq!(ch.volume, 7, "envelope must not change when period = 0");
     }
@@ -457,12 +527,12 @@ mod tests {
         ch.write_nr12(0xF0);
         ch.write_nr10(0x11); // period=1, negate=0, shift=1
         ch.write_nr13(0x00);
-        ch.write_nr14(0x87); // trigger, freq_hi=7 → freq = 0x700 = 1792
+        ch.write_nr14(0x87, false); // trigger, freq_hi=7 → freq = 0x700 = 1792
         // After trigger, sweep_shadow = 1792; one clock → new_freq = 1792 + (1792>>1) = 1792+896 = 2688 > 2047 → disable
         // Let's use a lower frequency so it doesn't overflow.
         // Reset with freq = 100.
         ch.write_nr13(0x64); // low byte = 100
-        ch.write_nr14(0x80); // trigger (freq_hi=0) → freq = 100
+        ch.write_nr14(0x80, false); // trigger (freq_hi=0) → freq = 100
         let initial_shadow = ch.sweep_shadow;
         assert_eq!(initial_shadow, 100);
         ch.clock_sweep();
@@ -480,7 +550,7 @@ mod tests {
         ch.write_nr12(0xF0);
         ch.write_nr10(0x19); // period=1, negate=1, shift=1
         ch.write_nr13(0x64); // freq = 100
-        ch.write_nr14(0x80);
+        ch.write_nr14(0x80, false);
         ch.clock_sweep();
         // new_freq = 100 - (100 >> 1) = 50
         assert_eq!(ch.sweep_shadow, 50);
@@ -495,7 +565,7 @@ mod tests {
         ch.write_nr10(0x11); // period=1, negate=0, shift=1
         // freq 2000 = 0x7D0 → hi=7, lo=0xD0
         ch.write_nr13(0xD0);
-        ch.write_nr14(0x87); // trigger, hi=7
+        ch.write_nr14(0x87, false); // trigger, hi=7
         assert_eq!(ch.freq, 0x7D0);
         ch.clock_sweep();
         assert!(
@@ -511,7 +581,7 @@ mod tests {
         ch.write_nr12(0xF0);
         ch.write_nr10(0x00);
         ch.write_nr13(0x64); // freq = 100
-        ch.write_nr14(0x80);
+        ch.write_nr14(0x80, false);
         ch.clock_sweep();
         assert_eq!(ch.freq, 100, "freq must not change when sweep is disabled");
         assert!(ch.is_active());
@@ -548,9 +618,9 @@ mod tests {
     fn test_nr14_reads_length_en_bit() {
         let mut ch = Channel1::new();
         ch.write_nr12(0xF0);
-        ch.write_nr14(0x40); // length_en=1, no trigger
+        ch.write_nr14(0x40, false); // length_en=1, no trigger
         assert_eq!(ch.read_nr14() & 0x40, 0x40);
-        ch.write_nr14(0x00);
+        ch.write_nr14(0x00, false);
         assert_eq!(ch.read_nr14() & 0x40, 0x00);
     }
 
@@ -567,7 +637,7 @@ mod tests {
         ch.write_nr10(0x10);
         // freq = 1400 = 0x578 → lo=0x78, hi=0x05
         ch.write_nr13(0x78);
-        ch.write_nr14(0x85); // trigger + freq_hi=5
+        ch.write_nr14(0x85, false); // trigger + freq_hi=5
         assert!(ch.is_active(), "channel must be active after trigger");
         // sweep fires: timer 1→0, reload=1, enabled=true, period=1
         // new_freq = 1400 + (1400>>0) = 2800 > 2047 → must disable
@@ -589,7 +659,7 @@ mod tests {
         // NR10: period=1, negate=1, shift=1 → 0x19
         ch.write_nr10(0x19);
         ch.write_nr13(0x64); // freq = 100
-        ch.write_nr14(0x80); // trigger
+        ch.write_nr14(0x80, false); // trigger
         assert!(ch.is_active(), "channel must be active after trigger");
         // One sweep clock in negate mode → negate_used must be set
         ch.clock_sweep();
@@ -602,6 +672,28 @@ mod tests {
         assert!(
             !ch.is_active(),
             "channel must be disabled when negate is cleared after a negate calculation"
+        );
+    }
+
+    #[test]
+    fn test_trigger_overflow_check_sets_negate_used() {
+        // Blargg 05-sweep details, sub-test 4:
+        // NR10=$09 (period=0, negate=1, shift=1): trigger performs a negate-mode
+        // overflow check (shift>0). Even though sweep_period=0 prevents periodic
+        // clocking, the trigger-time calculation uses negate mode, so `negate_used`
+        // must be set. Clearing negate in NR10 afterwards must disable the channel.
+        let mut ch = Channel1::new();
+        ch.write_nr12(0x08); // vol=0, add=1, period=0 → DAC on (0x08 & 0xF8 = 0x08 ≠ 0)
+        ch.write_nr10(0x09); // period=0, negate=true, shift=1
+        ch.write_nr13(0x00); // freq low = 0
+        ch.write_nr14(0xC0, false); // trigger + length enable; freq_hi = 0
+        assert!(ch.is_active(), "channel must be active after trigger");
+        // No sweep clock needed — the trigger itself performed a negate calculation.
+        // Now clear negate: period=1, negate=false, shift=0 → $10
+        ch.write_nr10(0x10);
+        assert!(
+            !ch.is_active(),
+            "channel must be disabled: negate was used during trigger overflow check"
         );
     }
 
@@ -619,7 +711,7 @@ mod tests {
         let mut ch = Channel1::new();
         ch.write_nr12(0xF0); // vol=15, DAC on
         ch.write_nr11(0x80); // 50% duty
-        ch.write_nr14(0x80); // trigger
+        ch.write_nr14(0x80, false); // trigger
         ch.duty_pos = 0; // 50% duty: step 0 → high
         // DUTY_TABLE[2][0] = 1
         assert!(

--- a/src/gb/apu/channel2.rs
+++ b/src/gb/apu/channel2.rs
@@ -15,7 +15,7 @@ pub struct Channel2 {
     dac_on: bool,
     duty_pos: u8,
     freq_timer: u16,
-    length_counter: u8,
+    pub(crate) length_counter: u8,
     volume: u8,
     env_timer: u8,
 }
@@ -158,11 +158,23 @@ impl Channel2 {
         self.freq = (self.freq & 0x0700) | u16::from(val);
     }
 
-    pub fn write_nr24(&mut self, val: u8) {
+    pub fn write_nr24(&mut self, val: u8, extra_clk: bool) {
+        let old_length_en = self.length_en;
         self.length_en = val & 0x40 != 0;
         self.freq = (self.freq & 0x00FF) | (u16::from(val & 0x07) << 8);
+
+        if extra_clk && !old_length_en && self.length_en && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.active = false;
+            }
+        }
+
         if val & 0x80 != 0 {
             self.trigger();
+            if extra_clk && self.length_en && self.length_counter == 64 {
+                self.length_counter = 63;
+            }
         }
     }
 
@@ -194,7 +206,7 @@ mod tests {
         let mut ch = Channel2::new();
         ch.write_nr22(0xF0); // DAC on, vol=15
         ch.write_nr21(0x80); // 50% duty
-        ch.write_nr24(0x80); // trigger
+        ch.write_nr24(0x80, false); // trigger
         ch
     }
 
@@ -208,7 +220,7 @@ mod tests {
     fn test_dac_off_prevents_activation() {
         let mut ch = Channel2::new();
         ch.write_nr22(0x00);
-        ch.write_nr24(0x80);
+        ch.write_nr24(0x80, false);
         assert!(!ch.is_active());
     }
 
@@ -217,7 +229,7 @@ mod tests {
         let mut ch = Channel2::new();
         ch.write_nr22(0xF0);
         ch.write_nr21(0xFF); // counter = 1
-        ch.write_nr24(0xC0); // trigger + length enable
+        ch.write_nr24(0xC0, false); // trigger + length enable
         ch.clock_length();
         assert!(!ch.is_active());
     }
@@ -227,7 +239,7 @@ mod tests {
         let mut ch = Channel2::new();
         ch.write_nr22(0xF0);
         ch.write_nr21(0xFF);
-        ch.write_nr24(0x80);
+        ch.write_nr24(0x80, false);
         ch.clock_length();
         assert!(ch.is_active());
     }
@@ -236,7 +248,7 @@ mod tests {
     fn test_envelope_decrements_volume() {
         let mut ch = Channel2::new();
         ch.write_nr22(0x71); // vol=7, sub, period=1
-        ch.write_nr24(0x80);
+        ch.write_nr24(0x80, false);
         ch.clock_envelope();
         assert_eq!(ch.volume, 6);
     }
@@ -245,7 +257,7 @@ mod tests {
     fn test_envelope_increments_volume() {
         let mut ch = Channel2::new();
         ch.write_nr22(0x79); // vol=7, add, period=1
-        ch.write_nr24(0x80);
+        ch.write_nr24(0x80, false);
         ch.clock_envelope();
         assert_eq!(ch.volume, 8);
     }
@@ -268,7 +280,7 @@ mod tests {
     fn test_nr24_length_en_readable() {
         let mut ch = Channel2::new();
         ch.write_nr22(0xF0);
-        ch.write_nr24(0x40);
+        ch.write_nr24(0x40, false);
         assert_eq!(ch.read_nr24() & 0x40, 0x40);
     }
 

--- a/src/gb/apu/channel3.rs
+++ b/src/gb/apu/channel3.rs
@@ -27,8 +27,9 @@ pub struct Channel3 {
     pub(crate) current_sample: u8,
     /// True when running a CGB-compatible ROM (gates wave RAM access behavior).
     is_cgb: bool,
-    /// Set during the M-cycle when CH3 reads a new sample from wave RAM.
-    /// On DMG, CPU can only access wave RAM during this window.
+    /// True when the last wave position advance consumed all remaining APU cycles
+    /// in a tick — i.e. a sample read occurred on the very last APU cycle of that
+    /// M-cycle. On DMG, CPU can only access wave RAM during this window.
     pub(crate) wave_just_read: bool,
 }
 

--- a/src/gb/apu/channel3.rs
+++ b/src/gb/apu/channel3.rs
@@ -18,13 +18,18 @@ pub struct Channel3 {
     length_en: bool,  // NR34 bit 6
 
     active: bool,
-    wave_pos: u8,        // 0-31 (position into 32-sample wave table)
-    freq_timer: u16,     // countdown; reloads to (2048 - freq) * 2
-    length_counter: u16, // 0-256
+    wave_pos: u8,                   // 0-31 (position into 32-sample wave table)
+    freq_timer: u16,                // countdown in APU cycles (2 MHz); reload = freq ^ 0x7FF
+    pub(crate) length_counter: u16, // 0-256
     /// Wave RAM: 16 bytes = 32 × 4-bit samples.
     wave_ram: [u8; 16],
     /// Byte currently being shifted out (set on wave position advance).
-    current_sample: u8,
+    pub(crate) current_sample: u8,
+    /// True when running a CGB-compatible ROM (gates wave RAM access behavior).
+    is_cgb: bool,
+    /// Set during the M-cycle when CH3 reads a new sample from wave RAM.
+    /// On DMG, CPU can only access wave RAM during this window.
+    pub(crate) wave_just_read: bool,
 }
 
 impl Default for Channel3 {
@@ -35,6 +40,10 @@ impl Default for Channel3 {
 
 impl Channel3 {
     pub fn new() -> Self {
+        Self::new_with_mode(false)
+    }
+
+    pub fn new_with_mode(is_cgb: bool) -> Self {
         Self {
             dac_on: false,
             length_load: 0,
@@ -47,6 +56,8 @@ impl Channel3 {
             length_counter: 0,
             wave_ram: [0u8; 16],
             current_sample: 0,
+            is_cgb,
+            wave_just_read: false,
         }
     }
 
@@ -72,18 +83,27 @@ impl Channel3 {
         (self.current_sample >> shift) as f32 / 15.0
     }
 
-    /// Advance the wave frequency timer by one M-cycle (= 4 T-cycles).
-    /// CH3 freq timer counts in T-cycles: reload = (2048 - freq) * 2.
+    /// Advance the wave frequency timer by one M-cycle (= 2 APU cycles at 2 MHz).
+    /// Mirrors SameBoy's `while (cycles_left > sample_countdown)` loop exactly.
+    /// The countdown is in APU cycles; reload = `freq ^ 0x7FF` = `2047 - freq`.
     pub fn tick(&mut self) {
-        if self.freq_timer == 0 {
-            self.freq_timer = (2048 - self.freq) * 2;
+        self.wave_just_read = false;
+
+        if !self.active {
+            return;
         }
-        if self.freq_timer > 4 {
-            self.freq_timer -= 4;
-        } else {
-            self.freq_timer = (2048 - self.freq) * 2;
+
+        let mut cycles_left: u16 = 2; // 2 APU cycles per M-cycle (normal speed)
+        while cycles_left > self.freq_timer {
+            cycles_left -= self.freq_timer + 1;
+            self.freq_timer = self.freq ^ 0x7FF;
             self.wave_pos = (self.wave_pos + 1) & 31;
             self.current_sample = self.read_wave_nibble(self.wave_pos);
+            self.wave_just_read = true;
+        }
+        if cycles_left > 0 {
+            self.freq_timer -= cycles_left;
+            self.wave_just_read = false;
         }
     }
 
@@ -108,6 +128,7 @@ impl Channel3 {
         self.freq_timer = 0;
         self.length_counter = 0;
         self.current_sample = 0;
+        self.wave_just_read = false;
         // Note: wave_ram is NOT cleared on power-off per hardware spec.
     }
 
@@ -147,11 +168,23 @@ impl Channel3 {
         self.freq = (self.freq & 0x0700) | u16::from(val);
     }
 
-    pub fn write_nr34(&mut self, val: u8) {
+    pub fn write_nr34(&mut self, val: u8, extra_clk: bool) {
+        let old_length_en = self.length_en;
         self.length_en = val & 0x40 != 0;
         self.freq = (self.freq & 0x00FF) | (u16::from(val & 0x07) << 8);
+
+        if extra_clk && !old_length_en && self.length_en && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.active = false;
+            }
+        }
+
         if val & 0x80 != 0 {
             self.trigger();
+            if extra_clk && self.length_en && self.length_counter == 256 {
+                self.length_counter = 255;
+            }
         }
     }
 
@@ -161,15 +194,50 @@ impl Channel3 {
     }
 
     fn trigger(&mut self) {
+        // DMG retrigger corruption: if CH3 is currently active on DMG
+        // and sample_countdown == 0 (about to read next sample)
+        if !self.is_cgb && self.active && self.freq_timer == 0 {
+            self.apply_dmg_retrigger_corruption();
+        }
+
+        self.wave_pos = 0;
+
         if self.dac_on {
             self.active = true;
         }
         if self.length_counter == 0 {
             self.length_counter = 256;
         }
-        self.freq_timer = (2048 - self.freq) * 2;
-        self.wave_pos = 0;
-        self.current_sample = self.read_wave_nibble(0);
+        // Pan Docs: "triggering does not immediately start playing wave RAM;
+        // the last sample ever read is output until the channel next reads a sample."
+
+        // Trigger countdown: (freq ^ 0x7FF) + 3 APU cycles = (2047 - freq) + 3
+        self.freq_timer = (self.freq ^ 0x7FF) + 3;
+    }
+
+    /// DMG-only: wave RAM corruption when retriggering CH3 while it just read a sample.
+    /// SameBoy: `offset = ((current_sample_index + 1) >> 1) & 0xF`.
+    /// If offset < 4: wave_ram[0] = wave_ram[offset].
+    /// If offset >= 4: wave_ram[0..4] = wave_ram[aligned..aligned+4] where aligned = offset & !3.
+    fn apply_dmg_retrigger_corruption(&mut self) {
+        let current_byte_index = ((self.wave_pos.wrapping_add(1)) / 2) & 0x0F;
+        if current_byte_index < 4 {
+            // Copy the single byte at current_byte_index to byte 0
+            self.wave_ram[0] = self.wave_ram[current_byte_index as usize];
+        } else {
+            // Copy the 4-byte aligned block to bytes 0-3
+            let aligned = (current_byte_index & !3) as usize;
+            let block = [
+                self.wave_ram[aligned],
+                self.wave_ram[aligned + 1],
+                self.wave_ram[aligned + 2],
+                self.wave_ram[aligned + 3],
+            ];
+            self.wave_ram[0] = block[0];
+            self.wave_ram[1] = block[1];
+            self.wave_ram[2] = block[2];
+            self.wave_ram[3] = block[3];
+        }
     }
 
     // ── Wave RAM ──────────────────────────────────────────────────────────
@@ -186,8 +254,14 @@ impl Channel3 {
 
     pub fn read_wave_ram(&self, addr: u16) -> u8 {
         if self.active {
-            // During playback, CPU reads return the byte at the current wave position.
-            self.wave_ram[(self.wave_pos / 2) as usize]
+            if self.is_cgb || self.wave_just_read {
+                // CGB: always return the byte at current wave position during playback.
+                // DMG: only accessible during the M-cycle when CH3 reads wave RAM.
+                self.wave_ram[(self.wave_pos / 2) as usize]
+            } else {
+                // DMG: outside the access window, reads return 0xFF.
+                0xFF
+            }
         } else {
             self.wave_ram[(addr - 0xFF30) as usize]
         }
@@ -195,8 +269,12 @@ impl Channel3 {
 
     pub fn write_wave_ram(&mut self, addr: u16, val: u8) {
         if self.active {
-            // During playback, writes go to the byte at the current wave position.
-            self.wave_ram[(self.wave_pos / 2) as usize] = val;
+            if self.is_cgb || self.wave_just_read {
+                // CGB: always write to current wave position during playback.
+                // DMG: only accessible during the M-cycle when CH3 reads wave RAM.
+                self.wave_ram[(self.wave_pos / 2) as usize] = val;
+            }
+            // DMG: outside the access window, writes are ignored.
         } else {
             self.wave_ram[(addr - 0xFF30) as usize] = val;
         }
@@ -213,7 +291,7 @@ mod tests {
         let mut ch = Channel3::new();
         ch.write_nr30(0x80); // DAC on
         ch.write_nr32(0x20); // output level = 1 (100%)
-        ch.write_nr34(0x80); // trigger
+        ch.write_nr34(0x80, false); // trigger
         ch
     }
 
@@ -229,7 +307,7 @@ mod tests {
     fn test_dac_off_prevents_activation() {
         let mut ch = Channel3::new();
         ch.write_nr30(0x00); // DAC off
-        ch.write_nr34(0x80); // trigger
+        ch.write_nr34(0x80, false); // trigger
         assert!(!ch.is_active());
     }
 
@@ -255,7 +333,7 @@ mod tests {
         let mut ch = Channel3::new();
         ch.write_nr30(0x80);
         ch.write_nr31(255); // counter = 1
-        ch.write_nr34(0xC0); // trigger + length enable
+        ch.write_nr34(0xC0, false); // trigger + length enable
         ch.clock_length();
         assert!(!ch.is_active());
     }
@@ -265,7 +343,7 @@ mod tests {
         let mut ch = Channel3::new();
         ch.write_nr30(0x80);
         ch.write_nr31(255);
-        ch.write_nr34(0x80); // trigger, no length enable
+        ch.write_nr34(0x80, false); // trigger, no length enable
         ch.clock_length();
         assert!(ch.is_active());
     }
@@ -277,7 +355,7 @@ mod tests {
         let mut ch = Channel3::new();
         ch.write_nr30(0x80);
         ch.write_nr32(0x00); // level = 0 → mute
-        ch.write_nr34(0x80);
+        ch.write_nr34(0x80, false);
         // Put a non-zero sample in wave RAM at position 0
         ch.wave_ram[0] = 0xFF;
         ch.trigger();
@@ -286,11 +364,14 @@ mod tests {
 
     #[test]
     fn test_output_100_percent() {
+        // Use freq=0 so period=(0^0x7FF)+3=2050 T-cycles on trigger.
+        // After trigger, tick many times to get first advance.
+        // Simpler: directly set current_sample and check output.
         let mut ch = Channel3::new();
         ch.write_nr30(0x80);
         ch.write_nr32(0x20); // level = 1 → 100%
-        ch.wave_ram[0] = 0xF0; // first nibble = 15
-        ch.write_nr34(0x80);
+        ch.active = true;
+        ch.current_sample = 15;
         assert!((ch.output() - 1.0).abs() < 0.001);
     }
 
@@ -298,9 +379,9 @@ mod tests {
     fn test_output_50_percent() {
         let mut ch = Channel3::new();
         ch.write_nr30(0x80);
-        ch.write_nr32(0x40); // level = 2 → 50%
-        ch.wave_ram[0] = 0xF0; // first nibble = 15; shifted right by 1 = 7
-        ch.write_nr34(0x80);
+        ch.write_nr32(0x40); // level = 2 → 50% (shift right 1)
+        ch.active = true;
+        ch.current_sample = 15; // 15 >> 1 = 7
         // 7 / 15 ≈ 0.4667
         assert!((ch.output() - 7.0 / 15.0).abs() < 0.001);
     }
@@ -309,9 +390,9 @@ mod tests {
     fn test_output_25_percent() {
         let mut ch = Channel3::new();
         ch.write_nr30(0x80);
-        ch.write_nr32(0x60); // level = 3 → 25%
-        ch.wave_ram[0] = 0xF0; // 15 >> 2 = 3
-        ch.write_nr34(0x80);
+        ch.write_nr32(0x60); // level = 3 → 25% (shift right 2)
+        ch.active = true;
+        ch.current_sample = 15; // 15 >> 2 = 3
         assert!((ch.output() - 3.0 / 15.0).abs() < 0.001);
     }
 
@@ -327,20 +408,32 @@ mod tests {
     }
 
     #[test]
-    fn test_wave_ram_read_returns_current_byte_during_playback() {
-        // During active playback, reads always return the byte at wave_pos/2.
-        let mut ch = Channel3::new();
+    fn test_wave_ram_read_returns_current_byte_during_playback_cgb() {
+        // On CGB, during active playback, reads always return the byte at wave_pos/2.
+        let mut ch = Channel3::new_with_mode(true); // CGB
         ch.write_nr30(0x80);
         ch.wave_ram[0] = 0x12; // wave_pos 0-1 → byte 0
         ch.wave_ram[1] = 0x34;
-        ch.write_nr34(0x80); // trigger → wave_pos = 0
+        ch.write_nr34(0x80, false); // trigger → wave_pos = 0
         assert!(ch.is_active());
-        // Read any address during playback → should return wave_ram[wave_pos/2] = wave_ram[0]
+        // CGB: read any address during playback → returns wave_ram[wave_pos/2] = wave_ram[0]
         assert_eq!(
             ch.read_wave_ram(0xFF3F),
             0x12,
-            "during playback, wave RAM read must return current byte"
+            "CGB: during playback, wave RAM read must return current byte"
         );
+    }
+
+    #[test]
+    fn test_wave_ram_read_returns_ff_outside_window_dmg() {
+        // On DMG, during active playback, reads return 0xFF unless wave_just_read.
+        let mut ch = Channel3::new_with_mode(false); // DMG
+        ch.write_nr30(0x80);
+        ch.wave_ram[0] = 0x12;
+        ch.active = true;
+        ch.freq_timer = 10; // not about to read
+        // wave_just_read is false → returns 0xFF
+        assert_eq!(ch.read_wave_ram(0xFF30), 0xFF);
     }
 
     // ── NR30/NR32/NR34 register reads ────────────────────────────────────
@@ -365,7 +458,129 @@ mod tests {
     fn test_nr34_reads_length_en() {
         let mut ch = Channel3::new();
         ch.write_nr30(0x80);
-        ch.write_nr34(0x40); // length en, no trigger
+        ch.write_nr34(0x40, false); // length en, no trigger
         assert_eq!(ch.read_nr34() & 0x40, 0x40);
+    }
+
+    // ── Trigger playback delay ────────────────────────────────────────────
+
+    #[test]
+    fn test_trigger_playback_delay_first_advance_at_tick_3_for_max_freq() {
+        // SameBoy: trigger countdown = (freq ^ 0x7FF) + 3 = (2046 ^ 0x7FF) + 3 = 4 APU cycles.
+        // tick() processes 2 APU cycles per M-cycle using `while (cycles_left > countdown)`.
+        // Tick 1: cl=2, cd=4. 2>4? No. cd=2.
+        // Tick 2: cl=2, cd=2. 2>2? No. cd=0.
+        // Tick 3: cl=2, cd=0. 2>0? Yes! Advance pos to 1. Reload=1. 1>1? No. cd=0.
+        // So first advance happens at tick 3 (the +3 delay in APU cycles).
+        let mut ch = Channel3::new();
+        ch.write_nr30(0x80);
+        ch.wave_ram = [
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB,
+            0xCD, 0xEF,
+        ];
+        ch.write_nr33(0xFE); // freq low = 0xFE
+        ch.write_nr34(0x87, false); // trigger, freq high = 7 → freq = 0x07FE = 2046
+
+        assert_eq!(ch.wave_pos, 0, "wave_pos must be 0 after trigger");
+
+        ch.tick(); // M-cycle 1: cd 4→2, no advance
+        assert_eq!(ch.wave_pos, 0, "wave_pos must still be 0 at tick 1");
+
+        ch.tick(); // M-cycle 2: cd 2→0, no advance
+        assert_eq!(ch.wave_pos, 0, "wave_pos must still be 0 at tick 2");
+
+        ch.tick(); // M-cycle 3: 2>0, advance to pos 1
+        assert_eq!(ch.wave_pos, 1, "wave_pos must advance to 1 at tick 3");
+    }
+
+    #[test]
+    fn test_trigger_does_not_immediately_read_sample() {
+        // Pan Docs: "triggering does not immediately start playing wave RAM;
+        // the last sample ever read is output until next read."
+        let mut ch = Channel3::new();
+        ch.write_nr30(0x80);
+        ch.write_nr32(0x20); // 100% volume
+        ch.wave_ram[0] = 0xF0; // nibble 0 = 0xF, nibble 1 = 0x0
+        // current_sample should be 0 (default, as if APU was just powered on)
+        ch.write_nr34(0x80, false); // trigger
+        // Output should still use the OLD sample (0), not nibble at pos 0
+        assert_eq!(
+            ch.output(),
+            0.0,
+            "trigger must not immediately read new sample"
+        );
+    }
+
+    #[test]
+    fn test_first_sample_read_is_index_1() {
+        // Pan Docs: "the first sample read is the one at index 1"
+        // After trigger (wave_pos=0), the first timer expiry reads nibble at pos 1.
+        let mut ch = Channel3::new();
+        ch.write_nr30(0x80);
+        ch.write_nr32(0x20); // 100% volume
+        ch.wave_ram[0] = 0xA5; // nibble 0 = 0xA, nibble 1 = 0x5
+        ch.write_nr33(0xFE);
+        ch.write_nr34(0x87, false); // trigger, freq=2046
+
+        // With 2 APU cycles/tick: countdown=4. Tick 1: cd=2. Tick 2: cd=0. Tick 3: advance to pos 1.
+        ch.tick(); // cd 4→2
+        ch.tick(); // cd 2→0
+        ch.tick(); // advance to pos 1, current_sample = nibble 1 = 0x5
+        assert_eq!(ch.wave_pos, 1, "first advance should reach pos 1");
+        assert_eq!(
+            ch.current_sample, 0x5,
+            "first sample read must be nibble at index 1"
+        );
+    }
+
+    // ── DMG retrigger corruption ──────────────────────────────────────────
+
+    #[test]
+    fn test_dmg_retrigger_corrupts_wave_ram_high_position() {
+        // SameBoy: On DMG, retriggering CH3 while sample_countdown == 0
+        // causes wave RAM corruption. offset = ((wave_pos+1) >> 1) & 0xF.
+        // For offset >= 4: first 4 bytes get the 4-byte-aligned block.
+        let mut ch = Channel3::new_with_mode(false); // DMG mode
+        ch.write_nr30(0x80);
+        ch.wave_ram = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD,
+            0xEE, 0xFF,
+        ];
+
+        // Set up channel as if it's playing and freq_timer just reached 0
+        ch.active = true;
+        ch.wave_pos = 9; // offset = ((9+1)>>1) & 0xF = 5. Aligned block = [4..8]
+        ch.freq_timer = 0;
+        ch.freq = 0;
+
+        // Retrigger while freq_timer == 0 → should corrupt
+        ch.write_nr34(0x80, false);
+
+        // offset=5, aligned=4 → copy wave_ram[4..8] to wave_ram[0..4]
+        assert_eq!(ch.wave_ram[0], 0x44, "byte 0 should be wave_ram[4]");
+        assert_eq!(ch.wave_ram[1], 0x55, "byte 1 should be wave_ram[5]");
+        assert_eq!(ch.wave_ram[2], 0x66, "byte 2 should be wave_ram[6]");
+        assert_eq!(ch.wave_ram[3], 0x77, "byte 3 should be wave_ram[7]");
+    }
+
+    #[test]
+    fn test_cgb_retrigger_does_not_corrupt_wave_ram() {
+        // On CGB, retriggering does NOT corrupt wave RAM.
+        let mut ch = Channel3::new_with_mode(true); // CGB mode
+        ch.write_nr30(0x80);
+        ch.wave_ram = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD,
+            0xEE, 0xFF,
+        ];
+        ch.active = true;
+        ch.wave_pos = 9;
+        ch.freq_timer = 0;
+        ch.freq = 0;
+        // Retrigger — no corruption on CGB
+        ch.write_nr34(0x80, false);
+        assert_eq!(ch.wave_ram[0], 0x00);
+        assert_eq!(ch.wave_ram[1], 0x11);
+        assert_eq!(ch.wave_ram[2], 0x22);
+        assert_eq!(ch.wave_ram[3], 0x33);
     }
 }

--- a/src/gb/apu/channel4.rs
+++ b/src/gb/apu/channel4.rs
@@ -19,7 +19,7 @@ pub struct Channel4 {
     dac_on: bool,
     lfsr: u16,
     freq_timer: u32,
-    length_counter: u8,
+    pub(crate) length_counter: u8,
     volume: u8,
     env_timer: u8,
 }
@@ -177,10 +177,22 @@ impl Channel4 {
         self.divisor_code = val & 0x07;
     }
 
-    pub fn write_nr44(&mut self, val: u8) {
+    pub fn write_nr44(&mut self, val: u8, extra_clk: bool) {
+        let old_length_en = self.length_en;
         self.length_en = val & 0x40 != 0;
+
+        if extra_clk && !old_length_en && self.length_en && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.active = false;
+            }
+        }
+
         if val & 0x80 != 0 {
             self.trigger();
+            if extra_clk && self.length_en && self.length_counter == 64 {
+                self.length_counter = 63;
+            }
         }
     }
 
@@ -210,7 +222,7 @@ mod tests {
     fn triggered_ch4() -> Channel4 {
         let mut ch = Channel4::new();
         ch.write_nr42(0xF1); // vol=15, sub, period=1, DAC on
-        ch.write_nr44(0x80); // trigger
+        ch.write_nr44(0x80, false); // trigger
         ch
     }
 
@@ -223,7 +235,7 @@ mod tests {
     fn test_dac_off_prevents_activation() {
         let mut ch = Channel4::new();
         ch.write_nr42(0x00);
-        ch.write_nr44(0x80);
+        ch.write_nr44(0x80, false);
         assert!(!ch.is_active());
     }
 
@@ -237,7 +249,7 @@ mod tests {
         let mut ch = Channel4::new();
         ch.write_nr42(0xF1);
         ch.write_nr41(0x3F); // counter = 1
-        ch.write_nr44(0xC0); // trigger + length enable
+        ch.write_nr44(0xC0, false); // trigger + length enable
         ch.clock_length();
         assert!(!ch.is_active());
     }
@@ -247,7 +259,7 @@ mod tests {
         let mut ch = Channel4::new();
         ch.write_nr42(0xF1);
         ch.write_nr41(0x3F);
-        ch.write_nr44(0x80);
+        ch.write_nr44(0x80, false);
         ch.clock_length();
         assert!(ch.is_active());
     }
@@ -256,7 +268,7 @@ mod tests {
     fn test_envelope_decrements_volume() {
         let mut ch = Channel4::new();
         ch.write_nr42(0x71); // vol=7, sub, period=1
-        ch.write_nr44(0x80);
+        ch.write_nr44(0x80, false);
         ch.clock_envelope();
         assert_eq!(ch.volume, 6);
     }
@@ -265,7 +277,7 @@ mod tests {
     fn test_envelope_increments_volume() {
         let mut ch = Channel4::new();
         ch.write_nr42(0x79); // vol=7, add, period=1
-        ch.write_nr44(0x80);
+        ch.write_nr44(0x80, false);
         ch.clock_envelope();
         assert_eq!(ch.volume, 8);
     }
@@ -276,7 +288,7 @@ mod tests {
         let mut ch = Channel4::new();
         ch.write_nr42(0xF0);
         ch.write_nr43(0x00); // 15-bit
-        ch.write_nr44(0x80); // trigger -> LFSR = 0x7FFF
+        ch.write_nr44(0x80, false); // trigger -> LFSR = 0x7FFF
         ch.clock_lfsr();
         assert_eq!(ch.lfsr, 0x3FFF);
     }
@@ -287,7 +299,7 @@ mod tests {
         let mut ch = Channel4::new();
         ch.write_nr42(0xF0);
         ch.write_nr43(0x08); // 7-bit
-        ch.write_nr44(0x80);
+        ch.write_nr44(0x80, false);
         ch.clock_lfsr();
         assert_eq!(ch.lfsr & (1 << 6), 0);
     }
@@ -297,12 +309,12 @@ mod tests {
         let mut ch15 = Channel4::new();
         ch15.write_nr42(0xF0);
         ch15.write_nr43(0x00);
-        ch15.write_nr44(0x80);
+        ch15.write_nr44(0x80, false);
 
         let mut ch7 = Channel4::new();
         ch7.write_nr42(0xF0);
         ch7.write_nr43(0x08);
-        ch7.write_nr44(0x80);
+        ch7.write_nr44(0x80, false);
 
         let bits15: Vec<u8> = (0..32)
             .map(|_| {
@@ -337,7 +349,7 @@ mod tests {
     fn test_nr44_reads_length_en() {
         let mut ch = Channel4::new();
         ch.write_nr42(0xF0);
-        ch.write_nr44(0x40);
+        ch.write_nr44(0x40, false);
         assert_eq!(ch.read_nr44() & 0x40, 0x40);
     }
 

--- a/src/gb/apu/mod.rs
+++ b/src/gb/apu/mod.rs
@@ -84,15 +84,19 @@ pub struct Apu {
     cycles_per_sample: f32,
     /// Pending output sample (`Some` when `sample_ready()` is true).
     pending_sample: Option<f32>,
+
+    /// `true` when running a CGB-compatible ROM (header byte 0x0143 ≥ 0x80).
+    /// Gates CGB-specific APU differences (length counter behavior on power off/on).
+    is_cgb: bool,
 }
 
 impl Apu {
     /// Create a new APU in the power-off state.
-    pub fn new() -> Self {
+    pub fn new(is_cgb: bool) -> Self {
         Self {
             ch1: Channel1::new(),
             ch2: Channel2::new(),
-            ch3: Channel3::new(),
+            ch3: Channel3::new_with_mode(is_cgb),
             ch4: Channel4::new(),
             nr50: 0x00,
             nr51: 0x00,
@@ -102,6 +106,7 @@ impl Apu {
             sample_acc: 0.0,
             cycles_per_sample: DMG_MCYCLES_PER_SEC / 44_100.0,
             pending_sample: None,
+            is_cgb,
         }
     }
 
@@ -282,37 +287,45 @@ impl Apu {
 
         if !self.powered {
             // On DMG, length counters remain writable when APU is off.
-            match addr {
-                0xFF11 => self.ch1.write_nr11_length_only(val),
-                0xFF16 => self.ch2.write_nr21_length_only(val),
-                0xFF1B => self.ch3.write_nr31_length_only(val),
-                0xFF20 => self.ch4.write_nr41_length_only(val),
-                _ => {}
+            // On CGB, all writes (including length) are rejected when off.
+            if !self.is_cgb {
+                match addr {
+                    0xFF11 => self.ch1.write_nr11_length_only(val),
+                    0xFF16 => self.ch2.write_nr21_length_only(val),
+                    0xFF1B => self.ch3.write_nr31_length_only(val),
+                    0xFF20 => self.ch4.write_nr41_length_only(val),
+                    _ => {}
+                }
             }
             return;
         }
+
+        // Extra length clocking: the FS next step would NOT clock length when
+        // the current fs_step is odd (1, 3, 5, 7). In that case, NRx4 writes
+        // that enable length_en or trigger with length_en get an extra clock.
+        let extra_clk = FS_TABLE[self.fs_step as usize] & 0x01 == 0;
 
         match addr {
             0xFF10 => self.ch1.write_nr10(val),
             0xFF11 => self.ch1.write_nr11(val),
             0xFF12 => self.ch1.write_nr12(val),
             0xFF13 => self.ch1.write_nr13(val),
-            0xFF14 => self.ch1.write_nr14(val),
+            0xFF14 => self.ch1.write_nr14(val, extra_clk),
             0xFF15 => {}
             0xFF16 => self.ch2.write_nr21(val),
             0xFF17 => self.ch2.write_nr22(val),
             0xFF18 => self.ch2.write_nr23(val),
-            0xFF19 => self.ch2.write_nr24(val),
+            0xFF19 => self.ch2.write_nr24(val, extra_clk),
             0xFF1A => self.ch3.write_nr30(val),
             0xFF1B => self.ch3.write_nr31(val),
             0xFF1C => self.ch3.write_nr32(val),
             0xFF1D => self.ch3.write_nr33(val),
-            0xFF1E => self.ch3.write_nr34(val),
+            0xFF1E => self.ch3.write_nr34(val, extra_clk),
             0xFF1F => {}
             0xFF20 => self.ch4.write_nr41(val),
             0xFF21 => self.ch4.write_nr42(val),
             0xFF22 => self.ch4.write_nr43(val),
-            0xFF23 => self.ch4.write_nr44(val),
+            0xFF23 => self.ch4.write_nr44(val, extra_clk),
             0xFF24 => self.nr50 = val,
             0xFF25 => self.nr51 = val,
             _ => {}
@@ -335,6 +348,13 @@ impl Apu {
             // Power on: reset frame sequencer.
             self.fs_step = 0;
             self.fs_timer = FS_MCYCLES_PER_STEP;
+            // On CGB, powering on resets all length counters to 0.
+            if self.is_cgb {
+                self.ch1.length_counter = 0;
+                self.ch2.length_counter = 0;
+                self.ch3.length_counter = 0;
+                self.ch4.length_counter = 0;
+            }
         }
     }
 
@@ -346,7 +366,7 @@ impl Apu {
 
 impl Default for Apu {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
@@ -357,7 +377,7 @@ mod tests {
     use super::*;
 
     fn powered_apu() -> Apu {
-        let mut apu = Apu::new();
+        let mut apu = Apu::new(false);
         apu.write_register(0xFF26, 0x80); // power on
         apu
     }
@@ -374,14 +394,14 @@ mod tests {
     #[test]
     fn test_nr52_power_off_bit_readable() {
         // Given: APU powered off (default); When: read NR52; Then: bit 7 is clear
-        let apu = Apu::new();
+        let apu = Apu::new(false);
         assert_eq!(apu.read_register(0xFF26) & 0x80, 0x00);
     }
 
     #[test]
     fn test_nr52_unused_bits_read_as_1() {
         // Bits 6-4 of NR52 read as 1 (open bus on DMG).
-        let apu = Apu::new();
+        let apu = Apu::new(false);
         assert_eq!(apu.read_register(0xFF26) & 0x70, 0x70);
     }
 
@@ -411,7 +431,7 @@ mod tests {
     #[test]
     fn test_power_off_ignores_nr50_write() {
         // When powered off, writes to NR50 are ignored.
-        let mut apu = Apu::new(); // starts powered off
+        let mut apu = Apu::new(false); // starts powered off
         apu.write_register(0xFF24, 0x77);
         assert_eq!(apu.nr50, 0x00, "NR50 write must be ignored when APU is off");
     }
@@ -436,7 +456,7 @@ mod tests {
 
     #[test]
     fn test_sample_not_ready_initially() {
-        let apu = Apu::new();
+        let apu = Apu::new(false);
         assert!(!apu.sample_ready());
     }
 
@@ -444,7 +464,7 @@ mod tests {
     fn test_sample_ready_after_enough_ticks() {
         // At 44100 Hz sample rate and DMG 1 048 576 M-cycles/s,
         // one sample ≈ every 23.77 M-cycles.
-        let mut apu = Apu::new();
+        let mut apu = Apu::new(false);
         apu.set_sample_rate(44_100.0);
         // Tick 30 M-cycles — must have produced at least one sample.
         apu.tick(30);
@@ -453,7 +473,7 @@ mod tests {
 
     #[test]
     fn test_take_sample_clears_ready_flag() {
-        let mut apu = Apu::new();
+        let mut apu = Apu::new(false);
         apu.tick(30);
         apu.take_sample();
         // After consuming the sample the flag must be clear.
@@ -463,7 +483,7 @@ mod tests {
     #[test]
     fn test_sample_is_silent_when_powered_off() {
         // With APU off, all samples must be 0.0.
-        let mut apu = Apu::new();
+        let mut apu = Apu::new(false);
         apu.tick(30);
         let s = apu.take_sample().unwrap_or(0.0);
         assert_eq!(s, 0.0);
@@ -525,8 +545,110 @@ mod tests {
 
     #[test]
     fn test_nr52_ch1_active_bit_reflects_channel1_state() {
-        let apu = Apu::new();
+        let apu = Apu::new(false);
         // CH1 is inactive by default → bit 0 clear
         assert_eq!(apu.read_register(0xFF26) & 0x01, 0x00);
+    }
+
+    // ── CGB-specific power behavior ─────────────────────────────────────
+
+    fn powered_cgb_apu() -> Apu {
+        let mut apu = Apu::new(true);
+        apu.write_register(0xFF26, 0x80); // power on
+        apu
+    }
+
+    #[test]
+    fn test_cgb_power_off_rejects_nr41_length_write() {
+        // On CGB, length counter writes are rejected when APU is off.
+        // Given: CGB APU powered on, set CH4 length, then power off
+        let mut apu = powered_cgb_apu();
+        apu.write_register(0xFF20, 0x3F); // NR41: length_load = 63 → counter = 1
+        apu.write_register(0xFF26, 0x00); // power off → clears length_counter to 0
+        // When: write NR41 while powered off
+        apu.write_register(0xFF20, 0x3F); // on DMG this sets counter=1, on CGB it's rejected
+        // Then: length_counter must remain 0
+        assert_eq!(
+            apu.ch4.length_counter, 0,
+            "CGB must reject length writes when APU is off"
+        );
+    }
+
+    #[test]
+    fn test_cgb_power_off_rejects_nr11_length_write() {
+        // Given: CGB APU powered off
+        let mut apu = Apu::new(true);
+        // When: write NR11 while powered off
+        apu.write_register(0xFF11, 0x3F); // length_load = 63 → counter would be 1 on DMG
+        // Then: length_counter must remain 0
+        assert_eq!(
+            apu.ch1.length_counter, 0,
+            "CGB must reject CH1 length writes when APU is off"
+        );
+    }
+
+    #[test]
+    fn test_cgb_power_off_rejects_nr21_length_write() {
+        let mut apu = Apu::new(true);
+        apu.write_register(0xFF16, 0x3F);
+        assert_eq!(
+            apu.ch2.length_counter, 0,
+            "CGB must reject CH2 length writes when APU is off"
+        );
+    }
+
+    #[test]
+    fn test_cgb_power_off_rejects_nr31_length_write() {
+        let mut apu = Apu::new(true);
+        apu.write_register(0xFF1B, 0xFF); // length_load = 255 → counter would be 1 on DMG
+        assert_eq!(
+            apu.ch3.length_counter, 0,
+            "CGB must reject CH3 length writes when APU is off"
+        );
+    }
+
+    #[test]
+    fn test_dmg_power_off_allows_nr41_length_write() {
+        // On DMG, length counter writes are allowed when APU is off.
+        let mut apu = Apu::new(false);
+        apu.write_register(0xFF20, 0x3F); // NR41: length_load = 63 → counter = 1
+        assert_eq!(
+            apu.ch4.length_counter, 1,
+            "DMG must allow length writes when APU is off"
+        );
+    }
+
+    #[test]
+    fn test_cgb_power_on_resets_length_counters() {
+        // On CGB, powering on the APU resets all length counters to 0.
+        // Given: CGB APU on, set length counters, power off then on
+        let mut apu = powered_cgb_apu();
+        apu.write_register(0xFF11, 0x00); // CH1: length_load=0 → counter=64
+        apu.write_register(0xFF16, 0x00); // CH2: length_load=0 → counter=64
+        apu.write_register(0xFF1B, 0x00); // CH3: length_load=0 → counter=256
+        apu.write_register(0xFF20, 0x00); // CH4: length_load=0 → counter=64
+        // Verify they're set
+        assert_eq!(apu.ch1.length_counter, 64);
+        assert_eq!(apu.ch4.length_counter, 64);
+        // Power off → counters cleared
+        apu.write_register(0xFF26, 0x00);
+        // Power on → on CGB, counters must be reset to 0
+        apu.write_register(0xFF26, 0x80);
+        assert_eq!(
+            apu.ch1.length_counter, 0,
+            "CGB power-on must reset CH1 length"
+        );
+        assert_eq!(
+            apu.ch2.length_counter, 0,
+            "CGB power-on must reset CH2 length"
+        );
+        assert_eq!(
+            apu.ch3.length_counter, 0,
+            "CGB power-on must reset CH3 length"
+        );
+        assert_eq!(
+            apu.ch4.length_counter, 0,
+            "CGB power-on must reset CH4 length"
+        );
     }
 }

--- a/src/gb/apu/mod.rs
+++ b/src/gb/apu/mod.rs
@@ -85,7 +85,7 @@ pub struct Apu {
     /// Pending output sample (`Some` when `sample_ready()` is true).
     pending_sample: Option<f32>,
 
-    /// `true` when running a CGB-compatible ROM (header byte 0x0143 ≥ 0x80).
+    /// `true` when running a CGB-compatible ROM (header byte 0x0143 is 0x80 or 0xC0).
     /// Gates CGB-specific APU differences (length counter behavior on power off/on).
     is_cgb: bool,
 }
@@ -300,9 +300,9 @@ impl Apu {
             return;
         }
 
-        // Extra length clocking: the FS next step would NOT clock length when
-        // the current fs_step is odd (1, 3, 5, 7). In that case, NRx4 writes
-        // that enable length_en or trigger with length_en get an extra clock.
+        // Extra length clocking: when the current FS step does NOT clock length
+        // (i.e. FS_TABLE[fs_step] has bit 0 clear — steps 1, 3, 5, 7), NRx4
+        // writes that enable length_en or trigger with length_en get an extra clock.
         let extra_clk = FS_TABLE[self.fs_step as usize] & 0x01 == 0;
 
         match addr {

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -58,6 +58,7 @@ pub struct DmgBus {
 
 impl DmgBus {
     pub fn new(cart: Box<dyn GbCartridge>) -> Self {
+        let is_cgb = cart.is_cgb();
         let mut bus = Self {
             cart,
             ppu: Ppu::new(),
@@ -65,7 +66,7 @@ impl DmgBus {
             hram: [0u8; 0x7F],
             timer: Timer::new(),
             joypad: Joypad::new(),
-            apu: Apu::new(),
+            apu: Apu::new(is_cgb),
             if_reg: 0,
             ie_reg: 0,
             boot_rom: DMG_BOOT_ROM,
@@ -92,7 +93,7 @@ impl DmgBus {
         self.ppu.write_register(0xFF40, 0x00); // power-on: LCD disabled
         self.timer = Timer::new();
         self.joypad = Joypad::new();
-        self.apu = Apu::new();
+        self.apu = Apu::new(self.cart.is_cgb());
         self.wram = [0u8; 0x2000];
         self.hram = [0u8; 0x7F];
         self.if_reg = 0;

--- a/src/gb/cartridge/cartridge.rs
+++ b/src/gb/cartridge/cartridge.rs
@@ -15,4 +15,14 @@ pub trait GbCartridge {
     /// Writes to ROM ($0000–$7FFF) are interpreted as MBC register writes.
     /// Writes to cartridge RAM ($A000–$BFFF) store data when RAM is enabled.
     fn write(&mut self, addr: u16, val: u8);
+
+    /// Returns `true` when the ROM header indicates CGB compatibility.
+    ///
+    /// Checks byte 0x0143: values 0x80 (CGB+DMG) or 0xC0 (CGB-only)
+    /// indicate a CGB-compatible cartridge. This gates CGB-specific
+    /// hardware behavior (e.g., APU length counter rules).
+    fn is_cgb(&self) -> bool {
+        let flag = self.read(0x0143);
+        flag == 0x80 || flag == 0xC0
+    }
 }

--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -352,7 +352,6 @@ fn test_dmg_sound_02_len_ctr() {
 }
 
 #[test]
-#[ignore = "failing: length counter clocking on trigger in first half of period — tracked in #2038"]
 fn test_dmg_sound_03_trigger() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/03-trigger.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
@@ -373,7 +372,6 @@ fn test_dmg_sound_04_sweep() {
 }
 
 #[test]
-#[ignore = "failing: sweep negate-mode exit disables channel — tracked in #2038"]
 fn test_dmg_sound_05_sweep_details() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/05-sweep details.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
@@ -417,7 +415,6 @@ fn test_dmg_sound_08_len_ctr_during_power() {
 }
 
 #[test]
-#[ignore = "failing: wave channel read-while-on behaviour — tracked in #2038"]
 fn test_dmg_sound_09_wave_read_while_on() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/09-wave read while on.gb");
@@ -429,7 +426,6 @@ fn test_dmg_sound_09_wave_read_while_on() {
 }
 
 #[test]
-#[ignore = "failing: wave channel trigger-while-on behaviour — tracked in #2038"]
 fn test_dmg_sound_10_wave_trigger_while_on() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/10-wave trigger while on.gb");
@@ -452,7 +448,6 @@ fn test_dmg_sound_11_regs_after_power() {
 }
 
 #[test]
-#[ignore = "failing: wave channel write-while-on behaviour — tracked in #2038"]
 fn test_dmg_sound_12_wave_write_while_on() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/dmg_sound/rom_singles/12-wave write while on.gb");
@@ -486,7 +481,6 @@ fn test_cgb_sound_02_len_ctr() {
 }
 
 #[test]
-#[ignore = "failing: length counter clocking on trigger in first half of period — tracked in #2038"]
 fn test_cgb_sound_03_trigger() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/03-trigger.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
@@ -507,7 +501,6 @@ fn test_cgb_sound_04_sweep() {
 }
 
 #[test]
-#[ignore = "failing: sweep negate-mode exit disables channel — tracked in #2038"]
 fn test_cgb_sound_05_sweep_details() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/05-sweep details.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
@@ -540,7 +533,6 @@ fn test_cgb_sound_07_len_sweep_period_sync() {
 }
 
 #[test]
-#[ignore = "failing: length counter behaviour during APU power cycle (CGB variant) — tracked in #2038"]
 fn test_cgb_sound_08_len_ctr_during_power() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/08-len ctr during power.gb");
@@ -552,7 +544,6 @@ fn test_cgb_sound_08_len_ctr_during_power() {
 }
 
 #[test]
-#[ignore = "failing: wave channel read-while-on behaviour — tracked in #2038"]
 fn test_cgb_sound_09_wave_read_while_on() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/09-wave read while on.gb");
@@ -575,7 +566,6 @@ fn test_cgb_sound_10_wave_trigger_while_on() {
 }
 
 #[test]
-#[ignore = "failing: APU power-off should clear NR41 length counter (CGB variant) — tracked in #2038"]
 fn test_cgb_sound_11_regs_after_power() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/cgb_sound/rom_singles/11-regs after power.gb");


### PR DESCRIPTION
## Summary

Fixes all 10 remaining Blargg `dmg_sound` / `cgb_sound` APU test failures, organized into 4 root causes:

### 1. Sweep negate exit (dmg_05, cgb_05)
Set `negate_used = true` in `Channel1::trigger()` when sweep_negate is active. This ensures the hardware quirk — disabling the channel when switching from negate to non-negate mode after a calculation — works correctly.

### 2. Trigger extra-clock (dmg_03, cgb_03)
Pass `fs_step` from APU to each channel's NRx4 write method. Apply extra length clocking when `length_en` transitions 0→1 on a non-length frame sequencer step, plus decrement-after-reload on trigger.

### 3. CGB mode detection (cgb_08, cgb_11)
Add `is_cgb` flag via `GbCartridge` trait, propagated through `DmgBus` to `Apu`. Gates CGB-specific behavior: length counter reset on power-on, reject length-only writes when powered off.

### 4. Wave channel timing (dmg_09, dmg_10, dmg_12, cgb_09)
Rewrote CH3 with SameBoy-accurate timing:
- **2 APU cycles per M-cycle** (not 4 T-cycles) — confirmed from SameBoy's `timing.c`: `apu_cycles += 1 << !cgb_double_speed`
- Trigger delay: countdown = `(freq ^ 0x7FF) + 3` APU cycles
- DMG retrigger corruption: wave RAM corruption when retriggering while `freq_timer == 0`
- DMG wave RAM access gating via `wave_just_read` flag
- CGB: always-accessible wave RAM reads/writes during playback

## Test Results

- **All 24 Blargg dmg_sound + cgb_sound tests pass** (0 ignored)
- **8651 total tests pass**, 0 regressions
- `cargo fmt`, `cargo clippy` clean

## Files Changed

| File | Changes |
|------|---------|
| `channel1.rs` | `negate_used` fix in trigger; `extra_clk` param; 4 new tests |
| `channel2.rs` | `extra_clk` param; updated tests |
| `channel3.rs` | Major: SameBoy-accurate wave timing, DMG corruption, access gating; 7 new tests |
| `channel4.rs` | `extra_clk` param; updated tests |
| `mod.rs` (APU) | `is_cgb`, CGB power behavior, `extra_clk` computation; 7 new tests |
| `dmg_bus.rs` | Pass `is_cgb` to APU |
| `cartridge.rs` | `is_cgb()` trait method |
| `blargg_tests.rs` | Remove `#[ignore]` from all 10 tests |

Closes #2038
