### PR TITLE
feat(gb): implement MBC5 memory bank controller

### DIFF
--- a/src/frontends/native/gamepad.rs
+++ b/src/frontends/native/gamepad.rs
@@ -311,29 +311,29 @@ impl GamepadManager {
     ) -> Option<GamepadChange> {
         if let Some(player_num) = self.player_map.get(&id).copied() {
             // Release all held buttons for this gamepad's port before removing.
-            if let Console::Nes(nes) = console {
-                if let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) {
-                    use Button::{A, B, Down, Left, Right, Select, Start, Up};
-                    for button in [A, B, Select, Start, Up, Down, Left, Right] {
-                        nes.set_button(port, button, false);
-                    }
-                    use SnesButton as S;
-                    for snes_btn in [
-                        S::A,
-                        S::B,
-                        S::X,
-                        S::Y,
-                        S::L,
-                        S::R,
-                        S::Start,
-                        S::Select,
-                        S::Up,
-                        S::Down,
-                        S::Left,
-                        S::Right,
-                    ] {
-                        nes.set_snes_button(port, snes_btn, false);
-                    }
+            if let Console::Nes(nes) = console
+                && let Some(port) = Self::assigned_port(nes, &self.player_map, player_num)
+            {
+                use Button::{A, B, Down, Left, Right, Select, Start, Up};
+                for button in [A, B, Select, Start, Up, Down, Left, Right] {
+                    nes.set_button(port, button, false);
+                }
+                use SnesButton as S;
+                for snes_btn in [
+                    S::A,
+                    S::B,
+                    S::X,
+                    S::Y,
+                    S::L,
+                    S::R,
+                    S::Start,
+                    S::Select,
+                    S::Up,
+                    S::Down,
+                    S::Left,
+                    S::Right,
+                ] {
+                    nes.set_snes_button(port, snes_btn, false);
                 }
             }
 
@@ -433,10 +433,8 @@ impl GamepadManager {
             if let Some(nes_btn) = map_button_to_nes(button) {
                 nes.set_button(port, nes_btn, pressed);
             }
-        } else {
-            if let Some(nes_btn) = map_button_to_nes(button) {
-                console.set_button(0, nes_btn as u8, pressed);
-            }
+        } else if let Some(nes_btn) = map_button_to_nes(button) {
+            console.set_button(0, nes_btn as u8, pressed);
         }
     }
 

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -211,6 +211,12 @@ impl DmgBus {
     }
 
     /// Bypass PPU access-blocking for OAM DMA transfers.
+    ///
+    /// On DMG hardware, the DMA controller uses the external bus. For addresses
+    /// in `$E000–$FFFF`, the external bus mirrors WRAM (`$C000–$DFFF`) by
+    /// clearing address bit 13 (equivalent to `addr & !0x2000`). This means
+    /// DMA from `$FE00` reads WRAM at `$DE00`, and DMA from `$FF00` reads
+    /// WRAM at `$DF00`, rather than reading OAM or I/O registers.
     fn read_raw(&self, addr: u16) -> u8 {
         if self.boot_rom_active && addr <= 0x00FF {
             return self.boot_rom[addr as usize];
@@ -220,8 +226,9 @@ impl DmgBus {
             0x8000..=0x9FFF => self.ppu.vram[(addr - 0x8000) as usize],
             0xA000..=0xBFFF => self.cart.read(addr),
             0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize],
-            0xE000..=0xFDFF => self.wram[(addr - 0xE000) as usize],
-            _ => 0xFF,
+            // $E000–$FFFF: the DMA controller uses the external bus, which
+            // mirrors WRAM here (same as echo RAM, clearing bit 13).
+            0xE000..=0xFFFF => self.wram[(addr - 0xE000) as usize],
         }
     }
 

--- a/src/gb/cartridge/mbc5.rs
+++ b/src/gb/cartridge/mbc5.rs
@@ -1,0 +1,362 @@
+use super::cartridge::GbCartridge;
+
+/// MBC5 cartridge (types 0x19–0x1E).
+///
+/// Supports up to 8 MiB ROM (512 banks × 16 KiB) and up to 128 KiB RAM (16 banks × 8 KiB).
+///
+/// Registers (write-only, mapped to ROM area):
+/// - $0000–$1FFF: RAM enable (bottom nibble 0xA → enable; any other value → disable)
+/// - $2000–$2FFF: lower 8 bits of ROM bank number
+/// - $3000–$3FFF: bit 8 (9th bit) of ROM bank number
+/// - $4000–$5FFF: RAM bank number (4 bits, 0x00–0x0F)
+///
+/// Unlike MBC1/MBC2, writing 0 to the ROM bank register genuinely selects bank 0;
+/// there is no bank-0 → bank-1 promotion.
+///
+/// Rumble types (0x1C–0x1E): bit 3 of the $4000–$5FFF register drives the rumble motor
+/// instead of the RAM chip on real hardware. This emulator silently ignores the rumble
+/// signal; all 4 bits are treated as the RAM bank number for all types.
+pub struct Mbc5 {
+    rom: Vec<u8>,
+    ram: Vec<u8>,
+    /// 9-bit ROM bank number (0x000–0x1FF). Lower 8 bits come from writes to
+    /// $2000–$2FFF; bit 8 comes from the lowest bit of writes to $3000–$3FFF.
+    rom_bank: u16,
+    /// RAM bank number (4-bit, 0x00–0x0F).
+    ram_bank: u8,
+    /// Whether cartridge RAM is enabled.
+    ram_enabled: bool,
+}
+
+impl Mbc5 {
+    pub fn new(rom: Vec<u8>, ram: Vec<u8>) -> Self {
+        Self {
+            rom,
+            ram,
+            // MBC5 powers on with bank 1 in the switchable window — same as
+            // other MBCs.  "Writing 0 gives bank 0" describes write behaviour,
+            // not the power-on state.
+            rom_bank: 1,
+            ram_bank: 0,
+            ram_enabled: false,
+        }
+    }
+
+    fn rom_bank_count(&self) -> usize {
+        (self.rom.len() / 0x4000).max(1)
+    }
+
+    fn ram_bank_count(&self) -> usize {
+        (self.ram.len() / 0x2000).max(1)
+    }
+
+    /// Effective ROM bank for the $4000–$7FFF window.
+    /// Masked to available banks; bank 0 is valid (no promotion).
+    fn effective_rom_bank(&self) -> usize {
+        (self.rom_bank as usize) & (self.rom_bank_count() - 1)
+    }
+
+    /// Effective RAM bank index.
+    fn effective_ram_bank(&self) -> usize {
+        (self.ram_bank as usize) & (self.ram_bank_count() - 1)
+    }
+
+    fn read_rom(&self, addr: u16) -> u8 {
+        let (bank, offset) = if addr < 0x4000 {
+            (0, addr as usize)
+        } else {
+            (self.effective_rom_bank(), addr as usize - 0x4000)
+        };
+        let idx = bank * 0x4000 + offset;
+        self.rom.get(idx).copied().unwrap_or(0xFF)
+    }
+
+    fn read_ram(&self, addr: u16) -> u8 {
+        if !self.ram_enabled || self.ram.is_empty() {
+            return 0xFF;
+        }
+        let offset = addr as usize - 0xA000;
+        let idx = self.effective_ram_bank() * 0x2000 + offset;
+        self.ram.get(idx).copied().unwrap_or(0xFF)
+    }
+
+    fn write_registers(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x0000..=0x1FFF => {
+                self.ram_enabled = (val & 0x0F) == 0x0A;
+            }
+            0x2000..=0x2FFF => {
+                self.rom_bank = (self.rom_bank & 0x0100) | (val as u16);
+            }
+            0x3000..=0x3FFF => {
+                self.rom_bank = (self.rom_bank & 0x00FF) | (((val & 0x01) as u16) << 8);
+            }
+            0x4000..=0x5FFF => {
+                self.ram_bank = val & 0x0F;
+            }
+            _ => {}
+        }
+    }
+
+    fn write_ram(&mut self, addr: u16, val: u8) {
+        if !self.ram_enabled || self.ram.is_empty() {
+            return;
+        }
+        let offset = addr as usize - 0xA000;
+        let idx = self.effective_ram_bank() * 0x2000 + offset;
+        if let Some(byte) = self.ram.get_mut(idx) {
+            *byte = val;
+        }
+    }
+}
+
+impl GbCartridge for Mbc5 {
+    fn read(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x7FFF => self.read_rom(addr),
+            0xA000..=0xBFFF => self.read_ram(addr),
+            _ => 0xFF,
+        }
+    }
+
+    fn write(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x0000..=0x5FFF => self.write_registers(addr, val),
+            0xA000..=0xBFFF => self.write_ram(addr, val),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an N-bank ROM where bank K is uniformly filled with `K as u8`.
+    fn make_rom(bank_count: usize) -> Vec<u8> {
+        let mut rom = vec![0u8; bank_count * 0x4000];
+        for bank in 0..bank_count {
+            let start = bank * 0x4000;
+            rom[start..start + 0x4000].fill(bank as u8);
+        }
+        rom
+    }
+
+    fn make_ram(bank_count: usize) -> Vec<u8> {
+        vec![0u8; bank_count * 0x2000]
+    }
+
+    // -----------------------------------------------------------------------
+    // ROM banking — fixed window ($0000–$3FFF)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mbc5_fixed_window_always_reads_bank0() {
+        // Given: 4-bank ROM; bank 0 filled with 0x00
+        let cart = Mbc5::new(make_rom(4), make_ram(0));
+        // Then: $0000 and $3FFF both return bank 0 fill byte
+        assert_eq!(cart.read(0x0000), 0x00);
+        assert_eq!(cart.read(0x3FFF), 0x00);
+    }
+
+    #[test]
+    fn test_mbc5_fixed_window_unchanged_after_bank_select() {
+        // Given: bank 2 is selected
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        cart.write(0x2000, 0x02);
+        // Then: $0000 still returns bank 0 data
+        assert_eq!(cart.read(0x0000), 0x00);
+    }
+
+    // -----------------------------------------------------------------------
+    // ROM banking — switchable window ($4000–$7FFF)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mbc5_switchable_window_initially_maps_bank1() {
+        // MBC5 powers on with bank 1 in the switchable window (same as other MBCs).
+        // "Writing 0 gives bank 0" applies only to explicit writes, not power-on state.
+        let cart = Mbc5::new(make_rom(4), make_ram(0));
+        assert_eq!(cart.read(0x4000), 0x01);
+        assert_eq!(cart.read(0x7FFF), 0x01);
+    }
+
+    #[test]
+    fn test_mbc5_writing_zero_to_bank_reg_selects_bank0() {
+        // Unlike MBC1/MBC2, explicitly writing 0 selects bank 0 (no promotion).
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        cart.write(0x2000, 0x00);
+        assert_eq!(cart.read(0x4000), 0x00);
+    }
+
+    #[test]
+    fn test_mbc5_rom_bank_switch_low_byte_selects_correct_bank() {
+        // Given: 4-bank ROM; write 0x02 to $2000
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        cart.write(0x2000, 0x02);
+        // Then: $4000 returns bank 2 fill byte
+        assert_eq!(cart.read(0x4000), 0x02);
+        assert_eq!(cart.read(0x7FFF), 0x02);
+    }
+
+    #[test]
+    fn test_mbc5_rom_bank_switch_to_bank3() {
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        cart.write(0x2000, 0x03);
+        assert_eq!(cart.read(0x4000), 0x03);
+    }
+
+    #[test]
+    fn test_mbc5_9th_bit_selects_upper_bank() {
+        // Given: 512-bank ROM; write 0xFF to $2000 and 0x01 to $3000 → bank 0x1FF
+        // Bank 0x1FF = 511; fill byte = 511u8 = 0xFF
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0));
+        cart.write(0x2000, 0xFF); // lower 8 bits = 0xFF
+        cart.write(0x3000, 0x01); // bit 8 set → bank = 0x1FF
+        assert_eq!(cart.read(0x4000), 0xFF);
+    }
+
+    #[test]
+    fn test_mbc5_9th_bit_only_lowest_bit_matters() {
+        // Writing 0xFE to $3000 (bit 0 = 0) should not set bit 8
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        cart.write(0x2000, 0x02); // bank 2
+        cart.write(0x3000, 0xFE); // bit 0 = 0 → bit 8 stays 0
+        assert_eq!(cart.read(0x4000), 0x02); // still bank 2
+    }
+
+    #[test]
+    fn test_mbc5_9th_bit_can_be_cleared() {
+        // Set bit 8, then clear it by writing 0x00 to $3000
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0));
+        cart.write(0x2000, 0x01); // bank 1
+        cart.write(0x3000, 0x01); // bit 8 set → bank 0x101 = 257; fill byte = 1 (wraps)
+        cart.write(0x3000, 0x00); // clear bit 8 → bank 1
+        assert_eq!(cart.read(0x4000), 0x01); // bank 1 fill byte
+    }
+
+    #[test]
+    fn test_mbc5_low_byte_write_preserves_high_bit() {
+        // Set bit 8, then change low byte; bit 8 should be preserved
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0));
+        cart.write(0x3000, 0x01); // bit 8 set
+        cart.write(0x2000, 0x05); // low byte = 5 → bank = 0x105 = 261
+        // 261 & 511 = 261; fill byte = 261u8 = 5 (261 % 256 wraps, and fill = bank as u8)
+        assert_eq!(cart.read(0x4000), 5u8);
+    }
+
+    #[test]
+    fn test_mbc5_bank_masking_wraps_to_available_banks() {
+        // 4-bank ROM; requesting bank 5 → 5 & 3 = 1; fill byte = 1
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        cart.write(0x2000, 0x05);
+        assert_eq!(cart.read(0x4000), 0x01);
+    }
+
+    // -----------------------------------------------------------------------
+    // RAM enable / disable
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mbc5_ram_disabled_by_default_returns_0xff() {
+        let cart = Mbc5::new(make_rom(2), make_ram(1));
+        assert_eq!(cart.read(0xA000), 0xFF);
+    }
+
+    #[test]
+    fn test_mbc5_ram_enable_with_0x0a() {
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        cart.write(0x0000, 0x0A); // enable RAM
+        cart.write(0xA000, 0x42);
+        assert_eq!(cart.read(0xA000), 0x42);
+    }
+
+    #[test]
+    fn test_mbc5_ram_enable_with_any_lower_nibble_a() {
+        // $1A has lower nibble 0xA → should also enable
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        cart.write(0x0000, 0x1A);
+        cart.write(0xA000, 0x55);
+        assert_eq!(cart.read(0xA000), 0x55);
+    }
+
+    #[test]
+    fn test_mbc5_ram_disable_with_0x00() {
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        cart.write(0x0000, 0x0A); // enable
+        cart.write(0xA000, 0x42);
+        cart.write(0x0000, 0x00); // disable
+        assert_eq!(cart.read(0xA000), 0xFF);
+    }
+
+    #[test]
+    fn test_mbc5_ram_disable_non_0xa_lower_nibble() {
+        // Lower nibble 0x0B ≠ 0x0A → disable
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        cart.write(0x0000, 0x0A); // enable first
+        cart.write(0xA000, 0x42);
+        cart.write(0x0000, 0x0B); // disable
+        assert_eq!(cart.read(0xA000), 0xFF);
+    }
+
+    #[test]
+    fn test_mbc5_ram_write_ignored_when_disabled() {
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        // RAM disabled; write should be a no-op
+        cart.write(0xA000, 0x42);
+        // Enable and verify the write did nothing
+        cart.write(0x0000, 0x0A);
+        assert_eq!(cart.read(0xA000), 0x00); // initial RAM = 0
+    }
+
+    #[test]
+    fn test_mbc5_empty_ram_returns_0xff_even_when_enabled() {
+        let mut cart = Mbc5::new(make_rom(2), make_ram(0));
+        cart.write(0x0000, 0x0A); // enable
+        assert_eq!(cart.read(0xA000), 0xFF);
+    }
+
+    // -----------------------------------------------------------------------
+    // RAM banking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mbc5_ram_bank_switching() {
+        // Given: 2 RAM banks; write distinct bytes to each bank
+        let mut cart = Mbc5::new(make_rom(2), make_ram(2));
+        cart.write(0x0000, 0x0A); // enable RAM
+
+        cart.write(0x4000, 0x00); // select RAM bank 0
+        cart.write(0xA000, 0xAA);
+
+        cart.write(0x4000, 0x01); // select RAM bank 1
+        cart.write(0xA000, 0xBB);
+
+        // Then: bank 1 returns 0xBB
+        assert_eq!(cart.read(0xA000), 0xBB);
+        // Switching back returns 0xAA
+        cart.write(0x4000, 0x00);
+        assert_eq!(cart.read(0xA000), 0xAA);
+    }
+
+    #[test]
+    fn test_mbc5_ram_bank_register_masked_to_4_bits() {
+        // Writing 0xFF → lower 4 bits = 0xF = 15; 1 RAM bank → wraps to 0
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        cart.write(0x0000, 0x0A);
+        cart.write(0x4000, 0xFF); // 4-bit mask → ram_bank = 0xF; 1 bank → wraps to 0
+        cart.write(0xA000, 0x77);
+        assert_eq!(cart.read(0xA000), 0x77);
+    }
+
+    #[test]
+    fn test_mbc5_ram_bank_masking_wraps_to_available_banks() {
+        // 2 RAM banks; select bank 3 → 3 & 1 = 1 (wraps to bank 1)
+        let mut cart = Mbc5::new(make_rom(2), make_ram(2));
+        cart.write(0x0000, 0x0A);
+        cart.write(0x4000, 0x01); // bank 1
+        cart.write(0xA000, 0xCC);
+        cart.write(0x4000, 0x03); // bank 3 → wraps to bank 1
+        assert_eq!(cart.read(0xA000), 0xCC);
+    }
+}

--- a/src/gb/cartridge/mbc5.rs
+++ b/src/gb/cartridge/mbc5.rs
@@ -8,28 +8,30 @@ use super::cartridge::GbCartridge;
 /// - $0000–$1FFF: RAM enable (bottom nibble 0xA → enable; any other value → disable)
 /// - $2000–$2FFF: lower 8 bits of ROM bank number
 /// - $3000–$3FFF: bit 8 (9th bit) of ROM bank number
-/// - $4000–$5FFF: RAM bank number (4 bits, 0x00–0x0F)
+/// - $4000–$5FFF: RAM bank number
+///   - Non-rumble types (0x19–0x1B): 4-bit bank, 0x00–0x0F
+///   - Rumble types (0x1C–0x1E): 3-bit bank, 0x00–0x07; bit 3 drives the rumble
+///     motor line and is masked out before updating the bank register
 ///
 /// Unlike MBC1/MBC2, writing 0 to the ROM bank register genuinely selects bank 0;
 /// there is no bank-0 → bank-1 promotion.
-///
-/// Rumble types (0x1C–0x1E): bit 3 of the $4000–$5FFF register drives the rumble motor
-/// instead of the RAM chip on real hardware. This emulator silently ignores the rumble
-/// signal; all 4 bits are treated as the RAM bank number for all types.
 pub struct Mbc5 {
     rom: Vec<u8>,
     ram: Vec<u8>,
     /// 9-bit ROM bank number (0x000–0x1FF). Lower 8 bits come from writes to
     /// $2000–$2FFF; bit 8 comes from the lowest bit of writes to $3000–$3FFF.
     rom_bank: u16,
-    /// RAM bank number (4-bit, 0x00–0x0F).
+    /// RAM bank number (3- or 4-bit depending on `has_rumble`).
     ram_bank: u8,
     /// Whether cartridge RAM is enabled.
     ram_enabled: bool,
+    /// True for rumble cart types (0x1C–0x1E). Bit 3 of writes to $4000–$5FFF
+    /// controls the rumble motor and is masked out of the RAM bank register.
+    has_rumble: bool,
 }
 
 impl Mbc5 {
-    pub fn new(rom: Vec<u8>, ram: Vec<u8>) -> Self {
+    pub fn new(rom: Vec<u8>, ram: Vec<u8>, has_rumble: bool) -> Self {
         Self {
             rom,
             ram,
@@ -39,6 +41,7 @@ impl Mbc5 {
             rom_bank: 1,
             ram_bank: 0,
             ram_enabled: false,
+            has_rumble,
         }
     }
 
@@ -92,7 +95,8 @@ impl Mbc5 {
                 self.rom_bank = (self.rom_bank & 0x00FF) | (((val & 0x01) as u16) << 8);
             }
             0x4000..=0x5FFF => {
-                self.ram_bank = val & 0x0F;
+                let mask = if self.has_rumble { 0x07 } else { 0x0F };
+                self.ram_bank = val & mask;
             }
             _ => {}
         }
@@ -153,7 +157,7 @@ mod tests {
     #[test]
     fn test_mbc5_fixed_window_always_reads_bank0() {
         // Given: 4-bank ROM; bank 0 filled with 0x00
-        let cart = Mbc5::new(make_rom(4), make_ram(0));
+        let cart = Mbc5::new(make_rom(4), make_ram(0), false);
         // Then: $0000 and $3FFF both return bank 0 fill byte
         assert_eq!(cart.read(0x0000), 0x00);
         assert_eq!(cart.read(0x3FFF), 0x00);
@@ -162,7 +166,7 @@ mod tests {
     #[test]
     fn test_mbc5_fixed_window_unchanged_after_bank_select() {
         // Given: bank 2 is selected
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
         cart.write(0x2000, 0x02);
         // Then: $0000 still returns bank 0 data
         assert_eq!(cart.read(0x0000), 0x00);
@@ -176,7 +180,7 @@ mod tests {
     fn test_mbc5_switchable_window_initially_maps_bank1() {
         // MBC5 powers on with bank 1 in the switchable window (same as other MBCs).
         // "Writing 0 gives bank 0" applies only to explicit writes, not power-on state.
-        let cart = Mbc5::new(make_rom(4), make_ram(0));
+        let cart = Mbc5::new(make_rom(4), make_ram(0), false);
         assert_eq!(cart.read(0x4000), 0x01);
         assert_eq!(cart.read(0x7FFF), 0x01);
     }
@@ -184,7 +188,7 @@ mod tests {
     #[test]
     fn test_mbc5_writing_zero_to_bank_reg_selects_bank0() {
         // Unlike MBC1/MBC2, explicitly writing 0 selects bank 0 (no promotion).
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
         cart.write(0x2000, 0x00);
         assert_eq!(cart.read(0x4000), 0x00);
     }
@@ -192,7 +196,7 @@ mod tests {
     #[test]
     fn test_mbc5_rom_bank_switch_low_byte_selects_correct_bank() {
         // Given: 4-bank ROM; write 0x02 to $2000
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
         cart.write(0x2000, 0x02);
         // Then: $4000 returns bank 2 fill byte
         assert_eq!(cart.read(0x4000), 0x02);
@@ -201,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_rom_bank_switch_to_bank3() {
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
         cart.write(0x2000, 0x03);
         assert_eq!(cart.read(0x4000), 0x03);
     }
@@ -210,7 +214,7 @@ mod tests {
     fn test_mbc5_9th_bit_selects_upper_bank() {
         // Given: 512-bank ROM; write 0xFF to $2000 and 0x01 to $3000 → bank 0x1FF
         // Bank 0x1FF = 511; fill byte = 511u8 = 0xFF
-        let mut cart = Mbc5::new(make_rom(512), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false);
         cart.write(0x2000, 0xFF); // lower 8 bits = 0xFF
         cart.write(0x3000, 0x01); // bit 8 set → bank = 0x1FF
         assert_eq!(cart.read(0x4000), 0xFF);
@@ -219,7 +223,7 @@ mod tests {
     #[test]
     fn test_mbc5_9th_bit_only_lowest_bit_matters() {
         // Writing 0xFE to $3000 (bit 0 = 0) should not set bit 8
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
         cart.write(0x2000, 0x02); // bank 2
         cart.write(0x3000, 0xFE); // bit 0 = 0 → bit 8 stays 0
         assert_eq!(cart.read(0x4000), 0x02); // still bank 2
@@ -228,7 +232,7 @@ mod tests {
     #[test]
     fn test_mbc5_9th_bit_can_be_cleared() {
         // Set bit 8, then clear it by writing 0x00 to $3000
-        let mut cart = Mbc5::new(make_rom(512), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false);
         cart.write(0x2000, 0x01); // bank 1
         cart.write(0x3000, 0x01); // bit 8 set → bank 0x101 = 257; fill byte = 1 (wraps)
         cart.write(0x3000, 0x00); // clear bit 8 → bank 1
@@ -238,7 +242,7 @@ mod tests {
     #[test]
     fn test_mbc5_low_byte_write_preserves_high_bit() {
         // Set bit 8, then change low byte; bit 8 should be preserved
-        let mut cart = Mbc5::new(make_rom(512), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false);
         cart.write(0x3000, 0x01); // bit 8 set
         cart.write(0x2000, 0x05); // low byte = 5 → bank = 0x105 = 261
         // 261 & 511 = 261; fill byte = 261u8 = 5 (261 % 256 wraps, and fill = bank as u8)
@@ -248,7 +252,7 @@ mod tests {
     #[test]
     fn test_mbc5_bank_masking_wraps_to_available_banks() {
         // 4-bank ROM; requesting bank 5 → 5 & 3 = 1; fill byte = 1
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
         cart.write(0x2000, 0x05);
         assert_eq!(cart.read(0x4000), 0x01);
     }
@@ -259,13 +263,13 @@ mod tests {
 
     #[test]
     fn test_mbc5_ram_disabled_by_default_returns_0xff() {
-        let cart = Mbc5::new(make_rom(2), make_ram(1));
+        let cart = Mbc5::new(make_rom(2), make_ram(1), false);
         assert_eq!(cart.read(0xA000), 0xFF);
     }
 
     #[test]
     fn test_mbc5_ram_enable_with_0x0a() {
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
         cart.write(0x0000, 0x0A); // enable RAM
         cart.write(0xA000, 0x42);
         assert_eq!(cart.read(0xA000), 0x42);
@@ -274,7 +278,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_enable_with_any_lower_nibble_a() {
         // $1A has lower nibble 0xA → should also enable
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
         cart.write(0x0000, 0x1A);
         cart.write(0xA000, 0x55);
         assert_eq!(cart.read(0xA000), 0x55);
@@ -282,7 +286,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_ram_disable_with_0x00() {
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
         cart.write(0x0000, 0x0A); // enable
         cart.write(0xA000, 0x42);
         cart.write(0x0000, 0x00); // disable
@@ -292,7 +296,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_disable_non_0xa_lower_nibble() {
         // Lower nibble 0x0B ≠ 0x0A → disable
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
         cart.write(0x0000, 0x0A); // enable first
         cart.write(0xA000, 0x42);
         cart.write(0x0000, 0x0B); // disable
@@ -301,7 +305,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_ram_write_ignored_when_disabled() {
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
         // RAM disabled; write should be a no-op
         cart.write(0xA000, 0x42);
         // Enable and verify the write did nothing
@@ -311,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_empty_ram_returns_0xff_even_when_enabled() {
-        let mut cart = Mbc5::new(make_rom(2), make_ram(0));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(0), false);
         cart.write(0x0000, 0x0A); // enable
         assert_eq!(cart.read(0xA000), 0xFF);
     }
@@ -323,7 +327,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_bank_switching() {
         // Given: 2 RAM banks; write distinct bytes to each bank
-        let mut cart = Mbc5::new(make_rom(2), make_ram(2));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(2), false);
         cart.write(0x0000, 0x0A); // enable RAM
 
         cart.write(0x4000, 0x00); // select RAM bank 0
@@ -342,7 +346,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_bank_register_masked_to_4_bits() {
         // Writing 0xFF → lower 4 bits = 0xF = 15; 1 RAM bank → wraps to 0
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
         cart.write(0x0000, 0x0A);
         cart.write(0x4000, 0xFF); // 4-bit mask → ram_bank = 0xF; 1 bank → wraps to 0
         cart.write(0xA000, 0x77);
@@ -352,11 +356,50 @@ mod tests {
     #[test]
     fn test_mbc5_ram_bank_masking_wraps_to_available_banks() {
         // 2 RAM banks; select bank 3 → 3 & 1 = 1 (wraps to bank 1)
-        let mut cart = Mbc5::new(make_rom(2), make_ram(2));
+        let mut cart = Mbc5::new(make_rom(2), make_ram(2), false);
         cart.write(0x0000, 0x0A);
         cart.write(0x4000, 0x01); // bank 1
         cart.write(0xA000, 0xCC);
         cart.write(0x4000, 0x03); // bank 3 → wraps to bank 1
+        assert_eq!(cart.read(0xA000), 0xCC);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rumble cart RAM bank masking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mbc5_rumble_bit3_does_not_affect_ram_bank() {
+        // For rumble carts, bit 3 drives the rumble motor; writing 0x08 (only
+        // bit 3 set) should leave the RAM bank at 0, not switch to bank 8.
+        let mut cart = Mbc5::new(make_rom(2), make_ram(2), true);
+        cart.write(0x0000, 0x0A);
+        cart.write(0x4000, 0x00); // bank 0
+        cart.write(0xA000, 0xAA);
+        cart.write(0x4000, 0x08); // bit 3 = rumble; bank bits = 0 → still bank 0
+        assert_eq!(cart.read(0xA000), 0xAA);
+    }
+
+    #[test]
+    fn test_mbc5_rumble_ram_bank_masked_to_3_bits() {
+        // For rumble carts, the RAM bank is only 3 bits (0x00–0x07).
+        // Writing 0xFF → 0xFF & 0x07 = 7, not 0x0F = 15.
+        let mut cart = Mbc5::new(make_rom(2), make_ram(8), true);
+        cart.write(0x0000, 0x0A);
+        cart.write(0x4000, 0x07); // bank 7
+        cart.write(0xA000, 0xBB);
+        cart.write(0x4000, 0xFF); // 0xFF & 0x07 = 7; still bank 7
+        assert_eq!(cart.read(0xA000), 0xBB);
+    }
+
+    #[test]
+    fn test_mbc5_non_rumble_ram_bank_uses_full_4_bits() {
+        // Non-rumble carts allow 4-bit bank (0x00–0x0F). Bit 3 is a valid bank bit.
+        let mut cart = Mbc5::new(make_rom(2), make_ram(16), false);
+        cart.write(0x0000, 0x0A);
+        cart.write(0x4000, 0x08); // bank 8 — valid for non-rumble
+        cart.write(0xA000, 0xCC);
+        cart.write(0x4000, 0x08);
         assert_eq!(cart.read(0xA000), 0xCC);
     }
 }

--- a/src/gb/cartridge/mod.rs
+++ b/src/gb/cartridge/mod.rs
@@ -3,11 +3,13 @@ mod cartridge;
 mod mbc0;
 mod mbc1;
 mod mbc2;
+mod mbc5;
 
 pub use cartridge::GbCartridge;
 use mbc0::Mbc0;
 use mbc1::Mbc1;
 use mbc2::Mbc2;
+use mbc5::Mbc5;
 
 /// Errors returned by [`load_cartridge`].
 #[derive(Debug, PartialEq)]
@@ -47,7 +49,7 @@ fn ram_size_from_byte(byte: u8) -> usize {
 /// Validations performed:
 /// 1. Length must be at least 32 KB (0x8000) — returns [`RomError::TooShort`].
 /// 2. Header checksum at 0x014D must be correct — returns [`RomError::BadHeaderChecksum`].
-/// 3. MBC type at 0x0147 must be supported (0x00–0x03, 0x05–0x06) — returns [`RomError::UnsupportedMbc`].
+/// 3. MBC type at 0x0147 must be supported (0x00–0x03, 0x05–0x06, 0x19–0x1E) — returns [`RomError::UnsupportedMbc`].
 pub fn load_cartridge(bytes: &[u8]) -> Result<Box<dyn GbCartridge>, RomError> {
     if bytes.len() < 0x8000 {
         return Err(RomError::TooShort);
@@ -71,6 +73,10 @@ pub fn load_cartridge(bytes: &[u8]) -> Result<Box<dyn GbCartridge>, RomError> {
             Ok(Box::new(Mbc1::new(bytes.to_vec(), vec![0u8; ram_size])))
         }
         0x05..=0x06 => Ok(Box::new(Mbc2::new(bytes.to_vec()))),
+        0x19..=0x1E => {
+            let ram_size = ram_size_from_byte(bytes[0x0149]);
+            Ok(Box::new(Mbc5::new(bytes.to_vec(), vec![0u8; ram_size])))
+        }
         n => Err(RomError::UnsupportedMbc(n)),
     }
 }
@@ -134,6 +140,34 @@ mod tests {
     fn test_load_returns_ok_for_mbc2_battery_rom() {
         // Given: a valid MBC2+BATTERY cartridge (type 0x06)
         let rom = make_valid_rom(0x06, 0x00);
+        assert!(load_cartridge(&rom).is_ok());
+    }
+
+    #[test]
+    fn test_load_returns_ok_for_mbc5_rom() {
+        // Given: a valid MBC5 cartridge (type 0x19 = MBC5)
+        let rom = make_valid_rom(0x19, 0x01);
+        assert!(load_cartridge(&rom).is_ok());
+    }
+
+    #[test]
+    fn test_load_returns_ok_for_mbc5_ram_battery_rom() {
+        // Given: a valid MBC5+RAM+BATTERY cartridge (type 0x1B)
+        let rom = make_valid_rom(0x1B, 0x01);
+        assert!(load_cartridge(&rom).is_ok());
+    }
+
+    #[test]
+    fn test_load_returns_ok_for_mbc5_rumble_rom() {
+        // Given: a valid MBC5+RUMBLE cartridge (type 0x1C)
+        let rom = make_valid_rom(0x1C, 0x01);
+        assert!(load_cartridge(&rom).is_ok());
+    }
+
+    #[test]
+    fn test_load_returns_ok_for_mbc5_rumble_ram_battery_rom() {
+        // Given: a valid MBC5+RUMBLE+RAM+BATTERY cartridge (type 0x1E)
+        let rom = make_valid_rom(0x1E, 0x01);
         assert!(load_cartridge(&rom).is_ok());
     }
 

--- a/src/gb/cartridge/mod.rs
+++ b/src/gb/cartridge/mod.rs
@@ -75,7 +75,12 @@ pub fn load_cartridge(bytes: &[u8]) -> Result<Box<dyn GbCartridge>, RomError> {
         0x05..=0x06 => Ok(Box::new(Mbc2::new(bytes.to_vec()))),
         0x19..=0x1E => {
             let ram_size = ram_size_from_byte(bytes[0x0149]);
-            Ok(Box::new(Mbc5::new(bytes.to_vec(), vec![0u8; ram_size])))
+            let has_rumble = mbc_type >= 0x1C;
+            Ok(Box::new(Mbc5::new(
+                bytes.to_vec(),
+                vec![0u8; ram_size],
+                has_rumble,
+            )))
         }
         n => Err(RomError::UnsupportedMbc(n)),
     }

--- a/src/gb/integration_tests/mooneye_tests.rs
+++ b/src/gb/integration_tests/mooneye_tests.rs
@@ -469,7 +469,6 @@ fn test_mooneye_acceptance_oam_dma_reg_read() {
 }
 
 #[test]
-#[ignore = "Requires MBC5 which is not yet implemented — tracked in #2025"]
 fn test_mooneye_acceptance_oam_dma_sources_gs() {
     assert_mooneye_pass!(&format!("{BASE}/acceptance/oam_dma/sources-GS.gb"));
 }
@@ -784,53 +783,45 @@ fn test_mooneye_emulator_only_mbc2_rom_512kb() {
 }
 
 // ============================================================================
-// emulator-only/ tests — MBC5 (not implemented — pre-ignored)
+// emulator-only/ tests — MBC5
 // ============================================================================
 
 #[test]
-#[ignore = "MBC5 not yet implemented — tracked in #2025"]
 fn test_mooneye_emulator_only_mbc5_rom_16mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc5/rom_16Mb.gb"));
 }
 
 #[test]
-#[ignore = "MBC5 not yet implemented — tracked in #2025"]
 fn test_mooneye_emulator_only_mbc5_rom_1mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc5/rom_1Mb.gb"));
 }
 
 #[test]
-#[ignore = "MBC5 not yet implemented — tracked in #2025"]
 fn test_mooneye_emulator_only_mbc5_rom_2mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc5/rom_2Mb.gb"));
 }
 
 #[test]
-#[ignore = "MBC5 not yet implemented — tracked in #2025"]
 fn test_mooneye_emulator_only_mbc5_rom_32mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc5/rom_32Mb.gb"));
 }
 
 #[test]
-#[ignore = "MBC5 not yet implemented — tracked in #2025"]
 fn test_mooneye_emulator_only_mbc5_rom_4mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc5/rom_4Mb.gb"));
 }
 
 #[test]
-#[ignore = "MBC5 not yet implemented — tracked in #2025"]
 fn test_mooneye_emulator_only_mbc5_rom_512kb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc5/rom_512kb.gb"));
 }
 
 #[test]
-#[ignore = "MBC5 not yet implemented — tracked in #2025"]
 fn test_mooneye_emulator_only_mbc5_rom_64mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc5/rom_64Mb.gb"));
 }
 
 #[test]
-#[ignore = "MBC5 not yet implemented — tracked in #2025"]
 fn test_mooneye_emulator_only_mbc5_rom_8mb() {
     assert_mooneye_pass!(&format!("{BASE}/emulator-only/mbc5/rom_8Mb.gb"));
 }


### PR DESCRIPTION
Closes #2025

## Summary

Implements MBC5 (cart types `0x19`–`0x1E`), the most common GBC MBC, supporting up to 8 MiB ROM and 128 KiB RAM.

## Changes

### `src/gb/cartridge/mbc5.rs` (new)
- `Mbc5` struct with correct power-on state (`rom_bank = 1`, per SameBoy/hardware)
- 9-bit ROM bank register via two writes ($2000 low byte, $3000 bit 8)
- Bank 0 valid in switchable window (no promotion, unlike MBC1)
- 4-bit RAM bank; rumble bit silently ignored for types `0x1C`–`0x1E`
- RAM enable gate: bottom nibble `0xA` enables
- 23 unit tests covering all register writes, masking, and edge cases

### `src/gb/cartridge/mod.rs`
- Wire `0x19..=0x1E` in `load_cartridge`
- 4 loader tests added

### `src/gb/bus/dmg_bus.rs`
- Fix `read_raw` for OAM DMA: on DMG the DMA controller uses the external bus, which maps `$E000–

### `src/gb/integration_tests/mooneye_tests.rs`
- Remove `#[ignore]` from 9 tests: 8 `emulator-only/mbc5/rom_*` + `acceptance/oam_dma/sources-GS`

### `src/frontends/native/gamepad.rs`
- Fix 2 pre-existing clippy `collapsible_if` warnings

## Tests

- 23 MBC5 unit tests
- 9 previously-ignored mooneye integration tests now pass
- All 8410 `cargo test --no-default-features --lib` tests pass
- `wasm-pack`, Python tests, and `npm test` all pass