### PR TITLE
feat(gb): add DMG-0 model support — boot_div-dmg0 and boot_regs-dmg0 now pass

### DIFF
--- a/src/gb/boot_rom.rs
+++ b/src/gb/boot_rom.rs
@@ -284,11 +284,10 @@ pub const DMG0_BOOT_ROM: [u8; 256] = [
     // ── $0000: LD SP, $FFFE ──────────────────────────────────────────────────
     0x31, 0xFE, 0xFF,
     // ── $0003: APU init ──────────────────────────────────────────────────────
-    // NR52 = $80  (enable APU, all channels off)
-    0x3E, 0x80, 0xE0, 0x26, // NR12 = $F3  (channel 1 envelope: initial vol 15, increase)
-    0x3E, 0xF3, 0xE0, 0x12, // NR51 = $F3  (reuse A; all channels routed to both outputs)
-    0xE0, 0x25, // NR50 = $77  (master volume: both outputs at 7)
-    0x3E, 0x77, 0xE0, 0x24,
+    0x3E, 0x80, 0xE0, 0x26, // NR52 = $80  (enable APU, all channels off)
+    0x3E, 0xF3, 0xE0, 0x12, // NR12 = $F3  (channel 1 envelope: initial vol 15, increase)
+    0xE0, 0x25, // NR51 = $F3  (reuse A; all channels routed to both outputs)
+    0x3E, 0x77, 0xE0, 0x24, // NR50 = $77  (master volume: both outputs at 7)
     // ── $0011: BGP = $FC ─────────────────────────────────────────────────────
     0x3E, 0xFC, 0xE0, 0x47,
     // ── $0015: Pre-LCD delay loop (187 iterations × 7 M-cycles + overhead) ──

--- a/src/gb/boot_rom.rs
+++ b/src/gb/boot_rom.rs
@@ -118,7 +118,7 @@ pub const DMG_BOOT_ROM: [u8; 256] = [
     0x3E, 0xAA, 0xE0, 0x47, // LD A,$AA; LDH [$FF47] (BGP dark)
     // .noPaletteChange:
     0x0D, // DEC C
-    0x20, 0xE7, // JR NZ, .animLoop
+    0x20, 0xE7, // JR NZ, .animLoop (-25, → $004F)
     // ── $006A: Final palette + wait ──────────────────────────────────────────
     // BGP=$FC (%11_11_11_00) = all-dark.  Wait ~60 frames (~1 second).
     0x3E, 0xFC, 0xE0, 0x47, // LD A,$FC; LDH [$FF47] (BGP)
@@ -231,5 +231,117 @@ pub const DMG_BOOT_ROM: [u8; 256] = [
     // The CPU's next fetch ($0100) goes to cartridge ROM.
     // This instruction must live at exactly $00FE (hardware constraint).
     // ─────────────────────────────────────────────────────────────────────────
+    0xE0, 0x50, // LDH [$FF50], A  (unmap boot ROM → execute $0100)
+];
+
+/// Open-source DMG-0 (first production run) boot ROM replacement.
+///
+/// DMG-0 had a simpler boot ROM than later DMG revisions: no logo scroll
+/// animation, no header verification. This replacement reproduces the exact
+/// post-boot hardware state measured from real DMG-0 hardware.
+///
+/// ## Post-boot state produced
+///
+/// | Register | Value |    | I/O       | Value |
+/// |----------|-------|----|-----------|-------|
+/// | A        | $01   |    | DIV       | $18   |
+/// | F        | $00   |    | LY        | $01   |
+/// | B        | $FF   |    | STAT      | $83   |
+/// | C        | $13   |    | BGP       | $FC   |
+/// | D        | $00   |    | LCDC      | $91   |
+/// | E        | $C1   |    |           |       |
+/// | H        | $84   |    |           |       |
+/// | L        | $03   |    |           |       |
+/// | SP       | $FFFE |    |           |       |
+///
+/// ## Timing
+///
+/// Total M-cycles: **1496**.  With `div_counter` initial value 204:
+///   `204 + 1496 × 4 = 6188`  →  DIV = $18 at boot exit.
+///
+/// The `boot_div-dmg0` test first reads DIV 53 M-cycles after `$0100`:
+///   `6188 + 53 × 4 = 6400 = $1900`  →  read returns $19 ✓, phase = 0 (just after increment).
+///
+/// LCD is enabled (`LCDC=$91`) at M-cycle 1342, so the PPU runs for
+/// 154 M-cycles = 616 T-cycles before the boot exits.
+/// Line 1 mode 3 spans T-cycles 536–707 from LCD enable;
+/// 616 is inside that window, giving `LY=$01 STAT=$83` at cartridge entry.
+///
+/// ## ROM layout
+///
+/// | Address | Content                              | M-cycles |
+/// |---------|--------------------------------------|----------|
+/// | $0000   | LD SP / APU init / BGP               | 26       |
+/// | $0015   | Pre-LCD delay loop (HL counter = 187)| 1311     |
+/// | $001D   | Enable LCD (LCDC = $91)              | 5        |
+/// | $0021   | Post-LCD delay (B counter = 33)      | 133      |
+/// | $0026   | 2 × NOP (fine-tune timing)           | 2        |
+/// | $0028   | Set post-boot CPU registers          | 12       |
+/// | $0034   | JP $00FE                             | 4        |
+/// | $00FE   | LDH [$FF50], A (unmap boot ROM)      | 3        |
+/// |         | **Total**                            | **1496** |
+pub const DMG0_BOOT_ROM: [u8; 256] = [
+    // ── $0000: LD SP, $FFFE ──────────────────────────────────────────────────
+    0x31, 0xFE, 0xFF,
+    // ── $0003: APU init ──────────────────────────────────────────────────────
+    // NR52 = $80  (enable APU, all channels off)
+    0x3E, 0x80, 0xE0, 0x26, // NR12 = $F3  (channel 1 envelope: initial vol 15, increase)
+    0x3E, 0xF3, 0xE0, 0x12, // NR51 = $F3  (reuse A; all channels routed to both outputs)
+    0xE0, 0x25, // NR50 = $77  (master volume: both outputs at 7)
+    0x3E, 0x77, 0xE0, 0x24,
+    // ── $0011: BGP = $FC ─────────────────────────────────────────────────────
+    0x3E, 0xFC, 0xE0, 0x47,
+    // ── $0015: Pre-LCD delay loop (187 iterations × 7 M-cycles + overhead) ──
+    // LD HL, 187  ($00BB)
+    0x21, 0xBB, 0x00,
+    // Loop: DEC HL; LD A,H; OR L; JR NZ → $0018  (7 M taken / 6 M last)
+    0x2B, 0x7C, 0xB5, 0x20, 0xFB,
+    // ── $001D: Enable LCD ────────────────────────────────────────────────────
+    // LD A, $91  (LCDC: LCD on, BG on, BG tile data $8000, BG map $9800)
+    0x3E, 0x91, // LDH ($FF40), A  — write LCDC; PPU begins at M-cycle 1342
+    0xE0, 0x40,
+    // ── $0021: Post-LCD delay loop (33 iterations × 4 M-cycles + overhead) ──
+    // LD B, 33  ($21)
+    0x06, 0x21, // Loop: DEC B; JR NZ → $0023  (4 M taken / 3 M last)
+    0x05, 0x20, 0xFD,
+    // ── $0026: Fine-tune NOPs (2 × 1 M-cycle) ────────────────────────────────
+    0x00, 0x00,
+    // ── $0028: Set post-boot CPU registers ───────────────────────────────────
+    0x01, 0x13, 0xFF, // LD BC, $FF13  →  B=$FF, C=$13
+    0x11, 0xC1, 0x00, // LD DE, $00C1  →  D=$00, E=$C1
+    0x21, 0x03, 0x84, // LD HL, $8403  →  H=$84, L=$03
+    0x3E, 0x01, // LD A, $01
+    0xB7, // OR A          →  F=$00 (Z=0, N=0, H=0, C=0)
+    // ── $0034: Jump to boot exit at $00FE ─────────────────────────────────────
+    0xC3, 0xFE, 0x00, // JP $00FE
+    // ── $0037–$00FD: Unused (fill with $00) ──────────────────────────────────
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $0037–$003E
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $003F–$0046
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $0047–$004E
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $004F–$0056
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $0057–$005E
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $005F–$0066
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $0067–$006E
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $006F–$0076
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $0077–$007E
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $007F–$0086
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $0087–$008E
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $008F–$0096
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $0097–$009E
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $009F–$00A6
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00A7–$00AE
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00AF–$00B6
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00B7–$00BE
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00BF–$00C6
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00C7–$00CE
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00CF–$00D6
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00D7–$00DE
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00DF–$00E6
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00E7–$00EE
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00EF–$00F6
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // $00F7–$00FD
+    // ── $00FE: BootGame ──────────────────────────────────────────────────────
+    // Placed at $00FE so that PC = $0100 after the instruction executes,
+    // which is the standard cartridge entry point.
     0xE0, 0x50, // LDH [$FF50], A  (unmap boot ROM → execute $0100)
 ];

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -90,7 +90,7 @@ pub struct DmgBus {
     /// Hardware model variant (DMG-ABC or DMG-0).
     /// Determines which boot ROM is loaded and which CPU post-boot register
     /// values are used on reset.
-    pub model: DmgModel,
+    model: DmgModel,
 }
 
 impl DmgBus {
@@ -106,9 +106,8 @@ impl DmgBus {
             wram: [0u8; 0x2000],
             hram: [0u8; 0x7F],
             // Real DMG-B hardware has a sub-byte div_counter phase of 204 T-cycles
-            // at power-on. Setting this initial value ensures our custom boot ROM
-            // exits at the correct clock phase (div_counter = 28364) so that
-            // serial clock edges align with acceptance-test expectations.
+            // at power-on. Setting this initial value ensures the serial clock edges
+            // align with acceptance-test expectations (serial/boot_sclk_align-dmgABCmgb).
             timer: Timer::with_div_counter(204),
             joypad: Joypad::new(),
             apu: Apu::new(is_cgb),
@@ -169,6 +168,11 @@ impl DmgBus {
     /// Returns `true` while the boot ROM is still mapped at $0000–$00FF.
     pub fn is_boot_rom_active(&self) -> bool {
         self.boot_rom_active
+    }
+
+    /// Returns the hardware model variant this bus was constructed for.
+    pub fn model(&self) -> DmgModel {
+        self.model
     }
 
     /// Returns bytes captured via serial transfer ($FF01/$FF02).

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -1,8 +1,9 @@
 use crate::gb::apu::Apu;
-use crate::gb::boot_rom::DMG_BOOT_ROM;
+use crate::gb::boot_rom::{DMG_BOOT_ROM, DMG0_BOOT_ROM};
 use crate::gb::bus::GbBus;
 use crate::gb::cartridge::GbCartridge;
 use crate::gb::input::joypad::Joypad;
+use crate::gb::model::DmgModel;
 use crate::gb::ppu::Ppu;
 use crate::gb::timer::Timer;
 
@@ -86,11 +87,19 @@ pub struct DmgBus {
     /// "edge injection" SameBoy performs — ensuring the first serial bit is
     /// timed at the correct phase relative to the div counter.
     serial_master_clock: bool,
+    /// Hardware model variant (DMG-ABC or DMG-0).
+    /// Determines which boot ROM is loaded and which CPU post-boot register
+    /// values are used on reset.
+    pub model: DmgModel,
 }
 
 impl DmgBus {
-    pub fn new(cart: Box<dyn GbCartridge>) -> Self {
+    pub fn new(cart: Box<dyn GbCartridge>, model: DmgModel) -> Self {
         let is_cgb = cart.is_cgb();
+        let boot_rom = match model {
+            DmgModel::DmgAbc => DMG_BOOT_ROM,
+            DmgModel::Dmg0 => DMG0_BOOT_ROM,
+        };
         let mut bus = Self {
             cart,
             ppu: Ppu::new(),
@@ -105,7 +114,7 @@ impl DmgBus {
             apu: Apu::new(is_cgb),
             if_reg: 0,
             ie_reg: 0,
-            boot_rom: DMG_BOOT_ROM,
+            boot_rom,
             boot_rom_active: true,
             sb: 0xFF,
             sc: 0x7E,
@@ -116,6 +125,7 @@ impl DmgBus {
             dma_source: 0,
             dma_position: 0,
             dma_oam_blocked: false,
+            model,
         };
         // Real DMG hardware powers on with LCDC=$00 (LCD disabled).
         // The boot ROM tile-loading runs while the LCD is off so VRAM writes
@@ -140,6 +150,10 @@ impl DmgBus {
         self.hram = [0u8; 0x7F];
         self.if_reg = 0;
         self.ie_reg = 0;
+        self.boot_rom = match self.model {
+            DmgModel::DmgAbc => DMG_BOOT_ROM,
+            DmgModel::Dmg0 => DMG0_BOOT_ROM,
+        };
         self.boot_rom_active = true;
         self.sb = 0xFF;
         self.sc = 0x7E;
@@ -470,7 +484,7 @@ mod tests {
     }
 
     fn make_bus() -> DmgBus {
-        DmgBus::new(rom_only_cart())
+        DmgBus::new(rom_only_cart(), DmgModel::DmgAbc)
     }
 
     // ── VRAM ─────────────────────────────────────────────────────────────────

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -4,6 +4,7 @@
 //! [`SharedAppContext`], providing the same interface that the NES side
 //! exposes so that frontends can drive both systems through `Console`.
 
+use crate::gb::DmgModel;
 use crate::gb::bus::DmgBus;
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
@@ -33,7 +34,7 @@ impl GameBoy {
     /// Load a `.gb` ROM image. Replaces any previously loaded ROM.
     pub fn load_rom(&mut self, bytes: &[u8], _name: &str) -> Result<(), String> {
         let cart = load_cartridge(bytes).map_err(|e| format!("{e:?}"))?;
-        self.gb = Some(Gb::new(DmgBus::new(cart)));
+        self.gb = Some(Gb::new(DmgBus::new(cart, DmgModel::DmgAbc)));
         Ok(())
     }
 

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -49,14 +49,14 @@ impl Gb<DmgBus> {
         if soft_reset {
             // Soft reset: restore post-boot register state and continue from
             // the cartridge entry point, preserving WRAM and bus state.
-            match self.cpu.bus.model {
+            match self.cpu.bus.model() {
                 DmgModel::DmgAbc => self.cpu.reset_registers(),
                 DmgModel::Dmg0 => self.cpu.reset_registers_dmg0(),
             }
         } else {
             // Hard reset: reinitialise all bus hardware and restart execution
             // from the boot ROM entry point.
-            match self.cpu.bus.model {
+            match self.cpu.bus.model() {
                 DmgModel::DmgAbc => self.cpu.reset_registers(),
                 DmgModel::Dmg0 => self.cpu.reset_registers_dmg0(),
             }

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -1,6 +1,7 @@
 use crate::gb::bus::DmgBus;
 use crate::gb::bus::GbBus;
 use crate::gb::cpu::Sm83;
+use crate::gb::model::DmgModel;
 
 pub mod gameboy;
 
@@ -48,15 +49,17 @@ impl Gb<DmgBus> {
         if soft_reset {
             // Soft reset: restore post-boot register state and continue from
             // the cartridge entry point, preserving WRAM and bus state.
-            self.cpu.reset_registers();
+            match self.cpu.bus.model {
+                DmgModel::DmgAbc => self.cpu.reset_registers(),
+                DmgModel::Dmg0 => self.cpu.reset_registers_dmg0(),
+            }
         } else {
             // Hard reset: reinitialise all bus hardware and restart execution
             // from the boot ROM entry point.
-            // reset_registers() restores the normal post-boot register defaults
-            // and clears internal CPU state (including ime_pending). We then
-            // override PC to $0000 so the reactivated boot ROM runs again from
-            // the start, establishing correct power-on behaviour.
-            self.cpu.reset_registers();
+            match self.cpu.bus.model {
+                DmgModel::DmgAbc => self.cpu.reset_registers(),
+                DmgModel::Dmg0 => self.cpu.reset_registers_dmg0(),
+            }
             self.cpu.regs.pc = 0x0000;
             self.cpu.bus.reset();
         }
@@ -107,7 +110,7 @@ mod tests {
     }
 
     fn make_dmg() -> Gb<DmgBus> {
-        Gb::new(DmgBus::new(minimal_cart()))
+        Gb::new(DmgBus::new(minimal_cart(), DmgModel::DmgAbc))
     }
 
     // ── reset: CPU registers ──────────────────────────────────────────────

--- a/src/gb/cpu/sm83.rs
+++ b/src/gb/cpu/sm83.rs
@@ -168,6 +168,23 @@ impl<B: GbBus> Sm83<B> {
         self.ime_pending = false;
     }
 
+    /// Reset the CPU registers to the post-boot-ROM (DMG-0) state.
+    ///
+    /// DMG-0 (first production run) exits its boot ROM with different register
+    /// values from later DMG revisions.
+    pub fn reset_registers_dmg0(&mut self) {
+        self.regs.set_af(0x0100); // A=$01, F=$00
+        self.regs.set_bc(0xFF13); // B=$FF, C=$13
+        self.regs.set_de(0x00C1); // D=$00, E=$C1
+        self.regs.set_hl(0x8403); // H=$84, L=$03
+        self.regs.sp = 0xFFFE;
+        self.regs.pc = 0x0100;
+        self.ime = false;
+        self.halted = false;
+        self.halt_bug = false;
+        self.ime_pending = false;
+    }
+
     /// Advance the cycle counter by 1 M-cycle and tick peripherals.
     ///
     /// Used for internal CPU cycles that do not correspond to a memory access

--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -1,11 +1,12 @@
 use crate::gb::bus::{DmgBus, GbBus};
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
+use crate::gb::model::DmgModel;
 
 fn load_gb_rom(path: &str) -> Gb<DmgBus> {
     let rom = std::fs::read(path).expect("ROM file should be present");
     let cart = load_cartridge(&rom).expect("valid GB ROM");
-    Gb::new(DmgBus::new(cart))
+    Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))
 }
 
 /// Generous M-cycle budget per test.

--- a/src/gb/integration_tests/boot_tests.rs
+++ b/src/gb/integration_tests/boot_tests.rs
@@ -1,6 +1,7 @@
 use crate::gb::bus::DmgBus;
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
+use crate::gb::model::DmgModel;
 
 /// The expected Nintendo logo bitmap (48 bytes) at cartridge header $0104–$0133.
 ///
@@ -66,7 +67,7 @@ fn run_until_cartridge_entry(gb: &mut Gb<DmgBus>) -> bool {
 fn test_dmg_boot_sets_correct_register_state() {
     let rom = build_test_rom(&NINTENDO_LOGO);
     let cart = load_cartridge(&rom).expect("valid ROM");
-    let mut gb = Gb::new(DmgBus::new(cart));
+    let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
 
     let reached = run_until_cartridge_entry(&mut gb);
 
@@ -96,7 +97,7 @@ fn test_dmg_boot_halts_on_corrupted_logo() {
     let bad_logo = [0u8; 48]; // all-zero logo — definitely wrong
     let rom = build_test_rom(&bad_logo);
     let cart = load_cartridge(&rom).expect("valid ROM");
-    let mut gb = Gb::new(DmgBus::new(cart));
+    let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
 
     let reached = run_until_cartridge_entry(&mut gb);
 

--- a/src/gb/integration_tests/mooneye_tests.rs
+++ b/src/gb/integration_tests/mooneye_tests.rs
@@ -10,6 +10,7 @@
 use crate::gb::bus::{DmgBus, GbBus};
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
+use crate::gb::model::DmgModel;
 
 /// Outcome of running a Mooneye test ROM to completion.
 #[derive(Debug, PartialEq)]
@@ -43,11 +44,18 @@ const MOONEYE_CYCLE_LIMIT: u64 = 10_000_000;
 /// LD B,B opcode used as a Mooneye software breakpoint.
 const LD_B_B: u8 = 0x40;
 
-/// Load a GB ROM from `path` and return a ready-to-step `Gb<DmgBus>`.
+/// Load a GB ROM from `path` and return a ready-to-step `Gb<DmgBus>` (DMG-ABC model).
 fn load_gb_rom(path: &str) -> Gb<DmgBus> {
     let rom = std::fs::read(path).expect("Mooneye ROM file should be present");
     let cart = load_cartridge(&rom).expect("valid GB ROM");
-    Gb::new(DmgBus::new(cart))
+    Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))
+}
+
+/// Load a GB ROM from `path` and return a ready-to-step `Gb<DmgBus>` (DMG-0 model).
+fn load_gb_rom_dmg0(path: &str) -> Gb<DmgBus> {
+    let rom = std::fs::read(path).expect("Mooneye ROM file should be present");
+    let cart = load_cartridge(&rom).expect("valid GB ROM");
+    Gb::new(DmgBus::new(cart, DmgModel::Dmg0))
 }
 
 /// Step `gb` until the Mooneye breakpoint fires or `cycle_limit` M-cycles elapse.
@@ -101,6 +109,12 @@ pub fn run_mooneye_rom(path: &str) -> MooneyeResult {
     detect_mooneye_result(&mut gb)
 }
 
+/// Run a Mooneye test ROM using the DMG-0 hardware model.
+pub fn run_mooneye_rom_dmg0(path: &str) -> MooneyeResult {
+    let mut gb = load_gb_rom_dmg0(path);
+    detect_mooneye_result(&mut gb)
+}
+
 // ============================================================================
 // Helper macro to produce a single-line pass assertion.
 // ============================================================================
@@ -112,6 +126,19 @@ macro_rules! assert_mooneye_pass {
             result,
             MooneyeResult::Pass,
             "Mooneye test failed: {:?} — ROM: {}",
+            result,
+            $path
+        );
+    };
+}
+
+macro_rules! assert_mooneye_pass_dmg0 {
+    ($path:expr) => {
+        let result = run_mooneye_rom_dmg0($path);
+        assert_eq!(
+            result,
+            MooneyeResult::Pass,
+            "Mooneye DMG-0 test failed: {:?} — ROM: {}",
             result,
             $path
         );
@@ -205,14 +232,14 @@ mod helper_tests {
     #[test]
     fn helper_detects_pass_when_fibonacci_registers_set() {
         let cart = load_cartridge(&make_pass_rom()).expect("valid test ROM");
-        let mut gb = Gb::new(DmgBus::new(cart));
+        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
         assert_eq!(detect_mooneye_result(&mut gb), MooneyeResult::Pass);
     }
 
     #[test]
     fn helper_detects_fail_when_registers_wrong() {
         let cart = load_cartridge(&make_fail_rom()).expect("valid test ROM");
-        let mut gb = Gb::new(DmgBus::new(cart));
+        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
         let result = detect_mooneye_result(&mut gb);
         assert!(
             matches!(result, MooneyeResult::Fail { b: 0xFF, .. }),
@@ -224,7 +251,7 @@ mod helper_tests {
     fn helper_returns_timeout_when_no_breakpoint() {
         let bytes = make_timeout_rom();
         let cart = load_cartridge(&bytes).expect("valid test ROM");
-        let mut gb = Gb::new(DmgBus::new(cart));
+        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
         assert_eq!(
             detect_mooneye_result_with_limit(&mut gb, 1_000),
             MooneyeResult::Timeout
@@ -260,13 +287,12 @@ fn test_mooneye_acceptance_bits_unused_hwio_gs() {
 }
 
 #[test]
-#[ignore = "failing: boot ROM accuracy gap — tracked in #2018"]
 fn test_mooneye_acceptance_boot_div_dmg0() {
-    assert_mooneye_pass!(&format!("{BASE}/acceptance/boot_div-dmg0.gb"));
+    assert_mooneye_pass_dmg0!(&format!("{BASE}/acceptance/boot_div-dmg0.gb"));
 }
 
 #[test]
-#[ignore = "failing: boot ROM accuracy gap — tracked in #2018"]
+#[ignore = "failing: boot ROM accuracy gap — tracked in #2072"]
 fn test_mooneye_acceptance_boot_div_dmgabcmgb() {
     assert_mooneye_pass!(&format!("{BASE}/acceptance/boot_div-dmgABCmgb.gb"));
 }
@@ -284,13 +310,13 @@ fn test_mooneye_acceptance_boot_div2_s() {
 }
 
 #[test]
-#[ignore = "failing: boot ROM accuracy gap — tracked in #2018"]
+#[ignore = "failing: boot ROM accuracy gap — tracked in #2072"]
 fn test_mooneye_acceptance_boot_hwio_dmg0() {
-    assert_mooneye_pass!(&format!("{BASE}/acceptance/boot_hwio-dmg0.gb"));
+    assert_mooneye_pass_dmg0!(&format!("{BASE}/acceptance/boot_hwio-dmg0.gb"));
 }
 
 #[test]
-#[ignore = "failing: boot ROM accuracy gap — tracked in #2018"]
+#[ignore = "failing: boot ROM accuracy gap — tracked in #2072"]
 fn test_mooneye_acceptance_boot_hwio_dmgabcmgb() {
     assert_mooneye_pass!(&format!("{BASE}/acceptance/boot_hwio-dmgABCmgb.gb"));
 }
@@ -302,9 +328,8 @@ fn test_mooneye_acceptance_boot_hwio_s() {
 }
 
 #[test]
-#[ignore = "failing: boot ROM accuracy gap — tracked in #2018"]
 fn test_mooneye_acceptance_boot_regs_dmg0() {
-    assert_mooneye_pass!(&format!("{BASE}/acceptance/boot_regs-dmg0.gb"));
+    assert_mooneye_pass_dmg0!(&format!("{BASE}/acceptance/boot_regs-dmg0.gb"));
 }
 
 #[test]

--- a/src/gb/integration_tests/ppu_tests.rs
+++ b/src/gb/integration_tests/ppu_tests.rs
@@ -1,11 +1,12 @@
 use crate::gb::bus::DmgBus;
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
+use crate::gb::model::DmgModel;
 
 fn load_gb_rom(path: &str) -> Gb<DmgBus> {
     let rom = std::fs::read(path).expect("ROM file should be present");
     let cart = load_cartridge(&rom).expect("valid GB ROM");
-    Gb::new(DmgBus::new(cart))
+    Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))
 }
 
 fn run_one_gb_frame(gb: &mut Gb<DmgBus>) {

--- a/src/gb/mod.rs
+++ b/src/gb/mod.rs
@@ -5,10 +5,12 @@ pub mod cartridge;
 pub mod console;
 pub mod cpu;
 pub mod input;
+pub mod model;
 pub mod ppu;
 pub mod timer;
 
 pub use console::gameboy::GameBoy;
+pub use model::DmgModel;
 
 #[cfg(test)]
 pub mod integration_tests;

--- a/src/gb/model.rs
+++ b/src/gb/model.rs
@@ -1,0 +1,21 @@
+/// Game Boy hardware model variant.
+///
+/// Distinguishes between the first-generation DMG-0 and the
+/// production DMG-A/B/C models.  The two variants differ in
+/// boot ROM content, post-boot CPU register values, and the
+/// DIV counter phase at boot exit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DmgModel {
+    /// Production DMG hardware: DMG-A, DMG-B, DMG-C.
+    ///
+    /// Post-boot CPU registers: A=$01 F=$B0 B=$00 C=$13 D=$00 E=$D8 H=$01 L=$4D SP=$FFFE.
+    /// DIV=$AD at cartridge entry.
+    #[default]
+    DmgAbc,
+
+    /// First-generation DMG-0 hardware.
+    ///
+    /// Post-boot CPU registers: A=$01 F=$00 B=$FF C=$13 D=$00 E=$C1 H=$84 L=$03 SP=$FFFE.
+    /// DIV=$19 at cartridge entry (shorter boot ROM).
+    Dmg0,
+}

--- a/src/gb/model.rs
+++ b/src/gb/model.rs
@@ -9,13 +9,13 @@ pub enum DmgModel {
     /// Production DMG hardware: DMG-A, DMG-B, DMG-C.
     ///
     /// Post-boot CPU registers: A=$01 F=$B0 B=$00 C=$13 D=$00 E=$D8 H=$01 L=$4D SP=$FFFE.
-    /// DIV=$AD at cartridge entry.
+    /// DIV=$AB at cartridge entry.
     #[default]
     DmgAbc,
 
     /// First-generation DMG-0 hardware.
     ///
     /// Post-boot CPU registers: A=$01 F=$00 B=$FF C=$13 D=$00 E=$C1 H=$84 L=$03 SP=$FFFE.
-    /// DIV=$19 at cartridge entry (shorter boot ROM).
+    /// DIV=$18 at cartridge entry (shorter boot ROM).
     Dmg0,
 }


### PR DESCRIPTION
Closes #2072 (partial — 2 of 5 tests now pass)

## What this PR does

Adds a `DmgModel` enum (`DmgAbc` / `Dmg0`) and wires it through `DmgBus` so the emulator selects the correct boot ROM at reset.

### DMG-0 support

- **`DMG0_BOOT_ROM`**: a new 1496 M-cycle boot ROM replacement for the first Game Boy production revision. No logo scroll, no header verification — matching documented DMG-0 hardware behaviour. Timing is tuned so `div_counter` at cartridge entry gives DIV=$18 (verified via the Mooneye test).
- **`reset_registers_dmg0()`** on SM83: sets the documented DMG-0 post-boot CPU register state (`A=$01 F=$00 B=$FF C=$13 D=$00 E=$C1 H=$84 L=$03 SP=$FFFE`).
- `Gb::reset()` dispatches on the stored `DmgModel`.

### Tests now passing

| Test | Before | After |
|------|--------|-------|
| `acceptance/boot_regs-dmg0` | ignored | ✅ PASS |
| `acceptance/boot_div-dmg0` | ignored | ✅ PASS |

### Remaining tests (still ignored)

| Test | Reason |
|------|--------|
| `acceptance/boot_div-dmgABCmgb` | Requires adjusting N_abc mod 16384 into [10943, 11006]. Any M-cycles added between the animation and WaitBFrames are absorbed by VBlank phase alignment — pre-LCD code space is fully used by the 256-byte ROM. Needs a fundamental ROM timing redesign. |
| `acceptance/boot_hwio-dmg0` | Needs full multi-frame boot ROM with I/O register init state. |
| `acceptance/boot_hwio-dmgABCmgb` | Same as above. |

### Existing tests unaffected

- All 8483 lib tests pass (`cargo test --no-default-features --lib`)
- `serial/boot_sclk_align-dmgABCmgb` continues to pass