### PR TITLE
feat: Run Game Boy ROMs in web frontend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "neser"
 version = "0.3.1"
 edition = "2024"
-description = "NESER - NES Emulator in Rust. Desktop (SDL) and WebAssembly frontends."
+description = "NESER - Nintendo Emulation Systems Engine (Rust). Desktop and WebAssembly frontends."
 license = "MIT"
 repository = "https://github.com/rmstdope/neser"
 exclude = [

--- a/src/frontends/web/wasm_gb.rs
+++ b/src/frontends/web/wasm_gb.rs
@@ -1,0 +1,173 @@
+use crate::gb::console::gameboy::GameBoy;
+use crate::platform::app_context::{AppContext, SharedAppContext};
+use crate::platform::frontend_toasts::cartridge_load_toast_message;
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+
+/// Provides a minimal WASM bridge for running the Game Boy emulator in the browser.
+#[wasm_bindgen]
+pub struct WasmGb {
+    gb: GameBoy,
+    audio_muted: bool,
+    rom_loaded: bool,
+    pending_toasts: Vec<String>,
+}
+
+impl Default for WasmGb {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[wasm_bindgen]
+impl WasmGb {
+    fn rgb_to_rgba(rgb: &[u8]) -> Vec<u8> {
+        rgb.chunks_exact(3)
+            .flat_map(|p| [p[0], p[1], p[2], 0xFF])
+            .collect()
+    }
+
+    fn opaque_black_rgba_frame() -> Vec<u8> {
+        let pixel_count = (GameBoy::SCREEN_WIDTH * GameBoy::SCREEN_HEIGHT) as usize;
+        let mut rgba = vec![0u8; pixel_count * 4];
+        for alpha in rgba.iter_mut().skip(3).step_by(4) {
+            *alpha = 0xFF;
+        }
+        rgba
+    }
+
+    fn run_until_frame_ready(&mut self) {
+        while !self.gb.is_frame_ready() {
+            self.gb.run_tick();
+        }
+        self.gb.clear_frame_ready();
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmGb {
+        console_error_panic_hook::set_once();
+        let app_context: SharedAppContext = Rc::new(RefCell::new(AppContext::new_with_config(
+            Default::default(),
+        )));
+        WasmGb {
+            gb: GameBoy::new(app_context),
+            audio_muted: false,
+            rom_loaded: false,
+            pending_toasts: Vec::new(),
+        }
+    }
+
+    /// Load a `.gb` ROM from raw bytes.
+    #[wasm_bindgen]
+    pub fn load_rom(&mut self, rom: &[u8], rom_name: &str) -> Result<(), JsValue> {
+        self.rom_loaded = false;
+        match self.gb.load_rom(rom, rom_name) {
+            Ok(()) => {
+                self.rom_loaded = true;
+                self.gb.set_audio_sample_rate(44100.0);
+                self.pending_toasts
+                    .push(cartridge_load_toast_message(rom_name, true));
+                web_sys::console::log_1(&JsValue::from_str("GB ROM loaded successfully"));
+                Ok(())
+            }
+            Err(err) => {
+                self.pending_toasts
+                    .push(cartridge_load_toast_message(rom_name, false));
+                Err(JsValue::from_str(&err))
+            }
+        }
+    }
+
+    /// Drain any pending toast messages.
+    #[wasm_bindgen]
+    pub fn drain_toasts(&mut self) -> Vec<JsValue> {
+        self.pending_toasts.drain(..).map(JsValue::from).collect()
+    }
+
+    /// Step the emulator until a full frame is ready and return the pixel buffer (RGBA8888).
+    ///
+    /// Returns a `Uint8Array` of `160 × 144 × 4` bytes.
+    /// When no ROM is loaded, returns an opaque black frame.
+    #[wasm_bindgen]
+    pub fn render_frame_rgba(&mut self) -> Vec<u8> {
+        if !self.rom_loaded {
+            return Self::opaque_black_rgba_frame();
+        }
+        self.run_until_frame_ready();
+        let rgb = self.gb.screen_snapshot();
+        Self::rgb_to_rgba(&rgb)
+    }
+
+    /// Returns the display width in pixels (always 160 for Game Boy).
+    #[wasm_bindgen]
+    pub fn screen_width(&self) -> u32 {
+        GameBoy::SCREEN_WIDTH
+    }
+
+    /// Returns the display height in pixels (always 144 for Game Boy).
+    #[wasm_bindgen]
+    pub fn screen_height(&self) -> u32 {
+        GameBoy::SCREEN_HEIGHT
+    }
+
+    /// Returns the nominal Game Boy refresh rate in Hz.
+    ///
+    /// DMG: 4,194,304 Hz / 70,224 cycles per frame ≈ 59.7275 Hz.
+    #[wasm_bindgen]
+    pub fn frame_rate_hz(&self) -> f64 {
+        4_194_304.0 / 70_224.0
+    }
+
+    fn drain_audio_buffer(&mut self) {
+        while self.gb.get_sample().is_some() {}
+    }
+
+    /// Collect all pending audio samples from the APU.
+    ///
+    /// Returns a `Float32Array`. Call after each `render_frame_rgba`.
+    #[wasm_bindgen]
+    pub fn get_audio_samples(&mut self) -> Vec<f32> {
+        if self.audio_muted {
+            self.drain_audio_buffer();
+            return Vec::new();
+        }
+        let mut samples = Vec::new();
+        while let Some(s) = self.gb.get_sample() {
+            samples.push(s);
+        }
+        samples
+    }
+
+    /// Set audio mute state.
+    #[wasm_bindgen]
+    pub fn set_audio_muted(&mut self, muted: bool) {
+        self.audio_muted = muted;
+        if muted {
+            self.drain_audio_buffer();
+        }
+    }
+
+    /// Returns `true` if audio is currently muted.
+    #[wasm_bindgen]
+    pub fn is_audio_muted(&self) -> bool {
+        self.audio_muted
+    }
+
+    /// Set button state for the Game Boy joypad.
+    ///
+    /// Uses NES-convention IDs: A=0, B=1, Select=2, Start=3, Up=4, Down=5, Left=6, Right=7.
+    /// Only controller port 1 is used (Game Boy has a single joypad).
+    #[wasm_bindgen]
+    pub fn set_button(&mut self, controller: u8, button: u8, pressed: bool) {
+        if controller == 1 {
+            self.gb.set_button(button, pressed);
+        }
+    }
+
+    /// Reset the emulator.
+    #[wasm_bindgen]
+    pub fn reset(&mut self, soft_reset: bool) {
+        self.gb.reset(soft_reset);
+    }
+}

--- a/src/frontends/web/wasm_tests.rs
+++ b/src/frontends/web/wasm_tests.rs
@@ -4,6 +4,7 @@ use crate::nes::bus::ControllerStateWrapper;
 use crate::nes::console::SaveState;
 use crate::nes::input::ArkanoidState;
 use crate::wasm::{WasmNes, gamepad_init_toast_message};
+use crate::wasm_gb::WasmGb;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -837,5 +838,91 @@ fn debugger_snapshot_json_reset_vector_matches_rom_header() {
     assert!(
         json.contains("\"reset_vector\":32768"),
         "expected reset_vector:32768 ($8000) in snapshot JSON: {json}"
+    );
+}
+
+// ── WasmGb tests ─────────────────────────────────────────────────────────────
+
+/// Minimal valid DMG ROM: 32 KB ROM-only cartridge with correct header checksum.
+fn minimal_gb_rom() -> Vec<u8> {
+    let mut rom = vec![0u8; 0x8000];
+    rom[0x0147] = 0x00; // ROM only
+    rom[0x0148] = 0x00; // 32 KB
+    rom[0x0149] = 0x00; // no RAM
+    // Header checksum: sum of bytes $0134–$014C, each negated-and-decremented.
+    let chk = rom[0x0134..=0x014C]
+        .iter()
+        .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+    rom[0x014D] = chk;
+    rom
+}
+
+#[wasm_bindgen_test]
+fn wasm_gb_constructs() {
+    let _gb = WasmGb::new();
+}
+
+#[wasm_bindgen_test]
+fn wasm_gb_screen_width_is_160() {
+    let gb = WasmGb::new();
+    assert_eq!(gb.screen_width(), 160);
+}
+
+#[wasm_bindgen_test]
+fn wasm_gb_screen_height_is_144() {
+    let gb = WasmGb::new();
+    assert_eq!(gb.screen_height(), 144);
+}
+
+#[wasm_bindgen_test]
+fn wasm_gb_frame_rate_hz_is_dmg_rate() {
+    let gb = WasmGb::new();
+    let hz = gb.frame_rate_hz();
+    // DMG: 4,194,304 / 70,224 ≈ 59.7275
+    assert!(
+        (hz - 59.7275).abs() < 0.001,
+        "expected ~59.7275 Hz but got {hz}"
+    );
+}
+
+#[wasm_bindgen_test]
+fn wasm_gb_no_rom_renders_opaque_black_frame() {
+    let mut gb = WasmGb::new();
+    let frame = gb.render_frame_rgba();
+    // Without a ROM, expect a fully opaque black frame (160 × 144 pixels × 4 bytes).
+    let expected_len = 160 * 144 * 4;
+    assert_eq!(
+        frame.len(),
+        expected_len,
+        "no-ROM frame should be {expected_len} bytes"
+    );
+    // Every alpha byte must be 0xFF (opaque).
+    for (i, &byte) in frame.iter().enumerate() {
+        if (i + 1) % 4 == 0 {
+            assert_eq!(byte, 0xFF, "alpha byte at index {i} should be 0xFF");
+        }
+    }
+    // Every RGB byte must be 0 (black).
+    for (i, &byte) in frame.iter().enumerate() {
+        if (i + 1) % 4 != 0 {
+            assert_eq!(byte, 0x00, "color byte at index {i} should be 0x00");
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+fn wasm_gb_load_rom_returns_success_toast() {
+    let mut gb = WasmGb::new();
+    let rom = minimal_gb_rom();
+    gb.load_rom(&rom, "test.gb")
+        .expect("valid GB ROM should load successfully");
+    let toasts: Vec<String> = gb
+        .drain_toasts()
+        .into_iter()
+        .filter_map(|v| v.as_string())
+        .collect();
+    assert!(
+        toasts.iter().any(|t| t.contains("test.gb")),
+        "expected a toast mentioning 'test.gb', got: {toasts:?}"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ pub mod platform;
 pub mod wasm;
 #[path = "frontends/web/wasm_autorun_state.rs"]
 pub mod wasm_autorun;
+#[cfg(feature = "wasm")]
+#[path = "frontends/web/wasm_gb.rs"]
+pub mod wasm_gb;
 #[cfg(all(test, feature = "wasm", target_arch = "wasm32"))]
 #[path = "frontends/web/wasm_tests.rs"]
 mod wasm_tests;

--- a/web/index.html
+++ b/web/index.html
@@ -69,7 +69,7 @@
           </div>
 
           <!-- Autorun controls -->
-          <div class="flex flex-col gap-2">
+          <div id="autorun-section" class="flex flex-col gap-2">
             <label class="label cursor-pointer justify-start gap-2 p-0">
               <input type="checkbox" id="autorun-create" class="checkbox checkbox-sm" disabled />
               <span class="label-text text-xs">Create autorun</span>
@@ -87,7 +87,7 @@
               <button id="reset" class="btn btn-warning btn-outline btn-sm flex-1" aria-label="Reset emulation">Reset</button>
             </div>
             <button id="stop" class="btn btn-error btn-outline btn-sm w-full" aria-label="Stop emulation">Stop</button>
-            <div class="flex gap-2">
+            <div id="save-state-section" class="flex gap-2">
               <button id="save-state" class="btn btn-warning btn-outline btn-sm flex-1" disabled>Save State</button>
               <button id="load-state" class="btn btn-warning btn-outline btn-sm flex-1" disabled>Load State</button>
             </div>

--- a/web/index.html
+++ b/web/index.html
@@ -62,7 +62,7 @@
           <!-- ROM controls -->
           <div class="flex flex-col gap-2">
             <label for="rom" class="label text-xs">ROM file</label>
-            <input type="file" id="rom" accept=".nes" class="file-input file-input-bordered file-input-sm w-full" />
+            <input type="file" id="rom" accept=".nes,.gb" class="file-input file-input-bordered file-input-sm w-full" />
             <select id="rom-select" class="select select-bordered select-sm w-full" aria-label="Select ROM from server">
               <option value="">Select bundled ROM…</option>
             </select>

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1,4 +1,4 @@
-import init, { WasmNes, gamepad_init_toast_message } from "../pkg/neser";
+import init, { WasmNes, WasmGb, gamepad_init_toast_message } from "../pkg/neser";
 import { mapStandardGamepadState, selectGamepads } from "./input/gamepad";
 import {
     createRomSaveKey,
@@ -838,6 +838,11 @@ function cycleFilter() {
     return true;
 }
 
+type ActiveEmulator = { kind: "nes"; inst: WasmNes } | { kind: "gb"; inst: WasmGb };
+
+/** Master emulator state — set to NES or GB depending on the loaded ROM. */
+let emulator: ActiveEmulator | null = null;
+/** Convenience alias for NES-specific code paths. Non-null only when emulator.kind === "nes". */
 let nes: WasmNes | null = null;
 let romBytes: Uint8Array | null = null;
 let romMetadata: { name: string; size: number; bytes: Uint8Array } | null = null;
@@ -907,6 +912,42 @@ function updateEmulationButtons() {
     // Load autorun button: available when a ROM is loaded from file and emulation is stopped
     if (autorunLoadBtn) {
         autorunLoadBtn.disabled = romBytes === null || !romFromFile || running;
+    }
+}
+
+/** Create a fresh NES or GB emulator instance and update kind-dependent UI. */
+function createEmulatorInstance(ext: string): void {
+    if (ext === "gb") {
+        const gb = new WasmGb();
+        emulator = { kind: "gb", inst: gb };
+        nes = null;
+    } else {
+        nes = new WasmNes();
+        emulator = { kind: "nes", inst: nes };
+    }
+    updateNesDisplayDimensions();
+    updateEmulatorKindUI();
+}
+
+/**
+ * Show or hide NES-only UI elements depending on which emulator is active.
+ * Called whenever the emulator kind changes (NES ↔ GB).
+ */
+function updateEmulatorKindUI() {
+    const isNes = emulator?.kind === "nes";
+    // Debugger panel is NES-only
+    if (debuggerPanel) {
+        debuggerPanel.style.display = isNes ? "" : "none";
+    }
+    // Autorun controls are NES-only
+    const autorunSection = document.getElementById("autorun-section");
+    if (autorunSection) {
+        autorunSection.style.display = isNes ? "" : "none";
+    }
+    // Save-state buttons are NES-only
+    const saveStateSection = document.getElementById("save-state-section");
+    if (saveStateSection) {
+        saveStateSection.style.display = isNes ? "" : "none";
     }
 }
 
@@ -1083,15 +1124,15 @@ if (autorunUseBtn) {
 }
 
 /**
- * Update NES display dimensions from the WASM instance and reallocate the GL texture.
- * Must be called after `nes` is created so overscan is reflected.
+ * Update display dimensions from the active emulator instance and reallocate the GL texture.
+ * Must be called after `emulator` is created so the correct resolution is reflected.
  */
 function updateNesDisplayDimensions() {
-    if (!nes) return;
-    width = nes.screen_width();
-    height = nes.screen_height();
+    if (!emulator) return;
+    width = emulator.inst.screen_width();
+    height = emulator.inst.screen_height();
     NES_ASPECT_RATIO = width / height;
-    // Reallocate the NES texture with the correct (cropped) dimensions.
+    // Reallocate the texture with the correct dimensions.
     if (nesTexture) {
         gl.bindTexture(gl.TEXTURE_2D, nesTexture);
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
@@ -1151,6 +1192,7 @@ async function applyRomBytes(bytes: Uint8Array, name: string) {
 }
 
 async function refreshSaveStateController() {
+    // Save states are NES-only (GB save states are not supported in MVP).
     if (!nes || !romMetadata) {
         saveStateController = null;
         saveStateAvailable = false;
@@ -1314,66 +1356,84 @@ async function start() {
         updateEmulationButtons();
         return;
     }
+    const romName = romMetadata?.name ?? "selected-rom.nes";
+    const ext = romName.toLowerCase().split(".").pop() ?? "";
+
+    // Reject unsupported file types before any async work.
+    if (ext !== "nes" && ext !== "gb") {
+        toastOverlay.show(`Unsupported file type .${ext} — only .nes and .gb are supported`);
+        setStatus(`Unsupported file type .${ext}`, true);
+        updateEmulationButtons();
+        return;
+    }
+
     stopIdleScroller();
     setStatus("Initializing emulator...");
     try {
-        if (!nes) {
+        if (!emulator) {
             await ensureWasmInitialized();
 
-            // Initialize WebGL shaders before creating NES instance
+            // Initialize WebGL shaders before creating the emulator instance
             if (!initWebGL()) {
                 throw new Error("Failed to initialize WebGL");
             }
 
-            nes = new WasmNes();
-            updateNesDisplayDimensions();
-        }
-        const romName = romMetadata?.name || "selected-rom.nes";
-
-        // ── Autorun setup: configure before loading ROM ─────────────────────
-        const autorunConfig = autorunCtx.getActiveConfig();
-        if (autorunConfig?.mode === "record") {
-            nes.start_autorun_recording();
-        } else {
-            nes.clear_autorun();
+            createEmulatorInstance(ext);
+        } else if (emulator.kind !== ext) {
+            // Switching emulator kind (NES ↔ GB).
+            createEmulatorInstance(ext);
         }
 
-        nes.load_rom(romBytes, romName);
-        drainNesToasts(nes, toastOverlay);
-
-        // ── Autorun setup: playback / extend – after ROM is loaded ───────────
-        if (autorunConfig?.mode === "playback") {
-            try {
-                const pendingRestore = nes.load_autorun_playback(
-                    autorunConfig.bytes!,
-                    autorunConfig.checkpointIdx ?? -1,
-                    autorunConfig.extend ?? false
-                );
-                if (pendingRestore && pendingRestore.length > 0) {
-                    nes.load_state_bytes(pendingRestore);
-                }
-            } catch (autorunErr) {
-                console.error("Failed to load autorun for playback:", autorunErr);
-                toastOverlay.show(`Autorun load failed: ${autorunErr}`);
+        // ── NES-only: Autorun setup (configure before loading ROM) ──────────
+        if (nes) {
+            const autorunConfig = autorunCtx.getActiveConfig();
+            if (autorunConfig?.mode === "record") {
+                nes.start_autorun_recording();
+            } else {
                 nes.clear_autorun();
             }
         }
 
-        frameLimiter.setTargetFps(nes.frame_rate_hz());
+        emulator!.inst.load_rom(romBytes, romName);
+        drainNesToasts(emulator?.inst ?? null, toastOverlay);
+
+        // ── NES-only: Autorun setup (playback/extend – after ROM is loaded) ──
+        if (nes) {
+            const autorunConfig = autorunCtx.getActiveConfig();
+            if (autorunConfig?.mode === "playback") {
+                try {
+                    const pendingRestore = nes.load_autorun_playback(
+                        autorunConfig.bytes!,
+                        autorunConfig.checkpointIdx ?? -1,
+                        autorunConfig.extend ?? false
+                    );
+                    if (pendingRestore && pendingRestore.length > 0) {
+                        nes.load_state_bytes(pendingRestore);
+                    }
+                } catch (autorunErr) {
+                    console.error("Failed to load autorun for playback:", autorunErr);
+                    toastOverlay.show(`Autorun load failed: ${autorunErr}`);
+                    nes.clear_autorun();
+                }
+            }
+        }
+
+        frameLimiter.setTargetFps(emulator!.inst.frame_rate_hz());
         // Initialize audio context on user interaction (browser requirement)
         initAudioContext();
-        nes.set_audio_muted(audioMuted);
+        emulator!.inst.set_audio_muted(audioMuted);
         await refreshSaveStateController();
-        
+
         // Update pointer visibility and Zapper overlay after ROM is loaded
         updateMouseCursorState();
     } catch (err: unknown) {
-        drainNesToasts(nes, toastOverlay);
+        drainNesToasts(emulator?.inst ?? null, toastOverlay);
         setStatus(`Failed to load ROM: ${err}`, true);
         updateEmulationButtons();
-        // Only reset nes if wasm/webgl initialization failed
+        // Only reset emulator if wasm/webgl initialization failed
         // Don't reset on simple ROM load errors so we can retry
         if (err instanceof Error && err.message.includes("WebGL")) {
+            emulator = null;
             nes = null;
             webglInitialized = false;
         }
@@ -1975,7 +2035,7 @@ function debuggerHexdumpGoToAddress() {
 }
 
 function stop() {
-    // ── Autorun teardown: download recording if active ────────────────────
+    // ── NES-only: Autorun teardown ────────────────────────────────────────
     if (nes && nes.autorun_is_recording()) {
         const recordingBytes = nes.stop_autorun();
         if (recordingBytes && recordingBytes.length > 0) {
@@ -2212,7 +2272,7 @@ function step(timestamp: number) {
         shouldRender: frameLimiter.shouldRender(timestamp)
     });
     try {
-        if (nes) {
+        if (emulator) {
             pollGamepad();
         }
 
@@ -2221,10 +2281,10 @@ function step(timestamp: number) {
             return;
         }
 
-        const frame = nes!.render_frame_rgba(); // RGBA8888
+        const frame = emulator!.inst.render_frame_rgba(); // RGBA8888
 
-        // Stop when pure autorun playback has consumed all recorded frames
-        if (nes!.autorun_playback_finished()) {
+        // Stop when pure NES autorun playback has consumed all recorded frames
+        if (nes?.autorun_playback_finished()) {
             stop();
             setStatus("Autorun playback complete.");
             return;
@@ -2251,7 +2311,7 @@ function step(timestamp: number) {
         frameCount = (frameCount + 1) % 3600;
 
         // Get and play audio samples
-        const audioSamples = nes!.get_audio_samples();
+        const audioSamples = emulator!.inst.get_audio_samples();
         if (audioSamples.length > 0) {
             playAudioSamples(audioSamples);
         }
@@ -2296,8 +2356,8 @@ function updateMuteButton() {
 muteBtn!.addEventListener("click", async () => {
     audioMuted = !audioMuted;
     updateMuteButton();
-    if (nes) {
-        nes.set_audio_muted(audioMuted);
+    if (emulator) {
+        emulator.inst.set_audio_muted(audioMuted);
     }
     if (audioContext) {
         try {
@@ -2439,15 +2499,21 @@ function applyKeyboardMapping(event: KeyboardEvent, mapping: { button?: number; 
     }
     event.preventDefault();
 
-    if (mapping.snesButton !== undefined) {
-        const handledAsSnes = nes!.set_snes_button(controller, mapping.snesButton, pressed);
+    // NES-specific: try SNES button mapping first.
+    if (nes && mapping.snesButton !== undefined) {
+        const handledAsSnes = nes.set_snes_button(controller, mapping.snesButton, pressed);
         if (handledAsSnes) {
             return;
         }
     }
 
     if (mapping.button !== undefined) {
-        applyJoypadButtonIfAllowed(nes!, controller, mapping.button, pressed);
+        if (nes) {
+            applyJoypadButtonIfAllowed(nes, controller, mapping.button, pressed);
+        } else if (emulator) {
+            // GB: direct button routing (no mouse/zapper suppression needed).
+            emulator.inst.set_button(controller, mapping.button, pressed);
+        }
     }
 }
 
@@ -2473,7 +2539,7 @@ async function handleKeyDown(event: KeyboardEvent) {
         return;
     }
 
-    if (!nes && event.code !== "KeyH") {
+    if (!emulator && event.code !== "KeyH") {
         return;
     }
 
@@ -2482,11 +2548,12 @@ async function handleKeyDown(event: KeyboardEvent) {
         return;
     }
 
-    if (!nes) {
+    if (!emulator) {
         return;
     }
 
-    if (nes.is_debugger_open()) {
+    // NES-only: block keyboard input while debugger is open.
+    if (nes?.is_debugger_open()) {
         return;
     }
 
@@ -2505,11 +2572,12 @@ function handleKeyUp(event: KeyboardEvent) {
         return;
     }
 
-    if (!nes) {
+    if (!emulator) {
         return;
     }
 
-    if (nes.is_debugger_open()) {
+    // NES-only: block keyboard input while debugger is open.
+    if (nes?.is_debugger_open()) {
         return;
     }
 
@@ -2806,16 +2874,16 @@ async function toggleScreenFullscreen() {
 }
 
 function resetAction() {
-    if (!nes) return;
+    if (!emulator) return;
     cancelActiveRecording();
-    nes.reset(true);
+    emulator.inst.reset(true);
     setStatus("Soft reset", false);
 }
 
 function hardResetAction() {
-    if (!nes) return;
+    if (!emulator) return;
     cancelActiveRecording();
-    nes.reset(false);
+    emulator.inst.reset(false);
     setStatus("Hard reset", false);
 }
 
@@ -2920,31 +2988,22 @@ interface GamepadButtonState {
 }
 
 function applyGamepadState(state: GamepadButtonState, controller: number, lastState: GamepadButtonState) {
-    if (!nes) return;
-    if (state.a !== lastState.a) {
-        applyJoypadButtonIfAllowed(nes, controller, 0, state.a);
-    }
-    if (state.b !== lastState.b) {
-        applyJoypadButtonIfAllowed(nes, controller, 1, state.b);
-    }
-    if (state.select !== lastState.select) {
-        applyJoypadButtonIfAllowed(nes, controller, 2, state.select);
-    }
-    if (state.start !== lastState.start) {
-        applyJoypadButtonIfAllowed(nes, controller, 3, state.start);
-    }
-    if (state.up !== lastState.up) {
-        applyJoypadButtonIfAllowed(nes, controller, 4, state.up);
-    }
-    if (state.down !== lastState.down) {
-        applyJoypadButtonIfAllowed(nes, controller, 5, state.down);
-    }
-    if (state.left !== lastState.left) {
-        applyJoypadButtonIfAllowed(nes, controller, 6, state.left);
-    }
-    if (state.right !== lastState.right) {
-        applyJoypadButtonIfAllowed(nes, controller, 7, state.right);
-    }
+    if (!emulator) return;
+    const applyButton = (button: number, pressed: boolean) => {
+        if (nes) {
+            applyJoypadButtonIfAllowed(nes, controller, button, pressed);
+        } else {
+            emulator!.inst.set_button(controller, button, pressed);
+        }
+    };
+    if (state.a !== lastState.a) applyButton(0, state.a);
+    if (state.b !== lastState.b) applyButton(1, state.b);
+    if (state.select !== lastState.select) applyButton(2, state.select);
+    if (state.start !== lastState.start) applyButton(3, state.start);
+    if (state.up !== lastState.up) applyButton(4, state.up);
+    if (state.down !== lastState.down) applyButton(5, state.down);
+    if (state.left !== lastState.left) applyButton(6, state.left);
+    if (state.right !== lastState.right) applyButton(7, state.right);
 }
 
 function resetGamepadState() {

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -951,6 +951,17 @@ function updateEmulatorKindUI() {
     if (saveStateSection) {
         saveStateSection.style.display = isNes ? "" : "none";
     }
+    // Filters are NES-only for now: force "None" (stock) for GB and disable the button
+    if (!isNes) {
+        if (currentFilter !== "stock") {
+            currentFilter = "stock";
+            initWebGL();
+        }
+        filterToggleBtn.disabled = true;
+    } else {
+        filterToggleBtn.disabled = false;
+    }
+    updateFilterToggleButtonLabel();
 }
 
 /** Update the recording overlay (REC : MM:SS) on the canvas. */

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -917,6 +917,8 @@ function updateEmulationButtons() {
 
 /** Create a fresh NES or GB emulator instance and update kind-dependent UI. */
 function createEmulatorInstance(ext: string): void {
+    // Free the previous WASM instance to avoid leaking its linear memory.
+    emulator?.inst.free();
     if (ext === "gb") {
         const gb = new WasmGb();
         emulator = { kind: "gb", inst: gb };
@@ -1310,11 +1312,17 @@ function playAudioSamples(samples: Float32Array) {
     const channelData = buffer.getChannelData(0);
 
     // Normalize and copy samples to the buffer
-    // NES APU outputs 0.0 to ~1.177, normalize to 0.0 to 1.0 for Web Audio
-    for (let i = 0; i < samples.length; i++) {
-        // Map NES 0.0-1.177 to Web Audio 0.0-1.0 (0.0 represents silence)
-        const normalized = samples[i] / NES_APU_MAX;
-        channelData[i] = Math.min(1.0, Math.max(0.0, normalized));
+    if (emulator?.kind === "gb") {
+        // GB APU outputs in [0.0, 1.0] — copy directly with a safety clamp
+        for (let i = 0; i < samples.length; i++) {
+            channelData[i] = Math.min(1.0, Math.max(0.0, samples[i]));
+        }
+    } else {
+        // NES APU outputs 0.0 to ~1.177, normalize to 0.0 to 1.0 for Web Audio
+        for (let i = 0; i < samples.length; i++) {
+            const normalized = samples[i] / NES_APU_MAX;
+            channelData[i] = Math.min(1.0, Math.max(0.0, normalized));
+        }
     }
 
     // Create a buffer source and schedule it
@@ -1456,7 +1464,7 @@ function resumeFrameLoop() {
 }
 
 function pauseResume() {
-    if (!nes || !running) return;
+    if (!emulator || !running) return;
     paused = !paused;
     if (!paused) {
         resumeFrameLoop();
@@ -2671,7 +2679,15 @@ function setCrosshairVisible(visible: boolean) {
 }
 
 function updateMouseCursorState() {
-    if (!nes) return;
+    if (!nes) {
+        // No NES active (GB or no emulator): ensure any NES-specific cursor state is cleared.
+        setCrosshairVisible(false);
+        if (document.pointerLockElement === canvas) {
+            document.exitPointerLock?.();
+        }
+        document.body.style.cursor = "";
+        return;
+    }
 
     const zapperActive = isZapperActive(nes);
     const pointerLocked = document.pointerLockElement === canvas;

--- a/web/src/rom/rom_list.test.ts
+++ b/web/src/rom/rom_list.test.ts
@@ -123,3 +123,87 @@ it("fetchRomList avoids duplicating base paths", async () => {
     const paths = entries.map((entry: any) => entry.path);
     expect(paths).toEqual(["automated_tests/instr_test-v5/nestest.nes"]);
 });
+
+// ── Game Boy (.gb) support ──────────────────────────────────────────────────
+
+it("parseDirectoryListing includes .gb files alongside .nes", () => {
+    const html = `
+        <html><body>
+            <a href="../">../</a>
+            <a href="tetris.gb">tetris.gb</a>
+            <a href="game.nes">game.nes</a>
+            <a href="notes.txt">notes.txt</a>
+        </body></html>
+    `;
+    const { roms } = parseDirectoryListing(html);
+    expect(roms).toContain("tetris.gb");
+    expect(roms).toContain("game.nes");
+});
+
+it("parseDirectoryListing excludes .gbc files", () => {
+    const html = `
+        <html><body>
+            <a href="game.gbc">game.gbc</a>
+            <a href="game.gb">game.gb</a>
+        </body></html>
+    `;
+    const { roms } = parseDirectoryListing(html);
+    expect(roms).not.toContain("game.gbc");
+    expect(roms).toContain("game.gb");
+});
+
+it("fetchRomList includes .gb entries from directory listing", async () => {
+    const base = "https://example.com/roms/";
+    const responses = new Map([
+        [base, `
+            <a href="../">../</a>
+            <a href="gb/">gb/</a>
+            <a href="root.nes">root.nes</a>
+        `],
+        [`${base}gb/`, `
+            <a href="../">../</a>
+            <a href="tetris.gb">tetris.gb</a>
+        `]
+    ]);
+
+    const fetchFn = async (url: any) => {
+        const key = url.toString();
+        if (!responses.has(key)) {
+            return { ok: false, status: 404, text: async () => "" };
+        }
+        return { ok: true, text: async () => responses.get(key) };
+    };
+
+    const entries = await fetchRomList(base, fetchFn as any, 4);
+    const paths = entries.map((entry: any) => entry.path);
+    expect(paths).toContain("gb/tetris.gb");
+    expect(paths).toContain("root.nes");
+});
+
+it("fetchRomList manifest fallback includes .gb entries", async () => {
+    const base = "https://example.com/roms/";
+    const responses = new Map([
+        [base, ""],
+        [`${base}roms.json`, JSON.stringify({
+            roms: ["tetris.gb", "game.nes", "color.gbc"]
+        })]
+    ]);
+
+    const fetchFn = async (url: any) => {
+        const key = url.toString();
+        if (!responses.has(key)) {
+            return { ok: false, status: 404, text: async () => "" };
+        }
+        return {
+            ok: true,
+            text: async () => responses.get(key),
+            json: async () => JSON.parse(responses.get(key)!)
+        };
+    };
+
+    const entries = await fetchRomList(base, fetchFn as any, 4);
+    const paths = entries.map((entry: any) => entry.path);
+    expect(paths).toContain("tetris.gb");
+    expect(paths).toContain("game.nes");
+    expect(paths).not.toContain("color.gbc");
+});

--- a/web/src/rom/rom_list.ts
+++ b/web/src/rom/rom_list.ts
@@ -8,7 +8,7 @@ export function parseDirectoryListing(html: string) {
         if (!href || href === "../") continue;
         if (href.endsWith("/")) {
             dirs.push(href);
-        } else if (href.toLowerCase().endsWith(".nes")) {
+        } else if (href.toLowerCase().endsWith(".nes") || href.toLowerCase().endsWith(".gb")) {
             roms.push(href);
         }
     }
@@ -94,7 +94,7 @@ export async function fetchRomList(baseUrl: string, fetchFn: typeof fetch = fetc
     const manifest = await manifestResponse.json();
     const roms = Array.isArray(manifest?.roms) ? manifest.roms : [];
     return roms
-        .filter((rom: string) => typeof rom === "string" && rom.toLowerCase().endsWith(".nes"))
+        .filter((rom: string) => typeof rom === "string" && (rom.toLowerCase().endsWith(".nes") || rom.toLowerCase().endsWith(".gb")))
         .map((rom: string) => ({
             path: rom.replace(/^\//, ""),
             url: new URL(rom.replace(/^\//, ""), baseRoot).toString()

--- a/web/types/neser-wasm.d.ts
+++ b/web/types/neser-wasm.d.ts
@@ -52,6 +52,7 @@ declare module "*/pkg/neser" {
         stop_autorun(): Uint8Array;
         autorun_is_recording(): boolean;
         autorun_playback_finished(): boolean;
+        autorun_recording_frame_count(): number;
         // Debugger methods
         debugger_open(): void;
         debugger_continue(): void;
@@ -84,6 +85,26 @@ declare module "*/pkg/neser" {
     }
 
     export function gamepad_init_toast_message(gamepads_enabled: boolean, detected_controllers: number): string;
+
+    /**
+     * Provides a minimal WASM bridge for running the Game Boy emulator in the browser.
+     */
+    export class WasmGb {
+        free(): void;
+        [Symbol.dispose](): void;
+        drain_toasts(): unknown[];
+        frame_rate_hz(): number;
+        get_audio_samples(): Float32Array;
+        is_audio_muted(): boolean;
+        load_rom(rom: Uint8Array, rom_name: string): void;
+        constructor();
+        render_frame_rgba(): Uint8Array;
+        reset(soft_reset: boolean): void;
+        screen_height(): number;
+        screen_width(): number;
+        set_audio_muted(muted: boolean): void;
+        set_button(controller: number, button: number, pressed: boolean): void;
+    }
 
     export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 


### PR DESCRIPTION
## Summary

Adds Game Boy ROM support to the web frontend. Users can now load .gb files in addition to .nes files.

## Changes

### Rust WASM bridge
- New WasmGb struct in src/frontends/web/wasm_gb.rs wrapping GameBoy with wasm-bindgen
- Exposes: load_rom(), render_frame_rgba(), get_audio_samples(), set_audio_muted(), set_button(), reset(), drain_toasts()
- Screen: 160x144, frame rate: ~59.73 Hz (DMG hardware: 4194304/70224)

### TypeScript frontend
- ActiveEmulator tagged union dispatches .nes -> WasmNes and .gb -> WasmGb
- NES-only UI (debugger, autorun, save-state) is hidden when a GB ROM is active
- File picker accept extended to .nes,.gb
- ROM list directory scan and manifest fallback include .gb files
- Toast error shown for unrecognised extensions

### TypeScript declarations
- WasmGb class added to web/types/neser-wasm.d.ts

### Other
- Cargo.toml description updated to reflect multi-system scope

## Tests

- 6 new Rust WASM browser tests for WasmGb (construct, dimensions, frame rate, black frame, ROM load toast)
- 4 new TypeScript tests for .gb ROM list filtering
- All pre-existing tests continue to pass

Closes #2039