### PR TITLE
feat(gb): cycle-accurate serial port timing (#2026)

### DIFF
--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -54,6 +54,24 @@ pub struct DmgBus {
     sc: u8,
     /// Bytes captured via serial transfer (written by ROM via SB/SC).
     serial_buf: Vec<u8>,
+    /// Bits remaining in the current internal-clock serial transfer.
+    /// 0 means no transfer is in progress; 1–8 means a transfer is active.
+    /// Each time the serial master clock (see below) transitions to false,
+    /// one bit is shifted; when this reaches 0 the transfer completes.
+    serial_bits_remaining: u8,
+    /// Persistent serial master clock toggle (mirrors SameBoy `serial_master_clock`).
+    ///
+    /// Toggles on every falling edge of bit 7 of the internal DIV counter
+    /// (i.e., every 256 T-cycles = 64 M-cycles).  A serial bit is shifted
+    /// only when this flag transitions to `false`, giving an effective clock
+    /// period of 512 T-cycles = 128 M-cycles = 8192 Hz.
+    ///
+    /// The flag is NOT reset when a transfer starts; it persists continuously
+    /// from power-on.  On SC write (start/restart transfer), if the flag is
+    /// currently `true` it is immediately forced to `false` — the same
+    /// "edge injection" SameBoy performs — ensuring the first serial bit is
+    /// timed at the correct phase relative to the div counter.
+    serial_master_clock: bool,
 }
 
 impl DmgBus {
@@ -64,7 +82,11 @@ impl DmgBus {
             ppu: Ppu::new(),
             wram: [0u8; 0x2000],
             hram: [0u8; 0x7F],
-            timer: Timer::new(),
+            // Real DMG-B hardware has a sub-byte div_counter phase of 204 T-cycles
+            // at power-on. Setting this initial value ensures our custom boot ROM
+            // exits at the correct clock phase (div_counter = 28364) so that
+            // serial clock edges align with acceptance-test expectations.
+            timer: Timer::with_div_counter(204),
             joypad: Joypad::new(),
             apu: Apu::new(is_cgb),
             if_reg: 0,
@@ -74,6 +96,8 @@ impl DmgBus {
             sb: 0xFF,
             sc: 0x7E,
             serial_buf: Vec::new(),
+            serial_bits_remaining: 0,
+            serial_master_clock: false,
         };
         // Real DMG hardware powers on with LCDC=$00 (LCD disabled).
         // The boot ROM tile-loading runs while the LCD is off so VRAM writes
@@ -91,7 +115,7 @@ impl DmgBus {
     pub fn reset(&mut self) {
         self.ppu = Ppu::new();
         self.ppu.write_register(0xFF40, 0x00); // power-on: LCD disabled
-        self.timer = Timer::new();
+        self.timer = Timer::with_div_counter(204);
         self.joypad = Joypad::new();
         self.apu = Apu::new(self.cart.is_cgb());
         self.wram = [0u8; 0x2000];
@@ -102,6 +126,8 @@ impl DmgBus {
         self.sb = 0xFF;
         self.sc = 0x7E;
         self.serial_buf.clear();
+        self.serial_bits_remaining = 0;
+        self.serial_master_clock = false;
     }
 
     /// Returns `true` while the boot ROM is still mapped at $0000–$00FF.
@@ -131,11 +157,38 @@ impl DmgBus {
     ///
     /// Propagates any timer interrupt to the IF register ($FF0F bit 2).
     /// Propagates PPU VBlank (bit 0) and STAT (bit 1) interrupts.
+    /// Drives the serial transfer: on each falling edge of bit 7 of the
+    /// internal DIV counter (64 M-cycles = 256 T-cycles), `serial_master_clock`
+    /// is toggled.  When it transitions to `false` and an internal-clock
+    /// transfer is active (SC = $81), one bit is shifted.  After 8 such
+    /// transitions the transfer completes, SB is overwritten with 0xFF,
+    /// SC bit 7 is cleared, and IF bit 3 (serial interrupt) is raised.
     pub fn tick(&mut self, m_cycles: u8) {
-        self.timer.tick(m_cycles);
-        if self.timer.interrupt_pending {
-            self.if_reg |= 0x04;
-            self.timer.interrupt_pending = false;
+        for _ in 0..m_cycles {
+            let pre_counter = self.timer.raw_counter();
+            let pre_bit7 = pre_counter & 0x080;
+            self.timer.tick(1);
+            if self.timer.interrupt_pending {
+                self.if_reg |= 0x04;
+                self.timer.interrupt_pending = false;
+            }
+            // Falling edge of bit 7 of the DIV counter (runs continuously).
+            let post_bit7 = self.timer.raw_counter() & 0x080;
+            if pre_bit7 != 0 && post_bit7 == 0 {
+                self.serial_master_clock ^= true;
+                if !self.serial_master_clock
+                    && self.serial_bits_remaining > 0
+                    && self.sc & 0x81 == 0x81
+                {
+                    self.serial_bits_remaining -= 1;
+                    if self.serial_bits_remaining == 0 {
+                        self.serial_buf.push(self.sb);
+                        self.sb = 0xFF;
+                        self.if_reg |= 0x08;
+                        self.sc &= 0x7F;
+                    }
+                }
+            }
         }
         self.ppu.tick_dots(u32::from(m_cycles) * 4);
         self.if_reg |= self.ppu.take_pending_interrupts();
@@ -219,20 +272,29 @@ impl GbBus for DmgBus {
             0xFF00 => self.joypad.write(val),
             0xFF01 => self.sb = val,
             0xFF02 => {
-                self.sc = val;
-                if val & 0x80 != 0 {
-                    // Internal clock transfer: capture SB, fire serial interrupt, clear transfer flag
-                    self.serial_buf.push(self.sb);
-                    self.if_reg |= 0x08;
-                    self.sc &= 0x7F;
+                // Clock-alignment step (mirrors SameBoy): if serial_master_clock is
+                // currently true, immediately force it to false before latching the
+                // new SC value.  This ensures the first serial bit is always timed
+                // at the correct phase relative to the div counter — exactly what
+                // real hardware does when a transfer begins mid-period.
+                if self.serial_master_clock {
+                    self.serial_master_clock = false;
                 }
+                self.sc = val;
+                if val & 0x80 != 0 && val & 0x01 != 0 {
+                    // Internal clock (bit 0 set): start / restart 8-bit transfer.
+                    self.serial_bits_remaining = 8;
+                }
+                // External clock (bit 0 clear): store SC but never start a transfer.
             }
             0xFF04..=0xFF07 => self.timer.write(addr, val),
             0xFF0F => self.if_reg = val & 0x1F,
             0xFF10..=0xFF3F => self.apu.write_register(addr, val),
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B => self.ppu.write_register(addr, val),
             0xFF46 => self.do_oam_dma(val),
-            0xFF50 => self.boot_rom_active = false,
+            0xFF50 => {
+                self.boot_rom_active = false;
+            }
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize] = val,
             0xFFFF => self.ie_reg = val,
             _ => {}
@@ -641,29 +703,175 @@ mod tests {
 
     #[test]
     fn test_serial_transfer_captures_byte() {
-        // Given: SB = 0x41; When: write SC = 0x81 (bit 7 set → start transfer);
-        // Then: serial_output contains the SB byte 0x41
+        // Given: SB = 0x41; When: write SC = 0x81 (start internal-clock transfer) and tick
+        // 1024 M-cycles; Then: serial_output contains 0x41
         let mut bus = make_bus();
         bus.write(0xFF01, 0x41);
         bus.write(0xFF02, 0x81);
+        for _ in 0..1024 {
+            bus.tick(1);
+        }
         assert_eq!(bus.serial_output(), &[0x41]);
     }
 
     #[test]
     fn test_serial_transfer_sets_if_bit3() {
-        // Given: trigger a serial transfer; Then: IF bit 3 (serial interrupt) is set
+        // Given: trigger a serial transfer; When: 1024 M-cycles pass; Then: IF bit 3 is set
         let mut bus = make_bus();
         bus.write(0xFF01, 0x42);
         bus.write(0xFF02, 0x81);
+        for _ in 0..1024 {
+            bus.tick(1);
+        }
         assert_eq!(bus.read(0xFF0F) & 0x08, 0x08);
     }
 
     #[test]
     fn test_serial_transfer_clears_sc_bit7() {
-        // Given: write 0x81 to SC; Then: reading SC immediately after returns bit 7 = 0
+        // Given: write 0x81 to SC; When: 1024 M-cycles pass; Then: SC bit 7 = 0
         let mut bus = make_bus();
         bus.write(0xFF02, 0x81);
+        for _ in 0..1024 {
+            bus.tick(1);
+        }
         assert_eq!(bus.read(0xFF02) & 0x80, 0x00);
+    }
+
+    #[test]
+    fn test_serial_transfer_not_immediate() {
+        // Given: SB = 0x42, SC = 0x81 (transfer started);
+        // When: fewer than 77 M-cycles have elapsed (before the first serial
+        //   count, which happens at M-cycle 77 with initial div_counter = 204
+        //   and serial_master_clock = false);
+        // Then: SC bit 7 still set, IF bit 3 still clear, serial_output empty
+        let mut bus = make_bus();
+        bus.write(0xFF01, 0x42);
+        bus.write(0xFF02, 0x81);
+        for _ in 0..76 {
+            bus.tick(1);
+        }
+        assert_eq!(
+            bus.read(0xFF02) & 0x80,
+            0x80,
+            "SC bit 7 should still be set"
+        );
+        assert_eq!(
+            bus.read(0xFF0F) & 0x08,
+            0x00,
+            "IF bit 3 should still be clear"
+        );
+        assert!(
+            bus.serial_output().is_empty(),
+            "serial_output should be empty"
+        );
+    }
+
+    #[test]
+    fn test_serial_transfer_completes_at_1024() {
+        // Given: transfer started at M-cycle 0;
+        // When: exactly 1024 M-cycles have elapsed;
+        // Then: transfer has completed (IF bit 3 set, SC bit 7 clear)
+        let mut bus = make_bus();
+        bus.write(0xFF01, 0x99);
+        bus.write(0xFF02, 0x81);
+        for _ in 0..1024 {
+            bus.tick(1);
+        }
+        assert_eq!(
+            bus.read(0xFF0F) & 0x08,
+            0x08,
+            "IF bit 3 should be set after 1024 M-cycles"
+        );
+        assert_eq!(
+            bus.read(0xFF02) & 0x80,
+            0x00,
+            "SC bit 7 should be cleared after 1024 M-cycles"
+        );
+    }
+
+    #[test]
+    fn test_serial_transfer_sets_sb_to_ff() {
+        // Given: SB = 0x42; When: transfer completes (1024 M-cycles);
+        // Then: SB is 0xFF (simulates receiving 0xFF from absent remote)
+        let mut bus = make_bus();
+        bus.write(0xFF01, 0x42);
+        bus.write(0xFF02, 0x81);
+        for _ in 0..1024 {
+            bus.tick(1);
+        }
+        assert_eq!(
+            bus.read(0xFF01),
+            0xFF,
+            "SB should be 0xFF after transfer completes"
+        );
+    }
+
+    #[test]
+    fn test_serial_external_clock_never_fires() {
+        // Given: SC = 0x80 (bit 7 set, bit 0 clear = external clock);
+        // When: 2048 M-cycles pass;
+        // Then: IF bit 3 never set and SC bit 7 remains set
+        let mut bus = make_bus();
+        bus.write(0xFF01, 0x55);
+        bus.write(0xFF02, 0x80);
+        for _ in 0..2048 {
+            bus.tick(1);
+        }
+        assert_eq!(
+            bus.read(0xFF0F) & 0x08,
+            0x00,
+            "IF bit 3 should never fire for external clock"
+        );
+        assert_eq!(
+            bus.read(0xFF02) & 0x80,
+            0x80,
+            "SC bit 7 should remain set for external clock"
+        );
+    }
+
+    #[test]
+    fn test_serial_transfer_restart() {
+        // Initial div_counter = 204; bit-7 falls at absolute M-cycles 13, 77, 141, 205, …
+        // With serial_master_clock (SMC) starting false, counts (SMC→false) at 77, 205, …, 973.
+        // Write SC=0x81 at M-cycle 0 (first transfer, byte 0x11).
+        // Restart with byte 0x22 at M-cycle 64 — before the first count at M-cycle 77.
+        //   At restart: SMC=true (one bit-7 fall at M-cycle 13) → force-aligned to false.
+        //   After restart: next bit-7 falls at 77 (SMC→true, no count), 141 (SMC→false,
+        //   COUNT), …, 1037 (8th count).  Interrupt fires at M-cycle 1037:
+        //   - no interrupt at M-cycle 1036 (972 M-cycles after restart)
+        //   - interrupt fires at M-cycle 1037 (973 M-cycles after restart)
+        let mut bus = make_bus();
+        bus.write(0xFF01, 0x11);
+        bus.write(0xFF02, 0x81); // first transfer
+        for _ in 0..64 {
+            bus.tick(1);
+        }
+        // Confirm no interrupt fired yet (first count not until M-cycle 77)
+        assert_eq!(bus.read(0xFF0F) & 0x08, 0x00, "no interrupt before restart");
+        // Restart
+        bus.write(0xFF01, 0x22);
+        bus.write(0xFF02, 0x81);
+        // Tick 972 more M-cycles (total 1036 from start) — one tick short of completion
+        for _ in 0..972 {
+            bus.tick(1);
+        }
+        assert_eq!(
+            bus.read(0xFF0F) & 0x08,
+            0x00,
+            "no interrupt 972 M-cycles after restart"
+        );
+        // One more tick reaches M-cycle 1037 — 8th counted bit fires interrupt
+        bus.tick(1);
+        assert_eq!(
+            bus.read(0xFF0F) & 0x08,
+            0x08,
+            "interrupt fires at 8th bit after restart"
+        );
+        assert_eq!(
+            bus.serial_output(),
+            &[0x22],
+            "only the restarted byte captured"
+        );
     }
 
     // ── IDU glitch notifications (Phase C) ───────────────────────────────────

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -272,12 +272,15 @@ impl GbBus for DmgBus {
             0xFF00 => self.joypad.write(val),
             0xFF01 => self.sb = val,
             0xFF02 => {
-                // Clock-alignment step (mirrors SameBoy): if serial_master_clock is
-                // currently true, immediately force it to false before latching the
-                // new SC value.  This ensures the first serial bit is always timed
-                // at the correct phase relative to the div counter — exactly what
-                // real hardware does when a transfer begins mid-period.
-                if self.serial_master_clock {
+                // Clock-alignment step (mirrors SameBoy): when *starting* an
+                // internal-clock transfer and serial_master_clock is currently
+                // true, immediately force it to false before latching SC.
+                // This ensures the first serial bit is always timed at the
+                // correct phase — exactly what real hardware does when a
+                // transfer begins mid-period.  Restricting to internal-clock
+                // starts avoids unintentionally shifting the clock phase on
+                // writes that merely inspect or clear SC.
+                if val & 0x81 == 0x81 && self.serial_master_clock {
                     self.serial_master_clock = false;
                 }
                 self.sc = val;
@@ -767,10 +770,13 @@ mod tests {
     }
 
     #[test]
-    fn test_serial_transfer_completes_at_1024() {
+    fn test_serial_transfer_completes_within_1024_m_cycles() {
         // Given: transfer started at M-cycle 0;
-        // When: exactly 1024 M-cycles have elapsed;
-        // Then: transfer has completed (IF bit 3 set, SC bit 7 clear)
+        // When: 1024 M-cycles have elapsed (the maximum transfer duration);
+        // Then: transfer has completed (IF bit 3 set, SC bit 7 clear).
+        // Note: with initial div_counter = 204 and SMC = false, the 8th bit
+        // is counted at M-cycle 973; this test confirms completion within the
+        // maximum window without asserting the exact cycle.
         let mut bus = make_bus();
         bus.write(0xFF01, 0x99);
         bus.write(0xFF02, 0x81);
@@ -780,12 +786,12 @@ mod tests {
         assert_eq!(
             bus.read(0xFF0F) & 0x08,
             0x08,
-            "IF bit 3 should be set after 1024 M-cycles"
+            "IF bit 3 should be set within 1024 M-cycles"
         );
         assert_eq!(
             bus.read(0xFF02) & 0x80,
             0x00,
-            "SC bit 7 should be cleared after 1024 M-cycles"
+            "SC bit 7 should be cleared within 1024 M-cycles"
         );
     }
 

--- a/src/gb/integration_tests/mooneye_tests.rs
+++ b/src/gb/integration_tests/mooneye_tests.rs
@@ -594,7 +594,6 @@ fn test_mooneye_acceptance_rst_timing() {
 }
 
 #[test]
-#[ignore = "Serial port not fully implemented — tracked in #2026"]
 fn test_mooneye_acceptance_serial_boot_sclk_align_dmgabcmgb() {
     assert_mooneye_pass!(&format!(
         "{BASE}/acceptance/serial/boot_sclk_align-dmgABCmgb.gb"

--- a/src/gb/timer/timer.rs
+++ b/src/gb/timer/timer.rs
@@ -34,8 +34,17 @@ const CLOCK_DIVS_T: [u16; 4] = [1024, 16, 64, 256];
 
 impl Timer {
     pub fn new() -> Self {
+        Self::with_div_counter(0)
+    }
+
+    /// Create a Timer with a specific initial `div_counter` value.
+    ///
+    /// Used by `DmgBus` to compensate for the sub-byte phase difference between
+    /// our custom boot ROM and real DMG-B hardware, ensuring serial clock edges
+    /// align correctly for acceptance tests.
+    pub(crate) fn with_div_counter(div_counter: u16) -> Self {
         Self {
-            div_counter: 0,
+            div_counter,
             tima: 0,
             tma: 0,
             tac: 0,
@@ -52,6 +61,14 @@ impl Timer {
             0xFF07 => self.tac | 0xF8, // upper bits read as 1
             _ => 0xFF,                 // 0xFF03 and all other addresses are unmapped
         }
+    }
+
+    /// Return the raw 16-bit internal counter value.
+    ///
+    /// Used by the serial port to detect falling edges of bit 8 (the 8192 Hz
+    /// serial bit-clock is derived from this bit of the counter).
+    pub fn raw_counter(&self) -> u16 {
+        self.div_counter
     }
 
     /// Write a timer register by address.

--- a/src/gb/timer/timer.rs
+++ b/src/gb/timer/timer.rs
@@ -65,8 +65,9 @@ impl Timer {
 
     /// Return the raw 16-bit internal counter value.
     ///
-    /// Used by the serial port to detect falling edges of bit 8 (the 8192 Hz
-    /// serial bit-clock is derived from this bit of the counter).
+    /// Used by the serial port to inspect the same divider state that
+    /// `DmgBus` derives serial clock timing from via its `0x080` mask
+    /// (falling edge of bit 7 = the 8192 Hz serial bit-clock base).
     pub fn raw_counter(&self) -> u16 {
         self.div_counter
     }


### PR DESCRIPTION
## Summary

Implements cycle-accurate serial transfer timing for the DMG bus, making the `boot_sclk_align-dmgABCmgb` Mooneye acceptance test pass.

## Approach

### Serial clock algorithm (SameBoy-accurate)

A persistent `serial_master_clock` (SMC) bool, never reset on SC writes, toggles on every **falling edge of bit 7** of the internal DIV counter (every 256 T-cycles = 64 M-cycles). A serial bit is shifted only when SMC transitions to **false**, giving the correct 8192 Hz effective rate (512 T-cycles per bit).

**Clock-alignment on SC write**: If SMC is currently `true` when the game writes to SC ($FF02) to start a transfer, it is immediately forced to `false`. This mirrors SameBoy's edge-injection behaviour and ensures the first serial bit is timed at the correct phase — critical for the boot_sclk_align test.

### Boot ROM phase offset

The internal div_counter is initialised to **204 T-cycles** at power-on (via `Timer::with_div_counter(204)`). Real DMG-B hardware exits the boot ROM with a sub-byte div phase of 204 T-cycles; starting from 0 leaves serial clock edges misaligned by 64 M-cycles relative to the test's expected interrupt at M-cycle 1011.

## Changes

| File | Change |
|------|--------|
| `src/gb/bus/dmg_bus.rs` | `serial_master_clock: bool` field; bit-7+SMC tick logic; SC write force-alignment |
| `src/gb/timer/timer.rs` | `Timer::with_div_counter(val)` constructor; `raw_counter()` getter |
| `src/gb/integration_tests/mooneye_tests.rs` | Removed `#[ignore]` from serial test; fixed duplicate `#[test]` |

## Tests

- ✅ **boot_sclk_align-dmgABCmgb** Mooneye acceptance test now passes
- ✅ All 10 serial unit tests pass (updated for new timing with div_counter=204)
- ✅ All 455 GB tests pass (0 failures, 75 ignored)

Closes #2026