### PR TITLE
feat(web): improve autorun UX

### DIFF
--- a/src/frontends/web/wasm.rs
+++ b/src/frontends/web/wasm.rs
@@ -393,6 +393,18 @@ impl WasmNes {
             .unwrap_or(false)
     }
 
+    /// Returns the current recording frame index (0 when not recording).
+    ///
+    /// Used by the web frontend to display a "REC : MM:SS" overlay.
+    #[wasm_bindgen]
+    pub fn autorun_recording_frame_count(&self) -> u32 {
+        self.autorun_state
+            .as_ref()
+            .filter(|s| s.is_recording())
+            .map(|s| s.current_frame_index() as u32)
+            .unwrap_or(0)
+    }
+
     /// Returns the display width in pixels after overscan removal.
     #[wasm_bindgen]
     pub fn screen_width(&self) -> u32 {

--- a/src/frontends/web/wasm_autorun_state.rs
+++ b/src/frontends/web/wasm_autorun_state.rs
@@ -1,6 +1,8 @@
 use crate::platform::autorun::AutorunMode;
 use crate::platform::autorun::{
-    AUTORUN_VERSION, AutorunCheckpoint, AutorunFile, AutorunFrame, CHECKPOINT_INTERVAL_FRAMES,
+    AUTORUN_VERSION, AutorunCheckpoint, AutorunFile, AutorunFileV2, AutorunFileV3OnDisk,
+    AutorunFileV3Ser, AutorunFrame, CHECKPOINT_INTERVAL_FRAMES, decode_rle_frames,
+    encode_rle_frames,
 };
 
 /// In-memory autorun state for the WASM frontend.
@@ -167,13 +169,20 @@ impl WasmAutorunState {
     }
 
     /// Append a final checkpoint and return the recording as serialized JSON bytes.
+    ///
+    /// The output uses v3 RLE-encoded frames, matching the native save format.
     pub fn finalize_recording(&mut self, screen_crc: u32, state_bytes: Vec<u8>) -> Vec<u8> {
         self.autorun.checkpoints.push(AutorunCheckpoint {
             frame_index: self.frame_index.saturating_sub(1) as u32,
             screen_crc,
             state_bytes,
         });
-        serde_json::to_vec_pretty(&self.autorun).unwrap_or_default()
+        let v3 = AutorunFileV3Ser {
+            version: AUTORUN_VERSION,
+            frames: encode_rle_frames(&self.autorun.frames),
+            checkpoints: &self.autorun.checkpoints,
+        };
+        serde_json::to_vec_pretty(&v3).unwrap_or_default()
     }
 
     /// Check whether the just-completed frame has a playback checkpoint, verify CRC.
@@ -242,12 +251,35 @@ impl WasmAutorunState {
 }
 
 fn parse_autorun_bytes(bytes: &[u8]) -> Result<AutorunFile, String> {
-    let file: AutorunFile =
+    let json_value: serde_json::Value =
         serde_json::from_slice(bytes).map_err(|e| format!("Failed to parse autorun file: {e}"))?;
-    if file.version != AUTORUN_VERSION {
-        return Err(format!("Unsupported autorun version: {}", file.version));
+
+    let version = json_value["version"]
+        .as_u64()
+        .and_then(|v| u32::try_from(v).ok())
+        .ok_or_else(|| "Missing or invalid version field in autorun file".to_string())?;
+
+    match version {
+        2 => {
+            let v2: AutorunFileV2 = serde_json::from_value(json_value)
+                .map_err(|e| format!("Failed to deserialize autorun v2 file: {e}"))?;
+            Ok(AutorunFile {
+                version: AUTORUN_VERSION,
+                frames: v2.frames,
+                checkpoints: v2.checkpoints,
+            })
+        }
+        3 => {
+            let v3: AutorunFileV3OnDisk = serde_json::from_value(json_value)
+                .map_err(|e| format!("Failed to deserialize autorun v3 file: {e}"))?;
+            Ok(AutorunFile {
+                version: AUTORUN_VERSION,
+                frames: decode_rle_frames(&v3.frames)?,
+                checkpoints: v3.checkpoints,
+            })
+        }
+        _ => Err(format!("Unsupported autorun version: {version}")),
     }
-    Ok(file)
 }
 
 #[cfg(test)]
@@ -269,17 +301,29 @@ mod tests {
                 }
             })
             .collect();
-        let file = AutorunFile {
+        let frames: Vec<AutorunFrame> = (0..num_frames)
+            .map(|i| AutorunFrame {
+                player1: (i % 256) as u8,
+                player2: 0,
+            })
+            .collect();
+        let v3 = AutorunFileV3Ser {
             version: AUTORUN_VERSION,
-            frames: (0..num_frames)
-                .map(|i| AutorunFrame {
-                    player1: (i % 256) as u8,
-                    player2: 0,
-                })
-                .collect(),
-            checkpoints,
+            frames: encode_rle_frames(&frames),
+            checkpoints: &checkpoints,
         };
-        serde_json::to_vec(&file).expect("serialize")
+        serde_json::to_vec(&v3).expect("serialize")
+    }
+
+    /// Serialize an in-memory AutorunFile to v3 RLE JSON bytes (for tests that
+    /// construct an AutorunFile manually).
+    fn autorun_to_v3_bytes(file: &AutorunFile) -> Vec<u8> {
+        let v3 = AutorunFileV3Ser {
+            version: AUTORUN_VERSION,
+            frames: encode_rle_frames(&file.frames),
+            checkpoints: &file.checkpoints,
+        };
+        serde_json::to_vec(&v3).expect("serialize")
     }
 
     // ── new_recording ────────────────────────────────────────────────────────
@@ -408,7 +452,7 @@ mod tests {
                 state_bytes: vec![],
             }],
         };
-        let bytes = serde_json::to_vec(&file).unwrap();
+        let bytes = autorun_to_v3_bytes(&file);
         let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
         state.begin_frame();
         let frame = state.next_playback_frame();
@@ -463,7 +507,7 @@ mod tests {
                 state_bytes: vec![],
             }],
         };
-        let bytes = serde_json::to_vec(&file).unwrap();
+        let bytes = autorun_to_v3_bytes(&file);
         let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
         state.begin_frame();
         state.next_playback_frame();
@@ -486,7 +530,7 @@ mod tests {
                 state_bytes: vec![],
             }],
         };
-        let bytes = serde_json::to_vec(&file).unwrap();
+        let bytes = autorun_to_v3_bytes(&file);
         let (mut state, _) = WasmAutorunState::new_playback(&bytes, None, false).unwrap();
         state.begin_frame();
         state.next_playback_frame();
@@ -541,5 +585,76 @@ mod tests {
         state.begin_frame();
         state.next_playback_frame();
         assert!(!state.is_playback_finished());
+    }
+
+    // ── version compatibility ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_autorun_bytes_accepts_v2_non_rle_format() {
+        // A v2 autorun file has per-frame entries without RLE compression.
+        // parse_autorun_bytes should accept v2 and normalize to v3 in memory.
+        let v2_json = serde_json::json!({
+            "version": 2,
+            "frames": [
+                {"player1": 4, "player2": 0},
+                {"player1": 4, "player2": 0},
+                {"player1": 7, "player2": 1}
+            ],
+            "checkpoints": []
+        });
+        let bytes = serde_json::to_vec(&v2_json).unwrap();
+        let file = parse_autorun_bytes(&bytes).expect("should accept v2 format");
+        assert_eq!(file.version, AUTORUN_VERSION);
+        assert_eq!(file.frames.len(), 3);
+        assert_eq!(file.frames[0].player1, 4);
+        assert_eq!(file.frames[2].player1, 7);
+        assert_eq!(file.frames[2].player2, 1);
+    }
+
+    #[test]
+    fn parse_autorun_bytes_accepts_v3_rle_format() {
+        // A v3 autorun file on disk uses RLE-encoded frames (with `repeat` field).
+        // parse_autorun_bytes should decode RLE and expand to per-frame entries.
+        let v3_json = serde_json::json!({
+            "version": 3,
+            "frames": [
+                {"player1": 0, "player2": 0, "repeat": 3},
+                {"player1": 1, "player2": 0, "repeat": 1}
+            ],
+            "checkpoints": []
+        });
+        let bytes = serde_json::to_vec(&v3_json).unwrap();
+        let file = parse_autorun_bytes(&bytes).expect("should accept v3 RLE format");
+        assert_eq!(file.version, AUTORUN_VERSION);
+        assert_eq!(file.frames.len(), 4);
+        assert_eq!(file.frames[0].player1, 0);
+        assert_eq!(file.frames[3].player1, 1);
+    }
+
+    #[test]
+    fn finalize_recording_produces_v3_rle_json() {
+        // finalize_recording should produce v3 JSON with RLE-encoded frames,
+        // matching the native save format.
+        let mut state = WasmAutorunState::new_recording();
+        // Record 3 identical frames + 1 different frame
+        state.record_frame(0, 0);
+        state.record_frame(0, 0);
+        state.record_frame(0, 0);
+        state.record_frame(1, 0);
+
+        let bytes = state.finalize_recording(0xDEAD, b"end".to_vec());
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        // The frames array should use RLE encoding (2 entries, not 4)
+        let frames = json["frames"].as_array().unwrap();
+        assert_eq!(
+            frames.len(),
+            2,
+            "should have 2 RLE entries, not 4 per-frame entries"
+        );
+        assert_eq!(frames[0]["repeat"], 3);
+        assert_eq!(frames[0]["player1"], 0);
+        assert_eq!(frames[1]["repeat"], 1);
+        assert_eq!(frames[1]["player1"], 1);
     }
 }

--- a/src/platform/autorun/mod.rs
+++ b/src/platform/autorun/mod.rs
@@ -4,6 +4,11 @@ pub use types::{
     CHECKPOINT_INTERVAL_FRAMES, StateConverter,
 };
 #[allow(unused_imports)]
+pub(crate) use utils::{
+    AutorunFileV2, AutorunFileV3OnDisk, AutorunFileV3Ser, AutorunRleFrame, decode_rle_frames,
+    encode_rle_frames,
+};
+#[allow(unused_imports)]
 pub use utils::{
     BINARY_MAGIC, autorun_path_for_rom, backup_autorun_file, convert_autorun_file, crc32,
     load_autorun_file, save_autorun_file, trim_recording,

--- a/src/platform/autorun/utils.rs
+++ b/src/platform/autorun/utils.rs
@@ -5,33 +5,33 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-struct AutorunRleFrame {
-    player1: u8,
-    player2: u8,
-    repeat: u32,
+pub(crate) struct AutorunRleFrame {
+    pub(crate) player1: u8,
+    pub(crate) player2: u8,
+    pub(crate) repeat: u32,
 }
 
 /// Serialization-only view of a v3 autorun file.  Borrows `checkpoints` to avoid cloning
 /// potentially large `state_bytes` blobs that live inside each checkpoint.
 #[derive(Debug, Serialize)]
-struct AutorunFileV3Ser<'a> {
-    version: u32,
-    frames: Vec<AutorunRleFrame>,
-    checkpoints: &'a [AutorunCheckpoint],
+pub(crate) struct AutorunFileV3Ser<'a> {
+    pub(crate) version: u32,
+    pub(crate) frames: Vec<AutorunRleFrame>,
+    pub(crate) checkpoints: &'a [AutorunCheckpoint],
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-struct AutorunFileV3OnDisk {
-    version: u32,
-    frames: Vec<AutorunRleFrame>,
-    checkpoints: Vec<AutorunCheckpoint>,
+pub(crate) struct AutorunFileV3OnDisk {
+    pub(crate) version: u32,
+    pub(crate) frames: Vec<AutorunRleFrame>,
+    pub(crate) checkpoints: Vec<AutorunCheckpoint>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-struct AutorunFileV2 {
-    version: u32,
-    frames: Vec<AutorunFrame>,
-    checkpoints: Vec<AutorunCheckpoint>,
+pub(crate) struct AutorunFileV2 {
+    pub(crate) version: u32,
+    pub(crate) frames: Vec<AutorunFrame>,
+    pub(crate) checkpoints: Vec<AutorunCheckpoint>,
 }
 
 /// Body of a binary autorun file (postcard-encoded, after the magic header).
@@ -65,7 +65,7 @@ fn build_input_frame(rle_frame: &AutorunRleFrame) -> AutorunFrame {
     }
 }
 
-fn encode_rle_frames(frames: &[AutorunFrame]) -> Vec<AutorunRleFrame> {
+pub(crate) fn encode_rle_frames(frames: &[AutorunFrame]) -> Vec<AutorunRleFrame> {
     if frames.is_empty() {
         return Vec::new();
     }
@@ -96,7 +96,9 @@ fn encode_rle_frames(frames: &[AutorunFrame]) -> Vec<AutorunRleFrame> {
 /// This prevents a crafted file with enormous `repeat` values from causing OOM.
 const MAX_DECODED_FRAMES: usize = 10_000_000;
 
-fn decode_rle_frames(rle_frames: &[AutorunRleFrame]) -> Result<Vec<AutorunFrame>, String> {
+pub(crate) fn decode_rle_frames(
+    rle_frames: &[AutorunRleFrame],
+) -> Result<Vec<AutorunFrame>, String> {
     // First pass: validate every entry and accumulate the total so we can pre-allocate
     // exactly the right capacity without risking OOM from a malicious `repeat` value.
     let mut total_frames: usize = 0;

--- a/web/index.html
+++ b/web/index.html
@@ -36,6 +36,7 @@
         <main class="flex-1 flex flex-col items-center justify-center p-4">
           <div class="screen-wrap" id="screen-wrap">
             <canvas id="screen" width="256" height="240" tabindex="0"></canvas>
+            <div id="rec-overlay" class="rec-overlay hidden" aria-hidden="true"></div>
             <div id="shortcut-help-overlay" class="shortcut-help-overlay hidden" aria-hidden="true"></div>
             <div id="debugger-panel" class="debugger-panel hidden" aria-label="Debugger panel"></div>
           </div>

--- a/web/main.css
+++ b/web/main.css
@@ -42,6 +42,38 @@ body {
   box-shadow: 0 0 24px #00f0ff18;
 }
 
+/* ── Recording overlay ───────────────────────────────────── */
+
+.rec-overlay {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 6px;
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #fff;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.rec-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #e11d48;
+  animation: rec-blink 1s step-end infinite;
+}
+
+@keyframes rec-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
 .screen-wrap:fullscreen {
   padding: 0;
 }

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -866,7 +866,7 @@ const recOverlay = document.getElementById("rec-overlay");
  *
  * - Gates "Create autorun" checkbox: disabled when running or paused.
  * - Updates Start/Stop button labels based on recording mode.
- * - Gates "Load autorun" button: available whenever a ROM is loaded.
+ * - Refreshes autorun status display.
  */
 function updateAutorunControls() {
     // Gate "Create autorun" checkbox: only checkable when stopped
@@ -897,10 +897,24 @@ function updateRecOverlay() {
     }
     const frames = nes.autorun_recording_frame_count();
     const fps = nes.frame_rate_hz();
+    if (!(fps > 0 && Number.isFinite(fps))) {
+        recOverlay.classList.add("hidden");
+        recOverlay.setAttribute("aria-hidden", "true");
+        return;
+    }
     const totalSec = Math.floor(frames / fps);
     const mm = String(Math.floor(totalSec / 60)).padStart(2, "0");
     const ss = String(totalSec % 60).padStart(2, "0");
-    recOverlay.innerHTML = `<span class="rec-dot"></span>REC ${mm}:${ss}`;
+    const timeStr = `REC ${mm}:${ss}`;
+    // Only update DOM when the displayed text changes
+    if (recOverlay.dataset.recTime !== timeStr) {
+        recOverlay.dataset.recTime = timeStr;
+        recOverlay.textContent = "";
+        const dot = document.createElement("span");
+        dot.className = "rec-dot";
+        recOverlay.appendChild(dot);
+        recOverlay.appendChild(document.createTextNode(timeStr));
+    }
     recOverlay.classList.remove("hidden");
     recOverlay.setAttribute("aria-hidden", "false");
 }

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -859,6 +859,51 @@ const autorunUseBtn = document.getElementById("autorun-use-btn") as HTMLButtonEl
 const autorunCancelBtn = document.getElementById("autorun-cancel");
 const autorunModalCancelBtn = document.getElementById("autorun-modal-cancel");
 const autorunModalEl = document.getElementById("autorun-modal") as HTMLDialogElement | null;
+const recOverlay = document.getElementById("rec-overlay");
+
+/**
+ * Update autorun-related UI controls based on current state.
+ *
+ * - Gates "Create autorun" checkbox: disabled when running or paused.
+ * - Updates Start/Stop button labels based on recording mode.
+ * - Gates "Load autorun" button: available whenever a ROM is loaded.
+ */
+function updateAutorunControls() {
+    // Gate "Create autorun" checkbox: only checkable when stopped
+    if (autorunCreateCheckbox) {
+        autorunCreateCheckbox.disabled = running || paused;
+    }
+
+    // Update Start/Stop button labels
+    const isRecording = autorunCtx.isCreateRecording();
+    if (startBtn) {
+        startBtn.textContent = isRecording ? "Start Recording" : "Start";
+    }
+    const stopBtnEl = document.getElementById("stop");
+    if (stopBtnEl) {
+        stopBtnEl.textContent = isRecording ? "Stop Recording" : "Stop";
+    }
+
+    updateAutorunStatus();
+}
+
+/** Update the recording overlay (REC : MM:SS) on the canvas. */
+function updateRecOverlay() {
+    if (!recOverlay) return;
+    if (!nes || !nes.autorun_is_recording() || !running) {
+        recOverlay.classList.add("hidden");
+        recOverlay.setAttribute("aria-hidden", "true");
+        return;
+    }
+    const frames = nes.autorun_recording_frame_count();
+    const fps = nes.frame_rate_hz();
+    const totalSec = Math.floor(frames / fps);
+    const mm = String(Math.floor(totalSec / 60)).padStart(2, "0");
+    const ss = String(totalSec % 60).padStart(2, "0");
+    recOverlay.innerHTML = `<span class="rec-dot"></span>REC ${mm}:${ss}`;
+    recOverlay.classList.remove("hidden");
+    recOverlay.setAttribute("aria-hidden", "false");
+}
 
 /** Update the small autorun status text and cancel button in the header. */
 function updateAutorunStatus() {
@@ -869,7 +914,7 @@ function updateAutorunStatus() {
         autorunCancelBtn?.classList.add("hidden");
     } else if (config.mode === "record") {
         autorunStatusEl.textContent = "Will record autorun";
-        autorunCancelBtn?.classList.remove("hidden");
+        autorunCancelBtn?.classList.add("hidden");
     } else {
         const info = autorunCtx.getLoadedFile();
         const cpText = config.checkpointIdx != null
@@ -891,7 +936,7 @@ if (autorunCreateCheckbox) {
             // Clear loaded file when switching to create-recording mode
             autorunCtx.clearLoadedFile();
         }
-        updateAutorunStatus();
+        updateAutorunControls();
     });
 }
 
@@ -900,7 +945,7 @@ if (autorunCancelBtn) {
         autorunCtx.clearLoadedFile();
         autorunCtx.setCreateRecording(false);
         if (autorunCreateCheckbox) autorunCreateCheckbox.checked = false;
-        updateAutorunStatus();
+        updateAutorunControls();
     });
 }
 
@@ -1285,6 +1330,7 @@ async function start() {
     paused = false;
     // Keep start button disabled while running; it is re-enabled in stop().
     setStatus("Running...");
+    updateAutorunControls();
     requestAnimationFrame(step);
 }
 
@@ -1303,6 +1349,7 @@ function pauseResume() {
     } else {
         setStatus("Paused");
     }
+    updateAutorunControls();
 }
 
 let debuggerHexdumpError = "";
@@ -1883,6 +1930,10 @@ function stop() {
         nes.clear_autorun();
     }
 
+    // Auto-uncheck "Create autorun" after recording stops
+    autorunCtx.setCreateRecording(false);
+    if (autorunCreateCheckbox) autorunCreateCheckbox.checked = false;
+
     running = false;
     paused = false;
     startBtn!.disabled = false;
@@ -1896,6 +1947,8 @@ function stop() {
     windowFocused = true;
     pointerReleasedByEscape = false;
     setStatus("Stopped. You can restart or load a new ROM");
+    updateRecOverlay();
+    updateAutorunControls();
 }
 
 /**
@@ -2146,6 +2199,8 @@ function step(timestamp: number) {
         if (audioSamples.length > 0) {
             playAudioSamples(audioSamples);
         }
+
+        updateRecOverlay();
 
         fpsFrames += 1;
         if (fpsLastTime === 0) {
@@ -2708,14 +2763,27 @@ async function toggleScreenFullscreen() {
 
 function resetAction() {
     if (!nes) return;
+    cancelActiveRecording();
     nes.reset(true);
     setStatus("Soft reset", false);
 }
 
 function hardResetAction() {
     if (!nes) return;
+    cancelActiveRecording();
     nes.reset(false);
     setStatus("Hard reset", false);
+}
+
+/** Cancel an active autorun recording (if any), updating UI and showing a toast. */
+function cancelActiveRecording() {
+    if (!nes || !nes.autorun_is_recording()) return;
+    nes.clear_autorun();
+    autorunCtx.setCreateRecording(false);
+    if (autorunCreateCheckbox) autorunCreateCheckbox.checked = false;
+    updateRecOverlay();
+    updateAutorunControls();
+    toastOverlay.show("Recording cancelled");
 }
 
 async function saveStateAction() {

--- a/web/src/rom/autorun_context.test.ts
+++ b/web/src/rom/autorun_context.test.ts
@@ -244,3 +244,45 @@ it("createAutorunContext setLoadedFile accepts v3 RLE file", () => {
     expect(loaded!.checkpointCount).toBe(2);
     expect(loaded!.frameCount).toBe(600);
 });
+
+// ── parseAutorunFile – v3 repeat validation ──────────────────────────────────
+
+it("parseAutorunFile throws for v3 frame with non-numeric repeat", () => {
+    const file = {
+        version: 3,
+        frames: [{ player1: 0, player2: 0, repeat: "abc" }],
+        checkpoints: []
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    expect(() => parseAutorunFile(bytes)).toThrow(/Invalid repeat/i);
+});
+
+it("parseAutorunFile throws for v3 frame with negative repeat", () => {
+    const file = {
+        version: 3,
+        frames: [{ player1: 0, player2: 0, repeat: -1 }],
+        checkpoints: []
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    expect(() => parseAutorunFile(bytes)).toThrow(/Invalid repeat/i);
+});
+
+it("parseAutorunFile throws for v3 frame with non-integer repeat", () => {
+    const file = {
+        version: 3,
+        frames: [{ player1: 0, player2: 0, repeat: 1.5 }],
+        checkpoints: []
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    expect(() => parseAutorunFile(bytes)).toThrow(/Invalid repeat/i);
+});
+
+it("parseAutorunFile throws when v3 total frames exceed maximum", () => {
+    const file = {
+        version: 3,
+        frames: [{ player1: 0, player2: 0, repeat: 10_000_001 }],
+        checkpoints: []
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    expect(() => parseAutorunFile(bytes)).toThrow(/exceeds maximum/i);
+});

--- a/web/src/rom/autorun_context.test.ts
+++ b/web/src/rom/autorun_context.test.ts
@@ -184,3 +184,63 @@ it("getActiveConfig returns record mode when both recording and file are set", (
     const config = ctx.getActiveConfig();
     expect(config?.mode).toBe("record");
 });
+
+// ── parseAutorunFile – v3 RLE format ─────────────────────────────────────────
+
+it("parseAutorunFile returns correct frameCount for v3 RLE file", () => {
+    const file = {
+        version: 3,
+        frames: [
+            { player1: 0, player2: 0, repeat: 3 },
+            { player1: 1, player2: 0, repeat: 1 }
+        ],
+        checkpoints: [{ frame_index: 3, screen_crc: 0, state_bytes: [] }]
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const info = parseAutorunFile(bytes);
+    expect(info.version).toBe(3);
+    expect(info.frameCount).toBe(4); // 3 + 1 = 4 total frames
+    expect(info.checkpointCount).toBe(1);
+});
+
+it("parseAutorunFile accepts both v2 and v3 formats", () => {
+    // v2 file
+    const v2 = {
+        version: 2,
+        frames: [{ player1: 0, player2: 0 }, { player1: 1, player2: 0 }],
+        checkpoints: []
+    };
+    const v2bytes = new TextEncoder().encode(JSON.stringify(v2));
+    const v2info = parseAutorunFile(v2bytes);
+    expect(v2info.frameCount).toBe(2);
+
+    // v3 file
+    const v3 = {
+        version: 3,
+        frames: [{ player1: 0, player2: 0, repeat: 2 }, { player1: 1, player2: 0, repeat: 1 }],
+        checkpoints: []
+    };
+    const v3bytes = new TextEncoder().encode(JSON.stringify(v3));
+    const v3info = parseAutorunFile(v3bytes);
+    expect(v3info.frameCount).toBe(3);
+});
+
+it("createAutorunContext setLoadedFile accepts v3 RLE file", () => {
+    const file = {
+        version: 3,
+        frames: [
+            { player1: 0, player2: 0, repeat: 600 }
+        ],
+        checkpoints: [
+            { frame_index: 299, screen_crc: 1, state_bytes: [] },
+            { frame_index: 599, screen_crc: 2, state_bytes: [] }
+        ]
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(file));
+    const ctx = createAutorunContext();
+    ctx.setLoadedFile(bytes);
+    const loaded = ctx.getLoadedFile();
+    expect(loaded !== null).toBeTruthy();
+    expect(loaded!.checkpointCount).toBe(2);
+    expect(loaded!.frameCount).toBe(600);
+});

--- a/web/src/rom/autorun_context.ts
+++ b/web/src/rom/autorun_context.ts
@@ -1,4 +1,5 @@
 const SUPPORTED_AUTORUN_VERSIONS = [2, 3];
+const MAX_LOGICAL_FRAMES = 10_000_000;
 
 /**
  * Parse an autorun file's bytes and return metadata about the recording.
@@ -29,7 +30,14 @@ export function parseAutorunFile(bytes: Uint8Array) {
         if (version === 3) {
             // v3 uses RLE: each entry has a `repeat` count
             for (const f of obj.frames) {
-                frameCount += (f as { repeat?: number }).repeat ?? 1;
+                const repeat = Number((f as { repeat?: unknown }).repeat ?? 1);
+                if (!Number.isFinite(repeat) || repeat < 1 || repeat !== Math.floor(repeat)) {
+                    throw new Error(`Invalid repeat value in v3 autorun frame: ${JSON.stringify(f)}`);
+                }
+                frameCount += repeat;
+                if (frameCount > MAX_LOGICAL_FRAMES) {
+                    throw new Error(`Autorun file exceeds maximum of ${MAX_LOGICAL_FRAMES} logical frames`);
+                }
             }
         } else {
             // v2: one entry per frame

--- a/web/src/rom/autorun_context.ts
+++ b/web/src/rom/autorun_context.ts
@@ -1,7 +1,10 @@
-const SUPPORTED_AUTORUN_VERSION = 2;
+const SUPPORTED_AUTORUN_VERSIONS = [2, 3];
 
 /**
  * Parse an autorun file's bytes and return metadata about the recording.
+ *
+ * Accepts both v2 (per-frame entries) and v3 (RLE-encoded frames with `repeat` field).
+ * For v3, the logical frame count is the sum of all `repeat` values.
  *
  * @param {Uint8Array} bytes - Raw bytes of a JSON-serialized AutorunFile.
  * @returns {{ version: number, frameCount: number, checkpointCount: number }}
@@ -15,14 +18,27 @@ export function parseAutorunFile(bytes: Uint8Array) {
     } catch (e: unknown) {
         throw new Error(`Failed to parse autorun file: ${e instanceof Error ? e.message : String(e)}`);
     }
-    if (obj.version !== SUPPORTED_AUTORUN_VERSION) {
+    if (!SUPPORTED_AUTORUN_VERSIONS.includes(obj.version as number)) {
         throw new Error(
-            `Unsupported autorun version: ${obj.version} (expected ${SUPPORTED_AUTORUN_VERSION})`
+            `Unsupported autorun version: ${obj.version} (expected one of ${SUPPORTED_AUTORUN_VERSIONS.join(", ")})`
         );
     }
+    const version = obj.version as number;
+    let frameCount = 0;
+    if (Array.isArray(obj.frames)) {
+        if (version === 3) {
+            // v3 uses RLE: each entry has a `repeat` count
+            for (const f of obj.frames) {
+                frameCount += (f as { repeat?: number }).repeat ?? 1;
+            }
+        } else {
+            // v2: one entry per frame
+            frameCount = obj.frames.length;
+        }
+    }
     return {
-        version: obj.version,
-        frameCount: Array.isArray(obj.frames) ? obj.frames.length : 0,
+        version,
+        frameCount,
         checkpointCount: Array.isArray(obj.checkpoints) ? obj.checkpoints.length : 0
     };
 }


### PR DESCRIPTION
Closes #2057

## Summary

Improves the web autorun UX with multiple small enhancements requested in #2057.

## Changes

### Version format alignment (v2 + v3 RLE support)
- `parse_autorun_bytes()` now accepts both v2 (per-frame) and v3 (RLE-encoded) autorun files
- `finalize_recording()` now outputs v3 RLE-encoded format, matching the native frontend
- Made autorun types and RLE encode/decode functions `pub(crate)` for cross-module reuse
- TypeScript `parseAutorunFile()` updated to parse v3 RLE frame counts

### Recording indicator overlay
- Red blinking dot with "REC MM:SS" overlay positioned top-right on the canvas
- Timer derived from `autorun_recording_frame_count()` / frame rate (frame-based, not wall clock)
- New WASM API: `autorun_recording_frame_count()` returns current frame index during recording

### UI gating and label updates
- Autorun checkbox disabled while emulation is running or paused
- Start/Stop buttons relabeled to "Start Recording" / "Stop Recording" when in create-recording mode

### Reset cancellation
- Soft and hard reset cancel any active recording with a toast notification
- Extracted `cancelActiveRecording()` helper to avoid duplication

### Auto-uncheck on stop
- Create-recording checkbox automatically unchecked when recording stops (via Stop button)
- Cancel button hidden during recording (only shown during playback)

## Testing
- 3 new Rust tests: v2 parse, v3 RLE parse, v3 RLE finalize output
- 3 new TypeScript tests: v3 RLE frame count, v2+v3 acceptance, v3 context integration
- All pre-merge checks pass:
  - cargo clippy: OK (2 pre-existing warnings in gamepad.rs, unrelated)
  - cargo fmt: OK
  - cargo test --no-default-features --lib: 8386 passed, 1 pre-existing failure (Gradius CRC mismatch)
  - wasm-pack test: 48 passed
  - Python tests: 201 passed
  - npm test: 188 passed (29 test files)

## Files changed (9)
- `src/frontends/web/wasm_autorun_state.rs` — v2+v3 parse, v3 RLE finalize, new tests
- `src/frontends/web/wasm.rs` — `autorun_recording_frame_count()` API
- `src/platform/autorun/mod.rs` — pub(crate) reexports
- `src/platform/autorun/utils.rs` — pub(crate) visibility for types and functions
- `web/src/app.ts` — UI gating, rec overlay, reset cancellation, auto-uncheck
- `web/src/rom/autorun_context.ts` — v2+v3 version support
- `web/src/rom/autorun_context.test.ts` — 3 new tests
- `web/index.html` — rec-overlay div
- `web/main.css` — rec-overlay styles
