### PR TITLE
feat(web): disable emulation buttons when action has no meaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ mappertool_settings.json
 rom_files.csv
 *.sav
 
+# Generated ROM manifest for web dev server
+web/roms/roms.json
+
 # wasm-bindgen output
 web/pkg/
 node_modules/

--- a/src/frontends/native/gamepad.rs
+++ b/src/frontends/native/gamepad.rs
@@ -311,29 +311,29 @@ impl GamepadManager {
     ) -> Option<GamepadChange> {
         if let Some(player_num) = self.player_map.get(&id).copied() {
             // Release all held buttons for this gamepad's port before removing.
-            if let Console::Nes(nes) = console {
-                if let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) {
-                    use Button::{A, B, Down, Left, Right, Select, Start, Up};
-                    for button in [A, B, Select, Start, Up, Down, Left, Right] {
-                        nes.set_button(port, button, false);
-                    }
-                    use SnesButton as S;
-                    for snes_btn in [
-                        S::A,
-                        S::B,
-                        S::X,
-                        S::Y,
-                        S::L,
-                        S::R,
-                        S::Start,
-                        S::Select,
-                        S::Up,
-                        S::Down,
-                        S::Left,
-                        S::Right,
-                    ] {
-                        nes.set_snes_button(port, snes_btn, false);
-                    }
+            if let Console::Nes(nes) = console
+                && let Some(port) = Self::assigned_port(nes, &self.player_map, player_num)
+            {
+                use Button::{A, B, Down, Left, Right, Select, Start, Up};
+                for button in [A, B, Select, Start, Up, Down, Left, Right] {
+                    nes.set_button(port, button, false);
+                }
+                use SnesButton as S;
+                for snes_btn in [
+                    S::A,
+                    S::B,
+                    S::X,
+                    S::Y,
+                    S::L,
+                    S::R,
+                    S::Start,
+                    S::Select,
+                    S::Up,
+                    S::Down,
+                    S::Left,
+                    S::Right,
+                ] {
+                    nes.set_snes_button(port, snes_btn, false);
                 }
             }
 
@@ -433,10 +433,8 @@ impl GamepadManager {
             if let Some(nes_btn) = map_button_to_nes(button) {
                 nes.set_button(port, nes_btn, pressed);
             }
-        } else {
-            if let Some(nes_btn) = map_button_to_nes(button) {
-                console.set_button(0, nes_btn as u8, pressed);
-            }
+        } else if let Some(nes_btn) = map_button_to_nes(button) {
+            console.set_button(0, nes_btn as u8, pressed);
         }
     }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,48 @@
 /// <reference types="vitest/config" />
 import { defineConfig, type Plugin } from "vite";
 import tailwindcss from "@tailwindcss/vite";
-import { readdirSync, statSync, writeFileSync, existsSync } from "fs";
-import { join, relative } from "path";
+import { readdirSync, realpathSync, statSync, writeFileSync, existsSync } from "fs";
+import { dirname, join, relative } from "path";
+import { fileURLToPath } from "url";
 
-/** Recursively find all .nes files under a directory, following symlinks. */
-function findNesFiles(dir: string, base: string): string[] {
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Recursively find all .nes files under a directory, following symlinks safely. */
+function findNesFiles(
+  dir: string,
+  base: string,
+  visited: Set<string> = new Set(),
+  baseReal?: string,
+): string[] {
   const results: string[] = [];
   if (!existsSync(dir)) return results;
+
+  let resolvedBase = baseReal;
+  try { resolvedBase ??= realpathSync(base); } catch { return results; }
+
+  const isWithinBase = (targetReal: string) => {
+    const rel = relative(resolvedBase!, targetReal);
+    return rel === "" || (!rel.startsWith("..") && !rel.startsWith("/"));
+  };
+
+  let resolvedDir: string;
+  try { resolvedDir = realpathSync(dir); } catch { return results; }
+
+  if (!isWithinBase(resolvedDir) || visited.has(resolvedDir)) return results;
+  visited.add(resolvedDir);
+
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const fullPath = join(dir, entry.name);
-    // Follow symlinks: use statSync (follows links) instead of entry.isDirectory
     let stat;
     try { stat = statSync(fullPath); } catch { continue; }
     if (stat.isDirectory()) {
-      results.push(...findNesFiles(fullPath, base));
+      results.push(...findNesFiles(fullPath, base, visited, resolvedBase));
     } else if (entry.name.toLowerCase().endsWith(".nes")) {
-      results.push(relative(base, fullPath));
+      let resolvedFile: string;
+      try { resolvedFile = realpathSync(fullPath); } catch { continue; }
+      if (isWithinBase(resolvedFile)) {
+        results.push(relative(base, fullPath));
+      }
     }
   }
   return results;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,49 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import tailwindcss from "@tailwindcss/vite";
+import { readdirSync, statSync, writeFileSync, existsSync } from "fs";
+import { join, relative } from "path";
+
+/** Recursively find all .nes files under a directory, following symlinks. */
+function findNesFiles(dir: string, base: string): string[] {
+  const results: string[] = [];
+  if (!existsSync(dir)) return results;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    // Follow symlinks: use statSync (follows links) instead of entry.isDirectory
+    let stat;
+    try { stat = statSync(fullPath); } catch { continue; }
+    if (stat.isDirectory()) {
+      results.push(...findNesFiles(fullPath, base));
+    } else if (entry.name.toLowerCase().endsWith(".nes")) {
+      results.push(relative(base, fullPath));
+    }
+  }
+  return results;
+}
+
+/** Vite plugin that generates web/roms/roms.json so the ROM picker works. */
+function romManifestPlugin(): Plugin {
+  const romsDir = join(__dirname, "web", "roms");
+  const manifestPath = join(romsDir, "roms.json");
+
+  function generate() {
+    const roms = findNesFiles(romsDir, romsDir).sort();
+    writeFileSync(manifestPath, JSON.stringify({ roms }, null, 2) + "\n");
+    console.log(`[rom-manifest] wrote ${roms.length} entries to web/roms/roms.json`);
+  }
+
+  return {
+    name: "rom-manifest",
+    buildStart() { generate(); },
+    configureServer() { generate(); },
+  };
+}
 
 export default defineConfig({
   root: "web",
   publicDir: false,
-  plugins: [tailwindcss()],
+  plugins: [tailwindcss(), romManifestPlugin()],
   build: {
     outDir: "../dist",
     emptyOutDir: true,

--- a/web/index.html
+++ b/web/index.html
@@ -25,7 +25,6 @@
             <button id="screen-plus" class="btn btn-outline btn-sm">Zoom +</button>
             <button id="fullscreen" class="btn btn-outline btn-sm">Fullscreen</button>
             <button id="filter-toggle" class="btn btn-outline btn-sm">Filter</button>
-            <button id="gamepad-toggle" class="btn btn-outline btn-sm" aria-pressed="true">Gamepad On</button>
             <button id="mute" class="btn btn-outline btn-sm" aria-pressed="false">Mute</button>
             <button id="save-state" class="btn btn-warning btn-outline btn-sm" disabled>Save State</button>
             <button id="load-state" class="btn btn-warning btn-outline btn-sm" disabled>Load State</button>
@@ -87,6 +86,17 @@
             </select>
           </div>
 
+          <!-- Autorun controls -->
+          <div class="flex flex-col gap-2">
+            <label class="label cursor-pointer justify-start gap-2 p-0">
+              <input type="checkbox" id="autorun-create" class="checkbox checkbox-sm" disabled />
+              <span class="label-text text-xs">Create autorun</span>
+            </label>
+            <button id="autorun-load" class="btn btn-info btn-outline btn-sm w-full" disabled>Load autorun</button>
+            <ul id="autorun-status" class="text-xs text-info list-none space-y-0.5"></ul>
+            <button id="autorun-cancel" class="btn btn-error btn-outline btn-sm w-full hidden" aria-label="Cancel autorun">✕ Cancel Autorun</button>
+          </div>
+
           <!-- Emulation controls -->
           <div class="flex flex-col gap-2">
             <button id="start" class="btn btn-success btn-sm w-full">Start</button>
@@ -95,17 +105,6 @@
               <button id="reset" class="btn btn-warning btn-outline btn-sm flex-1" aria-label="Reset emulation">Reset</button>
             </div>
             <button id="stop" class="btn btn-error btn-outline btn-sm w-full" aria-label="Stop emulation">Stop</button>
-          </div>
-
-          <!-- Autorun controls -->
-          <div class="flex flex-col gap-2">
-            <label class="label cursor-pointer justify-start gap-2 p-0">
-              <input type="checkbox" id="autorun-create" class="checkbox checkbox-sm" />
-              <span class="label-text text-xs">Create autorun</span>
-            </label>
-            <button id="autorun-load" class="btn btn-info btn-outline btn-sm w-full">Load autorun</button>
-            <span id="autorun-status" class="text-xs text-info"></span>
-            <button id="autorun-cancel" class="btn btn-error btn-outline btn-sm w-full hidden" aria-label="Cancel autorun">✕ Cancel</button>
           </div>
 
           <!-- Spacer to push content up -->

--- a/web/index.html
+++ b/web/index.html
@@ -26,8 +26,6 @@
             <button id="fullscreen" class="btn btn-outline btn-sm">Fullscreen</button>
             <button id="filter-toggle" class="btn btn-outline btn-sm">Filter</button>
             <button id="mute" class="btn btn-outline btn-sm" aria-pressed="false">Mute</button>
-            <button id="save-state" class="btn btn-warning btn-outline btn-sm" disabled>Save State</button>
-            <button id="load-state" class="btn btn-warning btn-outline btn-sm" disabled>Load State</button>
           </div>
         </header>
 
@@ -40,28 +38,12 @@
             <div id="debugger-panel" class="debugger-panel hidden" aria-label="Debugger panel"></div>
           </div>
           <div class="mt-3 flex items-center gap-2">
-            <span class="badge badge-neutral">Status</span>
-            <span id="status" class="status">Load a ROM to begin</span>
+            <span id="status" class="status"></span>
+            <span class="badge badge-neutral">Press 'h' for help</span>
           </div>
         </main>
 
-        <!-- Footer -->
-        <footer class="px-4 py-3 bg-base-200 border-t border-base-300 text-center text-sm text-base-content/60">
-          <div id="controls">
-            <kbd class="kbd kbd-sm">W</kbd><kbd class="kbd kbd-sm">A</kbd><kbd class="kbd kbd-sm">S</kbd><kbd class="kbd kbd-sm">D</kbd> D-Pad
-            &nbsp;|&nbsp;
-            <kbd class="kbd kbd-sm">F</kbd> A
-            &nbsp;|&nbsp;
-            <kbd class="kbd kbd-sm">G</kbd> B
-            &nbsp;|&nbsp;
-            <kbd class="kbd kbd-sm">R</kbd> Select
-            &nbsp;|&nbsp;
-            <kbd class="kbd kbd-sm">T</kbd> Start
-            &nbsp;|&nbsp;
-            <kbd class="kbd kbd-sm">H</kbd> Help
-          </div>
-          <div id="shortcut-reference" class="mt-1"></div>
-        </footer>
+        <!-- Footer removed -->
       </div>
 
       <!-- Sidebar -->
@@ -105,6 +87,10 @@
               <button id="reset" class="btn btn-warning btn-outline btn-sm flex-1" aria-label="Reset emulation">Reset</button>
             </div>
             <button id="stop" class="btn btn-error btn-outline btn-sm w-full" aria-label="Stop emulation">Stop</button>
+            <div class="flex gap-2">
+              <button id="save-state" class="btn btn-warning btn-outline btn-sm flex-1" disabled>Save State</button>
+              <button id="load-state" class="btn btn-warning btn-outline btn-sm flex-1" disabled>Load State</button>
+            </div>
           </div>
 
           <!-- Spacer to push content up -->

--- a/web/integration/helpers/lifecycle.helpers.ts
+++ b/web/integration/helpers/lifecycle.helpers.ts
@@ -47,7 +47,7 @@ export async function waitForIdleState(page: Page) {
 /** Load a NES ROM via the file input, setting romFromFile = true. */
 export async function loadRomFromFileInput(page: Page) {
     const romBytes = readMockRomBytes();
-    await page.locator("#rom-input").setInputFiles({
+    await page.locator("#rom").setInputFiles({
         name: BUNDLED_ROM_NAME,
         mimeType: "application/octet-stream",
         buffer: romBytes

--- a/web/integration/helpers/lifecycle.helpers.ts
+++ b/web/integration/helpers/lifecycle.helpers.ts
@@ -7,7 +7,6 @@ const STATUS_SELECTOR = "#status";
 const ROM_SELECT_ID = "rom-select";
 const ROM_SELECT_SELECTOR = `#${ROM_SELECT_ID}`;
 const BUNDLED_ROM_NAME = "cpu.nes";
-const IDLE_STATUS_PATTERN = /Load a ROM to begin|Stopped\. You can restart or load a new ROM/;
 
 function readMockRomBytes() {
     return readFileSync(path.join(process.cwd(), "roms", "nes", BUNDLED_ROM_NAME));
@@ -34,21 +33,24 @@ async function injectBundledRomOption(page: Page) {
 
 export async function openApp(page: Page) {
     await page.goto("/");
-    await expect(page.locator(STATUS_SELECTOR)).toBeVisible();
-    await expect(page.locator("#shortcut-reference")).toContainText("Shortcuts:", {
-        timeout: EXPECT_TIMEOUT_MS
-    });
+    await expect(page.locator("#start")).toBeVisible({ timeout: EXPECT_TIMEOUT_MS });
 }
 
 export async function waitForRunningState(page: Page) {
-    await expect(page.locator(STATUS_SELECTOR)).toContainText("Running...", {
-        timeout: EXPECT_TIMEOUT_MS
-    });
+    await expect(page.locator("#stop")).toBeEnabled({ timeout: EXPECT_TIMEOUT_MS });
 }
 
 export async function waitForIdleState(page: Page) {
-    await expect(page.locator(STATUS_SELECTOR)).toHaveText(IDLE_STATUS_PATTERN, {
-        timeout: EXPECT_TIMEOUT_MS
+    await expect(page.locator("#stop")).toBeDisabled({ timeout: EXPECT_TIMEOUT_MS });
+}
+
+/** Load a NES ROM via the file input, setting romFromFile = true. */
+export async function loadRomFromFileInput(page: Page) {
+    const romBytes = readMockRomBytes();
+    await page.locator("#rom-input").setInputFiles({
+        name: BUNDLED_ROM_NAME,
+        mimeType: "application/octet-stream",
+        buffer: romBytes
     });
 }
 

--- a/web/integration/specs/app-shell.integration.spec.ts
+++ b/web/integration/specs/app-shell.integration.spec.ts
@@ -9,7 +9,5 @@ test.describe("web app shell", () => {
         for (const selector of ESSENTIAL_CONTROL_SELECTORS) {
             await expect(page.locator(selector)).toBeVisible();
         }
-
-        await expect(page.locator("#status")).toContainText("Load a ROM to begin");
     });
 });

--- a/web/integration/specs/emulation-lifecycle.integration.spec.ts
+++ b/web/integration/specs/emulation-lifecycle.integration.spec.ts
@@ -8,7 +8,6 @@ import {
 
 const ESSENTIAL_CONTROL_SELECTORS = ["#screen", "#start", "#pause", "#stop", "#reset", "#status"];
 const START_BUTTON_SELECTOR = "#start";
-const STATUS_SELECTOR = "#status";
 const PAUSE_BUTTON_SELECTOR = "#pause";
 const STOP_BUTTON_SELECTOR = "#stop";
 const RESET_BUTTON_SELECTOR = "#reset";
@@ -37,7 +36,7 @@ test.describe("Phase 1 critical path lifecycle", () => {
         await startFromBundledRom(page);
 
         await page.locator(PAUSE_BUTTON_SELECTOR).click();
-        await expect(page.locator(STATUS_SELECTOR)).toHaveText(/Paused/);
+        await expect(page.locator(PAUSE_BUTTON_SELECTOR)).toHaveText("Resume");
 
         await page.locator(PAUSE_BUTTON_SELECTOR).click();
         await waitForRunningState(page);
@@ -57,7 +56,6 @@ test.describe("Phase 1 critical path lifecycle", () => {
 
         await page.locator(RESET_BUTTON_SELECTOR).click();
 
-        await expect(page.locator(STATUS_SELECTOR)).toContainText("Soft reset");
         await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
     });
 

--- a/web/integration/specs/extended-ux.integration.spec.ts
+++ b/web/integration/specs/extended-ux.integration.spec.ts
@@ -3,7 +3,8 @@ import { collectBrowserErrors } from "../helpers/browser-errors.helpers";
 import {
     openApp,
     startFromBundledRom,
-    waitForRunningState
+    waitForRunningState,
+    loadRomFromFileInput
 } from "../helpers/lifecycle.helpers";
 
 const AUTORUN_MODAL_SELECTOR = "#autorun-modal";
@@ -16,10 +17,8 @@ const AUTORUN_EXTEND_SELECTOR = "#autorun-extend-check";
 const AUTORUN_USE_BUTTON_SELECTOR = "#autorun-use-btn";
 const AUTORUN_STATUS_SELECTOR = "#autorun-status";
 const AUTORUN_CANCEL_SELECTOR = "#autorun-cancel";
-const SHORTCUT_REFERENCE_SELECTOR = "#shortcut-reference";
 const SHORTCUT_HELP_OVERLAY_SELECTOR = "#shortcut-help-overlay";
 const DEBUGGER_PANEL_SELECTOR = "#debugger-panel";
-const STATUS_SELECTOR = "#status";
 
 function createValidAutorunBuffer() {
     const payload = {
@@ -40,6 +39,7 @@ function createValidAutorunBuffer() {
 }
 
 async function openAutorunModal(page: Page) {
+    await loadRomFromFileInput(page);
     await page.locator(AUTORUN_LOAD_BUTTON_SELECTOR).click();
     await expect(page.locator(AUTORUN_MODAL_SELECTOR)).toBeVisible();
 }
@@ -103,7 +103,7 @@ test.describe("Phase 3 extended UX", () => {
         await expect(page.locator(AUTORUN_CANCEL_SELECTOR)).toBeHidden();
     });
 
-    test("Given app is opened, when shortcut help key is pressed, then overlay visibility state toggles", async ({ page }) => {
+    test("Given app shell is rendered, when shortcut help key is pressed, then overlay shows shortcuts", async ({ page }) => {
         await openApp(page);
 
         const shortcutHelpOverlay = page.locator(SHORTCUT_HELP_OVERLAY_SELECTOR);
@@ -124,21 +124,12 @@ test.describe("Phase 3 extended UX", () => {
         await expect(shortcutHelpOverlay).toBeHidden();
     });
 
-    test("Given app shell is rendered, when shortcut reference is displayed, then expected baseline content is visible", async ({ page }) => {
-        await openApp(page);
-
-        await expect(page.locator(SHORTCUT_REFERENCE_SELECTOR)).toContainText("Space = Pause/Resume");
-        await expect(page.locator(SHORTCUT_REFERENCE_SELECTOR)).toContainText("F5 = Debugger Toggle");
-        await expect(page.locator(SHORTCUT_REFERENCE_SELECTOR)).toContainText("H = Toggle Help");
-    });
-
     test("Given emulator is running, when debugger is toggled with shortcut, then panel visibility changes without browser errors", async ({ page }) => {
         const { consoleErrors, pageErrors } = collectBrowserErrors(page);
 
         await startFromBundledRom(page);
 
         const debuggerPanel = page.locator(DEBUGGER_PANEL_SELECTOR);
-        const statusLabel = page.locator(STATUS_SELECTOR);
 
         await expect(debuggerPanel).toBeHidden();
 
@@ -146,7 +137,6 @@ test.describe("Phase 3 extended UX", () => {
 
         await expect(debuggerPanel).toBeVisible();
         await expect(debuggerPanel.locator("#dbg-continue")).toBeVisible();
-        await expect(statusLabel).toContainText("Debugger paused");
 
         await page.keyboard.press("F5");
 

--- a/web/integration/specs/extended-ux.integration.spec.ts
+++ b/web/integration/specs/extended-ux.integration.spec.ts
@@ -40,6 +40,9 @@ function createValidAutorunBuffer() {
 
 async function openAutorunModal(page: Page) {
     await loadRomFromFileInput(page);
+    // Loading a ROM auto-starts emulation; stop it so Load Autorun becomes enabled
+    await page.locator("#stop").click();
+    await expect(page.locator("#stop")).toBeDisabled();
     await page.locator(AUTORUN_LOAD_BUTTON_SELECTOR).click();
     await expect(page.locator(AUTORUN_MODAL_SELECTOR)).toBeVisible();
 }

--- a/web/integration/specs/extended-ux.integration.spec.ts
+++ b/web/integration/specs/extended-ux.integration.spec.ts
@@ -93,9 +93,8 @@ test.describe("Phase 3 extended UX", () => {
         await page.locator(AUTORUN_CHECKPOINT_SELECTOR).selectOption("1");
         await page.locator(AUTORUN_USE_BUTTON_SELECTOR).click();
 
-        await expect(page.locator(AUTORUN_STATUS_SELECTOR)).toContainText("Autorun loaded");
-        await expect(page.locator(AUTORUN_STATUS_SELECTOR)).toContainText("from checkpoint 2");
-        await expect(page.locator(AUTORUN_STATUS_SELECTOR)).toContainText("extending");
+        await expect(page.locator(AUTORUN_STATUS_SELECTOR)).toContainText("From checkpoint 2");
+        await expect(page.locator(AUTORUN_STATUS_SELECTOR)).toContainText("Extending");
         await expect(page.locator(AUTORUN_CANCEL_SELECTOR)).toBeVisible();
 
         await page.locator(AUTORUN_CANCEL_SELECTOR).click();

--- a/web/integration/specs/runtime-controls.integration.spec.ts
+++ b/web/integration/specs/runtime-controls.integration.spec.ts
@@ -5,7 +5,6 @@ import {
     waitForRunningState
 } from "../helpers/lifecycle.helpers";
 
-const GAMEPAD_TOGGLE_SELECTOR = "#gamepad-toggle";
 const MUTE_BUTTON_SELECTOR = "#mute";
 const FILTER_TOGGLE_SELECTOR = "#filter-toggle";
 const SCREEN_PLUS_SELECTOR = "#screen-plus";
@@ -56,30 +55,6 @@ test.describe("Phase 2 runtime controls", () => {
         // Verify no errors occurred during input
         expect(consoleErrors).toHaveLength(0);
         expect(pageErrors).toHaveLength(0);
-    });
-
-    test("Given gamepad toggle exists, when toggled, then state and aria-pressed update correctly", async ({ page }) => {
-        await openApp(page);
-
-        const gamepadToggle = page.locator(GAMEPAD_TOGGLE_SELECTOR);
-
-        // Wait for element to be visible, enabled and stable
-        await expect(gamepadToggle).toBeVisible({ timeout: 20000 });
-        await expect(gamepadToggle).toBeEnabled({ timeout: 20000 });
-
-        // Initial state should be "on" (default)
-        await expect(gamepadToggle).toHaveAttribute("aria-pressed", "true");
-        await expect(gamepadToggle).toContainText(/Gamepad.*On/i);
-
-        // Click to toggle off
-        await gamepadToggle.click({ timeout: 60000 });
-        await expect(gamepadToggle).toHaveAttribute("aria-pressed", "false");
-        await expect(gamepadToggle).toContainText(/Gamepad.*Off/i);
-
-        // Click to toggle back on
-        await gamepadToggle.click({ timeout: 60000 });
-        await expect(gamepadToggle).toHaveAttribute("aria-pressed", "true");
-        await expect(gamepadToggle).toContainText(/Gamepad.*On/i);
     });
 
     test("Given mute button exists, when toggled, then state and aria-pressed update correctly", async ({ page }) => {

--- a/web/integration/specs/save-state-flows.integration.spec.ts
+++ b/web/integration/specs/save-state-flows.integration.spec.ts
@@ -75,7 +75,7 @@ test.describe("Phase 2 save-state flows", () => {
 
         // First save
         await saveButton.click();
-        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" }).first()).toBeVisible({
             timeout: 5000
         });
 
@@ -84,13 +84,13 @@ test.describe("Phase 2 save-state flows", () => {
 
         // Second save (should overwrite)
         await saveButton.click();
-        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" }).first()).toBeVisible({
             timeout: 5000
         });
 
         // Load should still work
         await loadButton.click();
-        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State loaded" })).toBeVisible({
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State loaded" }).first()).toBeVisible({
             timeout: 5000
         });
     });

--- a/web/integration/specs/save-state-flows.integration.spec.ts
+++ b/web/integration/specs/save-state-flows.integration.spec.ts
@@ -15,7 +15,6 @@ test.describe("Phase 2 save-state flows", () => {
         await startFromBundledRom(page);
 
         const saveButton = page.locator(SAVE_STATE_BUTTON_SELECTOR);
-        const statusLabel = page.locator(STATUS_SELECTOR);
 
         // Save button should be enabled after starting
         await expect(saveButton).toBeEnabled();
@@ -23,11 +22,13 @@ test.describe("Phase 2 save-state flows", () => {
         // Click save state
         await saveButton.click();
 
-        // Verify success status message
-        await expect(statusLabel).toContainText("State saved", { timeout: 5000 });
+        // Verify success via toast notification
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
+            timeout: 5000
+        });
 
         // Verify the save completed without errors
-        // The fact that we see "State saved" confirms persistence occurred
+        // The fact that we see a toast confirms persistence occurred
     });
 
     test("Given state has been saved, when load state is clicked in same session, then state restores successfully", async ({ page }) => {
@@ -35,11 +36,12 @@ test.describe("Phase 2 save-state flows", () => {
 
         const saveButton = page.locator(SAVE_STATE_BUTTON_SELECTOR);
         const loadButton = page.locator(LOAD_STATE_BUTTON_SELECTOR);
-        const statusLabel = page.locator(STATUS_SELECTOR);
 
         // Save state first
         await saveButton.click();
-        await expect(statusLabel).toContainText("State saved", { timeout: 5000 });
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
+            timeout: 5000
+        });
 
         // Load button should now be enabled (state exists)
         await expect(loadButton).toBeEnabled();
@@ -47,8 +49,10 @@ test.describe("Phase 2 save-state flows", () => {
         // Click load state
         await loadButton.click();
 
-        // Verify success status message
-        await expect(statusLabel).toContainText("State loaded", { timeout: 5000 });
+        // Verify success via toast notification
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State loaded" })).toBeVisible({
+            timeout: 5000
+        });
     });
 
     test("Given no saved state exists, when page loads, then load button is disabled", async ({ page }) => {
@@ -68,22 +72,27 @@ test.describe("Phase 2 save-state flows", () => {
 
         const saveButton = page.locator(SAVE_STATE_BUTTON_SELECTOR);
         const loadButton = page.locator(LOAD_STATE_BUTTON_SELECTOR);
-        const statusLabel = page.locator(STATUS_SELECTOR);
 
         // First save
         await saveButton.click();
-        await expect(statusLabel).toContainText("State saved", { timeout: 5000 });
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
+            timeout: 5000
+        });
 
         // Wait a moment for the save to complete
         await page.waitForTimeout(200);
 
         // Second save (should overwrite)
         await saveButton.click();
-        await expect(statusLabel).toContainText("State saved", { timeout: 5000 });
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
+            timeout: 5000
+        });
 
         // Load should still work
         await loadButton.click();
-        await expect(statusLabel).toContainText("State loaded", { timeout: 5000 });
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State loaded" })).toBeVisible({
+            timeout: 5000
+        });
     });
 
     test("Given emulator has started, when save state is clicked, then a toast notification is shown", async ({ page }) => {
@@ -103,10 +112,11 @@ test.describe("Phase 2 save-state flows", () => {
 
         const saveButton = page.locator(SAVE_STATE_BUTTON_SELECTOR);
         const loadButton = page.locator(LOAD_STATE_BUTTON_SELECTOR);
-        const statusLabel = page.locator(STATUS_SELECTOR);
 
         await saveButton.click();
-        await expect(statusLabel).toContainText("State saved", { timeout: 5000 });
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
+            timeout: 5000
+        });
 
         await loadButton.click();
 

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -964,7 +964,12 @@ function updateAutorunStatus() {
             ...(config.extend ? ["▸ Extending"] : []),
             ...(expectedRom ? [`▸ Load ${expectedRom}`] : []),
         ];
-        autorunStatusEl.innerHTML = items.map(t => `<li>${t}</li>`).join("");
+        autorunStatusEl.textContent = "";
+        for (const t of items) {
+            const li = document.createElement("li");
+            li.textContent = t;
+            autorunStatusEl.appendChild(li);
+        }
         autorunCancelBtn?.classList.remove("hidden");
     }
 }
@@ -2266,6 +2271,7 @@ function step(timestamp: number) {
         }
     } catch (err) {
         running = false;
+        paused = false;
         updateEmulationButtons();
         romInput.disabled = false;
         setStatus(`Emulation error: ${err}`, true);

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -74,8 +74,8 @@ if (!gl) {
 let width = 256 - 2 * 8; // default: horizontal_overscan=8 → 240
 let height = 240 - 2 * 8; // default: vertical_overscan=8  → 224
 const SCROLLER_TEXT = "Updates April 14, 2026: All known mappers implemented. Web UI revamped.  **";
-const SCROLLER_SPEED = 2.0;
-const SCROLLER_AMPLITUDE = 20;
+const SCROLLER_SPEED = 1.6;
+const SCROLLER_AMPLITUDE = 17;
 const SCROLLER_FREQUENCY = 0.0587;
 const SCROLLER_FONT_SIZE_PX = 15;
 const SCROLLER_FONT_FAMILY = "'VT323', monospace";
@@ -1133,8 +1133,8 @@ let lastGamepadState2 = {
 };
 
 function setStatus(msg: string, isError = false) {
-    statusEl!.textContent = msg;
-    statusEl!.style.color = isError ? "#f88" : "#8fe28f";
+    statusEl!.textContent = isError ? msg : "";
+    statusEl!.style.color = isError ? "#f88" : "";
 }
 
 async function applyRomBytes(bytes: Uint8Array, name: string) {

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -73,11 +73,11 @@ if (!gl) {
 // NES display dimensions after overscan removal (updated after NES instance is created).
 let width = 256 - 2 * 8; // default: horizontal_overscan=8 → 240
 let height = 240 - 2 * 8; // default: vertical_overscan=8  → 224
-const SCROLLER_TEXT = "Updates: Feb 24: Added recording/autorunner support and debugger support for web. Feb 19: Added scraping of ROM database for better comapatibility. Feb 14: Full PAL support! Keyboard shortcuts with 'H'. ** Feb 7: Added support for NES Zapper controller. ** Feb 5: Added support for Arkanoid controller!  **";
+const SCROLLER_TEXT = "Updates April 14, 2026: All known mappers implemented. Web UI revamped.  **";
 const SCROLLER_SPEED = 2.0;
 const SCROLLER_AMPLITUDE = 20;
-const SCROLLER_FREQUENCY = 0.05;
-const SCROLLER_FONT_SIZE_PX = 20;
+const SCROLLER_FREQUENCY = 0.0587;
+const SCROLLER_FONT_SIZE_PX = 15;
 const SCROLLER_FONT_FAMILY = "'VT323', monospace";
 
 const toastContainer = createToastContainer(screenWrap);
@@ -845,11 +845,12 @@ let saveStateController: { save(): Promise<boolean>; load(): Promise<boolean> } 
 let saveStateAvailable = false;
 let running = false;
 let paused = false;
+let romFromFile = false; // true only when ROM was loaded from the file input
 
 // ── Autorun context + DOM elements ───────────────────────────────────────────
 const autorunCtx = createAutorunContext();
 const autorunCreateCheckbox = document.getElementById("autorun-create") as HTMLInputElement | null;
-const autorunLoadBtn = document.getElementById("autorun-load");
+const autorunLoadBtn = document.getElementById("autorun-load") as HTMLButtonElement | null;
 const autorunStatusEl = document.getElementById("autorun-status");
 const autorunFileInput = document.getElementById("autorun-file-input") as AutorunFileInput | null;
 const autorunFileInfo = document.getElementById("autorun-file-info");
@@ -869,9 +870,9 @@ const recOverlay = document.getElementById("rec-overlay");
  * - Refreshes autorun status display.
  */
 function updateAutorunControls() {
-    // Gate "Create autorun" checkbox: only checkable when stopped
+    // Gate "Create autorun" checkbox: only checkable when stopped and ROM came from file input
     if (autorunCreateCheckbox) {
-        autorunCreateCheckbox.disabled = running || paused;
+        autorunCreateCheckbox.disabled = running || paused || !romFromFile;
     }
 
     updateAutorunStatus();
@@ -902,6 +903,10 @@ function updateEmulationButtons() {
     }
     if (resetBtn) {
         resetBtn.disabled = !states.resetEnabled;
+    }
+    // Load autorun button: available when a ROM is loaded from file and emulation is stopped
+    if (autorunLoadBtn) {
+        autorunLoadBtn.disabled = romBytes === null || !romFromFile || running;
     }
 }
 
@@ -945,18 +950,21 @@ function updateAutorunStatus() {
         autorunStatusEl.textContent = "";
         autorunCancelBtn?.classList.add("hidden");
     } else if (config.mode === "record") {
-        autorunStatusEl.textContent = "Will record autorun";
+        autorunStatusEl.textContent = "";
         autorunCancelBtn?.classList.add("hidden");
     } else {
         const info = autorunCtx.getLoadedFile();
         const cpText = config.checkpointIdx != null
-            ? `from checkpoint ${config.checkpointIdx + 1}`
-            : "from beginning";
-        const extText = config.extend ? ", extending" : "";
+            ? `From checkpoint ${config.checkpointIdx + 1}`
+            : "From beginning";
         const expectedRom = autorunCtx.getExpectedRomName();
-        const romHint = expectedRom ? ` · Load ${expectedRom}` : "";
-        autorunStatusEl.textContent =
-            `Autorun loaded (${info?.frameCount ?? "?"} frames, ${cpText}${extText})${romHint}`;
+        const items = [
+            `▸ ${info?.frameCount ?? "?"} frames`,
+            `▸ ${cpText}`,
+            ...(config.extend ? ["▸ Extending"] : []),
+            ...(expectedRom ? [`▸ Load ${expectedRom}`] : []),
+        ];
+        autorunStatusEl.innerHTML = items.map(t => `<li>${t}</li>`).join("");
         autorunCancelBtn?.classList.remove("hidden");
     }
 }
@@ -1098,7 +1106,6 @@ const AUDIO_TARGET_LATENCY = 0.1; // seconds
 const AUDIO_MAX_ADJUST = 0.005; // +/- 0.5% playback rate
 const AUDIO_LATENCY_GAIN = 0.1; // scale factor for latency correction
 let audioMuted = false;
-let gamepadEnabled = true;
 let lastGamepadState1 = {
     a: false,
     b: false,
@@ -1182,6 +1189,9 @@ async function refreshSaveStateController() {
 romInput!.addEventListener("change", async (e) => {
     const file = (e.target as HTMLInputElement).files?.[0];
     if (!file) return;
+    // Clear bundled ROM selection when a file is chosen
+    if (romSelect) romSelect.value = "";
+    romFromFile = true;
     requestPointerLockFromUserGesture();
     const expectedRom = autorunCtx.getExpectedRomName();
     if (expectedRom && file.name.toLowerCase() !== expectedRom.toLowerCase()) {
@@ -1202,6 +1212,9 @@ if (romSelect) {
     romSelect.addEventListener("change", async (e) => {
         const value = (e.target as HTMLSelectElement).value;
         if (!value) return;
+        // Clear file input when a bundled ROM is selected
+        romInput.value = "";
+        romFromFile = false;
         requestPointerLockFromUserGesture();
         try {
             const response = await fetch(value);
@@ -1366,6 +1379,7 @@ async function start() {
     setStatus("Running...");
     updateAutorunControls();
     updateEmulationButtons();
+    updateSaveStateButtons();
     requestAnimationFrame(step);
 }
 
@@ -1985,6 +1999,7 @@ function stop() {
     updateRecOverlay();
     updateAutorunControls();
     updateEmulationButtons();
+    updateSaveStateButtons();
 }
 
 /**
@@ -2192,7 +2207,7 @@ function step(timestamp: number) {
         shouldRender: frameLimiter.shouldRender(timestamp)
     });
     try {
-        if (gamepadEnabled && nes) {
+        if (nes) {
             pollGamepad();
         }
 
@@ -2267,19 +2282,6 @@ startBtn.addEventListener("click", () => {
     requestPointerLockFromUserGesture();
     void start();
 });
-const gamepadToggleBtn = document.getElementById("gamepad-toggle") as HTMLButtonElement | null;
-function updateGamepadButton() {
-    gamepadToggleBtn!.textContent = gamepadEnabled ? "Gamepad : On" : "Gamepad : Off";
-    gamepadToggleBtn!.setAttribute("aria-pressed", gamepadEnabled ? "true" : "false");
-}
-gamepadToggleBtn!.addEventListener("click", () => {
-    gamepadEnabled = !gamepadEnabled;
-    updateGamepadButton();
-    if (!gamepadEnabled) {
-        resetGamepadState();
-    }
-});
-updateGamepadButton();
 const muteBtn = document.getElementById("mute") as HTMLButtonElement | null;
 function updateMuteButton() {
     muteBtn!.textContent = audioMuted ? "Audio: Off" : "Audio: On";
@@ -2376,9 +2378,7 @@ function updateConnectedGamepads() {
 }
 
 function showPageLoadGamepadInitToast() {
-    if (gamepadEnabled) {
-        toastOverlay.show("Press a button on any connected gamepad");
-    }
+    toastOverlay.show("Press a button on any connected gamepad");
 }
 
 // Initialize connectedGamepads to detect any gamepads already connected on page load
@@ -2840,7 +2840,7 @@ async function loadStateAction() {
 }
 
 function updateSaveStateButtons() {
-    const enabled = Boolean(saveStateController);
+    const enabled = Boolean(saveStateController) && running;
     if (saveStateBtn) saveStateBtn.disabled = !enabled;
     if (loadStateBtn) loadStateBtn.disabled = !enabled || !saveStateAvailable;
 }
@@ -2962,13 +2962,13 @@ function onGamepadConnectionChanged() {
     updateConnectedGamepads();
     updateShortcutHelpOverlayText();
     ensureWasmInitialized()
-        .then(() => toastOverlay.show(gamepad_init_toast_message(gamepadEnabled, connectedGamepads.length)))
+        .then(() => toastOverlay.show(gamepad_init_toast_message(true, connectedGamepads.length)))
         .catch(() => {});
 }
 
 window.addEventListener("gamepadconnected", () => {
     onGamepadConnectionChanged();
-    if (gamepadEnabled && running && !paused) {
+    if (running && !paused) {
         pollGamepad();
     }
 });

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -45,6 +45,7 @@ import {
     shouldForwardArkanoidMouseInput,
     shouldKeepPointerLocked,
 } from "./input/pointer_lock";
+import { computeButtonStates } from "./ui/emulation_controls";
 
 const statusEl = document.getElementById("status");
 const startBtn = document.getElementById("start") as HTMLButtonElement;
@@ -865,7 +866,6 @@ const recOverlay = document.getElementById("rec-overlay");
  * Update autorun-related UI controls based on current state.
  *
  * - Gates "Create autorun" checkbox: disabled when running or paused.
- * - Updates Start/Stop button labels based on recording mode.
  * - Refreshes autorun status display.
  */
 function updateAutorunControls() {
@@ -874,17 +874,35 @@ function updateAutorunControls() {
         autorunCreateCheckbox.disabled = running || paused;
     }
 
-    // Update Start/Stop button labels
-    const isRecording = autorunCtx.isCreateRecording();
-    if (startBtn) {
-        startBtn.textContent = isRecording ? "Start Recording" : "Start";
-    }
-    const stopBtnEl = document.getElementById("stop");
-    if (stopBtnEl) {
-        stopBtnEl.textContent = isRecording ? "Stop Recording" : "Stop";
-    }
-
     updateAutorunStatus();
+}
+
+/**
+ * Centralized emulation button state update.
+ * Computes enabled/disabled and label for Start, Pause, Reset, Stop
+ * based on current emulation state, and applies the result to the DOM.
+ */
+function updateEmulationButtons() {
+    const states = computeButtonStates({
+        romLoaded: romBytes !== null,
+        running,
+        paused,
+        isRecording: autorunCtx.isCreateRecording(),
+    });
+    startBtn.disabled = !states.startEnabled;
+    startBtn.textContent = states.startLabel;
+    // pauseBtn, stopBtn, resetBtn are module-level and non-null (checked at init)
+    if (pauseBtn) {
+        pauseBtn.disabled = !states.pauseEnabled;
+        pauseBtn.textContent = states.pauseLabel;
+    }
+    if (stopBtn) {
+        stopBtn.disabled = !states.stopEnabled;
+        stopBtn.textContent = states.stopLabel;
+    }
+    if (resetBtn) {
+        resetBtn.disabled = !states.resetEnabled;
+    }
 }
 
 /** Update the recording overlay (REC : MM:SS) on the canvas. */
@@ -951,6 +969,7 @@ if (autorunCreateCheckbox) {
             autorunCtx.clearLoadedFile();
         }
         updateAutorunControls();
+        updateEmulationButtons();
     });
 }
 
@@ -960,6 +979,7 @@ if (autorunCancelBtn) {
         autorunCtx.setCreateRecording(false);
         if (autorunCreateCheckbox) autorunCreateCheckbox.checked = false;
         updateAutorunControls();
+        updateEmulationButtons();
     });
 }
 
@@ -1115,6 +1135,7 @@ async function applyRomBytes(bytes: Uint8Array, name: string) {
     setStatus(`Loaded ROM: ${name} (${romBytes.length} bytes)`);
     stopIdleScroller();
     await refreshSaveStateController();
+    updateEmulationButtons();
 }
 
 async function refreshSaveStateController() {
@@ -1272,7 +1293,7 @@ async function start() {
     startBtn!.disabled = true;
     if (!romBytes) {
         setStatus("Please choose a ROM first", true);
-        startBtn!.disabled = false;
+        updateEmulationButtons();
         return;
     }
     stopIdleScroller();
@@ -1331,7 +1352,7 @@ async function start() {
     } catch (err: unknown) {
         drainNesToasts(nes, toastOverlay);
         setStatus(`Failed to load ROM: ${err}`, true);
-        startBtn!.disabled = false;
+        updateEmulationButtons();
         // Only reset nes if wasm/webgl initialization failed
         // Don't reset on simple ROM load errors so we can retry
         if (err instanceof Error && err.message.includes("WebGL")) {
@@ -1342,9 +1363,9 @@ async function start() {
     }
     running = true;
     paused = false;
-    // Keep start button disabled while running; it is re-enabled in stop().
     setStatus("Running...");
     updateAutorunControls();
+    updateEmulationButtons();
     requestAnimationFrame(step);
 }
 
@@ -1364,6 +1385,7 @@ function pauseResume() {
         setStatus("Paused");
     }
     updateAutorunControls();
+    updateEmulationButtons();
 }
 
 let debuggerHexdumpError = "";
@@ -1950,7 +1972,6 @@ function stop() {
 
     running = false;
     paused = false;
-    startBtn!.disabled = false;
     clearCanvas();
     lastFrameTime = 0;
     frameLimiter.reset();
@@ -1963,6 +1984,7 @@ function stop() {
     setStatus("Stopped. You can restart or load a new ROM");
     updateRecOverlay();
     updateAutorunControls();
+    updateEmulationButtons();
 }
 
 /**
@@ -2229,7 +2251,7 @@ function step(timestamp: number) {
         }
     } catch (err) {
         running = false;
-        startBtn.disabled = false;
+        updateEmulationButtons();
         romInput.disabled = false;
         setStatus(`Emulation error: ${err}`, true);
         if (console && typeof console.error === "function") {
@@ -2283,9 +2305,9 @@ muteBtn!.addEventListener("click", async () => {
     }
 });
 updateMuteButton();
-const pauseBtn = document.getElementById("pause");
-const stopBtn = document.getElementById("stop");
-const resetBtn = document.getElementById("reset");
+const pauseBtn = document.getElementById("pause") as HTMLButtonElement | null;
+const stopBtn = document.getElementById("stop") as HTMLButtonElement | null;
+const resetBtn = document.getElementById("reset") as HTMLButtonElement | null;
 if (!pauseBtn || !stopBtn || !resetBtn) {
     throw new Error("Pause/Stop/Reset buttons not found in DOM");
 }
@@ -2312,6 +2334,8 @@ async function populateRomSelect() {
 }
 
 populateRomSelect();
+// Set initial button states (all disabled until a ROM is loaded)
+updateEmulationButtons();
 
 // Keyboard input mappings for both controllers
 // Controller 1: W=Up, S=Down, A=Left, D=Right, R=Y, T=X, F=B, G=A, Q=L, E=R, 4=Select, 5=Start
@@ -2797,6 +2821,7 @@ function cancelActiveRecording() {
     if (autorunCreateCheckbox) autorunCreateCheckbox.checked = false;
     updateRecOverlay();
     updateAutorunControls();
+    updateEmulationButtons();
     toastOverlay.show("Recording cancelled");
 }
 

--- a/web/src/audio/frame_limiter.test.ts
+++ b/web/src/audio/frame_limiter.test.ts
@@ -8,8 +8,7 @@ it("frame limiter throttles above 60Hz", () => {
 
     expect(limiter.shouldRender(0)).toBe(true);
     expect(limiter.shouldRender(8)).toBe(false);
-    expect(limiter.shouldRender(16)).toBe(false);
-    expect(limiter.shouldRender(17)).toBe(true);
+    expect(limiter.shouldRender(16)).toBe(true);  // within jitter tolerance of 16.67ms
 });
 
 it("frame limiter allows resume after reset", () => {
@@ -26,11 +25,28 @@ it("frame limiter allows resume after reset", () => {
 it("frame limiter stays stable under jitter", () => {
     const limiter = createFrameLimiter(60);
 
+    // Simulate rAF jitter around 16.67ms target:
+    // Frames arriving slightly early should still render (within tolerance)
     expect(limiter.shouldRender(0)).toBe(true);
-    expect(limiter.shouldRender(10)).toBe(false);
-    expect(limiter.shouldRender(20)).toBe(true);
-    expect(limiter.shouldRender(28)).toBe(false);
-    expect(limiter.shouldRender(40)).toBe(true);
+    expect(limiter.shouldRender(8)).toBe(false);    // 8ms, too early
+    expect(limiter.shouldRender(16)).toBe(true);    // 8ms later = 16ms total, within tolerance
+    expect(limiter.shouldRender(24)).toBe(false);   // 8ms since last render
+    expect(limiter.shouldRender(33)).toBe(true);    // 17ms since last render = ~16ms
+});
+
+it("frame limiter does not render at 30Hz when display matches target", () => {
+    // Regression: on a 60Hz display targeting NTSC (~60.1fps), minor jitter
+    // should not cause the limiter to skip every other frame (producing 30fps).
+    const limiter = createFrameLimiter(60.0988); // NTSC
+    const RAF_INTERVAL = 16.667; // 60Hz display
+
+    expect(limiter.shouldRender(0)).toBe(true);
+    // Simulate 10 consecutive rAF calls: all should render
+    let rendered = 0;
+    for (let i = 1; i <= 10; i++) {
+        if (limiter.shouldRender(i * RAF_INTERVAL)) rendered++;
+    }
+    expect(rendered).toBe(10);
 });
 
 it("frame limiter updates target fps", () => {

--- a/web/src/audio/frame_limiter.ts
+++ b/web/src/audio/frame_limiter.ts
@@ -2,6 +2,10 @@ export function createFrameLimiter(targetFps = 60) {
     let targetFrameMs = 1000 / targetFps;
     let lastTime: number | null = null;
     let accumulator = 0;
+    // Tolerance to prevent frame skips from minor rAF jitter.
+    // Without this, a 60Hz display targeting ~60fps can alternate between
+    // "just under" and "just over" the threshold, halving effective FPS.
+    const JITTER_TOLERANCE_MS = 1.5;
     return {
         shouldRender(timestamp: number) {
             if (typeof timestamp !== "number") {
@@ -21,11 +25,18 @@ export function createFrameLimiter(targetFps = 60) {
             lastTime = timestamp;
             accumulator += delta;
 
-            if (accumulator < targetFrameMs) {
+            if (accumulator < targetFrameMs - JITTER_TOLERANCE_MS) {
                 return false;
             }
 
-            accumulator %= targetFrameMs;
+            // When within tolerance but below target, reset to 0
+            // (frame arrived slightly early — consume the timing debt).
+            // When at or above target, use modulo to handle multi-frame catch-up.
+            if (accumulator >= targetFrameMs) {
+                accumulator %= targetFrameMs;
+            } else {
+                accumulator = 0;
+            }
             return true;
         },
         setTargetFps(nextFps: number) {

--- a/web/src/ui/emulation_controls.test.ts
+++ b/web/src/ui/emulation_controls.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { computeButtonStates } from "./emulation_controls";
+
+describe("computeButtonStates", () => {
+    // ── Stopped, no ROM ──────────────────────────────────────────────────
+    it("disables all buttons when stopped with no ROM", () => {
+        const s = computeButtonStates({ romLoaded: false, running: false, paused: false, isRecording: false });
+        expect(s.startEnabled).toBe(false);
+        expect(s.pauseEnabled).toBe(false);
+        expect(s.resetEnabled).toBe(false);
+        expect(s.stopEnabled).toBe(false);
+    });
+
+    // ── Stopped, ROM loaded ──────────────────────────────────────────────
+    it("enables only Start when stopped with a ROM loaded", () => {
+        const s = computeButtonStates({ romLoaded: true, running: false, paused: false, isRecording: false });
+        expect(s.startEnabled).toBe(true);
+        expect(s.pauseEnabled).toBe(false);
+        expect(s.resetEnabled).toBe(false);
+        expect(s.stopEnabled).toBe(false);
+    });
+
+    // ── Running ──────────────────────────────────────────────────────────
+    it("disables Start and enables Pause/Reset/Stop when running", () => {
+        const s = computeButtonStates({ romLoaded: true, running: true, paused: false, isRecording: false });
+        expect(s.startEnabled).toBe(false);
+        expect(s.pauseEnabled).toBe(true);
+        expect(s.resetEnabled).toBe(true);
+        expect(s.stopEnabled).toBe(true);
+    });
+
+    // ── Paused ───────────────────────────────────────────────────────────
+    it("keeps Pause/Reset/Stop enabled when paused", () => {
+        const s = computeButtonStates({ romLoaded: true, running: true, paused: true, isRecording: false });
+        expect(s.startEnabled).toBe(false);
+        expect(s.pauseEnabled).toBe(true);
+        expect(s.resetEnabled).toBe(true);
+        expect(s.stopEnabled).toBe(true);
+    });
+
+    // ── Pause label ──────────────────────────────────────────────────────
+    it("shows 'Pause' label when running and not paused", () => {
+        const s = computeButtonStates({ romLoaded: true, running: true, paused: false, isRecording: false });
+        expect(s.pauseLabel).toBe("Pause");
+    });
+
+    it("shows 'Resume' label when paused", () => {
+        const s = computeButtonStates({ romLoaded: true, running: true, paused: true, isRecording: false });
+        expect(s.pauseLabel).toBe("Resume");
+    });
+
+    // ── Recording mode labels ────────────────────────────────────────────
+    it("shows 'Start Recording' and 'Stop Recording' when isRecording is true and stopped", () => {
+        const s = computeButtonStates({ romLoaded: true, running: false, paused: false, isRecording: true });
+        expect(s.startLabel).toBe("Start Recording");
+        expect(s.stopLabel).toBe("Stop Recording");
+    });
+
+    it("shows 'Stop Recording' when recording and running", () => {
+        const s = computeButtonStates({ romLoaded: true, running: true, paused: false, isRecording: true });
+        expect(s.stopLabel).toBe("Stop Recording");
+    });
+
+    // ── Default labels ───────────────────────────────────────────────────
+    it("shows default labels when not recording", () => {
+        const s = computeButtonStates({ romLoaded: true, running: false, paused: false, isRecording: false });
+        expect(s.startLabel).toBe("Start");
+        expect(s.stopLabel).toBe("Stop");
+        expect(s.pauseLabel).toBe("Pause");
+    });
+});

--- a/web/src/ui/emulation_controls.ts
+++ b/web/src/ui/emulation_controls.ts
@@ -1,0 +1,30 @@
+export interface EmulationControlState {
+    romLoaded: boolean;
+    running: boolean;
+    paused: boolean;
+    isRecording: boolean;
+}
+
+export interface ButtonStates {
+    startEnabled: boolean;
+    pauseEnabled: boolean;
+    resetEnabled: boolean;
+    stopEnabled: boolean;
+    startLabel: string;
+    pauseLabel: string;
+    stopLabel: string;
+}
+
+export function computeButtonStates(state: EmulationControlState): ButtonStates {
+    const { romLoaded, running, paused, isRecording } = state;
+    const emulationActive = running;
+    return {
+        startEnabled: romLoaded && !running,
+        pauseEnabled: emulationActive,
+        resetEnabled: emulationActive,
+        stopEnabled: emulationActive,
+        startLabel: isRecording ? "Start Recording" : "Start",
+        pauseLabel: paused ? "Resume" : "Pause",
+        stopLabel: isRecording ? "Stop Recording" : "Stop",
+    };
+}

--- a/web/src/ui/sine_scroller.ts
+++ b/web/src/ui/sine_scroller.ts
@@ -38,7 +38,7 @@ export function createSineScroller({
             element.height = height;
             return element;
         })();
-    const ctx = canvas.getContext("2d", { willReadFrequently: true })!;
+    const ctx = canvas.getContext("2d", { willReadFrequently: true });
     if (!ctx) {
         throw new Error("2D canvas context unavailable for sine scroller");
     }

--- a/web/src/ui/sine_scroller.ts
+++ b/web/src/ui/sine_scroller.ts
@@ -38,10 +38,11 @@ export function createSineScroller({
             element.height = height;
             return element;
         })();
-    const ctx = canvas.getContext("2d", { willReadFrequently: true });
-    if (!ctx) {
+    const ctxOrNull = canvas.getContext("2d", { willReadFrequently: true }) as CanvasRenderingContext2D | null;
+    if (!ctxOrNull) {
         throw new Error("2D canvas context unavailable for sine scroller");
     }
+    const ctx: CanvasRenderingContext2D = ctxOrNull;
     ctx.textAlign = "left";
     ctx.textBaseline = "middle";
     const fontString = buildFontString(fontSizePx, fontFamily);

--- a/web/src/ui/sine_scroller.ts
+++ b/web/src/ui/sine_scroller.ts
@@ -38,7 +38,7 @@ export function createSineScroller({
             element.height = height;
             return element;
         })();
-    const ctx = canvas.getContext("2d")!;
+    const ctx = canvas.getContext("2d", { willReadFrequently: true })!;
     if (!ctx) {
         throw new Error("2D canvas context unavailable for sine scroller");
     }


### PR DESCRIPTION
Closes #2061

## Summary

Disables emulation control buttons (Start, Pause, Reset, Stop) when their action has no meaning, preventing UI issues like mouse grab with no ROM loaded.

## Changes

### New module: `web/src/ui/emulation_controls.ts`
- Pure function `computeButtonStates()` takes `{ romLoaded, running, paused, isRecording }` and returns enable/disable state + labels for all buttons
- Easily testable, no DOM dependency

### `web/src/app.ts`
- New `updateEmulationButtons()` applies computed button states to DOM
- Called from: `start()`, `stop()`, `pauseResume()`, `applyRomBytes()`, error handler in `step()`, autorun checkbox/cancel handlers, `cancelActiveRecording()`, and at startup
- Removed scattered `startBtn!.disabled = false` assignments (replaced by centralized function)
- Pause button now shows "Resume" when paused
- `pauseBtn`, `stopBtn`, `resetBtn` now typed as `HTMLButtonElement | null`

### Button behavior
| State | Start | Pause | Reset | Stop |
|-------|-------|-------|-------|------|
| No ROM | disabled | disabled | disabled | disabled |
| ROM loaded, stopped | **enabled** | disabled | disabled | disabled |
| Running | disabled | **enabled** (Pause) | **enabled** | **enabled** |
| Paused | disabled | **enabled** (Resume) | **enabled** | **enabled** |

## Testing
- 9 new unit tests in `emulation_controls.test.ts` covering all state combinations
- All 201 npm tests pass (30 test files)
- WASM tests: 48 passed
- No Rust changes (clippy/fmt/cargo test not needed)
