### PR TITLE
Fix GB web loading and frame_bench target warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ required-features = ["frontend"]
 
 [[bin]]
 name = "frame_bench"
-path = "benches/frame_bench.rs"
+path = "src/bin/frame_bench.rs"
 required-features = ["native"]
 
 [dev-dependencies]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
         command: WEB_APP_SERVER_COMMAND,
         url: WEB_APP_URL,
         reuseExistingServer: true,
-        timeout: 60_000
+        timeout: 120_000
     }
 });

--- a/src/bin/frame_bench.rs
+++ b/src/bin/frame_bench.rs
@@ -28,12 +28,10 @@ fn main() {
     nes.insert_cartridge(cart);
     nes.reset(false);
 
-    // Warm up: run 60 frames
     for _ in 0..60 {
         run_one_frame(&mut nes);
     }
 
-    // Benchmark
     let start = Instant::now();
     for _ in 0..num_frames {
         run_one_frame(&mut nes);
@@ -50,7 +48,6 @@ fn main() {
     println!("Per frame: {per_frame_ms:.3}ms");
     println!("FPS: {fps:.1}");
 
-    // Run multiple iterations for stable comparison
     println!("\nStability check (5 runs of {num_frames} frames):");
     for i in 0..5 {
         let start = Instant::now();

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -48,6 +48,7 @@ import {
 } from "./input/pointer_lock";
 import { computeButtonStates } from "./ui/emulation_controls";
 import { cycleFilterKey, filterOnConsoleSwitch, type FilterDef } from "./display/filters";
+import { selectRenderPipeline } from "./display/render_pipeline";
 import commonVertGlsl from "./shaders/common.vert.glsl?raw";
 import stockFragGlsl from "./shaders/stock.frag.glsl?raw";
 import crtFragGlsl from "./shaders/crt.frag.glsl?raw";
@@ -499,12 +500,13 @@ async function loadGbAssets() {
 }
 
 function setupGbPrograms() {
+    shaderProgram = createProgram(commonVertGlsl, stockFragGlsl);
     gbPass0Program = createProgram(gbPass0VertexSource, gbPass0FragmentSource);
     gbPass1Program = createProgram(gbPass1VertexSource, gbPass1FragmentSource);
     gbPass2Program = createProgram(gbBlurVertexSource, gbPass2FragmentSource);
     gbPass3Program = createProgram(gbBlurVertexSource, gbPass3FragmentSource);
     gbPass4Program = createProgram(gbPass4VertexSource, gbPass4FragmentSource);
-    if (!gbPass0Program || !gbPass1Program || !gbPass2Program || !gbPass3Program || !gbPass4Program) {
+    if (!shaderProgram || !gbPass0Program || !gbPass1Program || !gbPass2Program || !gbPass3Program || !gbPass4Program) {
         return false;
     }
     // Create previous-frame texture at source (GB) resolution
@@ -517,10 +519,27 @@ function setupGbPrograms() {
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 
     // FBOs created lazily in renderGbPass (to match canvas size)
-    shaderProgram = null;
     // Start async asset loading (palette + background PNGs)
     loadGbAssets();
     return true;
+}
+
+function renderFrameWithCurrentPipeline(frame: Uint8Array): boolean {
+    const pipeline = selectRenderPipeline({
+        filterType: filters[currentFilter]?.type,
+        gbAssetsLoaded,
+        hasSinglePassShader: shaderProgram !== null,
+    });
+
+    if (pipeline === "ntsc") {
+        return renderNtscPass(frame);
+    }
+
+    if (pipeline === "gb") {
+        return renderGbPass(frame);
+    }
+
+    return renderSinglePass(frame);
 }
 
 function setupFilterPrograms(filterName: string) {
@@ -1933,15 +1952,7 @@ function stepIdleScroller(timestamp: number) {
     }
 
     const frame = idleScroller!.renderFrame(timestamp);
-    const filter = filters[currentFilter];
-    let rendered = false;
-    if (filter?.type === "ntsc") {
-        rendered = renderNtscPass(frame);
-    } else if (filter?.type === "gb") {
-        rendered = renderGbPass(frame);
-    } else {
-        rendered = renderSinglePass(frame);
-    }
+    const rendered = renderFrameWithCurrentPipeline(frame);
 
     if (!rendered) {
         idleScrollerActive = false;
@@ -2218,17 +2229,10 @@ function step(timestamp: number) {
             return;
         }
 
-        const filter = filters[currentFilter];
         let rendered = true;
         const renderT0 = performance.now();
         if (shouldRender) {
-            if (filter?.type === "ntsc") {
-                rendered = renderNtscPass(frame);
-            } else if (filter?.type === "gb") {
-                rendered = renderGbPass(frame);
-            } else {
-                rendered = renderSinglePass(frame);
-            }
+            rendered = renderFrameWithCurrentPipeline(frame);
         }
         const renderElapsedMs = performance.now() - renderT0;
 

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -500,15 +500,32 @@ async function loadGbAssets() {
 }
 
 function setupGbPrograms() {
-    shaderProgram = createProgram(commonVertGlsl, stockFragGlsl);
-    gbPass0Program = createProgram(gbPass0VertexSource, gbPass0FragmentSource);
-    gbPass1Program = createProgram(gbPass1VertexSource, gbPass1FragmentSource);
-    gbPass2Program = createProgram(gbBlurVertexSource, gbPass2FragmentSource);
-    gbPass3Program = createProgram(gbBlurVertexSource, gbPass3FragmentSource);
-    gbPass4Program = createProgram(gbPass4VertexSource, gbPass4FragmentSource);
-    if (!shaderProgram || !gbPass0Program || !gbPass1Program || !gbPass2Program || !gbPass3Program || !gbPass4Program) {
+    const stockProgram = createProgram(commonVertGlsl, stockFragGlsl);
+    const pass0Program = createProgram(gbPass0VertexSource, gbPass0FragmentSource);
+    const pass1Program = createProgram(gbPass1VertexSource, gbPass1FragmentSource);
+    const pass2Program = createProgram(gbBlurVertexSource, gbPass2FragmentSource);
+    const pass3Program = createProgram(gbBlurVertexSource, gbPass3FragmentSource);
+    const pass4Program = createProgram(gbPass4VertexSource, gbPass4FragmentSource);
+    if (!stockProgram || !pass0Program || !pass1Program || !pass2Program || !pass3Program || !pass4Program) {
+        for (const program of [stockProgram, pass0Program, pass1Program, pass2Program, pass3Program, pass4Program]) {
+            if (program) {
+                gl.deleteProgram(program);
+            }
+        }
+        shaderProgram = null;
+        gbPass0Program = null;
+        gbPass1Program = null;
+        gbPass2Program = null;
+        gbPass3Program = null;
+        gbPass4Program = null;
         return false;
     }
+    shaderProgram = stockProgram;
+    gbPass0Program = pass0Program;
+    gbPass1Program = pass1Program;
+    gbPass2Program = pass2Program;
+    gbPass3Program = pass3Program;
+    gbPass4Program = pass4Program;
     // Create previous-frame texture at source (GB) resolution
     gbPrevFrameTex = gl.createTexture()!;
     gl.bindTexture(gl.TEXTURE_2D, gbPrevFrameTex);

--- a/web/src/display/render_pipeline.test.ts
+++ b/web/src/display/render_pipeline.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { selectRenderPipeline } from "./render_pipeline";
+
+describe("selectRenderPipeline", () => {
+    it("uses the GB pipeline once GB assets are ready", () => {
+        expect(
+            selectRenderPipeline({
+                filterType: "gb",
+                gbAssetsLoaded: true,
+                hasSinglePassShader: false,
+            }),
+        ).toBe("gb");
+    });
+
+    it("keeps GB rendering off the nullable single-pass shader while assets are loading", () => {
+        expect(
+            selectRenderPipeline({
+                filterType: "gb",
+                gbAssetsLoaded: false,
+                hasSinglePassShader: false,
+            }),
+        ).toBe("gb");
+    });
+
+    it("returns to single-pass rendering after switching back to NES", () => {
+        expect(
+            selectRenderPipeline({
+                filterType: "single",
+                gbAssetsLoaded: false,
+                hasSinglePassShader: true,
+            }),
+        ).toBe("single");
+    });
+
+    it("uses the NTSC pipeline for NTSC filters", () => {
+        expect(
+            selectRenderPipeline({
+                filterType: "ntsc",
+                gbAssetsLoaded: false,
+                hasSinglePassShader: false,
+            }),
+        ).toBe("ntsc");
+    });
+});

--- a/web/src/display/render_pipeline.ts
+++ b/web/src/display/render_pipeline.ts
@@ -1,0 +1,22 @@
+export type RenderPipeline = "single" | "ntsc" | "gb";
+
+export interface RenderPipelineState {
+    filterType: string | undefined;
+    gbAssetsLoaded: boolean;
+    hasSinglePassShader: boolean;
+}
+
+export function selectRenderPipeline(state: RenderPipelineState): RenderPipeline {
+    if (state.filterType === "ntsc") {
+        return "ntsc";
+    }
+
+    if (state.filterType === "gb") {
+        if (!state.gbAssetsLoaded) {
+            return state.hasSinglePassShader ? "single" : "gb";
+        }
+        return "gb";
+    }
+
+    return "single";
+}


### PR DESCRIPTION
## Summary
Fix GB ROM loading in the web frontend and include the related Cargo cleanup that removes the duplicate frame_bench target warning.

## What changed
- keep a valid single-pass shader available while GB shader assets are still loading
- centralize render pipeline selection used by the web render loops
- add focused regression coverage for GB render-path selection and NES switch-back behavior
- move the frame_bench binary out of benches/ so Cargo no longer defines it as both a bin and a bench target

## Validation
- manual verification: GB ROM loading works in the web frontend
- `npm test`
- `scripts/build_web.sh`
- `cargo check --bin frame_bench`
- `cargo fmt -- --check`

Fixes #2113
