### PR TITLE
fix(gb): SC bits 6-1 always read as 1 — fixes unused_hwio-GS (#2073)

### DIFF
--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -345,7 +345,7 @@ impl GbBus for DmgBus {
             0xFEA0..=0xFEFF => 0xFF,
             0xFF00 => self.joypad.read(),
             0xFF01 => self.sb,
-            0xFF02 => self.sc,
+            0xFF02 => self.sc | 0x7E, // bits 6-1 unused on DMG, always read as 1
             0xFF04..=0xFF07 => self.timer.read(addr),
             0xFF0F => self.if_reg | 0xE0,
             0xFF10..=0xFF3F => self.apu.read_register(addr),
@@ -815,10 +815,19 @@ mod tests {
     #[test]
     fn test_serial_sc_write_no_transfer_roundtrip() {
         // Given: fresh bus; When: write 0x40 (bit 7 clear, no transfer) to $FF02 (SC);
-        // Then: read back 0x40
+        // Then: read back 0x7E — bits 6-1 are unused on DMG and always return 1
         let mut bus = make_bus();
         bus.write(0xFF02, 0x40);
-        assert_eq!(bus.read(0xFF02), 0x40);
+        assert_eq!(bus.read(0xFF02), 0x7E);
+    }
+
+    #[test]
+    fn test_sc_unused_bits_always_one() {
+        // DMG hardware: SC bits 6-1 are unused and must always read as 1.
+        // Given: write 0x00 to SC; When: read SC; Then: bits 6-1 are still 1.
+        let mut bus = make_bus();
+        bus.write(0xFF02, 0x00);
+        assert_eq!(bus.read(0xFF02) & 0x7E, 0x7E);
     }
 
     #[test]

--- a/src/gb/integration_tests/mooneye_tests.rs
+++ b/src/gb/integration_tests/mooneye_tests.rs
@@ -281,7 +281,6 @@ fn test_mooneye_acceptance_bits_reg_f() {
 }
 
 #[test]
-#[ignore = "failing: emulation accuracy gap — tracked in #2018"]
 fn test_mooneye_acceptance_bits_unused_hwio_gs() {
     assert_mooneye_pass!(&format!("{BASE}/acceptance/bits/unused_hwio-GS.gb"));
 }


### PR DESCRIPTION
## Summary

Fixes #2073 — Mooneye acceptance test `unused_hwio-GS` (1 of 4 remaining in #2018).

## Root Cause

`DmgBus::read()` returned raw `self.sc` for $FF02 (SC). DMG hardware bits 6-1 are unused open-bus lines that always return 1. Writing `0x00` then reading back yielded `0x00` for those bits instead of `0x7E`, failing the test.

All other registers tested by `unused_hwio-GS` already OR in the correct unused-bit constant (P1 → `0xC0`, TAC → `0xF8`, IF → `0xE0`, STAT → `0x80`, APU channels each handle their own masks, unmapped addresses fall through to `0xFF`).

## Change

```rust
// before
0xFF02 => self.sc,
// after
0xFF02 => self.sc | 0x7E, // bits 6-1 unused on DMG, always read as 1
```

## Tests

- Removed `#[ignore]` from `test_mooneye_acceptance_bits_unused_hwio_gs` — now passes
- Updated `test_serial_sc_write_no_transfer_roundtrip` to expect hardware-correct `0x7E`
- Added `test_sc_unused_bits_always_one`: write `0x00`, read & `0x7E` == `0x7E`

All 8485 lib tests pass. All pre-merge checkpoints pass.