### PR TITLE
feat(gb): implement CGB PPU and bus for cgb-acid2 (#2099)

### DIFF
--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -119,7 +119,14 @@ impl CgbBus {
     fn read_raw(&self, addr: u16) -> u8 {
         match addr {
             0x0000..=0x7FFF => self.cart.read(addr),
-            0x8000..=0x9FFF => self.ppu.vram[(addr - 0x8000) as usize],
+            0x8000..=0x9FFF => {
+                let vram_addr = (addr - 0x8000) as usize;
+                if self.ppu.vbk & 0x01 != 0 {
+                    self.ppu.vram_bank1[vram_addr]
+                } else {
+                    self.ppu.vram[vram_addr]
+                }
+            }
             0xA000..=0xBFFF => self.cart.read(addr),
             0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize],
             0xE000..=0xFFFF => self.wram[(addr - 0xE000) as usize],

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -1,0 +1,235 @@
+use crate::gb::apu::Apu;
+use crate::gb::bus::GbBus;
+use crate::gb::cartridge::GbCartridge;
+use crate::gb::input::joypad::Joypad;
+use crate::gb::ppu::Ppu;
+use crate::gb::timer::Timer;
+
+/// Full CGB (Game Boy Color) memory bus.
+///
+/// Implements the CGB memory map for use with the generic `Gb<CgbBus>` console.
+/// Supports all CGB-specific PPU registers: VRAM bank (`$FF4F`), color palettes
+/// (`$FF68`–`$FF6B`), and object priority mode (`$FF6C`).
+///
+/// Differences from DMG:
+/// - No boot ROM: starts execution at `$0100` with the CGB post-boot CPU state (A=$11).
+/// - CGB-mode PPU (`Ppu::new_cgb()`): VRAM bank 1, color palette RAM.
+/// - `$FF4F`, `$FF68`–`$FF6B`, `$FF6C` route to CGB PPU helpers.
+/// - `$FF6C` OPRI: object priority mode register.
+/// - Double-speed, WRAM banking, and HDMA are **not** implemented (not required for
+///   cgb-acid2).
+///
+/// Memory map (same as DMG unless noted):
+/// - `$0000–$7FFF`: Cartridge ROM
+/// - `$8000–$9FFF`: VRAM (bank-switched in CGB mode via `$FF4F`)
+/// - `$A000–$BFFF`: Cartridge RAM
+/// - `$C000–$DFFF`: WRAM (single bank)
+/// - `$E000–$FDFF`: Echo RAM
+/// - `$FE00–$FE9F`: OAM
+/// - `$FF40–$FF4B`: PPU registers (same as DMG)
+/// - `$FF4F`:        VBK — VRAM bank select
+/// - `$FF68–$FF6B`:  BCPS/BCPD/OCPS/OCPD — color palette registers
+/// - `$FF6C`:        OPRI — object priority mode
+/// - `$FF80–$FFFE`:  HRAM
+/// - `$FFFF`:        IE register
+pub struct CgbBus {
+    cart: Box<dyn GbCartridge>,
+    pub ppu: Ppu,
+    wram: [u8; 0x2000],
+    hram: [u8; 0x7F],
+    timer: Timer,
+    pub joypad: Joypad,
+    apu: Apu,
+    if_reg: u8,
+    ie_reg: u8,
+    /// Whether an OAM DMA transfer is currently in progress.
+    dma_active: bool,
+    /// High byte of the OAM DMA source address.
+    dma_source: u8,
+    /// DMA position: 0=warm-up, 1–160=copy, 161=teardown.
+    dma_position: u8,
+    /// Whether OAM access is blocked by an active DMA transfer.
+    dma_oam_blocked: bool,
+}
+
+impl CgbBus {
+    /// Create a new CGB bus, starting at `$0100` (post-boot-ROM entry).
+    ///
+    /// The PPU is initialised in CGB mode with the LCD disabled.  Callers are
+    /// expected to call `Sm83::reset_registers_cgb()` on the CPU to set A=$11
+    /// and all other registers to the CGB post-boot-ROM state.
+    pub fn new(cart: Box<dyn GbCartridge>) -> Self {
+        let is_cgb = cart.is_cgb();
+        let mut bus = Self {
+            cart,
+            ppu: Ppu::new_cgb(),
+            wram: [0u8; 0x2000],
+            hram: [0u8; 0x7F],
+            timer: Timer::new(),
+            joypad: Joypad::new(),
+            apu: Apu::new(is_cgb),
+            if_reg: 0,
+            ie_reg: 0,
+            dma_active: false,
+            dma_source: 0,
+            dma_position: 0,
+            dma_oam_blocked: false,
+        };
+        // Start with LCD disabled; the cartridge code will enable it.
+        bus.ppu.write_register(0xFF40, 0x00);
+        bus
+    }
+
+    /// Advance system timers, PPU, and APU by `m_cycles` M-cycles.
+    pub fn tick(&mut self, m_cycles: u8) {
+        self.if_reg |= self.ppu.take_pending_interrupts();
+
+        for _ in 0..m_cycles {
+            self.timer.tick(1);
+            if self.timer.interrupt_pending {
+                self.if_reg |= 0x04;
+                self.timer.interrupt_pending = false;
+            }
+
+            if self.dma_active {
+                match self.dma_position {
+                    0 => {
+                        self.dma_position = 1;
+                    }
+                    1..=160 => {
+                        self.dma_oam_blocked = true;
+                        let byte_idx = (self.dma_position - 1) as u16;
+                        let src = (self.dma_source as u16) << 8 | byte_idx;
+                        self.ppu.oam[byte_idx as usize] = self.read_raw(src);
+                        self.dma_position += 1;
+                    }
+                    161 => {
+                        self.dma_active = false;
+                        self.dma_oam_blocked = false;
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+        self.ppu.tick_dots(u32::from(m_cycles) * 4);
+        self.apu.tick(m_cycles);
+    }
+
+    /// Raw read bypassing PPU access blocking (used by OAM DMA).
+    fn read_raw(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x7FFF => self.cart.read(addr),
+            0x8000..=0x9FFF => self.ppu.vram[(addr - 0x8000) as usize],
+            0xA000..=0xBFFF => self.cart.read(addr),
+            0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize],
+            0xE000..=0xFFFF => self.wram[(addr - 0xE000) as usize],
+        }
+    }
+
+    fn do_oam_dma(&mut self, val: u8) {
+        let preserve_blocking = self.dma_active && self.dma_oam_blocked;
+        self.dma_active = true;
+        self.dma_source = val;
+        self.dma_position = 0;
+        self.dma_oam_blocked = preserve_blocking;
+    }
+
+    /// Returns bytes captured via serial transfer ($FF01/$FF02).
+    /// CGB bus accepts serial writes but discards the data (no test harness needed).
+    pub fn serial_output(&self) -> &[u8] {
+        &[]
+    }
+
+    /// Set a button state on the joypad and propagate any resulting interrupt.
+    pub fn set_joypad_button(&mut self, id: u8, pressed: bool) {
+        if self.joypad.set_button(id, pressed) {
+            self.if_reg |= 0x10;
+        }
+    }
+
+    /// Returns `true` when the PPU has completed a full frame.
+    pub fn is_frame_ready(&self) -> bool {
+        self.ppu.is_frame_ready()
+    }
+
+    /// Clear the frame-ready flag.
+    pub fn clear_frame_ready(&mut self) {
+        self.ppu.clear_frame_ready();
+    }
+}
+
+impl GbBus for CgbBus {
+    fn read(&mut self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x7FFF => self.cart.read(addr),
+            0x8000..=0x9FFF => self.ppu.read_vram(addr),
+            0xA000..=0xBFFF => self.cart.read(addr),
+            0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize],
+            0xE000..=0xFDFF => self.wram[(addr - 0xE000) as usize],
+            0xFE00..=0xFE9F => {
+                if self.dma_oam_blocked {
+                    return 0xFF;
+                }
+                self.ppu.read_oam(addr)
+            }
+            0xFEA0..=0xFEFF => 0xFF,
+            0xFF00 => self.joypad.read(),
+            0xFF01 => 0xFF, // SB — stub
+            0xFF02 => 0xFF, // SC — stub
+            0xFF04..=0xFF07 => self.timer.read(addr),
+            0xFF0F => self.if_reg | 0xE0,
+            0xFF10..=0xFF3F => self.apu.read_register(addr),
+            0xFF40..=0xFF45 | 0xFF47..=0xFF4B => self.ppu.read_register(addr),
+            0xFF46 => self.dma_source,
+            // CGB-specific registers
+            0xFF4F | 0xFF68..=0xFF6C => self.ppu.read_cgb_register(addr).unwrap_or(0xFF),
+            0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
+            0xFFFF => self.ie_reg,
+            _ => 0xFF,
+        }
+    }
+
+    fn write(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x0000..=0x7FFF => self.cart.write(addr, val),
+            0x8000..=0x9FFF => self.ppu.write_vram(addr, val),
+            0xA000..=0xBFFF => self.cart.write(addr, val),
+            0xC000..=0xDFFF => self.wram[(addr - 0xC000) as usize] = val,
+            0xE000..=0xFDFF => self.wram[(addr - 0xE000) as usize] = val,
+            0xFE00..=0xFE9F => {
+                if !self.dma_oam_blocked {
+                    self.ppu.write_oam(addr, val);
+                }
+            }
+            0xFEA0..=0xFEFF => {}
+            0xFF00 => self.joypad.write(val),
+            0xFF01 | 0xFF02 => {} // SB/SC — stub
+            0xFF04..=0xFF07 => {
+                self.timer.write(addr, val);
+                if self.timer.fire_write_overflow_if_pending() {
+                    self.if_reg |= 0x04;
+                    self.timer.take_interrupt();
+                }
+            }
+            0xFF0F => self.if_reg = val & 0x1F,
+            0xFF10..=0xFF3F => self.apu.write_register(addr, val),
+            0xFF40..=0xFF45 | 0xFF47..=0xFF4B => {
+                self.ppu.write_register(addr, val);
+                self.if_reg |= self.ppu.take_pending_interrupts();
+            }
+            0xFF46 => self.do_oam_dma(val),
+            // CGB-specific registers
+            0xFF4F | 0xFF68..=0xFF6C => {
+                self.ppu.write_cgb_register(addr, val);
+            }
+            0xFF50 => {} // No boot ROM to unmap on CGB bus
+            0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize] = val,
+            0xFFFF => self.ie_reg = val,
+            _ => {}
+        }
+    }
+
+    fn tick(&mut self, m_cycles: u8) {
+        CgbBus::tick(self, m_cycles);
+    }
+}

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -156,6 +156,38 @@ impl CgbBus {
     pub fn clear_frame_ready(&mut self) {
         self.ppu.clear_frame_ready();
     }
+
+    /// Returns `true` when the APU has a sample ready to retrieve.
+    pub fn sample_ready(&self) -> bool {
+        self.apu.sample_ready()
+    }
+
+    /// Consume and return the next audio sample, or `None` if not ready.
+    pub fn take_sample(&mut self) -> Option<f32> {
+        self.apu.take_sample()
+    }
+
+    /// Set the APU output sample rate in Hz.
+    pub fn set_audio_sample_rate(&mut self, rate: f32) {
+        self.apu.set_sample_rate(rate);
+    }
+
+    /// Reset bus state (PPU, timer, joypad, APU, RAM, DMA).
+    pub fn reset(&mut self) {
+        self.ppu = Ppu::new_cgb();
+        self.ppu.write_register(0xFF40, 0x00);
+        self.timer = Timer::new();
+        self.joypad = Joypad::new();
+        self.apu = Apu::new(self.cart.is_cgb());
+        self.wram = [0u8; 0x2000];
+        self.hram = [0u8; 0x7F];
+        self.if_reg = 0;
+        self.ie_reg = 0;
+        self.dma_active = false;
+        self.dma_source = 0;
+        self.dma_position = 0;
+        self.dma_oam_blocked = false;
+    }
 }
 
 impl GbBus for CgbBus {

--- a/src/gb/bus/mod.rs
+++ b/src/gb/bus/mod.rs
@@ -1,7 +1,9 @@
 #[allow(unused_imports)]
 pub use bus::{GbBus, StubBus};
+pub use cgb_bus::CgbBus;
 pub use dmg_bus::DmgBus;
 
 #[allow(clippy::module_inception)]
 mod bus;
+mod cgb_bus;
 mod dmg_bus;

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -1,19 +1,108 @@
 //! Platform-facing Game Boy wrapper for the `Console` enum.
 //!
-//! `GameBoy` owns a [`Gb<DmgBus>`] (created lazily on [`load_rom`]) and a
+//! `GameBoy` owns a [`GbConsole`] (created lazily on [`load_rom`]) and a
 //! [`SharedAppContext`], providing the same interface that the NES side
 //! exposes so that frontends can drive both systems through `Console`.
+//!
+//! On load, the ROM's CGB flag byte (0x0143) determines whether a DMG or CGB
+//! bus is created; `.gbc` (CGB-only, 0xC0) and `.gb` CGB-compat (0x80) ROMs
+//! both get a [`CgbBus`], all others get a [`DmgBus`].
 
 use crate::gb::DmgModel;
-use crate::gb::bus::DmgBus;
+use crate::gb::bus::{CgbBus, DmgBus};
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
 use crate::platform::emulator::{Emulator, SystemType};
 
-/// Platform-facing Game Boy (DMG) console wrapper.
+/// Wraps either a DMG or CGB console, dispatching all platform operations.
+enum GbConsole {
+    Dmg(Box<Gb<DmgBus>>),
+    Cgb(Box<Gb<CgbBus>>),
+}
+
+impl GbConsole {
+    fn step(&mut self) -> u8 {
+        match self {
+            Self::Dmg(gb) => gb.step(),
+            Self::Cgb(gb) => gb.step(),
+        }
+    }
+
+    fn is_frame_ready(&self) -> bool {
+        match self {
+            Self::Dmg(gb) => gb.is_frame_ready(),
+            Self::Cgb(gb) => gb.is_frame_ready(),
+        }
+    }
+
+    fn clear_frame_ready(&mut self) {
+        match self {
+            Self::Dmg(gb) => gb.clear_frame_ready(),
+            Self::Cgb(gb) => gb.clear_frame_ready(),
+        }
+    }
+
+    fn screen_snapshot(&self) -> Vec<u8> {
+        match self {
+            Self::Dmg(gb) => gb.screen_snapshot(),
+            Self::Cgb(gb) => gb.screen_snapshot(),
+        }
+    }
+
+    fn screen_crc32(&self) -> u32 {
+        match self {
+            Self::Dmg(gb) => gb.screen_crc32(),
+            Self::Cgb(gb) => gb.screen_crc32(),
+        }
+    }
+
+    fn reset(&mut self, soft_reset: bool) {
+        match self {
+            Self::Dmg(gb) => gb.reset(soft_reset),
+            Self::Cgb(gb) => gb.reset(soft_reset),
+        }
+    }
+
+    fn set_joypad_button(&mut self, id: u8, pressed: bool) {
+        match self {
+            Self::Dmg(gb) => gb.cpu.bus.set_joypad_button(id, pressed),
+            Self::Cgb(gb) => gb.cpu.bus.set_joypad_button(id, pressed),
+        }
+    }
+
+    fn get_joypad_button_states(&self) -> u8 {
+        match self {
+            Self::Dmg(gb) => gb.cpu.bus.joypad.get_states(),
+            Self::Cgb(gb) => gb.cpu.bus.joypad.get_states(),
+        }
+    }
+
+    fn sample_ready(&self) -> bool {
+        match self {
+            Self::Dmg(gb) => gb.cpu.bus.sample_ready(),
+            Self::Cgb(gb) => gb.cpu.bus.sample_ready(),
+        }
+    }
+
+    fn take_sample(&mut self) -> Option<f32> {
+        match self {
+            Self::Dmg(gb) => gb.cpu.bus.take_sample(),
+            Self::Cgb(gb) => gb.cpu.bus.take_sample(),
+        }
+    }
+
+    fn set_audio_sample_rate(&mut self, rate: f32) {
+        match self {
+            Self::Dmg(gb) => gb.cpu.bus.set_audio_sample_rate(rate),
+            Self::Cgb(gb) => gb.cpu.bus.set_audio_sample_rate(rate),
+        }
+    }
+}
+
+/// Platform-facing Game Boy (DMG/CGB) console wrapper.
 pub struct GameBoy {
-    gb: Option<Gb<DmgBus>>,
+    gb: Option<GbConsole>,
     app_context: SharedAppContext,
 }
 
@@ -31,10 +120,20 @@ impl GameBoy {
         }
     }
 
-    /// Load a `.gb` ROM image. Replaces any previously loaded ROM.
+    /// Load a `.gb` or `.gbc` ROM image. Replaces any previously loaded ROM.
+    ///
+    /// Automatically selects DMG or CGB bus based on the ROM's CGB flag
+    /// byte at 0x0143: 0x80 (CGB+DMG) and 0xC0 (CGB-only) use [`CgbBus`];
+    /// all other values use [`DmgBus`].
     pub fn load_rom(&mut self, bytes: &[u8], _name: &str) -> Result<(), String> {
         let cart = load_cartridge(bytes).map_err(|e| format!("{e:?}"))?;
-        self.gb = Some(Gb::new(DmgBus::new(cart, DmgModel::DmgAbc)));
+        self.gb = Some(if cart.is_cgb() {
+            let mut gb = Gb::new(CgbBus::new(cart));
+            gb.cpu.reset_registers_cgb();
+            GbConsole::Cgb(Box::new(gb))
+        } else {
+            GbConsole::Dmg(Box::new(Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))))
+        });
         Ok(())
     }
 
@@ -82,7 +181,7 @@ impl GameBoy {
     /// Left=6, Right=7.
     pub fn set_button(&mut self, id: u8, pressed: bool) {
         if let Some(gb) = &mut self.gb {
-            gb.cpu.bus.set_joypad_button(id, pressed);
+            gb.set_joypad_button(id, pressed);
         }
     }
 
@@ -98,7 +197,7 @@ impl GameBoy {
     pub fn get_joypad_button_states(&self) -> u8 {
         self.gb
             .as_ref()
-            .map_or(0, |gb| gb.cpu.bus.joypad.get_states())
+            .map_or(0, |gb| gb.get_joypad_button_states())
     }
 
     /// Serialize emulator state (not supported for MVP — returns `Err`).
@@ -123,18 +222,18 @@ impl GameBoy {
 
     /// Returns `true` when the APU has a sample ready to retrieve.
     pub fn sample_ready(&self) -> bool {
-        self.gb.as_ref().is_some_and(|gb| gb.cpu.bus.sample_ready())
+        self.gb.as_ref().is_some_and(|gb| gb.sample_ready())
     }
 
     /// Retrieve the next APU audio sample, or `None` if not ready.
     pub fn get_sample(&mut self) -> Option<f32> {
-        self.gb.as_mut().and_then(|gb| gb.cpu.bus.take_sample())
+        self.gb.as_mut().and_then(|gb| gb.take_sample())
     }
 
     /// Set the APU output sample rate in Hz.
     pub fn set_audio_sample_rate(&mut self, rate: f32) {
         if let Some(gb) = &mut self.gb {
-            gb.cpu.bus.set_audio_sample_rate(rate);
+            gb.set_audio_sample_rate(rate);
         }
     }
 
@@ -267,6 +366,19 @@ mod tests {
         rom
     }
 
+    fn minimal_cgb_rom() -> Vec<u8> {
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0143] = 0xC0; // CGB-only flag
+        rom[0x0147] = 0x00; // ROM only
+        rom[0x0148] = 0x00; // 32 KB
+        rom[0x0149] = 0x00; // no RAM
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+        rom
+    }
+
     // ── safety before ROM load ──────────────────────────────────────────────
 
     #[test]
@@ -318,6 +430,36 @@ mod tests {
     fn test_load_valid_rom_succeeds() {
         let mut gb = make_gameboy();
         assert!(gb.load_rom(&minimal_rom(), "test.gb").is_ok());
+    }
+
+    #[test]
+    fn test_load_cgb_rom_succeeds() {
+        let mut gb = make_gameboy();
+        assert!(gb.load_rom(&minimal_cgb_rom(), "test.gbc").is_ok());
+    }
+
+    #[test]
+    fn test_cgb_rom_run_tick_returns_nonzero_cycles() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_cgb_rom(), "test.gbc").unwrap();
+        let cycles = gb.run_tick();
+        assert!(cycles > 0, "expected non-zero cycles, got {cycles}");
+    }
+
+    #[test]
+    fn test_cgb_rom_joypad_roundtrip() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_cgb_rom(), "test.gbc").unwrap();
+        let mask: u8 = 0b0000_0001; // A pressed
+        gb.set_joypad_button_states(mask);
+        assert_eq!(gb.get_joypad_button_states(), mask);
+    }
+
+    #[test]
+    fn test_cgb_rom_audio_sample_rate_does_not_panic() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_cgb_rom(), "test.gbc").unwrap();
+        gb.set_audio_sample_rate(48_000.0);
     }
 
     #[test]

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -92,6 +92,19 @@ impl Gb<DmgBus> {
 
 /// CGB screen and frame API.
 impl Gb<CgbBus> {
+    /// Reset the console.
+    ///
+    /// - `soft_reset = true`: resets only the CPU registers to the CGB
+    ///   post-boot-ROM state (bus state preserved).
+    /// - `soft_reset = false`: resets CPU registers **and** all bus state.
+    pub fn reset(&mut self, soft_reset: bool) {
+        self.cpu.reset_registers_cgb();
+        if !soft_reset {
+            self.cpu.regs.pc = 0x0100;
+            self.cpu.bus.reset();
+        }
+    }
+
     /// Snapshot the current rendered screen as a 160×144 RGB byte vector.
     pub fn screen_snapshot(&self) -> Vec<u8> {
         self.cpu.bus.ppu.screen_buffer().snapshot()

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -1,3 +1,4 @@
+use crate::gb::bus::CgbBus;
 use crate::gb::bus::DmgBus;
 use crate::gb::bus::GbBus;
 use crate::gb::cpu::Sm83;
@@ -68,6 +69,29 @@ impl Gb<DmgBus> {
 
 /// DMG-specific screen and frame API.
 impl Gb<DmgBus> {
+    /// Snapshot the current rendered screen as a 160×144 RGB byte vector.
+    pub fn screen_snapshot(&self) -> Vec<u8> {
+        self.cpu.bus.ppu.screen_buffer().snapshot()
+    }
+
+    /// True if the PPU has completed a full frame since the last `clear_frame_ready`.
+    pub fn is_frame_ready(&self) -> bool {
+        self.cpu.bus.ppu.is_frame_ready()
+    }
+
+    /// Clear the frame-ready flag.
+    pub fn clear_frame_ready(&mut self) {
+        self.cpu.bus.ppu.clear_frame_ready();
+    }
+
+    /// CRC32 of the current screen buffer.
+    pub fn screen_crc32(&self) -> u32 {
+        self.cpu.bus.ppu.screen_buffer().crc32()
+    }
+}
+
+/// CGB screen and frame API.
+impl Gb<CgbBus> {
     /// Snapshot the current rendered screen as a 160×144 RGB byte vector.
     pub fn screen_snapshot(&self) -> Vec<u8> {
         self.cpu.bus.ppu.screen_buffer().snapshot()

--- a/src/gb/cpu/sm83.rs
+++ b/src/gb/cpu/sm83.rs
@@ -185,6 +185,23 @@ impl<B: GbBus> Sm83<B> {
         self.ime_pending = false;
     }
 
+    /// Reset the CPU registers to the post-boot-ROM CGB state.
+    ///
+    /// A CGB exits its boot ROM with A=$11 (hardware identifier), which allows
+    /// cartridges to detect CGB hardware at runtime.
+    pub fn reset_registers_cgb(&mut self) {
+        self.regs.set_af(0x1180); // A=$11, F=$80
+        self.regs.set_bc(0x0000);
+        self.regs.set_de(0xFF56);
+        self.regs.set_hl(0x000D);
+        self.regs.sp = 0xFFFE;
+        self.regs.pc = 0x0100;
+        self.ime = false;
+        self.halted = false;
+        self.halt_bug = false;
+        self.ime_pending = false;
+    }
+
     /// Advance the cycle counter by 1 M-cycle and tick peripherals.
     ///
     /// Used for internal CPU cycles that do not correspond to a memory access

--- a/src/gb/integration_tests/ppu_tests.rs
+++ b/src/gb/integration_tests/ppu_tests.rs
@@ -1,3 +1,4 @@
+use crate::gb::bus::CgbBus;
 use crate::gb::bus::DmgBus;
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
@@ -9,7 +10,23 @@ fn load_gb_rom(path: &str) -> Gb<DmgBus> {
     Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))
 }
 
+fn load_cgb_rom(path: &str) -> Gb<CgbBus> {
+    let rom = std::fs::read(path).expect("ROM file should be present");
+    let cart = load_cartridge(&rom).expect("valid GB ROM");
+    let mut gb = Gb::new(CgbBus::new(cart));
+    // Set CGB post-boot-ROM CPU register state (A=$11 = CGB hardware identifier).
+    gb.cpu.reset_registers_cgb();
+    gb
+}
+
 fn run_one_gb_frame(gb: &mut Gb<DmgBus>) {
+    gb.clear_frame_ready();
+    while !gb.is_frame_ready() {
+        gb.step();
+    }
+}
+
+fn run_one_cgb_frame(gb: &mut Gb<CgbBus>) {
     gb.clear_frame_ready();
     while !gb.is_frame_ready() {
         gb.step();
@@ -24,8 +41,45 @@ fn run_frames_and_crc(gb: &mut Gb<DmgBus>, n: u32) -> u32 {
     gb.cpu.bus.ppu.screen_buffer().crc32()
 }
 
+/// Run `n` CGB frames and return the CRC-32 of the screen buffer.
+fn run_cgb_frames_and_crc(gb: &mut Gb<CgbBus>, n: u32) -> u32 {
+    for _ in 0..n {
+        run_one_cgb_frame(gb);
+    }
+    gb.cpu.bus.ppu.screen_buffer().crc32()
+}
+
 /// Save the screen buffer as a PNG to `path` for visual inspection.
 fn save_screen_png(gb: &Gb<DmgBus>, path: &str) {
+    use crate::gb::ppu::screen_buffer::ScreenBuffer;
+    use png::{BitDepth, ColorType, Encoder};
+    use std::fs::File;
+    use std::io::{BufWriter, Write};
+
+    let buf = gb.cpu.bus.ppu.screen_buffer();
+    let w = ScreenBuffer::WIDTH;
+    let h = ScreenBuffer::HEIGHT;
+    let file = File::create(path).expect("should create PNG file");
+    let mut bw = BufWriter::new(file);
+    let mut enc = Encoder::new(&mut bw, w, h);
+    enc.set_color(ColorType::Rgb);
+    enc.set_depth(BitDepth::Eight);
+    let mut png_writer = enc.write_header().expect("write PNG header");
+    let raw: Vec<u8> = (0..h)
+        .flat_map(|y| {
+            (0..w).flat_map(move |x| {
+                let (r, g, b) = buf.get_pixel(x, y);
+                [r, g, b]
+            })
+        })
+        .collect();
+    png_writer.write_image_data(&raw).expect("write PNG data");
+    drop(png_writer);
+    bw.flush().expect("flush PNG writer");
+}
+
+/// Save the CGB screen buffer as a PNG to `path` for visual inspection.
+fn save_cgb_screen_png(gb: &Gb<CgbBus>, path: &str) {
     use crate::gb::ppu::screen_buffer::ScreenBuffer;
     use png::{BitDepth, ColorType, Encoder};
     use std::fs::File;
@@ -73,18 +127,18 @@ fn test_dmg_acid2_frame_matches_reference_crc() {
 
 /// Validate that `cgb-acid2.gbc` renders a frame matching the expected CRC.
 ///
-/// This test is ignored until CGB emulation is implemented.
+/// Baseline CRC established after visual confirmation against the published
+/// cgb-acid2 CGB reference image (color smiley face, correct CGB palette/priority).
 /// Tracking issue: https://github.com/rmstdope/neser/issues/2099
 #[test]
-#[ignore = "CGB emulation not yet implemented — unignore once CgbBus exists and baseline is confirmed"]
 fn test_cgb_acid2_frame_matches_reference_crc() {
-    // TODO: replace with a CGB-capable Gb<CgbBus> once CGB emulation is implemented.
-    let mut gb = load_gb_rom("roms/gb/automated_tests/cgb-acid2/cgb-acid2.gbc");
+    let mut gb = load_cgb_rom("roms/gb/automated_tests/cgb-acid2/cgb-acid2.gbc");
 
-    let crc = run_frames_and_crc(&mut gb, 200);
+    // Run 200 frames to allow the ROM to render its test output.
+    let crc = run_cgb_frames_and_crc(&mut gb, 200);
 
-    // Replace with visually confirmed CRC once CGB emulation is implemented.
-    const EXPECTED_CRC: u32 = 0x0000_0000;
+    // CRC established after visual confirmation — see PR for screenshot.
+    const EXPECTED_CRC: u32 = 0x0E0B_C136;
     assert_eq!(
         crc, EXPECTED_CRC,
         "cgb-acid2 frame CRC mismatch: got {crc:#010X}, expected {EXPECTED_CRC:#010X}"
@@ -102,5 +156,19 @@ fn save_dmg_acid2_screenshot() {
     }
     save_screen_png(&gb, "dmg-acid2-screenshot.png");
     println!("Screenshot saved to dmg-acid2-screenshot.png");
+    println!("CRC: {:#010X}", gb.cpu.bus.ppu.screen_buffer().crc32());
+}
+
+/// Screenshot helper: saves `cgb-acid2.gbc` frame 200 to `cgb-acid2-screenshot.png`.
+/// Run with `cargo test -- --ignored` for visual baseline inspection.
+#[test]
+#[ignore = "screenshot helper — run manually for visual baseline inspection"]
+fn save_cgb_acid2_screenshot() {
+    let mut gb = load_cgb_rom("roms/gb/automated_tests/cgb-acid2/cgb-acid2.gbc");
+    for _ in 0..200 {
+        run_one_cgb_frame(&mut gb);
+    }
+    save_cgb_screen_png(&gb, "cgb-acid2-screenshot.png");
+    println!("Screenshot saved to cgb-acid2-screenshot.png");
     println!("CRC: {:#010X}", gb.cpu.bus.ppu.screen_buffer().crc32());
 }

--- a/src/gb/ppu/background.rs
+++ b/src/gb/ppu/background.rs
@@ -201,4 +201,81 @@ mod tests {
         // Then: colour index 2
         assert_eq!(idx, 2);
     }
+
+    // ── CGB background pixel tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_cgb_bg_palette_num_extracted_from_attrs() {
+        // Given: tile attrs at map slot (0,0) in VRAM bank 1 with palette_num=5 (bits 0-2 = 0b101)
+        let vram = blank_vram();
+        let mut bank1 = blank_vram();
+        bank1[0x1800] = 0x05; // palette bits 0-2 = 5
+        // When: fetch at (0, 0)
+        let px = fetch_bg_pixel_cgb(0, 0, &vram, &bank1, 0x91, 0, 0);
+        // Then: palette_num == 5
+        assert_eq!(px.palette_num, 5);
+    }
+
+    #[test]
+    fn test_cgb_bg_priority_flag_extracted_from_attrs() {
+        // Given: tile attrs with bit 7 set (bg_priority)
+        let vram = blank_vram();
+        let mut bank1 = blank_vram();
+        bank1[0x1800] = 0x80; // bg_priority bit set
+        let px = fetch_bg_pixel_cgb(0, 0, &vram, &bank1, 0x91, 0, 0);
+        assert!(px.bg_priority);
+        // Without bit 7: false
+        bank1[0x1800] = 0x00;
+        let px2 = fetch_bg_pixel_cgb(0, 0, &vram, &bank1, 0x91, 0, 0);
+        assert!(!px2.bg_priority);
+    }
+
+    #[test]
+    fn test_cgb_bg_tile_data_read_from_vram_bank1_when_attr_bit3_set() {
+        // Given: tile index 0 in map bank 0; attrs with VRAM bank bit (bit 3) set
+        // Tile 0 in bank 0: all zeros
+        // Tile 0 in bank 1: row 0 low=0xFF → colour 1 for all pixels
+        let vram = blank_vram();
+        let mut bank1 = blank_vram();
+        bank1[0x1800] = 0x08; // VRAM bank bit set, palette 0
+        bank1[0x0000] = 0xFF; // tile 0 row 0 low byte in bank 1
+        bank1[0x0001] = 0x00; // tile 0 row 0 high byte in bank 1
+        let px = fetch_bg_pixel_cgb(0, 0, &vram, &bank1, 0x91, 0, 0);
+        // Pixel 0 (leftmost): bit = 7, colour = (0>>7)&1 << 1 | (0xFF>>7)&1 = 1
+        assert_eq!(px.colour_index, 1);
+        assert_eq!(px.vram_bank, 1);
+    }
+
+    #[test]
+    fn test_cgb_bg_x_flip_reverses_pixel_order() {
+        // Tile 0 row 0: low=0x01 → only bit 0 (rightmost pixel, pixel_in_tile=7) has colour 1.
+        // Without x_flip: pixel at x=7 (rightmost) has colour 1; x=0 has colour 0.
+        // With x_flip: pixel at x=0 (leftmost) has colour 1.
+        let mut vram = blank_vram();
+        let mut bank1 = blank_vram();
+        vram[0x0000] = 0x01; // only bit 0 set → colour 1 at rightmost pixel
+        // No flip (attrs=0): x=0 should see bit 7 → colour 0
+        let px_no_flip = fetch_bg_pixel_cgb(0, 0, &vram, &bank1, 0x91, 0, 0);
+        assert_eq!(px_no_flip.colour_index, 0);
+        // x_flip set (attrs bit 5): x=0 should see bit 0 → colour 1
+        bank1[0x1800] = 0x20; // x_flip bit
+        let px_x_flip = fetch_bg_pixel_cgb(0, 0, &vram, &bank1, 0x91, 0, 0);
+        assert_eq!(px_x_flip.colour_index, 1);
+    }
+
+    #[test]
+    fn test_cgb_bg_y_flip_reverses_row_order() {
+        // Tile 0: row 7 (bottom) has colour 1; row 0 (top) has colour 0.
+        let mut vram = blank_vram();
+        let mut bank1 = blank_vram();
+        vram[0x000E] = 0xFF; // tile 0 row 7 low byte (row_offset = 7*2 = 14)
+        vram[0x000F] = 0x00;
+        // No y_flip: scanline=0 → row 0 → colour 0
+        let px_no = fetch_bg_pixel_cgb(0, 0, &vram, &bank1, 0x91, 0, 0);
+        assert_eq!(px_no.colour_index, 0);
+        // y_flip set (attrs bit 6): scanline=0 → row_in_tile = 7-0 = 7 → colour 1
+        bank1[0x1800] = 0x40; // y_flip bit
+        let px_yf = fetch_bg_pixel_cgb(0, 0, &vram, &bank1, 0x91, 0, 0);
+        assert_eq!(px_yf.colour_index, 1);
+    }
 }

--- a/src/gb/ppu/background.rs
+++ b/src/gb/ppu/background.rs
@@ -36,6 +36,98 @@ pub fn fetch_bg_pixel(x: u32, scanline: u8, vram: &[u8; 0x2000], lcdc: u8, scx: 
     ((high >> bit) & 1) << 1 | ((low >> bit) & 1)
 }
 
+/// CGB background pixel with full tile attribute information.
+#[derive(Debug, Clone, Copy)]
+pub struct BgPixelCgb {
+    /// Colour index (0–3) from the tile data.
+    pub colour_index: u8,
+    /// BG palette number (0–7) from VRAM bank 1 tile attribute bits 0–2.
+    pub palette_num: u8,
+    /// Whether the tile data comes from VRAM bank 1 (attribute bit 3).
+    pub vram_bank: u8,
+    /// Background-to-OAM priority flag (attribute bit 7).
+    /// When true and the BG colour index is non-zero, the BG pixel is drawn
+    /// on top of OBJ pixels (in master-priority mode).
+    pub bg_priority: bool,
+}
+
+/// Fetch a CGB background pixel and its tile attributes for a given screen pixel.
+///
+/// Tile data is fetched from VRAM bank 0 or bank 1 according to the attribute's
+/// VRAM bank bit.  Tile attributes are always read from VRAM bank 1 at the same
+/// tile map address as the tile index in bank 0.
+///
+/// # Arguments
+/// * `x`           — Screen X coordinate (0–159)
+/// * `scanline`    — Current scanline (LY, 0–143)
+/// * `vram`        — VRAM bank 0 ($8000–$9FFF)
+/// * `vram_bank1`  — VRAM bank 1
+/// * `lcdc`        — Current LCDC register value
+/// * `scx`         — Horizontal scroll (SCX)
+/// * `scy`         — Vertical scroll (SCY)
+pub fn fetch_bg_pixel_cgb(
+    x: u32,
+    scanline: u8,
+    vram: &[u8; 0x2000],
+    vram_bank1: &[u8; 0x2000],
+    lcdc: u8,
+    scx: u8,
+    scy: u8,
+) -> BgPixelCgb {
+    let bg_x = scx.wrapping_add(x as u8);
+    let bg_y = scy.wrapping_add(scanline);
+
+    let map_base: usize = if lcdc & 0x08 != 0 { 0x1C00 } else { 0x1800 };
+    let tile_col = (bg_x / 8) as usize;
+    let tile_row = (bg_y / 8) as usize;
+    let map_offset = map_base + tile_row * 32 + tile_col;
+
+    let tile_index_raw = vram[map_offset];
+    // Tile attributes live at the same map offset in VRAM bank 1.
+    let attrs = vram_bank1[map_offset];
+
+    let palette_num = attrs & 0x07;
+    let tile_vram_bank = (attrs >> 3) & 0x01;
+    let x_flip = attrs & 0x20 != 0;
+    let y_flip = attrs & 0x40 != 0;
+    let bg_priority = attrs & 0x80 != 0;
+
+    let tile_data_start: usize = if lcdc & 0x10 != 0 {
+        (tile_index_raw as usize) * 16
+    } else {
+        (0x1000i32 + (tile_index_raw as i8 as i32) * 16) as usize
+    };
+
+    let mut row_in_tile = (bg_y % 8) as usize;
+    if y_flip {
+        row_in_tile = 7 - row_in_tile;
+    }
+
+    let pixel_in_tile = bg_x % 8;
+    let bit = if x_flip {
+        pixel_in_tile
+    } else {
+        7 - pixel_in_tile
+    };
+
+    let tile_vram = if tile_vram_bank != 0 {
+        vram_bank1
+    } else {
+        vram
+    };
+    let addr = tile_data_start + row_in_tile * 2;
+    let low = tile_vram[addr];
+    let high = tile_vram[addr + 1];
+    let colour_index = ((high >> bit) & 1) << 1 | ((low >> bit) & 1);
+
+    BgPixelCgb {
+        colour_index,
+        palette_num,
+        vram_bank: tile_vram_bank,
+        bg_priority,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gb/ppu/mod.rs
+++ b/src/gb/ppu/mod.rs
@@ -13,10 +13,14 @@ use timing::{PpuMode, Timing};
 /// Dots per CPU M-cycle — the granularity at which Mode 3 length is observable.
 const DOTS_PER_M_CYCLE: u16 = 4;
 
-/// DMG PPU.
+/// DMG/CGB PPU.
 ///
 /// Owns VRAM ($8000–$9FFF) and OAM ($FE00–$FE9F) buffers, all I/O registers,
 /// timing state, and the rendered screen buffer.
+///
+/// In CGB mode (`cgb_mode = true`) the PPU additionally owns VRAM bank 1,
+/// CGB color palette RAM, and handles the CGB-specific registers
+/// (`$FF4F` VBK, `$FF68/$FF69` BCPS/BCPD, `$FF6A/$FF6B` OCPS/OCPD, `$FF6C` OPRI).
 pub struct Ppu {
     pub vram: [u8; 0x2000],
     pub oam: [u8; 0xA0],
@@ -35,6 +39,25 @@ pub struct Ppu {
     /// Changing LYC while the LCD is off has no effect on this bit.
     /// When the LCD is re-enabled, the bit is updated immediately (LY=0).
     lyc_eq_ly_frozen: bool,
+
+    // ── CGB-only fields ───────────────────────────────────────────────────────
+    /// `true` when running in CGB mode; enables bank-1 VRAM and color palettes.
+    pub cgb_mode: bool,
+    /// CGB VRAM bank 1 ($8000–$9FFF when VBK=$01). Holds BG tile attributes and
+    /// additional tile data for sprites.
+    pub vram_bank1: [u8; 0x2000],
+    /// `$FF4F` VBK — VRAM bank select (bit 0: 0=bank0, 1=bank1; upper bits read as 1).
+    pub vbk: u8,
+    /// CGB BG color palette RAM — 8 palettes × 4 colors × 2 bytes (5-5-5 little-endian).
+    pub bg_palette_ram: [u8; 64],
+    /// CGB OBJ color palette RAM — 8 palettes × 4 colors × 2 bytes (5-5-5 little-endian).
+    pub obj_palette_ram: [u8; 64],
+    /// `$FF68` BCPS — BG Color Palette Specification (index + auto-increment flag).
+    pub bcps: u8,
+    /// `$FF6A` OCPS — OBJ Color Palette Specification (index + auto-increment flag).
+    pub ocps: u8,
+    /// `$FF6C` OPRI bit 0 — Object priority mode: `false`=OAM order (CGB), `true`=X-coord (DMG).
+    pub opri: bool,
 }
 
 impl Ppu {
@@ -49,6 +72,22 @@ impl Ppu {
             window_line: 0,
             prev_stat_irq_line: false,
             lyc_eq_ly_frozen: false,
+            cgb_mode: false,
+            vram_bank1: [0u8; 0x2000],
+            vbk: 0,
+            bg_palette_ram: [0u8; 64],
+            obj_palette_ram: [0u8; 64],
+            bcps: 0,
+            ocps: 0,
+            opri: false,
+        }
+    }
+
+    /// Create a new PPU initialised for CGB (Game Boy Color) mode.
+    pub fn new_cgb() -> Self {
+        Self {
+            cgb_mode: true,
+            ..Self::new()
         }
     }
 
@@ -86,14 +125,29 @@ impl Ppu {
         // Render the current visible scanline when Mode 3→Mode 0 transition fires.
         if events.render_scanline {
             let scanline = self.timing.ly();
-            rendering::render_scanline(
-                scanline,
-                &self.vram,
-                &self.oam,
-                &self.registers,
-                &mut self.window_line,
-                &mut self.screen_buffer,
-            );
+            if self.cgb_mode {
+                rendering::render_scanline_cgb(
+                    scanline,
+                    &self.vram,
+                    &self.vram_bank1,
+                    &self.oam,
+                    &self.registers,
+                    &self.bg_palette_ram,
+                    &self.obj_palette_ram,
+                    &mut self.window_line,
+                    self.opri,
+                    &mut self.screen_buffer,
+                );
+            } else {
+                rendering::render_scanline(
+                    scanline,
+                    &self.vram,
+                    &self.oam,
+                    &self.registers,
+                    &mut self.window_line,
+                    &mut self.screen_buffer,
+                );
+            }
         }
 
         // V-Blank interrupt (IF bit 0).
@@ -178,22 +232,34 @@ impl Ppu {
     ///
     /// Returns 0xFF if the CPU is blocked (Mode 3 — Pixel Transfer while LCD on).
     /// When LCD is disabled VRAM is always accessible.
+    /// In CGB mode, routes to bank 0 or bank 1 based on the VBK register.
     pub fn read_vram(&self, addr: u16) -> u8 {
         if self.registers.lcd_enabled() && self.timing.mode() == PpuMode::PixelTransfer {
             return 0xFF;
         }
-        self.vram[(addr - 0x8000) as usize]
+        let offset = (addr - 0x8000) as usize;
+        if self.cgb_mode && self.vbk & 0x01 != 0 {
+            self.vram_bank1[offset]
+        } else {
+            self.vram[offset]
+        }
     }
 
     /// Write to VRAM address $8000–$9FFF.
     ///
     /// Silently ignored if the CPU is blocked (Mode 3 — Pixel Transfer while LCD on).
     /// When LCD is disabled VRAM is always accessible.
+    /// In CGB mode, routes to bank 0 or bank 1 based on the VBK register.
     pub fn write_vram(&mut self, addr: u16, val: u8) {
         if self.registers.lcd_enabled() && self.timing.mode() == PpuMode::PixelTransfer {
             return;
         }
-        self.vram[(addr - 0x8000) as usize] = val;
+        let offset = (addr - 0x8000) as usize;
+        if self.cgb_mode && self.vbk & 0x01 != 0 {
+            self.vram_bank1[offset] = val;
+        } else {
+            self.vram[offset] = val;
+        }
     }
 
     /// Read from OAM address $FE00–$FE9F.
@@ -283,6 +349,68 @@ impl Ppu {
         }
         // LCD 1→0: lyc_eq_ly_frozen is intentionally NOT cleared here —
         // hardware retains the last LYC=LY state when the LCD is powered off.
+    }
+
+    // ── CGB color palette & bank registers ───────────────────────────────────
+
+    /// Read a CGB-specific PPU register.
+    ///
+    /// Handles `$FF4F` (VBK), `$FF68` (BCPS), `$FF69` (BCPD), `$FF6A` (OCPS),
+    /// `$FF6B` (OCPD), `$FF6C` (OPRI).  Returns `None` if the address is not
+    /// a CGB register.
+    pub fn read_cgb_register(&self, addr: u16) -> Option<u8> {
+        match addr {
+            // VBK: bit 0 = selected bank; upper bits always read as 1.
+            0xFF4F => Some(0xFE | (self.vbk & 0x01)),
+            0xFF68 => Some(self.bcps),
+            0xFF69 => Some(self.bg_palette_ram[(self.bcps & 0x3F) as usize]),
+            0xFF6A => Some(self.ocps),
+            0xFF6B => Some(self.obj_palette_ram[(self.ocps & 0x3F) as usize]),
+            0xFF6C => Some(0xFE | self.opri as u8),
+            _ => None,
+        }
+    }
+
+    /// Write a CGB-specific PPU register.
+    ///
+    /// Returns `true` if the address was handled.
+    pub fn write_cgb_register(&mut self, addr: u16, val: u8) -> bool {
+        match addr {
+            0xFF4F => {
+                self.vbk = val & 0x01;
+                true
+            }
+            0xFF68 => {
+                self.bcps = val;
+                true
+            }
+            0xFF69 => {
+                let index = (self.bcps & 0x3F) as usize;
+                self.bg_palette_ram[index] = val;
+                // Auto-increment address after write if bit 7 is set.
+                if self.bcps & 0x80 != 0 {
+                    self.bcps = 0x80 | ((self.bcps + 1) & 0x3F);
+                }
+                true
+            }
+            0xFF6A => {
+                self.ocps = val;
+                true
+            }
+            0xFF6B => {
+                let index = (self.ocps & 0x3F) as usize;
+                self.obj_palette_ram[index] = val;
+                if self.ocps & 0x80 != 0 {
+                    self.ocps = 0x80 | ((self.ocps + 1) & 0x3F);
+                }
+                true
+            }
+            0xFF6C => {
+                self.opri = val & 0x01 != 0;
+                true
+            }
+            _ => false,
+        }
     }
 
     // ── Interrupt interface ───────────────────────────────────────────────────

--- a/src/gb/ppu/rendering.rs
+++ b/src/gb/ppu/rendering.rs
@@ -103,6 +103,148 @@ pub fn render_scanline(
     }
 }
 
+/// Convert a 5-bit CGB palette component to 8-bit.
+///
+/// Uses the formula specified by the cgb-acid2 test: `(c5 << 3) | (c5 >> 2)`.
+#[inline]
+fn cgb_5bit_to_8bit(c5: u8) -> u8 {
+    (c5 << 3) | (c5 >> 2)
+}
+
+/// Look up an RGB color from CGB palette RAM.
+///
+/// `palette_ram` — 64-byte palette RAM (8 palettes × 4 colors × 2 bytes, 5-5-5 LE).
+/// `palette_num` — Palette index (0–7).
+/// `colour_index` — Color slot within the palette (0–3; 0 is transparent for OBJ).
+///
+/// Returns `(r8, g8, b8)` with 8-bit components.
+fn cgb_palette_lookup(palette_ram: &[u8; 64], palette_num: u8, colour_index: u8) -> (u8, u8, u8) {
+    let base = (palette_num as usize) * 8 + (colour_index as usize) * 2;
+    let lo = palette_ram[base];
+    let hi = palette_ram[base + 1];
+    let color = u16::from_le_bytes([lo, hi]);
+    let r5 = (color & 0x1F) as u8;
+    let g5 = ((color >> 5) & 0x1F) as u8;
+    let b5 = ((color >> 10) & 0x1F) as u8;
+    (
+        cgb_5bit_to_8bit(r5),
+        cgb_5bit_to_8bit(g5),
+        cgb_5bit_to_8bit(b5),
+    )
+}
+
+/// Render one full CGB scanline (0–143) into `screen_buffer`.
+///
+/// Implements CGB compositing rules:
+/// - `LCDC bit 0` is the **master priority** flag (not BG enable as in DMG).
+///   - 0: OBJ pixels always win over BG/Window pixels.
+///   - 1: Normal priority — BG tile priority bit and/or OBJ priority bit can
+///     cause BG to appear on top when the BG colour index is non-zero.
+/// - OBJ priority is determined by OAM order when `opri_dmg_mode` is false
+///   (CGB default), or by X-coordinate when true.
+#[allow(clippy::too_many_arguments)]
+pub fn render_scanline_cgb(
+    scanline: u8,
+    vram: &[u8; 0x2000],
+    vram_bank1: &[u8; 0x2000],
+    oam: &[u8; 0xA0],
+    registers: &Registers,
+    bg_palette_ram: &[u8; 64],
+    obj_palette_ram: &[u8; 64],
+    window_line: &mut u8,
+    opri_dmg_mode: bool,
+    screen_buffer: &mut ScreenBuffer,
+) {
+    let lcdc = registers.lcdc;
+    let obj_enabled = lcdc & 0x02 != 0;
+    let win_enabled = lcdc & 0x20 != 0;
+    // In CGB mode, LCDC bit 0 is master priority (not BG enable).
+    let master_priority = lcdc & 0x01 != 0;
+
+    let sprite_indices = if obj_enabled {
+        sprites::scan_oam_line(scanline, oam, lcdc)
+    } else {
+        Vec::new()
+    };
+
+    let mut window_active = false;
+
+    for x in 0..ScreenBuffer::WIDTH {
+        // Fetch BG pixel (always rendered in CGB mode regardless of LCDC bit 0).
+        let bg_px = background::fetch_bg_pixel_cgb(
+            x,
+            scanline,
+            vram,
+            vram_bank1,
+            lcdc,
+            registers.scx,
+            registers.scy,
+        );
+
+        // Window may override BG.
+        let bw_px = if win_enabled {
+            match window::fetch_window_pixel_cgb(
+                x,
+                scanline,
+                vram,
+                vram_bank1,
+                lcdc,
+                registers.wx,
+                registers.wy,
+                *window_line,
+            ) {
+                Some(win_px) => {
+                    window_active = true;
+                    win_px
+                }
+                None => bg_px,
+            }
+        } else {
+            bg_px
+        };
+
+        // Fetch OBJ pixel.
+        let sprite_px = if obj_enabled {
+            sprites::fetch_sprite_pixel_cgb(
+                x,
+                scanline,
+                &sprite_indices,
+                oam,
+                vram,
+                vram_bank1,
+                lcdc,
+                opri_dmg_mode,
+            )
+        } else {
+            None
+        };
+
+        // CGB compositing:
+        // - If no OBJ pixel → render BG/Window.
+        // - If BG colour index == 0 → OBJ wins.
+        // - If master priority == 0 → OBJ always wins.
+        // - If master priority == 1 and (BG tile priority or OBJ priority) and BG colour != 0 → BG wins.
+        // - Otherwise OBJ wins.
+        let (r, g, b) = if let Some(sp) = sprite_px {
+            let bg_wins =
+                bw_px.colour_index != 0 && master_priority && (bw_px.bg_priority || sp.bg_priority);
+            if bg_wins {
+                cgb_palette_lookup(bg_palette_ram, bw_px.palette_num, bw_px.colour_index)
+            } else {
+                cgb_palette_lookup(obj_palette_ram, sp.cgb_palette, sp.colour_index)
+            }
+        } else {
+            cgb_palette_lookup(bg_palette_ram, bw_px.palette_num, bw_px.colour_index)
+        };
+
+        screen_buffer.set_pixel(x, scanline as u32, r, g, b);
+    }
+
+    if window_active {
+        *window_line = window_line.wrapping_add(1);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gb/ppu/rendering.rs
+++ b/src/gb/ppu/rendering.rs
@@ -353,4 +353,133 @@ mod tests {
             );
         }
     }
+
+    // ── CGB rendering helper tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_cgb_5bit_to_8bit_known_values() {
+        assert_eq!(cgb_5bit_to_8bit(0), 0);
+        assert_eq!(cgb_5bit_to_8bit(31), 255); // (31<<3)|(31>>2) = 248|7 = 255
+        assert_eq!(cgb_5bit_to_8bit(1), 8); // (1<<3)|(1>>2) = 8|0 = 8
+        assert_eq!(cgb_5bit_to_8bit(16), 132); // (16<<3)|(16>>2) = 128|4 = 132
+    }
+
+    #[test]
+    fn test_cgb_palette_lookup_decodes_5_5_5_le() {
+        // palette 0, colour 1: R=31, G=0, B=0 → lo=0x1F, hi=0x00
+        let mut palette_ram = [0u8; 64];
+        palette_ram[2] = 0x1F; // colour 1 lo byte: R=31 (bits 0-4)
+        palette_ram[3] = 0x00; // colour 1 hi byte
+        let (r, g, b) = cgb_palette_lookup(&palette_ram, 0, 1);
+        assert_eq!(r, 255, "R should be max");
+        assert_eq!(g, 0, "G should be 0");
+        assert_eq!(b, 0, "B should be 0");
+    }
+
+    fn blank_vram_bank1() -> [u8; 0x2000] {
+        [0u8; 0x2000]
+    }
+
+    fn blank_palette_ram() -> [u8; 64] {
+        [0u8; 64]
+    }
+
+    /// Build palette_ram with colour `slot` in palette 0 = max white (0x7FFF in 5-5-5 LE).
+    fn palette_ram_with_white_at(slot: usize) -> [u8; 64] {
+        let mut p = blank_palette_ram();
+        p[slot * 2] = 0xFF;
+        p[slot * 2 + 1] = 0x7F;
+        p
+    }
+
+    #[test]
+    fn test_cgb_master_priority_off_obj_always_wins() {
+        // LCDC bit 0 = 0 → master_priority = false → OBJ always wins over BG.
+        // Sprite at (screen_x=0, screen_y=0); bg tile at (0,0).
+        // BG palette colour 1 = white; OBJ palette colour 1 = black.
+        // Even with bg_priority flag on the BG tile, OBJ should win.
+        let mut vram = blank_vram();
+        let mut oam = blank_oam();
+        // Sprite at screen (0,0): oam_y=16, oam_x=8, tile 0, attrs=0x80 (bg_priority set)
+        oam[0] = 16;
+        oam[1] = 8;
+        oam[2] = 0;
+        oam[3] = 0x80;
+        // BG tile 0 row 0: colour 1 (bank 0 attr in bank1[0x1800] has bg_priority bit set)
+        vram[0x0000] = 0xFF; // tile 0 row 0 low: colour 1 for all pixels
+        let mut bank1_with_bgprio = blank_vram_bank1();
+        bank1_with_bgprio[0x1800] = 0x80; // BG tile attr: bg_priority
+        // Sprite tile 0 row 0: black via obj_palette_ram (all zeros)
+        // vram tile 0 is reused (colour 1); OBJ also colour 1 → both non-transparent
+
+        let mut regs = default_registers();
+        regs.lcdc = 0x92u8; // 1001_0010: LCD on, tile_data $8000 (bit4), sprites on (bit1), master_priority=0 (bit0=0)
+
+        let bg_palette = palette_ram_with_white_at(1); // palette 0, colour 1 = white
+        let obj_palette = blank_palette_ram(); // palette 0, colour 1 = black (all zeros)
+
+        let mut sb = ScreenBuffer::new();
+        let mut wl = 0u8;
+        render_scanline_cgb(
+            0,
+            &vram,
+            &bank1_with_bgprio,
+            &oam,
+            &regs,
+            &bg_palette,
+            &obj_palette,
+            &mut wl,
+            false,
+            &mut sb,
+        );
+        // master_priority=false → OBJ always wins → black
+        assert_eq!(
+            sb.get_pixel(0, 0),
+            (0, 0, 0),
+            "OBJ (black) must win when master_priority=false"
+        );
+    }
+
+    #[test]
+    fn test_cgb_bg_priority_beats_obj_when_master_priority_set() {
+        // LCDC bit 0 = 1 → master_priority = true.
+        // BG tile has bg_priority=true and colour_index != 0 → BG wins.
+        // BG palette colour 1 = white; OBJ palette colour 1 = black.
+        let mut vram = blank_vram();
+        let mut oam = blank_oam();
+        oam[0] = 16;
+        oam[1] = 8;
+        oam[2] = 0;
+        oam[3] = 0x00; // sprite at (0,0), no priority flag
+        vram[0x0000] = 0xFF; // tile 0 row 0 low: colour 1
+        let mut bank1 = blank_vram_bank1();
+        bank1[0x1800] = 0x80; // BG tile attr: bg_priority bit set
+
+        let mut regs = default_registers();
+        // 1001_0011: LCD on, tile data $8000 (bit4), sprites on (bit1), master_priority=1 (bit0)
+        regs.lcdc = 0x93u8;
+
+        let bg_palette = palette_ram_with_white_at(1); // colour 1 = white
+        let obj_palette = blank_palette_ram(); // colour 1 = black
+
+        let mut sb = ScreenBuffer::new();
+        let mut wl = 0u8;
+        render_scanline_cgb(
+            0,
+            &vram,
+            &bank1,
+            &oam,
+            &regs,
+            &bg_palette,
+            &obj_palette,
+            &mut wl,
+            false,
+            &mut sb,
+        );
+        assert_eq!(
+            sb.get_pixel(0, 0),
+            (255, 255, 255),
+            "BG (white) must win with master_priority=true and bg_priority"
+        );
+    }
 }

--- a/src/gb/ppu/sprites.rs
+++ b/src/gb/ppu/sprites.rs
@@ -660,4 +660,106 @@ mod tests {
         assert_eq!(calculate_obj_penalty(&indices, &oam, 3), 11);
         assert_eq!(calculate_obj_penalty(&indices, &oam, 7), 11);
     }
+
+    // ── CGB sprite pixel tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_cgb_sprite_palette_bits_extracted_from_attrs() {
+        // Sprite at (screen_x=0, screen_y=0): oam_x=8, oam_y=16
+        // attrs = 0x05 → CGB palette 5 (bits 0-2)
+        let mut oam = blank_oam();
+        oam[0] = 16; // oam_y
+        oam[1] = 8; // oam_x
+        oam[2] = 0; // tile 0
+        oam[3] = 0x05; // palette 5
+        let mut vram = blank_vram();
+        vram[0x0000] = 0xFF; // tile 0, row 0: colour 1 (all pixels non-transparent)
+        let bank1 = blank_vram();
+        let lcdc = 0x02u8; // sprites enabled (bit 1)
+        let indices = [0usize];
+        let result = fetch_sprite_pixel_cgb(0, 0, &indices, &oam, &vram, &bank1, lcdc, false);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().cgb_palette, 5);
+    }
+
+    #[test]
+    fn test_cgb_sprite_tile_data_read_from_vram_bank1_when_attr_bit3_set() {
+        // attrs bit 3 = VRAM bank 1. Tile 0 in bank 0 all zeros; tile 0 in bank 1 has data.
+        let mut oam = blank_oam();
+        oam[0] = 16;
+        oam[1] = 8;
+        oam[2] = 0;
+        oam[3] = 0x08; // VRAM bank bit (bit 3)
+        let vram = blank_vram(); // bank 0: all zero (transparent)
+        let mut bank1 = blank_vram();
+        bank1[0x0000] = 0xFF; // tile 0, row 0 in bank 1: colour 1
+        let lcdc = 0x02u8;
+        let indices = [0usize];
+        // Without bank1 flag this would return None (transparent); must return Some
+        let result = fetch_sprite_pixel_cgb(0, 0, &indices, &oam, &vram, &bank1, lcdc, false);
+        assert!(result.is_some(), "tile data should come from VRAM bank 1");
+        assert_eq!(result.unwrap().colour_index, 1);
+    }
+
+    #[test]
+    fn test_cgb_sprite_oam_order_priority_when_dmg_mode_false() {
+        // Two sprites overlapping at x=1.
+        // Sprite 0: oam_x=9 (screen_x=1), tile 0, colour 1
+        // Sprite 1: oam_x=8 (screen_x=0, covers x=0..7), tile 1, colour 3
+        // In CGB (OAM order) mode: sprite 0 wins (lower OAM index).
+        let mut oam = blank_oam();
+        // Sprite 0 at screen_x=1
+        oam[0] = 16;
+        oam[1] = 9;
+        oam[2] = 0;
+        oam[3] = 0x01; // palette 1
+        // Sprite 1 at screen_x=0
+        oam[4] = 16;
+        oam[5] = 8;
+        oam[6] = 1;
+        oam[7] = 0x02; // palette 2
+        let mut vram = blank_vram();
+        vram[0x0000] = 0xFF; // tile 0 row 0: colour 1
+        vram[0x0010] = 0xFF;
+        vram[0x0011] = 0xFF; // tile 1 row 0: colour 3
+        let bank1 = blank_vram();
+        let lcdc = 0x02u8;
+        let indices = [0usize, 1usize];
+        let result = fetch_sprite_pixel_cgb(1, 0, &indices, &oam, &vram, &bank1, lcdc, false);
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap().cgb_palette,
+            1,
+            "OAM-order: sprite 0 (palette 1) should win"
+        );
+    }
+
+    #[test]
+    fn test_cgb_sprite_dmg_xcoord_priority_when_dmg_mode_true() {
+        // Same two sprites; in DMG-compat (dmg_priority_mode=true) X-coord wins.
+        // Sprite 1 has lower oam_x=8 < oam_x=9, so it should win.
+        let mut oam = blank_oam();
+        oam[0] = 16;
+        oam[1] = 9;
+        oam[2] = 0;
+        oam[3] = 0x01; // palette 1
+        oam[4] = 16;
+        oam[5] = 8;
+        oam[6] = 1;
+        oam[7] = 0x02; // palette 2
+        let mut vram = blank_vram();
+        vram[0x0000] = 0xFF;
+        vram[0x0010] = 0xFF;
+        vram[0x0011] = 0xFF;
+        let bank1 = blank_vram();
+        let lcdc = 0x02u8;
+        let indices = [0usize, 1usize];
+        let result = fetch_sprite_pixel_cgb(1, 0, &indices, &oam, &vram, &bank1, lcdc, true);
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap().cgb_palette,
+            2,
+            "X-coord priority: sprite 1 (palette 2, lower X) should win"
+        );
+    }
 }

--- a/src/gb/ppu/sprites.rs
+++ b/src/gb/ppu/sprites.rs
@@ -3,8 +3,12 @@
 pub struct SpritePixel {
     /// Colour index (1–3; 0 is transparent and will never appear here).
     pub colour_index: u8,
-    /// Palette selection: 0 = OBP0, 1 = OBP1.
+    /// DMG palette selection: 0 = OBP0, 1 = OBP1.
+    /// In CGB mode this is unused; use `cgb_palette` instead.
     pub palette: u8,
+    /// CGB OBJ palette number (0–7, from OAM attribute bits 0–2).
+    /// Always 0 in DMG mode.
+    pub cgb_palette: u8,
     /// Priority: if true the sprite is drawn behind BG colours 1–3.
     pub bg_priority: bool,
 }
@@ -123,6 +127,109 @@ pub fn fetch_sprite_pixel(
         return Some(SpritePixel {
             colour_index,
             palette,
+            cgb_palette: 0,
+            bg_priority,
+        });
+    }
+    None
+}
+
+/// Fetch the highest-priority visible sprite pixel in CGB mode at screen position `x`.
+///
+/// When `dmg_priority_mode` is `false` (CGB default), priority is determined by OAM
+/// order (earlier entry wins). When `true`, X-coordinate priority is used as in DMG.
+///
+/// CGB OAM attributes (byte 3):
+/// - Bits 0–2: OBJ palette number (0–7)
+/// - Bit 3: Tile VRAM bank (0=bank0, 1=bank1)
+/// - Bit 5: H-flip
+/// - Bit 6: V-flip
+/// - Bit 7: OBJ-to-BG priority
+#[allow(clippy::too_many_arguments)]
+pub fn fetch_sprite_pixel_cgb(
+    x: u32,
+    scanline: u8,
+    sprite_indices: &[usize],
+    oam: &[u8; 0xA0],
+    vram: &[u8; 0x2000],
+    vram_bank1: &[u8; 0x2000],
+    lcdc: u8,
+    dmg_priority_mode: bool,
+) -> Option<SpritePixel> {
+    let height: u8 = if lcdc & 0x04 != 0 { 16 } else { 8 };
+
+    // In CGB mode (dmg_priority_mode=false) sprites are prioritized by OAM order
+    // (scan_oam_line already returns them in OAM index order).
+    // In DMG compatibility mode (dmg_priority_mode=true) sort by X-coord.
+    let mut sorted = [0usize; 10];
+    let mut count = 0usize;
+    for &i in sprite_indices.iter().take(10) {
+        sorted[count] = i;
+        count += 1;
+    }
+    if dmg_priority_mode {
+        sorted[..count].sort_by_key(|&i| (oam[i * 4 + 1], i));
+    }
+
+    for &i in &sorted[..count] {
+        let oam_y = oam[i * 4];
+        let oam_x = oam[i * 4 + 1];
+        let tile_num = oam[i * 4 + 2];
+        let attrs = oam[i * 4 + 3];
+
+        let screen_y = oam_y.wrapping_sub(16);
+        let screen_x = oam_x.wrapping_sub(8);
+
+        if x < screen_x as u32 || x >= screen_x as u32 + 8 {
+            continue;
+        }
+
+        let y_flip = attrs & 0x40 != 0;
+        let x_flip = attrs & 0x20 != 0;
+        let cgb_palette = attrs & 0x07;
+        let tile_vram_bank = (attrs >> 3) & 0x01;
+        let bg_priority = attrs & 0x80 != 0;
+
+        let mut row = (scanline - screen_y) as usize;
+        if y_flip {
+            row = (height as usize - 1) - row;
+        }
+
+        let mut pixel_x = (x as u8).wrapping_sub(screen_x);
+        if x_flip {
+            pixel_x = 7 - pixel_x;
+        }
+
+        let tile_index = if height == 16 {
+            if row < 8 {
+                (tile_num & 0xFE) as usize
+            } else {
+                row -= 8;
+                (tile_num | 0x01) as usize
+            }
+        } else {
+            tile_num as usize
+        };
+
+        let tile_vram = if tile_vram_bank != 0 {
+            vram_bank1
+        } else {
+            vram
+        };
+        let tile_addr = tile_index * 16;
+        let low = tile_vram[tile_addr + row * 2];
+        let high = tile_vram[tile_addr + row * 2 + 1];
+        let bit = 7 - pixel_x;
+        let colour_index = ((high >> bit) & 1) << 1 | ((low >> bit) & 1);
+
+        if colour_index == 0 {
+            continue;
+        }
+
+        return Some(SpritePixel {
+            colour_index,
+            palette: 0,
+            cgb_palette,
             bg_priority,
         });
     }

--- a/src/gb/ppu/window.rs
+++ b/src/gb/ppu/window.rs
@@ -1,3 +1,5 @@
+use crate::gb::ppu::background::BgPixelCgb;
+
 /// Fetch the DMG window layer colour index (0–3) for a given screen pixel.
 ///
 /// Returns `None` if the window does not cover pixel `(x, scanline)`.
@@ -60,6 +62,87 @@ pub fn fetch_window_pixel(
     let low = vram[addr];
     let high = vram[addr + 1];
     Some(((high >> bit) & 1) << 1 | ((low >> bit) & 1))
+}
+
+/// Fetch the CGB window pixel at `(x, scanline)` with full tile attribute info.
+///
+/// Returns `None` if the window does not cover the pixel.
+/// The window uses the same tile map indexing as the background, with tile
+/// attributes fetched from VRAM bank 1 at the same map address.
+#[allow(clippy::too_many_arguments)]
+pub fn fetch_window_pixel_cgb(
+    x: u32,
+    scanline: u8,
+    vram: &[u8; 0x2000],
+    vram_bank1: &[u8; 0x2000],
+    lcdc: u8,
+    wx: u8,
+    wy: u8,
+    window_line: u8,
+) -> Option<BgPixelCgb> {
+    if lcdc & 0x20 == 0 {
+        return None;
+    }
+    if scanline < wy {
+        return None;
+    }
+    let win_x_start = wx.saturating_sub(7);
+    if x < win_x_start as u32 {
+        return None;
+    }
+
+    let win_x = (x as u8).wrapping_sub(win_x_start);
+    let win_y = window_line;
+
+    // Window tile map: LCDC bit 6 (0 = $9800, 1 = $9C00).
+    let map_base: usize = if lcdc & 0x40 != 0 { 0x1C00 } else { 0x1800 };
+    let tile_col = (win_x / 8) as usize;
+    let tile_row = (win_y / 8) as usize;
+    let map_offset = map_base + tile_row * 32 + tile_col;
+
+    let tile_index_raw = vram[map_offset];
+    let attrs = vram_bank1[map_offset];
+
+    let palette_num = attrs & 0x07;
+    let tile_vram_bank = (attrs >> 3) & 0x01;
+    let x_flip = attrs & 0x20 != 0;
+    let y_flip = attrs & 0x40 != 0;
+    let bg_priority = attrs & 0x80 != 0;
+
+    let tile_data_start: usize = if lcdc & 0x10 != 0 {
+        (tile_index_raw as usize) * 16
+    } else {
+        (0x1000i32 + (tile_index_raw as i8 as i32) * 16) as usize
+    };
+
+    let mut row_in_tile = (win_y % 8) as usize;
+    if y_flip {
+        row_in_tile = 7 - row_in_tile;
+    }
+
+    let pixel_in_tile = win_x % 8;
+    let bit = if x_flip {
+        pixel_in_tile
+    } else {
+        7 - pixel_in_tile
+    };
+
+    let tile_vram = if tile_vram_bank != 0 {
+        vram_bank1
+    } else {
+        vram
+    };
+    let addr = tile_data_start + row_in_tile * 2;
+    let low = tile_vram[addr];
+    let high = tile_vram[addr + 1];
+    let colour_index = ((high >> bit) & 1) << 1 | ((low >> bit) & 1);
+
+    Some(BgPixelCgb {
+        colour_index,
+        palette_num,
+        vram_bank: tile_vram_bank,
+        bg_priority,
+    })
 }
 
 #[cfg(test)]

--- a/src/gb/ppu/window.rs
+++ b/src/gb/ppu/window.rs
@@ -86,12 +86,13 @@ pub fn fetch_window_pixel_cgb(
     if scanline < wy {
         return None;
     }
-    let win_x_start = wx.saturating_sub(7);
-    if x < win_x_start as u32 {
+    let win_x_start = i16::from(wx) - 7;
+    let visible_win_x_start = win_x_start.max(0) as u32;
+    if x < visible_win_x_start {
         return None;
     }
 
-    let win_x = (x as u8).wrapping_sub(win_x_start);
+    let win_x = ((x as i16) - win_x_start) as u8;
     let win_y = window_line;
 
     // Window tile map: LCDC bit 6 (0 = $9800, 1 = $9C00).
@@ -212,5 +213,73 @@ mod tests {
         let result = fetch_window_pixel(0, 0, &vram, lcdc, 7, 0, 0);
         // Then: colour index 3
         assert_eq!(result, Some(3));
+    }
+
+    // ── CGB window pixel tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_cgb_window_palette_num_extracted_from_bank1_attrs() {
+        // Given: window tile map entry (0,0) in bank 1 has palette_num=3 (bits 0-2)
+        let vram = blank_vram();
+        let mut bank1 = blank_vram();
+        bank1[0x1800] = 0x03; // palette 3
+        // LCDC: window enabled (bit5), tile data $8000 (bit4)
+        let lcdc = 0x30u8;
+        let result = fetch_window_pixel_cgb(0, 0, &vram, &bank1, lcdc, 7, 0, 0);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().palette_num, 3);
+    }
+
+    #[test]
+    fn test_cgb_window_bg_priority_extracted_from_bank1_attrs() {
+        // Given: attrs with bit 7 set
+        let vram = blank_vram();
+        let mut bank1 = blank_vram();
+        bank1[0x1800] = 0x80; // bg_priority bit
+        let lcdc = 0x30u8;
+        let result = fetch_window_pixel_cgb(0, 0, &vram, &bank1, lcdc, 7, 0, 0);
+        assert!(result.unwrap().bg_priority);
+    }
+
+    #[test]
+    fn test_cgb_window_wx_less_than_7_shifts_tilemap_correctly() {
+        // WX=0 places the window 7 pixels off-screen to the left.
+        // Screen x=0 should correspond to tile-map pixel 7 (tile col 0, pixel_in_tile=7).
+        // Tile 0 row 0: low=0x01 → only bit 0 has colour 1 (tile pixel 7, rightmost).
+        // With signed WX math: win_x = 0 - (0-7) = 7 → pixel_in_tile=7 → bit=0 → colour=1.
+        let mut vram = blank_vram();
+        let bank1 = blank_vram();
+        vram[0x1800] = 0; // tile index 0
+        vram[0x0000] = 0x01; // low byte: only bit 0 set
+        vram[0x0001] = 0x00; // high byte
+        let lcdc = 0x30u8; // window on (bit5), tile data $8000 (bit4)
+        let result = fetch_window_pixel_cgb(0, 0, &vram, &bank1, lcdc, 0, 0, 0);
+        assert!(
+            result.is_some(),
+            "window should be visible at x=0 when WX=0"
+        );
+        assert_eq!(
+            result.unwrap().colour_index,
+            1,
+            "screen x=0 with WX=0 must map to tile pixel 7 (colour 1)"
+        );
+    }
+
+    #[test]
+    fn test_cgb_window_tile_data_read_from_vram_bank1_when_attr_bit3_set() {
+        // Given: tile index 0 in map; attrs with VRAM bank bit (bit 3) set
+        // Tile 0 in bank 0: all zeros; tile 0 in bank 1 row 0: low=0xFF → colour 1
+        let vram = blank_vram();
+        let mut bank1 = blank_vram();
+        bank1[0x1800] = 0x08; // VRAM bank bit
+        bank1[0x0000] = 0xFF; // tile 0 row 0 in bank 1
+        bank1[0x0001] = 0x00;
+        let lcdc = 0x30u8;
+        let result = fetch_window_pixel_cgb(0, 0, &vram, &bank1, lcdc, 7, 0, 0);
+        assert!(result.is_some());
+        let px = result.unwrap();
+        assert_eq!(px.vram_bank, 1);
+        // Leftmost pixel: bit=7 of low byte 0xFF → (0xFF>>7)&1 = 1 → colour=1
+        assert_eq!(px.colour_index, 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ fn detect_system_type(path: &str) -> platform::emulator::SystemType {
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("");
-    if ext.eq_ignore_ascii_case("gb") {
+    if ext.eq_ignore_ascii_case("gb") || ext.eq_ignore_ascii_case("gbc") {
         platform::emulator::SystemType::GameBoy
     } else {
         platform::emulator::SystemType::Nes
@@ -429,6 +429,16 @@ mod tests {
     #[test]
     fn detect_system_type_gb_extension_returns_gameboy() {
         assert_eq!(detect_system_type("tetris.gb"), SystemType::GameBoy);
+    }
+
+    #[test]
+    fn detect_system_type_gbc_extension_returns_gameboy() {
+        assert_eq!(detect_system_type("game.gbc"), SystemType::GameBoy);
+    }
+
+    #[test]
+    fn detect_system_type_uppercase_gbc_returns_gameboy() {
+        assert_eq!(detect_system_type("GAME.GBC"), SystemType::GameBoy);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements Game Boy Color (CGB) emulation to make the cgb-acid2 test ROM pass.

## Changes

### New files
- `src/gb/bus/cgb_bus.rs`: CgbBus struct implementing GbBus with CGB-specific registers ($FF4F VBK, $FF68-$FF6B BCPS/BCPD/OCPS/OCPD, $FF6C OPRI)

### Modified files
- **sm83**: `reset_registers_cgb()` for CGB post-boot CPU state (A=$11, F=$80, BC=$0000, DE=$FF56, HL=$000D)
- **ppu**: extended with CGB fields (VRAM bank 1, 64-byte BG/OBJ palette RAMs, VBK/BCPS/OCPS/OPRI registers); bank-aware VRAM reads/writes; CGB rendering dispatch
- **background**: BgPixelCgb struct + fetch_bg_pixel_cgb() (tile attrs, H/V flip, palette, VRAM bank)
- **window**: fetch_window_pixel_cgb()
- **sprites**: SpritePixel extended with cgb_palette; fetch_sprite_pixel_cgb() with OAM-order priority
- **rendering**: cgb_5bit_to_8bit(), cgb_palette_lookup(), render_scanline_cgb() with master priority compositing rules
- **console**: Gb<CgbBus> screen/frame API impl block
- **tests**: removed #[ignore] from cgb-acid2 test; CRC 0x0E0BC136 established (visually confirmed)

## CGB features implemented

- VRAM bank 1 (tile attributes for BG, tile data for OBJ)
- CGB color palettes: 8x4-color BG + OBJ palettes (64 bytes each)
- LCDC bit 0 as master priority (not BG enable)
- CGB compositing: OBJ wins unless BG colour index != 0 AND master_priority AND (bg_tile_priority OR obj_priority)
- OAM-order OBJ priority (OPRI default CGB mode)
- 5-bit to 8-bit color conversion: (c5 << 3) | (c5 >> 2)

## Not implemented (not needed by cgb-acid2)

- Double-speed mode, WRAM banking, HDMA/GDMA, T-cycle accuracy

## Test results

- cgb-acid2 test passes with CRC 0x0E0BC136 (visually confirmed against reference image)
- All 8513 existing tests pass (no DMG regressions)
- WASM tests: 54 passed
- Python tests: 201 passed
- npm tests: 244 passed

Closes #2099