### PR TITLE
feat(gb): implement MBC2 mapper (#2024)

### DIFF
--- a/src/gb/cartridge/mbc2.rs
+++ b/src/gb/cartridge/mbc2.rs
@@ -1,0 +1,240 @@
+use super::cartridge::GbCartridge;
+
+/// MBC2 cartridge (types 0x05 = MBC2, 0x06 = MBC2+BATTERY).
+///
+/// Supports up to 16 ROM banks (256 KB) and has 512 × 4-bit built-in RAM
+/// at $A000–$A1FF (mirrored across $A000–$BFFF).
+///
+/// Register writes ($0000–$3FFF):
+/// - Bit 8 of address **clear**: RAM enable gate (lower nibble 0xA → enable; else disable)
+/// - Bit 8 of address **set**: ROM bank register (lower 4 bits; bank 0 promoted to bank 1)
+pub struct Mbc2 {
+    rom: Vec<u8>,
+    /// 512-byte built-in RAM (each slot stores a full byte; upper nibble masked on reads).
+    ram: [u8; 512],
+    /// Raw ROM bank register (0 is promoted to 1 on access).
+    rom_bank: u8,
+    /// Whether cartridge RAM is enabled.
+    ram_enabled: bool,
+}
+
+impl Mbc2 {
+    pub fn new(rom: Vec<u8>) -> Self {
+        Self {
+            rom,
+            ram: [0u8; 512],
+            rom_bank: 0,
+            ram_enabled: false,
+        }
+    }
+
+    fn rom_bank_count(&self) -> usize {
+        (self.rom.len() / 0x4000).max(1)
+    }
+
+    /// Effective ROM bank for the $4000–$7FFF window.
+    /// Lower 4 bits; bank 0 promotes to bank 1; masked to available banks.
+    fn effective_rom_bank(&self) -> usize {
+        let raw = (self.rom_bank & 0x0F) as usize;
+        let promoted = if raw == 0 { 1 } else { raw };
+        promoted & (self.rom_bank_count() - 1)
+    }
+
+    fn read_rom(&self, addr: u16) -> u8 {
+        let (bank, offset) = if addr < 0x4000 {
+            (0, addr as usize)
+        } else {
+            (self.effective_rom_bank(), addr as usize - 0x4000)
+        };
+        let idx = bank * 0x4000 + offset;
+        self.rom.get(idx).copied().unwrap_or(0xFF)
+    }
+
+    fn read_ram(&self, addr: u16) -> u8 {
+        if !self.ram_enabled {
+            return 0xFF;
+        }
+        let idx = (addr as usize - 0xA000) & 0x1FF;
+        self.ram[idx] | 0xF0
+    }
+
+    fn write_registers(&mut self, addr: u16, val: u8) {
+        if addr & 0x0100 == 0 {
+            // Bit 8 clear → RAM enable gate
+            self.ram_enabled = (val & 0x0F) == 0x0A;
+        } else {
+            // Bit 8 set → ROM bank select (lower 4 bits)
+            self.rom_bank = val & 0x0F;
+        }
+    }
+
+    fn write_ram(&mut self, addr: u16, val: u8) {
+        if !self.ram_enabled {
+            return;
+        }
+        let idx = (addr as usize - 0xA000) & 0x1FF;
+        self.ram[idx] = val;
+    }
+}
+
+impl GbCartridge for Mbc2 {
+    fn read(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x7FFF => self.read_rom(addr),
+            0xA000..=0xBFFF => self.read_ram(addr),
+            _ => 0xFF,
+        }
+    }
+
+    fn write(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x0000..=0x3FFF => self.write_registers(addr, val),
+            0xA000..=0xBFFF => self.write_ram(addr, val),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a test ROM with `bank_count` banks, where each bank's bytes are
+    /// all set to `bank_index as u8`.
+    fn make_rom(bank_count: usize) -> Vec<u8> {
+        let mut rom = vec![0u8; bank_count * 0x4000];
+        for bank in 0..bank_count {
+            let fill = bank as u8;
+            let start = bank * 0x4000;
+            rom[start..start + 0x4000].fill(fill);
+        }
+        rom
+    }
+
+    // -----------------------------------------------------------------------
+    // ROM banking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mbc2_initial_rom_bank0_readable() {
+        // Bank 0 is always at $0000–$3FFF; fill byte = 0
+        let cart = Mbc2::new(make_rom(4));
+        assert_eq!(cart.read(0x0000), 0x00);
+        assert_eq!(cart.read(0x3FFF), 0x00);
+    }
+
+    #[test]
+    fn test_mbc2_initial_high_region_maps_bank1() {
+        // rom_bank = 0 → promotes to 1; fill byte = 1
+        let cart = Mbc2::new(make_rom(4));
+        assert_eq!(cart.read(0x4000), 0x01);
+        assert_eq!(cart.read(0x7FFF), 0x01);
+    }
+
+    #[test]
+    fn test_mbc2_rom_bank_switch_selects_bank() {
+        // Write 0x02 to addr with bit 8 set (e.g. $0100) → bank 2
+        let mut cart = Mbc2::new(make_rom(4));
+        cart.write(0x0100, 0x02);
+        assert_eq!(cart.read(0x4000), 0x02);
+    }
+
+    #[test]
+    fn test_mbc2_writing_zero_bank_reg_promotes_to_bank1() {
+        // Explicitly write 0 to bank reg → still maps to bank 1
+        let mut cart = Mbc2::new(make_rom(4));
+        cart.write(0x0100, 0x00);
+        assert_eq!(cart.read(0x4000), 0x01);
+    }
+
+    #[test]
+    fn test_mbc2_bank_reg_masked_to_4_bits() {
+        // Writing 0x1F → lower 4 bits = 0xF = 15
+        let mut cart = Mbc2::new(make_rom(16));
+        cart.write(0x0100, 0x1F);
+        assert_eq!(cart.read(0x4000), 0x0F);
+    }
+
+    #[test]
+    fn test_mbc2_bank_wraps_to_available_banks() {
+        // 4-bank ROM; requesting bank 5 → 5 & 3 = 1 (effective_rom_bank &
+        // (bank_count - 1) masking); fill byte = 1
+        let mut cart = Mbc2::new(make_rom(4));
+        cart.write(0x0100, 0x05); // lower 4 bits = 5; 5 & (4-1) = 1
+        assert_eq!(cart.read(0x4000), 0x01);
+    }
+
+    // -----------------------------------------------------------------------
+    // RAM gate
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mbc2_ram_disabled_by_default_returns_0xff() {
+        let cart = Mbc2::new(make_rom(2));
+        assert_eq!(cart.read(0xA000), 0xFF);
+    }
+
+    #[test]
+    fn test_mbc2_ram_enable_any_lower_nibble_0xa() {
+        // 0x2A has lower nibble 0xA → enables; addr has bit 8 clear (0x0000)
+        let mut cart = Mbc2::new(make_rom(2));
+        cart.write(0x0000, 0x2A);
+        cart.write(0xA000, 0x05);
+        assert_eq!(cart.read(0xA000), 0x05 | 0xF0);
+    }
+
+    #[test]
+    fn test_mbc2_ram_disable_non_0xa_lower_nibble() {
+        // Enable first, then write 0x00 (lower nibble 0) → disabled
+        let mut cart = Mbc2::new(make_rom(2));
+        cart.write(0x0000, 0x0A); // enable
+        cart.write(0xA000, 0x07);
+        cart.write(0x0000, 0x00); // disable
+        assert_eq!(cart.read(0xA000), 0xFF);
+    }
+
+    #[test]
+    fn test_mbc2_ram_write_and_read_when_enabled() {
+        let mut cart = Mbc2::new(make_rom(2));
+        cart.write(0x0000, 0x0A);
+        cart.write(0xA000, 0x03);
+        assert_eq!(cart.read(0xA000), 0x03 | 0xF0);
+    }
+
+    #[test]
+    fn test_mbc2_ram_read_returns_upper_nibble_0xf() {
+        // Stored value 0x05; read must return 0xF5
+        let mut cart = Mbc2::new(make_rom(2));
+        cart.write(0x0000, 0x0A);
+        cart.write(0xA001, 0x05);
+        assert_eq!(cart.read(0xA001), 0xF5);
+    }
+
+    #[test]
+    fn test_mbc2_ram_mirrors_a200_to_bfff() {
+        // Write to $A000; read back at $A200 (512 bytes later, same slot)
+        let mut cart = Mbc2::new(make_rom(2));
+        cart.write(0x0000, 0x0A);
+        cart.write(0xA000, 0x09);
+        assert_eq!(cart.read(0xA200), 0x09 | 0xF0);
+    }
+
+    #[test]
+    fn test_mbc2_writes_to_bit8_clear_addr_do_not_change_bank() {
+        // Bit 8 clear → RAM gate write; should NOT change current ROM bank
+        let mut cart = Mbc2::new(make_rom(4));
+        cart.write(0x0100, 0x03); // select bank 3 first
+        cart.write(0x0000, 0x0A); // RAM enable (bit 8 clear) — must not reset bank
+        assert_eq!(cart.read(0x4000), 0x03);
+    }
+
+    #[test]
+    fn test_mbc2_writes_to_bit8_set_addr_do_not_enable_ram() {
+        // Bit 8 set → ROM bank select; should NOT change RAM enabled state
+        let mut cart = Mbc2::new(make_rom(4));
+        // RAM disabled by default; write bank select with 0x0A value but bit 8 set
+        cart.write(0x0100, 0x0A);
+        // RAM should still be disabled
+        assert_eq!(cart.read(0xA000), 0xFF);
+    }
+}

--- a/src/gb/cartridge/mod.rs
+++ b/src/gb/cartridge/mod.rs
@@ -2,10 +2,12 @@
 mod cartridge;
 mod mbc0;
 mod mbc1;
+mod mbc2;
 
 pub use cartridge::GbCartridge;
 use mbc0::Mbc0;
 use mbc1::Mbc1;
+use mbc2::Mbc2;
 
 /// Errors returned by [`load_cartridge`].
 #[derive(Debug, PartialEq)]
@@ -68,6 +70,7 @@ pub fn load_cartridge(bytes: &[u8]) -> Result<Box<dyn GbCartridge>, RomError> {
             let ram_size = ram_size_from_byte(bytes[0x0149]);
             Ok(Box::new(Mbc1::new(bytes.to_vec(), vec![0u8; ram_size])))
         }
+        0x05..=0x06 => Ok(Box::new(Mbc2::new(bytes.to_vec()))),
         n => Err(RomError::UnsupportedMbc(n)),
     }
 }
@@ -121,12 +124,26 @@ mod tests {
     }
 
     #[test]
-    fn test_load_returns_error_for_unsupported_mbc_type() {
-        // Given: a ROM with MBC2 type byte (0x05), which is not yet supported
+    fn test_load_returns_ok_for_mbc2_rom() {
+        // Given: a valid MBC2 cartridge (type 0x05)
         let rom = make_valid_rom(0x05, 0x00);
+        assert!(load_cartridge(&rom).is_ok());
+    }
+
+    #[test]
+    fn test_load_returns_ok_for_mbc2_battery_rom() {
+        // Given: a valid MBC2+BATTERY cartridge (type 0x06)
+        let rom = make_valid_rom(0x06, 0x00);
+        assert!(load_cartridge(&rom).is_ok());
+    }
+
+    #[test]
+    fn test_load_returns_error_for_unsupported_mbc_type() {
+        // Given: a ROM with an unrecognised MBC type byte (0xFF)
+        let rom = make_valid_rom(0xFF, 0x00);
         assert!(matches!(
             load_cartridge(&rom),
-            Err(RomError::UnsupportedMbc(0x05))
+            Err(RomError::UnsupportedMbc(0xFF))
         ));
     }
 }

--- a/src/gb/cartridge/mod.rs
+++ b/src/gb/cartridge/mod.rs
@@ -47,7 +47,7 @@ fn ram_size_from_byte(byte: u8) -> usize {
 /// Validations performed:
 /// 1. Length must be at least 32 KB (0x8000) — returns [`RomError::TooShort`].
 /// 2. Header checksum at 0x014D must be correct — returns [`RomError::BadHeaderChecksum`].
-/// 3. MBC type at 0x0147 must be supported (0x00–0x03) — returns [`RomError::UnsupportedMbc`].
+/// 3. MBC type at 0x0147 must be supported (0x00–0x03, 0x05–0x06) — returns [`RomError::UnsupportedMbc`].
 pub fn load_cartridge(bytes: &[u8]) -> Result<Box<dyn GbCartridge>, RomError> {
     if bytes.len() < 0x8000 {
         return Err(RomError::TooShort);

--- a/src/gb/integration_tests/mooneye_tests.rs
+++ b/src/gb/integration_tests/mooneye_tests.rs
@@ -745,47 +745,40 @@ fn test_mooneye_emulator_only_mbc1_rom_8mb() {
 }
 
 // ============================================================================
-// emulator-only/ tests — MBC2 (not implemented — pre-ignored)
+// emulator-only/ tests — MBC2
 // ============================================================================
 
 #[test]
-#[ignore = "MBC2 not yet implemented — tracked in #2024"]
 fn test_mooneye_emulator_only_mbc2_bits_ramg() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc2/bits_ramg.gb"));
 }
 
 #[test]
-#[ignore = "MBC2 not yet implemented — tracked in #2024"]
 fn test_mooneye_emulator_only_mbc2_bits_romb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc2/bits_romb.gb"));
 }
 
 #[test]
-#[ignore = "MBC2 not yet implemented — tracked in #2024"]
 fn test_mooneye_emulator_only_mbc2_bits_unused() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc2/bits_unused.gb"));
 }
 
 #[test]
-#[ignore = "MBC2 not yet implemented — tracked in #2024"]
 fn test_mooneye_emulator_only_mbc2_ram() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc2/ram.gb"));
 }
 
 #[test]
-#[ignore = "MBC2 not yet implemented — tracked in #2024"]
 fn test_mooneye_emulator_only_mbc2_rom_1mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc2/rom_1Mb.gb"));
 }
 
 #[test]
-#[ignore = "MBC2 not yet implemented — tracked in #2024"]
 fn test_mooneye_emulator_only_mbc2_rom_2mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc2/rom_2Mb.gb"));
 }
 
 #[test]
-#[ignore = "MBC2 not yet implemented — tracked in #2024"]
 fn test_mooneye_emulator_only_mbc2_rom_512kb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc2/rom_512kb.gb"));
 }


### PR DESCRIPTION
## Summary

Implements MBC2 cartridge support for the Game Boy emulator, enabling cartridge types `0x05` (MBC2) and `0x06` (MBC2+BATTERY) to load and run correctly.

## Changes

### New file: `src/gb/cartridge/mbc2.rs`
- `Mbc2` struct with `[u8; 512]` built-in RAM, 4-bit ROM bank register, RAM enable gate.
- ROM banking: lower 4 bits of written value when bit 8 of write address is set; bank 0 promotes to 1; masked to available bank count.
- RAM gate: bit 8 of write address clear; lower nibble 0xA enables, anything else disables.
- RAM addressing: `0xA000–0xA1FF` mirrored across `0xA000–0xBFFF` via `addr & 0x1FF`; upper nibble set to `0xF` on reads.
- 14 unit tests covering all behaviours.

### Modified: `src/gb/cartridge/mod.rs`
- Declare and use `mod mbc2`.
- Add `0x05..=0x06` arm to `load_cartridge`.
- Update `test_load_returns_error_for_unsupported_mbc_type` to use `0xFF` instead of `0x05`.
- Add tests for successful `0x05` and `0x06` loading.

### Modified: `src/gb/integration_tests/mooneye_tests.rs`
- Remove `#[ignore]` from all 7 Mooneye `emulator-only/mbc2/` tests.

## Test results

- All 34 cartridge unit tests pass.
- All 7 previously-ignored Mooneye MBC2 integration tests now pass.
- Full suite: 8376 passed, 0 failed.
- wasm-pack: 48 passed, 0 failed.
- Python: 201 passed, OK.
- npm/Vitest: 185 passed, 29 test files.

Closes #2024