### PR TITLE
Improve test_scanline accuracy: 428 -> 20 failures (#2054)

### DIFF
--- a/src/nes/cpu/master_clock.rs
+++ b/src/nes/cpu/master_clock.rs
@@ -14,6 +14,20 @@ pub struct MasterClock {
 }
 
 impl MasterClock {
+    // Shift between read and write bus-access timing within a CPU cycle.
+    //
+    // In the real NES, the PPU and CPU share a master clock.  The data-bus
+    // access (read or write) occurs at a specific master-clock position
+    // inside each CPU cycle.  Writes are placed later than reads.
+    //
+    // For NTSC (cpu_div=12, ppu_div=4, start=6):
+    //   Write: before = start + shift = 6+2 = 8  → 8/4 = 2 PPU ticks before
+    //          after  = end   - shift = 6-2 = 4  → 4/4 = 1 PPU tick  after
+    //   Read:  before = start - shift = 6-2 = 4  → 4/4 = 1 PPU tick  before
+    //          after  = end   + shift = 6+2 = 8  → 8/4 = 2 PPU ticks after
+    //
+    // This matches Mesen2's PPU-driven model where 2 PPU dots execute
+    // before the CPU write takes effect on each CPU write cycle.
     const READ_WRITE_SHIFT: u64 = 1;
     pub fn new(tv_system: TimingMode) -> Self {
         // Dividers from Mesen2 NesCpu.cpp SetMasterClockDivider():

--- a/src/nes/cpu/master_clock.rs
+++ b/src/nes/cpu/master_clock.rs
@@ -20,14 +20,14 @@ impl MasterClock {
     // access (read or write) occurs at a specific master-clock position
     // inside each CPU cycle.  Writes are placed later than reads.
     //
-    // For NTSC (cpu_div=12, ppu_div=4, start=6):
-    //   Write: before = start + shift = 6+2 = 8  → 8/4 = 2 PPU ticks before
-    //          after  = end   - shift = 6-2 = 4  → 4/4 = 1 PPU tick  after
-    //   Read:  before = start - shift = 6-2 = 4  → 4/4 = 1 PPU tick  before
-    //          after  = end   + shift = 6+2 = 8  → 8/4 = 2 PPU ticks after
+    // For NTSC (cpu_div=12, ppu_div=4, start=6, end=6, shift=1):
+    //   Write: before = start + shift = 6+1 = 7  → 7/4 = 1 PPU tick  before
+    //          after  = end   - shift = 6-1 = 5  → 5/4 = 1 PPU tick  after
+    //   Read:  before = start - shift = 6-1 = 5  → 5/4 = 1 PPU tick  before
+    //          after  = end   + shift = 6+1 = 7  → 7/4 = 1 PPU tick  after
     //
-    // This matches Mesen2's PPU-driven model where 2 PPU dots execute
-    // before the CPU write takes effect on each CPU write cycle.
+    // This matches the implementation below, where writes are shifted one
+    // master tick later than reads within the CPU cycle.
     const READ_WRITE_SHIFT: u64 = 1;
     pub fn new(tv_system: TimingMode) -> Self {
         // Dividers from Mesen2 NesCpu.cpp SetMasterClockDivider():

--- a/src/nes/integration_tests/mapper_tests.rs
+++ b/src/nes/integration_tests/mapper_tests.rs
@@ -462,12 +462,12 @@ mod tests {
         test_mmc5_exram_crc_sequence,
         "roms/nes/automated_tests/exram/mmc5exram.nes",
         [
-            (60, 0x90428465u32),
-            (120, 0x4E2BA407u32),
+            (60, 0x4B2FB7FAu32),
+            (120, 0xCC0E5AA9u32),
             (180, 0x01ECA2E8u32),
-            (240, 0x138E5FE2u32),
-            (300, 0xC7C91CC3u32),
-            (360, 0xEFBFD0D1u32),
+            (240, 0x1E78FE6Du32),
+            (300, 0x33422A1Fu32),
+            (360, 0xC3E6BDD0u32),
             (420, 0xD57CD303u32),
         ]
     );

--- a/src/nes/integration_tests/ppu_tests.rs
+++ b/src/nes/integration_tests/ppu_tests.rs
@@ -934,9 +934,12 @@ AA AA 01 01 10 10 01 01 00 00\n\
             }
         }
 
-        // Diagnostic: print failures before asserting
-        if !all_failures.is_empty() {
-            // Print summary by frame
+        // Target: at most 20 unwanted pixels across all 10 checked frames.
+        // The remaining 20 failures are $2001 BG-enable timing edge cases at
+        // x=200-201 on frames 3 and 7 only (period-4 pattern).  Even Mesen
+        // has a few NTSC failures in this test area.  See issue #2054.
+        if all_failures.len() > 20 {
+            // Print per-frame breakdown only when the assertion is about to fail
             for f in 0..10 {
                 let frame_fails: Vec<_> = all_failures
                     .iter()
@@ -949,18 +952,11 @@ AA AA 01 01 10 10 01 01 00 00\n\
                     }
                 }
             }
-            eprintln!("{} total failures across 10 frames", all_failures.len());
+            panic!(
+                "expected at most 20 scanline test failures, but got {} failures:\n{}",
+                all_failures.len(),
+                all_failures.join("\n")
+            );
         }
-
-        // Target: at most 20 unwanted pixels across all 10 checked frames.
-        // The remaining 20 failures are $2001 BG-enable timing edge cases at
-        // x=200-201 on frames 3 and 7 only (period-4 pattern).  Even Mesen
-        // has a few NTSC failures in this test area.  See issue #2054.
-        assert!(
-            all_failures.len() <= 20,
-            "expected at most 20 scanline test failures, but got {} failures:\n{}",
-            all_failures.len(),
-            all_failures.join("\n")
-        );
     }
 }

--- a/src/nes/integration_tests/ppu_tests.rs
+++ b/src/nes/integration_tests/ppu_tests.rs
@@ -934,28 +934,33 @@ AA AA 01 01 10 10 01 01 00 00\n\
             }
         }
 
-        // An average of 42.8 failures per frame across 10 frames is the
-        // best we can do for now with the current OAM implementation
+        // Diagnostic: print failures before asserting
+        if !all_failures.is_empty() {
+            // Print summary by frame
+            for f in 0..10 {
+                let frame_fails: Vec<_> = all_failures
+                    .iter()
+                    .filter(|s| s.starts_with(&format!("frame_offset={},", f)))
+                    .collect();
+                if !frame_fails.is_empty() {
+                    eprintln!("Frame {}: {} failures", f, frame_fails.len());
+                    for fail in &frame_fails[..frame_fails.len().min(40)] {
+                        eprintln!("  {}", fail);
+                    }
+                }
+            }
+            eprintln!("{} total failures across 10 frames", all_failures.len());
+        }
+
+        // Target: at most 20 unwanted pixels across all 10 checked frames.
+        // The remaining 20 failures are $2001 BG-enable timing edge cases at
+        // x=200-201 on frames 3 and 7 only (period-4 pattern).  Even Mesen
+        // has a few NTSC failures in this test area.  See issue #2054.
         assert!(
-            all_failures.len() <= 428,
-            "expected no more than 428 scanline test failures, but got:\n{}",
+            all_failures.len() <= 20,
+            "expected at most 20 scanline test failures, but got {} failures:\n{}",
+            all_failures.len(),
             all_failures.join("\n")
         );
-        // if !all_failures.is_empty() {
-        //     // Print summary by frame
-        //     for f in 0..10 {
-        //         let frame_fails: Vec<_> = all_failures
-        //             .iter()
-        //             .filter(|s| s.starts_with(&format!("frame_offset={},", f)))
-        //             .collect();
-        //         if !frame_fails.is_empty() {
-        //             eprintln!("Frame {}: {} failures", f, frame_fails.len());
-        //             for fail in &frame_fails[..frame_fails.len().min(20)] {
-        //                 eprintln!("  {}", fail);
-        //             }
-        //         }
-        //     }
-        //     panic!("{} total failures across 10 frames", all_failures.len());
-        // }
     }
 }

--- a/src/nes/ppu/background.rs
+++ b/src/nes/ppu/background.rs
@@ -16,6 +16,10 @@ pub struct Background {
     pattern_lo_latch: u8,
     /// Pattern table high byte latch
     pattern_hi_latch: u8,
+    /// Latched tile address computed at nametable-byte fetch time.
+    /// This captures the pattern table base + tile index + fine Y so that
+    /// mid-tile $2000 writes do not affect the current tile's pattern fetch.
+    tile_addr: u16,
 }
 
 impl Default for Background {
@@ -36,6 +40,7 @@ impl Background {
             attribute_latch: 0,
             pattern_lo_latch: 0,
             pattern_hi_latch: 0,
+            tile_addr: 0,
         }
     }
 
@@ -49,6 +54,7 @@ impl Background {
         self.attribute_latch = 0;
         self.pattern_lo_latch = 0;
         self.pattern_hi_latch = 0;
+        self.tile_addr = 0;
     }
 
     // Debug: Get shift register state
@@ -56,13 +62,23 @@ impl Background {
     //     (self.bg_pattern_shift_lo, self.bg_pattern_shift_hi)
     // }
 
-    /// Fetch nametable byte from memory
-    pub fn fetch_nametable<F>(&mut self, v: u16, read_nametable: F)
+    /// Fetch nametable byte from memory and latch the full tile address.
+    ///
+    /// The tile address is computed here (combining the nametable byte with
+    /// the current pattern-table base and fine-Y from `v`) so that a
+    /// mid-tile write to $2000 does not change the pattern table for the
+    /// tile currently being fetched — matching real hardware and Mesen.
+    pub fn fetch_nametable<F>(&mut self, v: u16, pattern_table_base: u16, read_nametable: F)
     where
         F: Fn(u16) -> u8,
     {
         let addr = 0x2000 | (v & 0x0FFF);
         self.nametable_latch = read_nametable(addr);
+
+        // Latch tile address: pattern_table | (tile_index << 4) | fine_y
+        let tile_index = self.nametable_latch as u16;
+        let fine_y = (v >> 12) & 0x07;
+        self.tile_addr = pattern_table_base | (tile_index << 4) | fine_y;
     }
 
     /// Fetch attribute byte from memory
@@ -74,26 +90,20 @@ impl Background {
         self.attribute_latch = read_nametable(addr);
     }
 
-    /// Fetch pattern table low byte from CHR ROM
-    pub fn fetch_pattern_lo<F>(&mut self, pattern_table_base: u16, v: u16, read_chr: F)
+    /// Fetch pattern table low byte from CHR ROM using the latched tile address.
+    pub fn fetch_pattern_lo<F>(&mut self, read_chr: F)
     where
         F: Fn(u16) -> u8,
     {
-        let tile_index = self.nametable_latch as u16;
-        let fine_y = (v >> 12) & 0x07;
-        let addr = pattern_table_base | (tile_index << 4) | fine_y;
-        self.pattern_lo_latch = read_chr(addr);
+        self.pattern_lo_latch = read_chr(self.tile_addr);
     }
 
-    /// Fetch pattern table high byte from CHR ROM
-    pub fn fetch_pattern_hi<F>(&mut self, pattern_table_base: u16, v: u16, read_chr: F)
+    /// Fetch pattern table high byte from CHR ROM using the latched tile address.
+    pub fn fetch_pattern_hi<F>(&mut self, read_chr: F)
     where
         F: Fn(u16) -> u8,
     {
-        let tile_index = self.nametable_latch as u16;
-        let fine_y = (v >> 12) & 0x07;
-        let addr = pattern_table_base | (tile_index << 4) | fine_y | 0x08;
-        self.pattern_hi_latch = read_chr(addr);
+        self.pattern_hi_latch = read_chr(self.tile_addr | 0x08);
     }
 
     /// Load shift registers from latches
@@ -256,8 +266,11 @@ mod tests {
     #[test]
     fn test_fetch_nametable() {
         let mut bg = Background::new();
-        bg.fetch_nametable(0x2000, |_| 0x42);
+        // v=0x2000: fine_y = (0x2000 >> 12) & 7 = 2
+        bg.fetch_nametable(0x2000, 0x0000, |_| 0x42);
         assert_eq!(bg.nametable_latch, 0x42);
+        // tile_addr = pattern_table(0) | (0x42 << 4) | fine_y(2) = 0x0422
+        assert_eq!(bg.tile_addr, 0x0422);
     }
 
     #[test]

--- a/src/nes/ppu/ppu.rs
+++ b/src/nes/ppu/ppu.rs
@@ -151,6 +151,11 @@ pub struct Ppu {
     vs_ppu_type: Option<VsPpuType>,
     /// VS System palette override (set from vs_ppu_type).
     vs_palette: Option<&'static [(u8, u8, u8); 64]>,
+    /// Delayed v=t update countdown (3 PPU cycles after second $2006 write).
+    /// Based on Visual NES findings, documented in Mesen2 NesPpu.cpp.
+    update_vram_addr_delay: u8,
+    /// The pending VRAM address value when a delayed v=t update is active.
+    pending_vram_addr: u16,
 }
 
 impl Ppu {
@@ -288,6 +293,8 @@ impl Ppu {
             famicom_emphasis: false,
             vs_ppu_type: None,
             vs_palette: None,
+            update_vram_addr_delay: 0,
+            pending_vram_addr: 0,
         }
     }
 
@@ -295,6 +302,22 @@ impl Ppu {
     #[cfg(test)]
     pub fn new_for_testing(tv_system: TimingMode) -> Self {
         Self::new(tv_system, crate::nes::console::RamInitMode::Zero)
+    }
+
+    /// Flush any pending delayed VRAM address update.
+    ///
+    /// In real hardware, consecutive CPU writes are separated by at least 3 PPU
+    /// cycles (one CPU cycle), so a $2006 delay always completes before the
+    /// next register access. Unit tests that call write methods directly without
+    /// ticking the PPU need to call this to mimic that elapsed time.
+    #[cfg(test)]
+    pub fn flush_pending_vram_addr(&mut self) {
+        if self.update_vram_addr_delay > 0 {
+            let old_v = self.registers.v();
+            self.registers.set_v(self.pending_vram_addr);
+            self.prime_a12_and_notify_mapper(old_v, self.pending_vram_addr);
+            self.update_vram_addr_delay = 0;
+        }
     }
 
     #[cfg(test)]
@@ -555,7 +578,7 @@ impl Ppu {
             self.registers.v(),
         );
         let old_v = self.registers.v();
-        self.registers.write_address(value, is_dummy_write);
+        let was_second_write = self.registers.write_address(value, is_dummy_write);
         trace_ppu!(3; "ppuaddr write value={:02X} w_after={} t_after={:04X} v_after={:04X}",
             value,
             self.registers.w(),
@@ -564,10 +587,26 @@ impl Ppu {
         );
         self.registers.set_io_bus(value); // Update I/O bus
 
-        // Notify mapper if v register changed (happens on second write to $2006)
-        // This is needed for MMC3 A12 detection when manually toggling address
-        let new_v = self.registers.v();
-        self.prime_a12_and_notify_mapper(old_v, new_v);
+        if was_second_write {
+            let new_addr = self.registers.v(); // v was set to t by write_address
+
+            // During rendering scanlines the v=t update is delayed by 3 PPU
+            // cycles (based on Visual NES findings, ref Mesen2 NesPpu.cpp).
+            // Outside rendering, it takes effect immediately.
+            let scanline = self.timing.scanline();
+            let prerender = tick::prerender_scanline(self.timing.tv_system());
+            let is_rendering_scanline = scanline < 240 || scanline == prerender;
+
+            if is_rendering_scanline && self.registers.is_rendering_enabled() {
+                // Undo the immediate v=t; the tick loop will apply it after the delay.
+                self.registers.set_v(old_v);
+                self.update_vram_addr_delay = 3;
+                self.pending_vram_addr = new_addr;
+            } else {
+                // Immediate update outside rendering; notify mapper of address change.
+                self.prime_a12_and_notify_mapper(old_v, new_addr);
+            }
+        }
     }
 
     /// Read from data register ($2007)
@@ -1915,6 +1954,7 @@ mod tests {
 
         ppu.write_address(0x20, false);
         ppu.write_address(0x00, false);
+        ppu.flush_pending_vram_addr(); // In hardware, ≥3 PPU cycles elapse before next write
         ppu.write_data(0x12);
 
         assert_eq!(ppu.v_register(), 0x3001);

--- a/src/nes/ppu/ppu.rs
+++ b/src/nes/ppu/ppu.rs
@@ -595,7 +595,9 @@ impl Ppu {
             // Outside rendering, it takes effect immediately.
             let scanline = self.timing.scanline();
             let prerender = tick::prerender_scanline(self.timing.tv_system());
-            let is_rendering_scanline = scanline < 240 || scanline == prerender;
+            let is_rendering_scanline = scanline
+                < crate::nes::ppu::timing::LAST_VISIBLE_SCANLINE_PLUS_ONE
+                || scanline == prerender;
 
             if is_rendering_scanline && self.registers.is_rendering_enabled() {
                 // Undo the immediate v=t; the tick loop will apply it after the delay.

--- a/src/nes/ppu/ppu/tick.rs
+++ b/src/nes/ppu/ppu/tick.rs
@@ -86,6 +86,7 @@ pub(super) fn tick(ppu: &mut Ppu) {
     tick_background(ppu);
     tick_sprites(ppu);
     tick_pixel_output(ppu);
+    tick_delayed_updates(ppu);
 }
 
 /// Phase 1: Advance timing, detect frame boundaries, and notify mappers.
@@ -247,8 +248,11 @@ fn tick_background(ppu: &mut Ppu) {
                 let v = ppu.registers.v();
                 match fetch_step {
                     0 => {
-                        // Fetch nametable byte (cycle 2 of tile)
-                        ppu.background.fetch_nametable(v, |addr| {
+                        // Fetch nametable byte (cycle 2 of tile).
+                        // The pattern-table base and fine-Y are latched here
+                        // so that a mid-tile $2000 write does not affect this
+                        // tile's pattern fetch (matching real HW / Mesen).
+                        ppu.background.fetch_nametable(v, bg_pattern_table, |addr| {
                             ppu.memory.read_nametable_mapped(addr, cartridge)
                         });
                     }
@@ -260,19 +264,17 @@ fn tick_background(ppu: &mut Ppu) {
                     }
                     2 => {
                         // Fetch pattern table low byte (cycle 6 of tile)
-                        ppu.background
-                            .fetch_pattern_lo(bg_pattern_table, v, |addr| {
-                                Ppu::notify_chr_fetch_kind(cartridge, false);
-                                ppu.memory.read_chr(addr, cartridge)
-                            });
+                        ppu.background.fetch_pattern_lo(|addr| {
+                            Ppu::notify_chr_fetch_kind(cartridge, false);
+                            ppu.memory.read_chr(addr, cartridge)
+                        });
                     }
                     3 => {
                         // Fetch pattern table high byte (cycle 8 of tile)
-                        ppu.background
-                            .fetch_pattern_hi(bg_pattern_table, v, |addr| {
-                                Ppu::notify_chr_fetch_kind(cartridge, false);
-                                ppu.memory.read_chr(addr, cartridge)
-                            });
+                        ppu.background.fetch_pattern_hi(|addr| {
+                            Ppu::notify_chr_fetch_kind(cartridge, false);
+                            ppu.memory.read_chr(addr, cartridge)
+                        });
                     }
                     _ => {}
                 }
@@ -306,8 +308,10 @@ fn tick_background(ppu: &mut Ppu) {
             // Two dummy nametable fetches at pixels 337 and 339
             // (The NES PPU does these but they're not used)
             let v = ppu.registers.v();
-            ppu.background
-                .fetch_nametable(v, |addr| ppu.memory.read_nametable_mapped(addr, cartridge));
+            let bg_pt = ppu.registers.bg_pattern_table_addr();
+            ppu.background.fetch_nametable(v, bg_pt, |addr| {
+                ppu.memory.read_nametable_mapped(addr, cartridge)
+            });
         }
 
         // Handle scroll register updates during visible pixels
@@ -625,6 +629,40 @@ fn tick_pixel_output(ppu: &mut Ppu) {
             ppu.rendering
                 .screen_buffer_mut()
                 .set_pixel(screen_x, screen_y, final_r, final_g, final_b);
+        }
+    }
+}
+
+/// Phase 6: Process delayed register updates (runs at end of each PPU cycle).
+///
+/// The second write to $2006 does NOT update v immediately on real hardware.
+/// Instead, t is copied to v after a 3 PPU cycle delay (based on Visual NES
+/// findings, ref Mesen2 NesPpu.cpp `_updateVramAddrDelay`).
+fn tick_delayed_updates(ppu: &mut Ppu) {
+    if ppu.update_vram_addr_delay > 0 {
+        ppu.update_vram_addr_delay -= 1;
+        if ppu.update_vram_addr_delay == 0 {
+            let old_v = ppu.registers.v();
+            let new_v = ppu.pending_vram_addr;
+            ppu.registers.set_v(new_v);
+
+            // Notify mapper of address change (needed for MMC3 A12 detection)
+            ppu.prime_a12_and_notify_mapper(old_v, new_v);
+
+            // When rendering is disabled, also update the bus address for mapper hooks
+            let scanline = ppu.timing.scanline();
+            let is_rendering_enabled = ppu.registers.is_rendering_enabled();
+            if scanline >= LAST_VISIBLE_SCANLINE_PLUS_ONE || !is_rendering_enabled {
+                ppu.with_mapper_mut(|mapper| {
+                    mapper.ppu_address_changed(new_v & 0x3FFF);
+                });
+            }
+
+            trace_ppu!(3; "delayed v=t applied v={:04X} y={} x={}",
+                new_v,
+                ppu.timing.scanline(),
+                ppu.timing.pixel(),
+            );
         }
     }
 }

--- a/src/nes/ppu/ppu/tick.rs
+++ b/src/nes/ppu/ppu/tick.rs
@@ -646,17 +646,9 @@ fn tick_delayed_updates(ppu: &mut Ppu) {
             let new_v = ppu.pending_vram_addr;
             ppu.registers.set_v(new_v);
 
-            // Notify mapper of address change (needed for MMC3 A12 detection)
+            // Notify mapper of the delayed address change exactly once
+            // (this also handles MMC3 A12 tracking).
             ppu.prime_a12_and_notify_mapper(old_v, new_v);
-
-            // When rendering is disabled, also update the bus address for mapper hooks
-            let scanline = ppu.timing.scanline();
-            let is_rendering_enabled = ppu.registers.is_rendering_enabled();
-            if scanline >= LAST_VISIBLE_SCANLINE_PLUS_ONE || !is_rendering_enabled {
-                ppu.with_mapper_mut(|mapper| {
-                    mapper.ppu_address_changed(new_v & 0x3FFF);
-                });
-            }
 
             trace_ppu!(3; "delayed v=t applied v={:04X} y={} x={}",
                 new_v,

--- a/src/nes/ppu/registers.rs
+++ b/src/nes/ppu/registers.rs
@@ -174,7 +174,9 @@ impl Registers {
     }
 
     /// Write to address register ($2006)
-    pub fn write_address(&mut self, value: u8, is_dummy_write: bool) {
+    /// Write to address register ($2006).
+    /// Returns `true` when this was the second write (v was updated from t).
+    pub fn write_address(&mut self, value: u8, is_dummy_write: bool) -> bool {
         // Dummy writes from RMW instructions DO toggle w and modify registers
         // They just write the unmodified value (which was already there)
         // So the behavior is the same as a normal write - no special handling needed
@@ -188,6 +190,7 @@ impl Registers {
             // w:                  <- 1
             self.t = (self.t & 0x80FF) | (((value & 0x3F) as u16) << 8);
             self.w = true;
+            false
         } else {
             // Second write: low byte
             // t: ....... ABCDEFGH <- d: ABCDEFGH
@@ -196,6 +199,7 @@ impl Registers {
             self.t = (self.t & 0xFF00) | (value as u16);
             self.v = self.t;
             self.w = false;
+            true
         }
     }
 
@@ -293,6 +297,11 @@ impl Registers {
     /// Get write toggle
     pub fn w(&self) -> bool {
         self.w
+    }
+
+    /// Set the VRAM address directly (used by delayed v=t update).
+    pub fn set_v(&mut self, v: u16) {
+        self.v = v;
     }
 
     /// Clear write toggle (used when reading status)

--- a/src/nes/ppu/registers.rs
+++ b/src/nes/ppu/registers.rs
@@ -173,7 +173,6 @@ impl Registers {
         }
     }
 
-    /// Write to address register ($2006)
     /// Write to address register ($2006).
     /// Returns `true` when this was the second write (v was updated from t).
     pub fn write_address(&mut self, value: u8, is_dummy_write: bool) -> bool {
@@ -300,8 +299,10 @@ impl Registers {
     }
 
     /// Set the VRAM address directly (used by delayed v=t update).
+    /// The PPU v register is 15-bit internally (fine Y in bits 12-14),
+    /// so mask off bit 15 as a safety invariant.
     pub fn set_v(&mut self, v: u16) {
-        self.v = v;
+        self.v = v & 0x7FFF;
     }
 
     /// Clear write toggle (used when reading status)


### PR DESCRIPTION
## Summary

Two key PPU timing improvements matching Mesen2/real hardware, reducing scanline test failures from **428 to 20**:

### 1. Tile address latching
Compute the full CHR pattern address (pattern_table_base | tile_index << 4 | fine_y) at nametable-byte fetch time and reuse it for pattern_lo/hi fetches. This prevents mid-tile writes to PPUCTRL bit 4 from affecting the current tiles pattern fetch, matching Mesens LoadTileInfo().

### 2. $2006 v=t 3-cycle delay
The second write to $2006 no longer updates v immediately during rendering scanlines. Instead, v is updated after a 3 PPU cycle delay via tick_delayed_updates(), matching Mesens _updateVramAddrDelay mechanism.

### CRC updates
- Updated MMC5 ExRAM CRC test values (tile address latching changes rendering)
- Regenerated mapper 25 autorun CRCs ($2006 delay changes rendering)

### Remaining 20 failures
All are $2001 BG-enable timing edge cases at x=200-201 on frames 3 and 7 only. Even Mesen has NTSC failures in this area.

Closes #2054