### PR TITLE
refactor: input handlers use Console trait dispatch (#2045)

### DIFF
--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -272,13 +272,7 @@ impl NativeEventLoop {
     /// Called once per frame to ensure grab/visibility stay in sync after
     /// cartridge switches, focus changes, or controller hot-swaps.
     fn sync_mouse_grab_state(&mut self) {
-        // Mouse grab is only relevant for NES (Zapper / SNES Mouse controllers).
-        let has_mouse = {
-            let Console::Nes(nes) = &self.console else {
-                return;
-            };
-            mouse::has_any_mouse_controller(nes)
-        };
+        let has_mouse = mouse::has_any_mouse_controller(&self.console);
         let should_grab = crate::nes::input::mouse_mapping::should_grab_mouse_input(
             has_mouse,
             self.state.window_focused,
@@ -300,10 +294,8 @@ impl NativeEventLoop {
                     let cx = w as f32 / 2.0;
                     let cy = h as f32 / 2.0;
                     self.state.virtual_cursor = (cx, cy);
-                    if let Console::Nes(nes) = &mut self.console {
-                        self.state.last_zapper_position =
-                            mouse::update_mouse_motion(nes, cx as i32, cy as i32, w, h);
-                    }
+                    self.state.last_zapper_position =
+                        mouse::update_mouse_motion(&mut self.console, cx as i32, cy as i32, w, h);
                 } else {
                     let _ = gl.set_mouse_grab(false);
                     gl.window().set_cursor_visible(true);
@@ -815,13 +807,7 @@ impl ApplicationHandler for NativeEventLoop {
                     gl.handle_mouse_button(button, state);
                 }
 
-                // Mouse controller logic is NES-only.
-                let has_mouse = {
-                    let Console::Nes(nes) = &self.console else {
-                        return;
-                    };
-                    mouse::has_any_mouse_controller(nes)
-                };
+                let has_mouse = mouse::has_any_mouse_controller(&self.console);
 
                 // Left-click grabs immediately so the same click is also forwarded
                 // as a button press (unlike deferring to the next frame, which
@@ -850,10 +836,13 @@ impl ApplicationHandler for NativeEventLoop {
                             let cx = w as f32 / 2.0;
                             let cy = h as f32 / 2.0;
                             self.state.virtual_cursor = (cx, cy);
-                            if let Console::Nes(nes) = &mut self.console {
-                                self.state.last_zapper_position =
-                                    mouse::update_mouse_motion(nes, cx as i32, cy as i32, w, h);
-                            }
+                            self.state.last_zapper_position = mouse::update_mouse_motion(
+                                &mut self.console,
+                                cx as i32,
+                                cy as i32,
+                                w,
+                                h,
+                            );
                         }
                         self.state.mouse_grabbed = true;
                         if !mouse::should_forward_grab_click(was_released_by_escape) {
@@ -870,9 +859,12 @@ impl ApplicationHandler for NativeEventLoop {
                         winit::event::MouseButton::Right => Some(mouse::MouseButton::Right),
                         _ => None,
                     };
-                    if let (Some(btn), Console::Nes(nes)) = (btn, &mut self.console as &mut Console)
-                    {
-                        mouse::update_mouse_button(nes, btn, state == ElementState::Pressed);
+                    if let Some(btn) = btn {
+                        mouse::update_mouse_button(
+                            &mut self.console,
+                            btn,
+                            state == ElementState::Pressed,
+                        );
                     }
                 }
             }
@@ -929,13 +921,12 @@ impl ApplicationHandler for NativeEventLoop {
                 // Render and apply debugger UI actions
                 let action = if let Some(ref mut gl) = self.gl_wrapper {
                     gl.update_breakpoints(self.debugger_controller.breakpoints());
-                    let (overlay, crosshair) = if let Console::Nes(nes) = &self.console {
-                        (
-                            self.state.overlay_text(nes, self.autorun_state.as_ref()),
-                            mouse::zapper_crosshair(nes, self.state.last_zapper_position),
-                        )
+                    let crosshair =
+                        mouse::zapper_crosshair(&self.console, self.state.last_zapper_position);
+                    let overlay = if let Console::Nes(nes) = &self.console {
+                        self.state.overlay_text(nes, self.autorun_state.as_ref())
                     } else {
-                        (None, None)
+                        None
                     };
                     gl.render(
                         &self.console,
@@ -971,22 +962,23 @@ impl ApplicationHandler for NativeEventLoop {
                 return;
             }
 
-            // Mouse motion routing is NES-only.
-            let Console::Nes(nes) = &mut self.console else {
-                return;
-            };
-
             let (w, h) = self
                 .gl_wrapper
                 .as_ref()
                 .map(|gl| gl.window_size())
                 .unwrap_or((320, 240));
 
-            if nes.has_snes_mouse() && !mouse::has_zapper(nes) {
+            if mouse::has_snes_mouse(&self.console) && !mouse::has_zapper(&self.console) {
                 // SNES Mouse: pass raw deltas directly.
                 // Zapper takes precedence — if a Zapper is also connected,
                 // fall through to the virtual-cursor path (matching SDL logic).
-                mouse::apply_snes_mouse_relative_motion(nes, dx as i32, dy as i32, w, h);
+                mouse::apply_snes_mouse_relative_motion(
+                    &mut self.console,
+                    dx as i32,
+                    dy as i32,
+                    w,
+                    h,
+                );
             } else {
                 // Zapper / Arkanoid: accumulate deltas into a virtual cursor
                 // position clamped to the window, then map to NES coordinates.
@@ -1001,8 +993,13 @@ impl ApplicationHandler for NativeEventLoop {
                 );
                 self.state.virtual_cursor = (new_vx, new_vy);
 
-                self.state.last_zapper_position =
-                    mouse::update_mouse_motion(nes, new_vx as i32, new_vy as i32, w, h);
+                self.state.last_zapper_position = mouse::update_mouse_motion(
+                    &mut self.console,
+                    new_vx as i32,
+                    new_vy as i32,
+                    w,
+                    h,
+                );
             }
         }
     }

--- a/src/frontends/native/gamepad.rs
+++ b/src/frontends/native/gamepad.rs
@@ -4,7 +4,6 @@
 //! buttons and analog axes to NES/SNES controller inputs, and manages
 //! hot-plug player assignment.
 
-use crate::nes::console::Nes;
 use crate::nes::input::{Button, ControllerInput, SnesButton};
 use crate::platform::emulator::Console;
 
@@ -219,77 +218,28 @@ impl GamepadManager {
     /// any hot-plug connect/disconnect events that occurred.
     pub fn process_events(&mut self, console: &mut Console) -> Vec<GamepadChange> {
         let mut changes = Vec::new();
-        match console {
-            Console::Nes(nes) => {
-                while let Some(event) = self.gilrs.next_event() {
-                    match event.event {
-                        EventType::ButtonPressed(button, _) => {
-                            self.handle_button(nes, event.id, button, true);
-                        }
-                        EventType::ButtonReleased(button, _) => {
-                            self.handle_button(nes, event.id, button, false);
-                        }
-                        EventType::AxisChanged(axis, value, _) => {
-                            self.handle_axis(nes, event.id, axis, value);
-                        }
-                        EventType::Connected => {
-                            if let Some(change) = self.handle_connected(event.id) {
-                                changes.push(change);
-                            }
-                        }
-                        EventType::Disconnected => {
-                            if let Some(change) = self.handle_disconnected(nes, event.id) {
-                                changes.push(change);
-                            }
-                        }
-                        _ => {}
+        while let Some(event) = self.gilrs.next_event() {
+            match event.event {
+                EventType::ButtonPressed(button, _) => {
+                    self.handle_button(console, event.id, button, true);
+                }
+                EventType::ButtonReleased(button, _) => {
+                    self.handle_button(console, event.id, button, false);
+                }
+                EventType::AxisChanged(axis, value, _) => {
+                    self.handle_axis(console, event.id, axis, value);
+                }
+                EventType::Connected => {
+                    if let Some(change) = self.handle_connected(event.id) {
+                        changes.push(change);
                     }
                 }
-            }
-            Console::GameBoy(_) => {
-                while let Some(event) = self.gilrs.next_event() {
-                    match event.event {
-                        EventType::ButtonPressed(button, _) => {
-                            if let Some(nes_btn) = map_button_to_nes(button) {
-                                console.set_button(0, nes_btn as u8, true);
-                            }
-                        }
-                        EventType::ButtonReleased(button, _) => {
-                            if let Some(nes_btn) = map_button_to_nes(button) {
-                                console.set_button(0, nes_btn as u8, false);
-                            }
-                        }
-                        EventType::AxisChanged(axis, value, _) => {
-                            let state = self.gamepad_states.entry(event.id).or_default();
-                            let axis_changes = match axis {
-                                Axis::LeftStickX => state.axis.update_x(value),
-                                Axis::LeftStickY => state.axis.update_y(value),
-                                _ => vec![],
-                            };
-                            for (btn, pressed) in axis_changes {
-                                console.set_button(0, btn as u8, pressed);
-                            }
-                        }
-                        EventType::Connected => {
-                            if let Some(change) = self.handle_connected(event.id) {
-                                changes.push(change);
-                            }
-                        }
-                        EventType::Disconnected => {
-                            if let Some(player_num) = self.player_map.get(&event.id).copied() {
-                                self.player_map.remove(&event.id);
-                                self.gamepad_states.remove(&event.id);
-                                self.reassign_players();
-                                if self.player_map.is_empty() {
-                                    // Release all GB buttons only when the last gamepad disconnects.
-                                    console.set_joypad_button_states(0, 0);
-                                }
-                                changes.push(GamepadChange::Disconnected(player_num));
-                            }
-                        }
-                        _ => {}
+                EventType::Disconnected => {
+                    if let Some(change) = self.handle_disconnected(console, event.id) {
+                        changes.push(change);
                     }
                 }
+                _ => {}
             }
         }
         changes
@@ -354,30 +304,36 @@ impl GamepadManager {
     ///
     /// Returns a [`GamepadChange::Disconnected`] with the player number that
     /// was assigned to the gamepad, or `None` if the gamepad wasn't tracked.
-    fn handle_disconnected(&mut self, nes: &mut Nes, id: GamepadId) -> Option<GamepadChange> {
+    fn handle_disconnected(
+        &mut self,
+        console: &mut Console,
+        id: GamepadId,
+    ) -> Option<GamepadChange> {
         if let Some(player_num) = self.player_map.get(&id).copied() {
             // Release all held buttons for this gamepad's port before removing.
-            if let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) {
-                use Button::{A, B, Down, Left, Right, Select, Start, Up};
-                for button in [A, B, Select, Start, Up, Down, Left, Right] {
-                    nes.set_button(port, button, false);
-                }
-                use SnesButton as S;
-                for snes_btn in [
-                    S::A,
-                    S::B,
-                    S::X,
-                    S::Y,
-                    S::L,
-                    S::R,
-                    S::Start,
-                    S::Select,
-                    S::Up,
-                    S::Down,
-                    S::Left,
-                    S::Right,
-                ] {
-                    nes.set_snes_button(port, snes_btn, false);
+            if let Console::Nes(nes) = console {
+                if let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) {
+                    use Button::{A, B, Down, Left, Right, Select, Start, Up};
+                    for button in [A, B, Select, Start, Up, Down, Left, Right] {
+                        nes.set_button(port, button, false);
+                    }
+                    use SnesButton as S;
+                    for snes_btn in [
+                        S::A,
+                        S::B,
+                        S::X,
+                        S::Y,
+                        S::L,
+                        S::R,
+                        S::Start,
+                        S::Select,
+                        S::Up,
+                        S::Down,
+                        S::Left,
+                        S::Right,
+                    ] {
+                        nes.set_snes_button(port, snes_btn, false);
+                    }
                 }
             }
 
@@ -387,6 +343,12 @@ impl GamepadManager {
                 "Gamepad disconnected (was player {player_num})"
             ));
             self.reassign_players();
+
+            // Release all buttons when the last gamepad disconnects (non-NES systems).
+            if !matches!(console, Console::Nes(_)) && self.player_map.is_empty() {
+                console.set_joypad_button_states(0, 0);
+            }
+
             Some(GamepadChange::Disconnected(player_num))
         } else {
             None
@@ -420,7 +382,11 @@ impl GamepadManager {
     ///
     /// Mirrors the SDL frontend's `assigned_gamepad_port` logic:
     /// only assigns to ports whose controller type accepts gamepad input.
-    fn assigned_port(nes: &Nes, player_map: &HashMap<GamepadId, u8>, player_num: u8) -> Option<u8> {
+    fn assigned_port(
+        nes: &crate::nes::console::Nes,
+        player_map: &HashMap<GamepadId, u8>,
+        player_num: u8,
+    ) -> Option<u8> {
         let gamepad_ports: Vec<u8> = (1..=4)
             .filter(|&port| nes.controller_input_type(port) == Some(ControllerInput::Gamepad))
             .collect();
@@ -440,52 +406,72 @@ impl GamepadManager {
         })
     }
 
-    /// Handles a button press or release, dispatching to the correct NES port.
-    fn handle_button(&self, nes: &mut Nes, id: GamepadId, button: gilrs::Button, pressed: bool) {
-        let Some(&player_num) = self.player_map.get(&id) else {
-            return;
-        };
-        let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) else {
-            return;
-        };
-
-        // Port-aware mapping: try SNES first, fall back to NES.
-        if let Some(snes_btn) = map_button_to_snes(button)
-            && nes.set_snes_button(port, snes_btn, pressed)
-        {
-            return;
-        }
-        if let Some(nes_btn) = map_button_to_nes(button) {
-            nes.set_button(port, nes_btn, pressed);
+    /// Handles a button press or release, dispatching to the correct port.
+    ///
+    /// For NES: uses port routing and tries SNES mapping first.
+    /// For other systems: dispatches via [`Console::set_button`] on port 0.
+    fn handle_button(
+        &self,
+        console: &mut Console,
+        id: GamepadId,
+        button: gilrs::Button,
+        pressed: bool,
+    ) {
+        if let Console::Nes(nes) = console {
+            let Some(&player_num) = self.player_map.get(&id) else {
+                return;
+            };
+            let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) else {
+                return;
+            };
+            // Port-aware mapping: try SNES first, fall back to NES.
+            if let Some(snes_btn) = map_button_to_snes(button)
+                && nes.set_snes_button(port, snes_btn, pressed)
+            {
+                return;
+            }
+            if let Some(nes_btn) = map_button_to_nes(button) {
+                nes.set_button(port, nes_btn, pressed);
+            }
+        } else {
+            if let Some(nes_btn) = map_button_to_nes(button) {
+                console.set_button(0, nes_btn as u8, pressed);
+            }
         }
     }
 
     /// Handles an axis change event, converting to digital D-pad presses.
-    fn handle_axis(&mut self, nes: &mut Nes, id: GamepadId, axis: Axis, value: f32) {
-        let Some(&player_num) = self.player_map.get(&id) else {
-            return;
-        };
-        let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) else {
-            return;
-        };
-        let Some(state) = self.gamepad_states.get_mut(&id) else {
-            return;
-        };
-
+    ///
+    /// For NES: uses port routing and tries SNES D-pad mapping first.
+    /// For other systems: dispatches via [`Console::set_button`] on port 0.
+    fn handle_axis(&mut self, console: &mut Console, id: GamepadId, axis: Axis, value: f32) {
+        let state = self.gamepad_states.entry(id).or_default();
         let changes = match axis {
             Axis::LeftStickX => state.axis.update_x(value),
             Axis::LeftStickY => state.axis.update_y(value),
             _ => return,
         };
 
-        for (button, pressed) in changes {
-            // Mirror handle_button: try SNES D-pad first, fall back to NES.
-            if let Some(snes_btn) = nes_dpad_to_snes(button)
-                && nes.set_snes_button(port, snes_btn, pressed)
-            {
-                continue;
+        if let Console::Nes(nes) = console {
+            let Some(&player_num) = self.player_map.get(&id) else {
+                return;
+            };
+            let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) else {
+                return;
+            };
+            for (button, pressed) in changes {
+                // Mirror handle_button: try SNES D-pad first, fall back to NES.
+                if let Some(snes_btn) = nes_dpad_to_snes(button)
+                    && nes.set_snes_button(port, snes_btn, pressed)
+                {
+                    continue;
+                }
+                nes.set_button(port, button, pressed);
             }
-            nes.set_button(port, button, pressed);
+        } else {
+            for (btn, pressed) in changes {
+                console.set_button(0, btn as u8, pressed);
+            }
         }
     }
 }

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -5,7 +5,6 @@
 //! Ctrl+Q (quit), Ctrl+R (reset), Space (pause), and so on.
 
 use crate::frontends::native::app_state::NativeAppState;
-use crate::nes::console::Nes;
 use crate::nes::input::{Button, PowerPadButton, SnesButton};
 use crate::platform::audio::EmulatorAudio;
 use crate::platform::emulator::Console;
@@ -51,14 +50,14 @@ pub fn handle_key_pressed(
     audio: Option<&dyn EmulatorAudio>,
 ) -> KeyOutcome {
     match console {
-        Console::Nes(nes) => {
+        Console::Nes(_) => {
             if app_state.cart_switch.open {
                 return handle_cartridge_switch_key(key_code, app_state);
             }
             if app_state.modifiers.control_key() {
-                return handle_ctrl_hotkey(nes, key_code, app_state);
+                return handle_ctrl_hotkey(console, key_code, app_state);
             }
-            handle_unmodified_key(nes, key_code, app_state, audio)
+            handle_unmodified_key(console, key_code, app_state, audio)
         }
         Console::GameBoy(_) => handle_gameboy_key_pressed(console, key_code, app_state, audio),
     }
@@ -79,9 +78,9 @@ pub fn handle_key_released(
     four_score: bool,
 ) {
     match console {
-        Console::Nes(nes) => {
+        Console::Nes(_) => {
             let ports = keyboard_target_ports(gamepad_count, four_score);
-            handle_controller_key(nes, key_code, false, ports);
+            handle_controller_key(console, key_code, false, ports);
         }
         Console::GameBoy(_) => {
             if let Some(btn_id) = gameboy_key_to_button_id(key_code) {
@@ -221,14 +220,14 @@ fn handle_gameboy_key_pressed(
 }
 
 fn handle_ctrl_hotkey(
-    nes: &mut Nes,
+    console: &mut Console,
     key_code: KeyCode,
     app_state: &mut NativeAppState,
 ) -> KeyOutcome {
     match key_code {
         KeyCode::KeyQ => KeyOutcome::Quit,
         KeyCode::KeyR => {
-            nes.reset(!app_state.modifiers.shift_key());
+            console.reset(!app_state.modifiers.shift_key());
             KeyOutcome::Continue
         }
         KeyCode::KeyO => KeyOutcome::OpenCartridgeSwitch,
@@ -241,7 +240,7 @@ fn handle_ctrl_hotkey(
 }
 
 fn handle_unmodified_key(
-    nes: &mut Nes,
+    console: &mut Console,
     key_code: KeyCode,
     app_state: &mut NativeAppState,
     audio: Option<&dyn EmulatorAudio>,
@@ -254,10 +253,10 @@ fn handle_unmodified_key(
         KeyCode::KeyH => app_state.help_overlay_visible = !app_state.help_overlay_visible,
         KeyCode::F5 => return KeyOutcome::ToggleDebugger,
         KeyCode::F6 => {
-            crate::nes::console::save_state_io::save_state_to_disk(nes);
+            crate::nes::console::save_state_io::save_state_to_disk(console);
         }
         KeyCode::F7 => {
-            crate::nes::console::save_state_io::load_state_from_disk(nes);
+            crate::nes::console::save_state_io::load_state_from_disk(console);
             if let Some(audio) = audio {
                 audio.drain_buffer();
             }
@@ -267,7 +266,7 @@ fn handle_unmodified_key(
         _ => {
             let ports =
                 keyboard_target_ports(app_state.gamepad_count, app_state.four_score_enabled);
-            handle_controller_key(nes, key_code, true, ports);
+            handle_controller_key(console, key_code, true, ports);
         }
     }
 
@@ -288,7 +287,10 @@ fn adjust_volume(audio: Option<&dyn EmulatorAudio>, delta: f32) {
 /// determined by [`keyboard_target_ports`].  P1 keys (WASD etc.) are sent to the first
 /// port in `ports` (ports.first()); P2-specific keys (IJKL etc.) are sent to port 2
 /// only if 2 is in `ports`.
-fn handle_controller_key(nes: &mut Nes, key_code: KeyCode, pressed: bool, ports: &[u8]) {
+fn handle_controller_key(console: &mut Console, key_code: KeyCode, pressed: bool, ports: &[u8]) {
+    let Console::Nes(nes) = console else {
+        return;
+    };
     match key_code {
         // ── Player 1: 1/2/3 → Power Pad buttons ──────────────────────────
         KeyCode::Digit1 => pp_p1(nes, PowerPadButton::One, pressed, ports),
@@ -376,19 +378,25 @@ fn handle_controller_key(nes: &mut Nes, key_code: KeyCode, pressed: bool, ports:
 
 // ── Player-1 button helpers (route to the primary keyboard port) ───────────────────────────────────────
 
-fn pp_p1(nes: &mut Nes, pp: PowerPadButton, pressed: bool, ports: &[u8]) {
+fn pp_p1(nes: &mut crate::nes::console::Nes, pp: PowerPadButton, pressed: bool, ports: &[u8]) {
     if let Some(&port) = ports.first() {
         nes.set_power_pad_button(port, pp, pressed);
     }
 }
 
-fn snes_p1(nes: &mut Nes, snes: SnesButton, pressed: bool, ports: &[u8]) {
+fn snes_p1(nes: &mut crate::nes::console::Nes, snes: SnesButton, pressed: bool, ports: &[u8]) {
     if let Some(&port) = ports.first() {
         nes.set_snes_button(port, snes, pressed);
     }
 }
 
-fn btn_or_snes_p1(nes: &mut Nes, btn: Button, snes: SnesButton, pressed: bool, ports: &[u8]) {
+fn btn_or_snes_p1(
+    nes: &mut crate::nes::console::Nes,
+    btn: Button,
+    snes: SnesButton,
+    pressed: bool,
+    ports: &[u8],
+) {
     if let Some(&port) = ports.first()
         && !nes.set_snes_button(port, snes, pressed)
     {
@@ -396,7 +404,13 @@ fn btn_or_snes_p1(nes: &mut Nes, btn: Button, snes: SnesButton, pressed: bool, p
     }
 }
 
-fn pp_or_snes_p1(nes: &mut Nes, pp: PowerPadButton, snes: SnesButton, pressed: bool, ports: &[u8]) {
+fn pp_or_snes_p1(
+    nes: &mut crate::nes::console::Nes,
+    pp: PowerPadButton,
+    snes: SnesButton,
+    pressed: bool,
+    ports: &[u8],
+) {
     if let Some(&port) = ports.first()
         && !nes.set_power_pad_button(port, pp, pressed)
     {
@@ -405,7 +419,7 @@ fn pp_or_snes_p1(nes: &mut Nes, pp: PowerPadButton, snes: SnesButton, pressed: b
 }
 
 fn pp_or_btn_or_snes_p1(
-    nes: &mut Nes,
+    nes: &mut crate::nes::console::Nes,
     pp: PowerPadButton,
     btn: Button,
     snes: SnesButton,
@@ -422,19 +436,25 @@ fn pp_or_btn_or_snes_p1(
 
 // ── Player-2-only button helpers ─────────────────────────────────────────────
 
-fn btn_p2(nes: &mut Nes, btn: Button, pressed: bool, ports: &[u8]) {
+fn btn_p2(nes: &mut crate::nes::console::Nes, btn: Button, pressed: bool, ports: &[u8]) {
     if let Some(&port) = ports.get(1) {
         nes.set_button(port, btn, pressed);
     }
 }
 
-fn pp_p2(nes: &mut Nes, pp: PowerPadButton, pressed: bool, ports: &[u8]) {
+fn pp_p2(nes: &mut crate::nes::console::Nes, pp: PowerPadButton, pressed: bool, ports: &[u8]) {
     if let Some(&port) = ports.get(1) {
         nes.set_power_pad_button(port, pp, pressed);
     }
 }
 
-fn pp_or_btn_p2(nes: &mut Nes, pp: PowerPadButton, btn: Button, pressed: bool, ports: &[u8]) {
+fn pp_or_btn_p2(
+    nes: &mut crate::nes::console::Nes,
+    pp: PowerPadButton,
+    btn: Button,
+    pressed: bool,
+    ports: &[u8],
+) {
     if let Some(&port) = ports.get(1)
         && !nes.set_power_pad_button(port, pp, pressed)
     {
@@ -533,7 +553,7 @@ fn key_code_to_filter_char(key_code: KeyCode, shift: bool) -> Option<char> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nes::console::{Config, NesConfig};
+    use crate::nes::console::{Config, Nes, NesConfig};
     use crate::platform::app_context::AppContext;
     use crate::platform::emulator::Console;
     use winit::keyboard::ModifiersState;

--- a/src/frontends/native/mouse.rs
+++ b/src/frontends/native/mouse.rs
@@ -120,7 +120,7 @@ pub fn zapper_crosshair(console: &Console, last_position: Option<(u8, u8)>) -> O
     let Console::Nes(nes) = console else {
         return None;
     };
-    if !has_zapper_nes(nes) && !nes.has_expansion_zapper() {
+    if !has_zapper_nes(nes) {
         None
     } else {
         last_position.map(|(x, y)| Crosshair {

--- a/src/frontends/native/mouse.rs
+++ b/src/frontends/native/mouse.rs
@@ -4,9 +4,9 @@
 //! (Zapper, Arkanoid paddle, SNES Mouse) and manages the cursor
 //! grab/release state machine.
 
-use crate::nes::console::Nes;
 use crate::nes::input::ControllerInput;
 use crate::nes::input::mouse_mapping;
+use crate::platform::emulator::Console;
 use crate::platform::rendering::Crosshair;
 
 /// Mouse button abstraction (frontend-independent).
@@ -19,14 +19,31 @@ pub enum MouseButton {
 // ── Device detection ─────────────────────────────────────────────────────────
 
 /// Returns `true` when any controller port or expansion device uses mouse input.
-pub fn has_any_mouse_controller(nes: &Nes) -> bool {
+///
+/// Always returns `false` for non-NES consoles.
+pub fn has_any_mouse_controller(console: &Console) -> bool {
+    let Console::Nes(nes) = console else {
+        return false;
+    };
     (1..=2).any(|port| nes.controller_input_type(port) == Some(ControllerInput::Mouse))
         || nes.has_expansion_mouse_controller()
 }
 
 /// Returns `true` when a Zapper is connected on any port or expansion.
-pub fn has_zapper(nes: &Nes) -> bool {
+///
+/// Always returns `false` for non-NES consoles.
+pub fn has_zapper(console: &Console) -> bool {
+    let Console::Nes(nes) = console else {
+        return false;
+    };
     (1..=2).any(|port| nes.is_zapper_active(port)) || nes.has_expansion_zapper()
+}
+
+pub fn has_snes_mouse(console: &Console) -> bool {
+    let Console::Nes(nes) = console else {
+        return false;
+    };
+    nes.has_snes_mouse()
 }
 
 // ── Coordinate routing ───────────────────────────────────────────────────────
@@ -37,15 +54,19 @@ pub fn has_zapper(nes: &Nes) -> bool {
 /// - Arkanoid paddle: non-linear curve on X axis only.
 ///
 /// Returns `Some((x, y))` in NES coordinates when a Zapper-style device is
-/// active (for crosshair rendering), or `None` for paddle-only input.
+/// active (for crosshair rendering), or `None` for paddle-only input or
+/// non-NES consoles.
 pub fn update_mouse_motion(
-    nes: &mut Nes,
+    console: &mut Console,
     x: i32,
     y: i32,
     window_width: u32,
     window_height: u32,
 ) -> Option<(u8, u8)> {
-    if has_zapper(nes) || nes.has_snes_mouse() {
+    let Console::Nes(nes) = console else {
+        return None;
+    };
+    if has_zapper_nes(nes) || nes.has_snes_mouse() {
         let x_pos = mouse_mapping::map_mouse_axis_to_zapper_position(x, window_width);
         let y_pos = mouse_mapping::map_mouse_axis_to_zapper_position(y, window_height);
         nes.set_mouse_x_position(x_pos);
@@ -59,21 +80,31 @@ pub fn update_mouse_motion(
 }
 
 /// Applies relative mouse deltas (from locked cursor mode) to the SNES Mouse.
+///
+/// No-op for non-NES consoles.
 pub fn apply_snes_mouse_relative_motion(
-    nes: &mut Nes,
+    console: &mut Console,
     xrel: i32,
     yrel: i32,
     window_width: u32,
     window_height: u32,
 ) {
+    let Console::Nes(nes) = console else {
+        return;
+    };
     let dx = mouse_mapping::map_relative_mouse_delta_to_axis_delta(xrel, window_width);
     let dy = mouse_mapping::map_relative_mouse_delta_to_axis_delta(yrel, window_height);
     nes.add_mouse_delta(dx, dy);
 }
 
 /// Forwards a mouse button press/release to the appropriate NES controller.
-pub fn update_mouse_button(nes: &mut Nes, button: MouseButton, pressed: bool) {
-    if has_any_mouse_controller(nes) {
+///
+/// No-op for non-NES consoles.
+pub fn update_mouse_button(console: &mut Console, button: MouseButton, pressed: bool) {
+    let Console::Nes(nes) = console else {
+        return;
+    };
+    if has_any_mouse_controller_nes(nes) {
         match button {
             MouseButton::Left => nes.set_mouse_left_button(pressed),
             MouseButton::Right => nes.set_mouse_right_button(pressed),
@@ -83,8 +114,13 @@ pub fn update_mouse_button(nes: &mut Nes, button: MouseButton, pressed: bool) {
 
 /// Returns a [`Crosshair`] for the Zapper if one is connected and a position
 /// has been recorded.
-pub fn zapper_crosshair(nes: &Nes, last_position: Option<(u8, u8)>) -> Option<Crosshair> {
-    if !has_zapper(nes) && !nes.has_expansion_zapper() {
+///
+/// Always returns `None` for non-NES consoles.
+pub fn zapper_crosshair(console: &Console, last_position: Option<(u8, u8)>) -> Option<Crosshair> {
+    let Console::Nes(nes) = console else {
+        return None;
+    };
+    if !has_zapper_nes(nes) && !nes.has_expansion_zapper() {
         None
     } else {
         last_position.map(|(x, y)| Crosshair {
@@ -92,6 +128,17 @@ pub fn zapper_crosshair(nes: &Nes, last_position: Option<(u8, u8)>) -> Option<Cr
             y: y as f32,
         })
     }
+}
+
+// ── NES-specific internal helpers ─────────────────────────────────────────────
+
+fn has_any_mouse_controller_nes(nes: &crate::nes::console::Nes) -> bool {
+    (1..=2).any(|port| nes.controller_input_type(port) == Some(ControllerInput::Mouse))
+        || nes.has_expansion_mouse_controller()
+}
+
+fn has_zapper_nes(nes: &crate::nes::console::Nes) -> bool {
+    (1..=2).any(|port| nes.is_zapper_active(port)) || nes.has_expansion_zapper()
 }
 
 /// Scales factor applied to raw `DeviceEvent::MouseMotion` deltas when
@@ -141,78 +188,83 @@ mod tests {
     use super::*;
     use crate::nes::console::Config;
     use crate::platform::app_context::AppContext;
+    use crate::platform::emulator::Console;
 
-    fn make_nes() -> Nes {
-        Nes::new(AppContext::new_with_config(Config::default()))
+    fn make_console() -> Console {
+        Console::new_nes(AppContext::new_with_config(Config::default()))
     }
 
-    fn make_nes_with_controller(
+    fn make_console_with_controller(
         port: u8,
         controller_type: crate::nes::input::ControllerType,
-    ) -> Nes {
-        let nes = make_nes();
+    ) -> Console {
+        let console = make_console();
+        let Console::Nes(ref nes) = console else {
+            panic!("expected NES console");
+        };
         nes.bus()
             .borrow_mut()
             .set_controller_type(port, controller_type);
-        nes
+        console
     }
 
     // ── Device detection ─────────────────────────────────────────────────
 
     #[test]
     fn no_mouse_controller_by_default() {
-        let nes = make_nes();
-        assert!(!has_any_mouse_controller(&nes));
+        let console = make_console();
+        assert!(!has_any_mouse_controller(&console));
     }
 
     #[test]
     fn detects_zapper_as_mouse_controller() {
-        let nes = make_nes_with_controller(1, crate::nes::input::ControllerType::Zapper);
-        assert!(has_any_mouse_controller(&nes));
+        let console = make_console_with_controller(1, crate::nes::input::ControllerType::Zapper);
+        assert!(has_any_mouse_controller(&console));
     }
 
     #[test]
     fn detects_arkanoid_as_mouse_controller() {
-        let nes = make_nes_with_controller(1, crate::nes::input::ControllerType::Arkanoid);
-        assert!(has_any_mouse_controller(&nes));
+        let console = make_console_with_controller(1, crate::nes::input::ControllerType::Arkanoid);
+        assert!(has_any_mouse_controller(&console));
     }
 
     #[test]
     fn detects_snes_mouse_as_mouse_controller() {
-        let nes = make_nes_with_controller(1, crate::nes::input::ControllerType::SnesMouse);
-        assert!(has_any_mouse_controller(&nes));
+        let console = make_console_with_controller(1, crate::nes::input::ControllerType::SnesMouse);
+        assert!(has_any_mouse_controller(&console));
     }
 
     #[test]
     fn joypad_is_not_a_mouse_controller() {
-        let nes = make_nes_with_controller(1, crate::nes::input::ControllerType::Joypad);
-        assert!(!has_any_mouse_controller(&nes));
+        let console = make_console_with_controller(1, crate::nes::input::ControllerType::Joypad);
+        assert!(!has_any_mouse_controller(&console));
     }
 
     #[test]
     fn has_zapper_detects_port1() {
-        let nes = make_nes_with_controller(1, crate::nes::input::ControllerType::Zapper);
-        assert!(has_zapper(&nes));
+        let console = make_console_with_controller(1, crate::nes::input::ControllerType::Zapper);
+        assert!(has_zapper(&console));
     }
 
     #[test]
     fn has_zapper_detects_port2() {
-        let nes = make_nes_with_controller(2, crate::nes::input::ControllerType::Zapper);
-        assert!(has_zapper(&nes));
+        let console = make_console_with_controller(2, crate::nes::input::ControllerType::Zapper);
+        assert!(has_zapper(&console));
     }
 
     #[test]
     fn has_zapper_false_for_arkanoid() {
-        let nes = make_nes_with_controller(1, crate::nes::input::ControllerType::Arkanoid);
-        assert!(!has_zapper(&nes));
+        let console = make_console_with_controller(1, crate::nes::input::ControllerType::Arkanoid);
+        assert!(!has_zapper(&console));
     }
 
     // ── Coordinate routing ───────────────────────────────────────────────
 
     #[test]
     fn zapper_motion_returns_nes_coordinates() {
-        let mut nes = make_nes_with_controller(2, crate::nes::input::ControllerType::Zapper);
-        let result = update_mouse_motion(&mut nes, 160, 120, 320, 240);
+        let mut console =
+            make_console_with_controller(2, crate::nes::input::ControllerType::Zapper);
+        let result = update_mouse_motion(&mut console, 160, 120, 320, 240);
         assert!(result.is_some());
         let (x, y) = result.unwrap();
         assert_eq!(x, 128); // 160/319 * 255 ≈ 128
@@ -221,15 +273,17 @@ mod tests {
 
     #[test]
     fn arkanoid_motion_returns_none() {
-        let mut nes = make_nes_with_controller(1, crate::nes::input::ControllerType::Arkanoid);
-        let result = update_mouse_motion(&mut nes, 160, 120, 320, 240);
+        let mut console =
+            make_console_with_controller(1, crate::nes::input::ControllerType::Arkanoid);
+        let result = update_mouse_motion(&mut console, 160, 120, 320, 240);
         assert!(result.is_none());
     }
 
     #[test]
     fn snes_mouse_motion_returns_nes_coordinates() {
-        let mut nes = make_nes_with_controller(1, crate::nes::input::ControllerType::SnesMouse);
-        let result = update_mouse_motion(&mut nes, 160, 120, 320, 240);
+        let mut console =
+            make_console_with_controller(1, crate::nes::input::ControllerType::SnesMouse);
+        let result = update_mouse_motion(&mut console, 160, 120, 320, 240);
         assert!(result.is_some());
     }
 
@@ -237,8 +291,12 @@ mod tests {
 
     #[test]
     fn snes_mouse_relative_motion_applies_delta() {
-        let mut nes = make_nes_with_controller(1, crate::nes::input::ControllerType::SnesMouse);
-        apply_snes_mouse_relative_motion(&mut nes, 10, 5, 320, 240);
+        let mut console =
+            make_console_with_controller(1, crate::nes::input::ControllerType::SnesMouse);
+        apply_snes_mouse_relative_motion(&mut console, 10, 5, 320, 240);
+        let Console::Nes(ref nes) = console else {
+            panic!("expected NES console");
+        };
         let state = nes.bus().borrow().capture_state();
         if let crate::nes::bus::ControllerStateWrapper::SnesAdapter(snes) = state.port1_controller {
             // Accumulator starts at 0, so after a (+10,+5) delta the positions
@@ -260,17 +318,21 @@ mod tests {
 
     #[test]
     fn button_ignored_when_no_mouse_controller() {
-        let mut nes = make_nes();
+        let mut console = make_console();
         // Should not panic
-        update_mouse_button(&mut nes, MouseButton::Left, true);
-        update_mouse_button(&mut nes, MouseButton::Right, true);
+        update_mouse_button(&mut console, MouseButton::Left, true);
+        update_mouse_button(&mut console, MouseButton::Right, true);
     }
 
     #[test]
     fn button_routes_left_to_zapper_trigger() {
-        let mut nes = make_nes_with_controller(1, crate::nes::input::ControllerType::Zapper);
+        let mut console =
+            make_console_with_controller(1, crate::nes::input::ControllerType::Zapper);
 
-        update_mouse_button(&mut nes, MouseButton::Left, true);
+        update_mouse_button(&mut console, MouseButton::Left, true);
+        let Console::Nes(ref nes) = console else {
+            panic!("expected NES console");
+        };
         let state = nes.bus().borrow().capture_state();
         if let crate::nes::bus::ControllerStateWrapper::Zapper(z) = state.port1_controller {
             assert!(z.trigger, "Expected trigger set after left-button press");
@@ -278,7 +340,10 @@ mod tests {
             panic!("Expected Zapper state on port 1");
         }
 
-        update_mouse_button(&mut nes, MouseButton::Left, false);
+        update_mouse_button(&mut console, MouseButton::Left, false);
+        let Console::Nes(ref nes) = console else {
+            unreachable!()
+        };
         let state = nes.bus().borrow().capture_state();
         if let crate::nes::bus::ControllerStateWrapper::Zapper(z) = state.port1_controller {
             assert!(
@@ -294,20 +359,20 @@ mod tests {
 
     #[test]
     fn crosshair_returns_none_without_zapper() {
-        let nes = make_nes();
-        assert!(zapper_crosshair(&nes, Some((128, 128))).is_none());
+        let console = make_console();
+        assert!(zapper_crosshair(&console, Some((128, 128))).is_none());
     }
 
     #[test]
     fn crosshair_returns_none_when_no_position() {
-        let nes = make_nes_with_controller(2, crate::nes::input::ControllerType::Zapper);
-        assert!(zapper_crosshair(&nes, None).is_none());
+        let console = make_console_with_controller(2, crate::nes::input::ControllerType::Zapper);
+        assert!(zapper_crosshair(&console, None).is_none());
     }
 
     #[test]
     fn crosshair_returns_position_with_zapper() {
-        let nes = make_nes_with_controller(2, crate::nes::input::ControllerType::Zapper);
-        let ch = zapper_crosshair(&nes, Some((100, 200)));
+        let console = make_console_with_controller(2, crate::nes::input::ControllerType::Zapper);
+        let ch = zapper_crosshair(&console, Some((100, 200)));
         assert!(ch.is_some());
         let ch = ch.unwrap();
         assert_eq!(ch.x, 100.0);

--- a/src/nes/console/save_state_io.rs
+++ b/src/nes/console/save_state_io.rs
@@ -36,6 +36,8 @@ pub fn save_state_to_disk(console: &mut Console) {
     }
 
     // Atomic write: write to temp file, then rename.
+    // On Windows, rename fails if the destination already exists, so we
+    // remove it first (best-effort) before the rename.
     let mut tmp_path = state_path.clone();
     tmp_path.set_extension(format!("state.tmp.{}", std::process::id()));
 
@@ -47,6 +49,9 @@ pub fn save_state_to_disk(console: &mut Console) {
             .add_toast("Failed to save state");
         return;
     }
+
+    #[cfg(windows)]
+    let _ = fs::remove_file(&state_path);
 
     if let Err(err) = fs::rename(&tmp_path, &state_path) {
         log_info(format!("Failed to finalize save-state: {err}"));

--- a/src/nes/console/save_state_io.rs
+++ b/src/nes/console/save_state_io.rs
@@ -1,22 +1,23 @@
 use std::fs;
 
-use crate::nes::console::{Nes, SaveState};
 use crate::platform::debugging::log_info;
+use crate::platform::emulator::Console;
 
-/// Saves the current NES state to disk.
+/// Saves the current emulator state to disk.
 ///
 /// Shows a toast notification on success or failure.
-pub fn save_state_to_disk(nes: &mut Nes) {
-    let Some(state_path) = nes.state_path() else {
+/// Does nothing if no ROM is loaded or the system has no state path.
+pub fn save_state_to_disk(console: &mut Console) {
+    let Some(state_path) = console.state_path() else {
         return;
     };
 
-    let state = nes.save_state();
-    let bytes = match state.to_bytes() {
+    let bytes = match console.save_state_bytes() {
         Ok(bytes) => bytes,
         Err(err) => {
             log_info(format!("Failed to serialize save-state: {err}"));
-            nes.app_context()
+            console
+                .app_context()
                 .borrow_mut()
                 .add_toast("Failed to save state");
             return;
@@ -27,7 +28,8 @@ pub fn save_state_to_disk(nes: &mut Nes) {
         && let Err(err) = fs::create_dir_all(parent)
     {
         log_info(format!("Failed to create save-state directory: {err}"));
-        nes.app_context()
+        console
+            .app_context()
             .borrow_mut()
             .add_toast("Failed to save state");
         return;
@@ -39,7 +41,8 @@ pub fn save_state_to_disk(nes: &mut Nes) {
 
     if let Err(err) = fs::write(&tmp_path, bytes) {
         log_info(format!("Failed to write save-state: {err}"));
-        nes.app_context()
+        console
+            .app_context()
             .borrow_mut()
             .add_toast("Failed to save state");
         return;
@@ -48,60 +51,54 @@ pub fn save_state_to_disk(nes: &mut Nes) {
     if let Err(err) = fs::rename(&tmp_path, &state_path) {
         log_info(format!("Failed to finalize save-state: {err}"));
         let _ = fs::remove_file(&tmp_path);
-        nes.app_context()
+        console
+            .app_context()
             .borrow_mut()
             .add_toast("Failed to save state");
         return;
     }
 
-    nes.app_context().borrow_mut().add_toast("State saved");
+    console.app_context().borrow_mut().add_toast("State saved");
 }
 
-/// Loads a previously saved NES state from disk.
+/// Loads a previously saved emulator state from disk.
 ///
 /// Shows a toast notification on success, failure, or when no save file exists.
-pub fn load_state_from_disk(nes: &mut Nes) {
-    let Some(state_path) = nes.state_path() else {
+/// Does nothing if no ROM is loaded or the system has no state path.
+pub fn load_state_from_disk(console: &mut Console) {
+    let Some(state_path) = console.state_path() else {
         return;
     };
 
     let bytes = match fs::read(&state_path) {
         Ok(bytes) => bytes,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            nes.app_context()
+            console
+                .app_context()
                 .borrow_mut()
                 .add_toast("No save state found");
             return;
         }
         Err(err) => {
             log_info(format!("Failed to read save-state: {err}"));
-            nes.app_context()
+            console
+                .app_context()
                 .borrow_mut()
                 .add_toast("Failed to load state");
             return;
         }
     };
 
-    let state = match SaveState::from_bytes(&bytes) {
-        Ok(state) => state,
-        Err(err) => {
-            log_info(format!("Failed to deserialize save-state: {err}"));
-            nes.app_context()
-                .borrow_mut()
-                .add_toast("Failed to load state");
-            return;
-        }
-    };
-
-    if let Err(err) = nes.load_state(&state) {
+    if let Err(err) = console.load_state_bytes(&bytes) {
         log_info(format!("Failed to restore save-state: {err}"));
-        nes.app_context()
+        console
+            .app_context()
             .borrow_mut()
             .add_toast("Failed to load state");
         return;
     }
 
-    nes.app_context().borrow_mut().add_toast("State loaded");
+    console.app_context().borrow_mut().add_toast("State loaded");
 }
 
 #[cfg(test)]
@@ -110,31 +107,38 @@ mod tests {
     use crate::nes::cartridge::Cartridge;
     use crate::nes::console::Config;
     use crate::platform::app_context::AppContext;
+    use crate::platform::emulator::Console;
     use std::fs;
     use std::time::Instant;
     use tempfile::TempDir;
 
-    fn setup_nes_with_temp_rom(temp_dir: &TempDir) -> Nes {
+    fn setup_console_with_temp_rom(temp_dir: &TempDir) -> Console {
         let rom_path = temp_dir.path().join("test.nes");
         fs::copy("roms/nes/automated_tests/nestest/nestest.nes", &rom_path)
             .expect("Failed to copy test ROM");
         let rom_bytes = fs::read(&rom_path).expect("Failed to read ROM");
-        let mut nes = Nes::new(AppContext::new_with_config(Config::default()));
+        let mut console = Console::new_nes(AppContext::new_with_config(Config::default()));
+        let Console::Nes(ref nes) = console else {
+            panic!("expected NES console");
+        };
         let cart = Cartridge::load_from_file(&rom_bytes, &rom_path, Some(nes.rom_db()))
             .expect("Failed to load ROM");
+        let Console::Nes(ref mut nes) = console else {
+            unreachable!()
+        };
         nes.insert_cartridge(cart);
-        nes.reset(false);
-        nes
+        console.reset(false);
+        console
     }
 
     #[test]
     fn test_save_state_to_disk_shows_state_saved_toast() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let mut nes = setup_nes_with_temp_rom(&temp_dir);
+        let mut console = setup_console_with_temp_rom(&temp_dir);
 
-        save_state_to_disk(&mut nes);
+        save_state_to_disk(&mut console);
 
-        let toasts = nes
+        let toasts = console
             .app_context()
             .borrow_mut()
             .visible_toasts(Instant::now());
@@ -147,11 +151,11 @@ mod tests {
     #[test]
     fn test_load_state_from_disk_shows_no_save_state_found_toast_when_file_absent() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let mut nes = setup_nes_with_temp_rom(&temp_dir);
+        let mut console = setup_console_with_temp_rom(&temp_dir);
 
-        load_state_from_disk(&mut nes);
+        load_state_from_disk(&mut console);
 
-        let toasts = nes
+        let toasts = console
             .app_context()
             .borrow_mut()
             .visible_toasts(Instant::now());
@@ -164,12 +168,12 @@ mod tests {
     #[test]
     fn test_load_state_from_disk_shows_state_loaded_toast_when_file_exists() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let mut nes = setup_nes_with_temp_rom(&temp_dir);
+        let mut console = setup_console_with_temp_rom(&temp_dir);
 
-        save_state_to_disk(&mut nes);
-        load_state_from_disk(&mut nes);
+        save_state_to_disk(&mut console);
+        load_state_from_disk(&mut console);
 
-        let toasts = nes
+        let toasts = console
             .app_context()
             .borrow_mut()
             .visible_toasts(Instant::now());
@@ -182,16 +186,16 @@ mod tests {
     #[test]
     fn test_save_state_to_disk_shows_failed_toast_on_io_error() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let mut nes = setup_nes_with_temp_rom(&temp_dir);
+        let mut console = setup_console_with_temp_rom(&temp_dir);
 
         // Block the rename by occupying the target state path with a directory.
         let rom_path = temp_dir.path().join("test.nes");
         let state_path = rom_path.with_extension("state");
         fs::create_dir_all(&state_path).expect("Failed to create blocking directory");
 
-        save_state_to_disk(&mut nes);
+        save_state_to_disk(&mut console);
 
-        let toasts = nes
+        let toasts = console
             .app_context()
             .borrow_mut()
             .visible_toasts(Instant::now());
@@ -204,16 +208,16 @@ mod tests {
     #[test]
     fn test_load_state_from_disk_shows_failed_toast_on_read_error() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let mut nes = setup_nes_with_temp_rom(&temp_dir);
+        let mut console = setup_console_with_temp_rom(&temp_dir);
 
         // Place a directory at the state path so fs::read returns an EISDIR error.
         let rom_path = temp_dir.path().join("test.nes");
         let state_path = rom_path.with_extension("state");
         fs::create_dir_all(&state_path).expect("Failed to create blocking directory");
 
-        load_state_from_disk(&mut nes);
+        load_state_from_disk(&mut console);
 
-        let toasts = nes
+        let toasts = console
             .app_context()
             .borrow_mut()
             .visible_toasts(Instant::now());

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -10,6 +10,8 @@
 //! [`as_core()`](Console::as_core) / [`as_core_mut()`](Console::as_core_mut),
 //! keeping a single pair of match arms instead of one pair per method.
 
+use std::path::PathBuf;
+
 use crate::gb::GameBoy;
 use crate::nes::console::Nes;
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
@@ -208,6 +210,15 @@ impl Console {
     /// Restore emulator state from previously serialized bytes.
     pub fn load_state_bytes(&mut self, data: &[u8]) -> Result<(), String> {
         self.as_core_mut().load_state_bytes(data)
+    }
+
+    /// Returns the file path where save-state data should be stored, or `None`
+    /// if no ROM is loaded or the system does not support disk save states.
+    pub fn state_path(&self) -> Option<PathBuf> {
+        match self {
+            Console::Nes(nes) => nes.state_path(),
+            Console::GameBoy(_) => None,
+        }
     }
 
     /// Reset the emulator.


### PR DESCRIPTION
## Summary

Closes #2045

Refactors the native frontend input handlers (keyboard, gamepad, mouse) and save-state I/O to accept `&Console` / `&mut Console` instead of `&mut Nes`, removing the tight coupling to the NES console type.

## Changes

### `src/platform/emulator.rs`
- Added `Console::state_path() -> Option<PathBuf>` — NES returns a path derived from the ROM file, GameBoy returns `None`

### `src/nes/console/save_state_io.rs`
- `save_state_to_disk` and `load_state_from_disk` now accept `&mut Console`
- Tests updated to construct `Console` instead of `Nes` directly

### `src/frontends/native/keyboard.rs`
- Removed module-level `use crate::nes::console::Nes` import (retained locally in `mod tests`)
- `handle_ctrl_hotkey`, `handle_unmodified_key`, `handle_controller_key` → `&mut Console`
- Private button helpers use full path `crate::nes::console::Nes` (no top-level import needed)

### `src/frontends/native/gamepad.rs`
- Removed `use crate::nes::console::Nes` import
- Unified `process_events` into a single event loop (was two separate NES/GB loops)
- `handle_button`, `handle_axis`, `handle_disconnected` → `&mut Console`

### `src/frontends/native/mouse.rs`
- All public functions accept `&Console` / `&mut Console`
- Added `has_snes_mouse(&Console) -> bool` helper (mirrors the existing `has_zapper` pattern)
- Private NES-specific helpers `has_any_mouse_controller_nes` / `has_zapper_nes` added
- All tests rewritten to use `Console`

### `src/frontends/native/event_loop.rs`
- All mouse function call-sites now pass `&self.console` / `&mut self.console` directly
- Removed all `Console::Nes(nes)` extractions that existed solely to satisfy the old `&mut Nes` signatures

## Testing

- `cargo check --features native` — ✅ clean
- `cargo test` — ✅ 8646 passed (1 pre-existing unrelated failure in autorun format conversion)