### PR TITLE
Add joystick-style touch D-pad controls

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -35,12 +35,9 @@
           <div id="touch-controls" class="touch-controls" aria-hidden="true">
             <!-- D-pad (left of canvas) -->
             <div class="touch-dpad-area">
-              <div class="touch-dpad">
-                <div class="touch-dpad-btn touch-dpad-up" data-button="up" aria-label="D-pad Up"></div>
-                <div class="touch-dpad-btn touch-dpad-down" data-button="down" aria-label="D-pad Down"></div>
-                <div class="touch-dpad-btn touch-dpad-left" data-button="left" aria-label="D-pad Left"></div>
-                <div class="touch-dpad-btn touch-dpad-right" data-button="right" aria-label="D-pad Right"></div>
-                <div class="touch-dpad-center"></div>
+              <div class="touch-joystick" data-touch-zone="joystick" aria-label="Directional joystick">
+                <div class="touch-joystick-base"></div>
+                <div class="touch-joystick-knob"></div>
               </div>
             </div>
 

--- a/web/main.css
+++ b/web/main.css
@@ -187,72 +187,57 @@ body.touch-running .touch-hide {
   display: none;
 }
 
-/* ── D-pad styling ─────────────────────────────────── */
+/* ── Joystick styling ───────────────────────────────── */
 
-.touch-dpad {
+.touch-joystick {
   position: relative;
-  width: 130px;
-  height: 130px;
-}
-
-.touch-dpad-btn {
-  position: absolute;
-  background: #3a3a3a;
-  border: 2px solid #555;
+  width: 132px;
+  height: 132px;
+  --touch-stick-x: 0px;
+  --touch-stick-y: 0px;
   touch-action: none;
   user-select: none;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
 }
 
-.touch-dpad-btn.pressed {
-  background: #2a2a2a;
-  border-color: #444;
-  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.5);
-}
-
-.touch-dpad-up {
-  top: 0;
-  left: 40px;
-  width: 50px;
-  height: 45px;
-  border-radius: 6px 6px 0 0;
-}
-
-.touch-dpad-down {
-  bottom: 0;
-  left: 40px;
-  width: 50px;
-  height: 45px;
-  border-radius: 0 0 6px 6px;
-}
-
-.touch-dpad-left {
-  top: 40px;
-  left: 0;
-  width: 45px;
-  height: 50px;
-  border-radius: 6px 0 0 6px;
-}
-
-.touch-dpad-right {
-  top: 40px;
-  right: 0;
-  width: 45px;
-  height: 50px;
-  border-radius: 0 6px 6px 0;
-}
-
-.touch-dpad-center {
+.touch-joystick-base,
+.touch-joystick-knob {
   position: absolute;
-  top: 40px;
-  left: 40px;
-  width: 50px;
-  height: 50px;
-  background: #3a3a3a;
-  border: 2px solid #555;
-  border-radius: 0;
   pointer-events: none;
+}
+
+.touch-joystick-base {
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #5c5c5c 0%, #3a3a3a 58%, #262626 100%);
+  border: 2px solid #5b5b5b;
+  box-shadow: inset 0 8px 16px rgba(255, 255, 255, 0.08), inset 0 -10px 16px rgba(0, 0, 0, 0.35), 0 4px 14px rgba(0, 0, 0, 0.28);
+}
+
+.touch-joystick-knob {
+  left: 50%;
+  top: 50%;
+  width: 58px;
+  height: 58px;
+  margin-left: -29px;
+  margin-top: -29px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 32% 28%, #f7f7f7 0%, #cbcbcb 22%, #8a8a8a 62%, #5c5c5c 100%);
+  border: 2px solid #4c4c4c;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.38), inset 0 2px 4px rgba(255, 255, 255, 0.18);
+  transform: translate(var(--touch-stick-x), var(--touch-stick-y));
+  transition: transform 60ms linear, box-shadow 80ms ease, background 80ms ease;
+}
+
+.touch-joystick.pressed .touch-joystick-base {
+  border-color: #707070;
+  box-shadow: inset 0 10px 18px rgba(255, 255, 255, 0.1), inset 0 -12px 18px rgba(0, 0, 0, 0.45), 0 4px 16px rgba(0, 0, 0, 0.32);
+}
+
+.touch-joystick.pressed .touch-joystick-knob {
+  background: radial-gradient(circle at 32% 28%, #ffffff 0%, #dadada 20%, #989898 60%, #666666 100%);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.34), inset 0 2px 4px rgba(255, 255, 255, 0.22);
 }
 
 /* ── Action buttons (A/B) ──────────────────────────── */

--- a/web/src/input/touch_controls.test.ts
+++ b/web/src/input/touch_controls.test.ts
@@ -305,12 +305,12 @@ describe("TouchInputManager", () => {
         expect(manager.activeCount).toBe(0);
     });
 
-    it("tracks the active button for each touch identifier", () => {
+    it("tracks the active buttons for each touch identifier", () => {
         manager.handleTouchStart(fakeTouch(0, btnA));
         manager.handleTouchStart(fakeTouch(1, btnB));
 
-        expect(manager.getButtonForTouch(0)).toBe(NES_BUTTON.A);
-        expect(manager.getButtonForTouch(1)).toBe(NES_BUTTON.B);
+        expect(manager.getButtonsForTouch(0)).toEqual([NES_BUTTON.A]);
+        expect(manager.getButtonsForTouch(1)).toEqual([NES_BUTTON.B]);
         expect(manager.activeCount).toBe(2);
     });
 
@@ -337,7 +337,25 @@ describe("TouchInputManager", () => {
         expect(callback).toHaveBeenCalledTimes(1);
         expect(callback).toHaveBeenCalledWith(NES_BUTTON.RIGHT, false);
         expect(manager.activeCount).toBe(1);
-        expect(manager.getButtonForTouch(1)).toBe(NES_BUTTON.A);
+        expect(manager.getButtonsForTouch(1)).toEqual([NES_BUTTON.A]);
+    });
+
+    it("does not release a button while another touch still holds the same button", () => {
+        manager.handleTouchStart(fakeTouch(0, btnRight));
+        callback.mockClear();
+
+        manager.handleTouchStart(fakeTouch(1, btnRight));
+
+        expect(callback).not.toHaveBeenCalled();
+
+        manager.handleTouchEnd(fakeTouch(0, btnRight));
+
+        expect(callback).not.toHaveBeenCalled();
+
+        manager.handleTouchEnd(fakeTouch(1, btnRight));
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(NES_BUTTON.RIGHT, false);
     });
 
     // -----------------------------------------------------------------------
@@ -353,7 +371,7 @@ describe("TouchInputManager", () => {
 
         expect(callback).toHaveBeenCalledWith(NES_BUTTON.UP, false);
         expect(callback).toHaveBeenCalledWith(NES_BUTTON.RIGHT, true);
-        expect(manager.getButtonForTouch(0)).toBe(NES_BUTTON.RIGHT);
+        expect(manager.getButtonsForTouch(0)).toEqual([NES_BUTTON.RIGHT]);
     });
 
     it("does not fire callback when finger stays on the same button during move", () => {
@@ -399,12 +417,32 @@ describe("TouchInputManager", () => {
             manager.handleTouchMove(fakeTouch(0, joystickZone, clientX, clientY));
 
             expect(manager.activeCount).toBe(1);
+            expect(manager.getButtonsForTouch(0)).toEqual(expectedButtons);
             expect(callback).toHaveBeenCalledTimes(expectedButtons.length);
             expect(callback.mock.calls).toEqual(
                 expect.arrayContaining(expectedButtons.map((button) => [button, true])),
             );
         },
     );
+
+    it("does not release a direction while another joystick touch still holds it", () => {
+        manager.handleTouchStart(fakeTouch(0, joystickZone, 118, 64));
+        callback.mockClear();
+
+        manager.handleTouchStart(fakeTouch(1, joystickZone, 118, 64));
+
+        expect(callback).not.toHaveBeenCalled();
+
+        manager.handleTouchEnd(fakeTouch(0, joystickZone, 118, 64));
+
+        expect(callback).not.toHaveBeenCalled();
+        expect(manager.getButtonsForTouch(1)).toEqual([NES_BUTTON.RIGHT]);
+
+        manager.handleTouchEnd(fakeTouch(1, joystickZone, 118, 64));
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(NES_BUTTON.RIGHT, false);
+    });
 
     it("Given a captured joystick touch, When the thumb returns to the deadzone, Then the active directions are released", () => {
         manager.handleTouchStart(fakeTouch(0, joystickZone, 64, 64));

--- a/web/src/input/touch_controls.test.ts
+++ b/web/src/input/touch_controls.test.ts
@@ -22,6 +22,30 @@ function makeButtonElement(button: string): Element {
     return el;
 }
 
+/** Create a touch zone element with a fixed client rect for geometry tests. */
+function makeTouchZoneElement(
+    zone: string,
+    rect: { left: number; top: number; width: number; height: number },
+): Element {
+    const el = document.createElement("div");
+    el.setAttribute("data-touch-zone", zone);
+    Object.defineProperty(el, "getBoundingClientRect", {
+        configurable: true,
+        value: () => ({
+            x: rect.left,
+            y: rect.top,
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
+            right: rect.left + rect.width,
+            bottom: rect.top + rect.height,
+            toJSON: () => rect,
+        }),
+    });
+    return el;
+}
+
 /** Build a container that houses several button elements and can resolve
  *  elementFromPoint queries. */
 function makeContainer(buttons: Record<string, Element>) {
@@ -215,6 +239,7 @@ describe("TouchInputManager", () => {
     let btnB: Element;
     let btnUp: Element;
     let btnRight: Element;
+    let joystickZone: Element;
 
     beforeEach(() => {
         callback = vi.fn();
@@ -224,11 +249,18 @@ describe("TouchInputManager", () => {
         btnB = makeButtonElement("b");
         btnUp = makeButtonElement("up");
         btnRight = makeButtonElement("right");
+        joystickZone = makeTouchZoneElement("joystick", {
+            left: 0,
+            top: 0,
+            width: 128,
+            height: 128,
+        });
         container = makeContainer({
             a: btnA,
             b: btnB,
             up: btnUp,
             right: btnRight,
+            joystick: joystickZone,
         }) as HTMLElement;
     });
 
@@ -343,6 +375,98 @@ describe("TouchInputManager", () => {
 
         expect(callback).toHaveBeenCalledWith(NES_BUTTON.A, false);
         expect(manager.activeCount).toBe(0);
+    });
+
+    // -----------------------------------------------------------------------
+    // Geometry-driven touch zones — joystick
+    // -----------------------------------------------------------------------
+
+    it.each([
+        ["up", 64, 14, [NES_BUTTON.UP]],
+        ["up-right", 110, 18, [NES_BUTTON.UP, NES_BUTTON.RIGHT]],
+        ["right", 118, 64, [NES_BUTTON.RIGHT]],
+        ["down-right", 110, 110, [NES_BUTTON.DOWN, NES_BUTTON.RIGHT]],
+        ["down", 64, 118, [NES_BUTTON.DOWN]],
+        ["down-left", 18, 110, [NES_BUTTON.DOWN, NES_BUTTON.LEFT]],
+        ["left", 10, 64, [NES_BUTTON.LEFT]],
+        ["up-left", 18, 18, [NES_BUTTON.UP, NES_BUTTON.LEFT]],
+    ])(
+        "Given a captured joystick touch, When the thumb moves to the %s sector, Then the matching directions are pressed",
+        (_label, clientX, clientY, expectedButtons) => {
+            manager.handleTouchStart(fakeTouch(0, joystickZone, 64, 64));
+            callback.mockClear();
+
+            manager.handleTouchMove(fakeTouch(0, joystickZone, clientX, clientY));
+
+            expect(manager.activeCount).toBe(1);
+            expect(callback).toHaveBeenCalledTimes(expectedButtons.length);
+            expect(callback.mock.calls).toEqual(
+                expect.arrayContaining(expectedButtons.map((button) => [button, true])),
+            );
+        },
+    );
+
+    it("Given a captured joystick touch, When the thumb returns to the deadzone, Then the active directions are released", () => {
+        manager.handleTouchStart(fakeTouch(0, joystickZone, 64, 64));
+        manager.handleTouchMove(fakeTouch(0, joystickZone, 118, 64));
+        callback.mockClear();
+
+        manager.handleTouchMove(fakeTouch(0, joystickZone, 64, 64));
+
+        expect(manager.activeCount).toBe(1);
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith(NES_BUTTON.RIGHT, false);
+    });
+
+    it("Given a captured joystick touch, When the thumb moves beyond the circle, Then the direction stays active until release", () => {
+        manager.handleTouchStart(fakeTouch(0, joystickZone, 64, 64));
+        manager.handleTouchMove(fakeTouch(0, joystickZone, 18, 110));
+        callback.mockClear();
+
+        manager.handleTouchMove(fakeTouch(0, joystickZone, -48, 192));
+
+        expect(manager.activeCount).toBe(1);
+        expect(callback).not.toHaveBeenCalled();
+
+        manager.handleTouchEnd(fakeTouch(0, joystickZone, -48, 192));
+
+        expect(callback.mock.calls).toEqual(
+            expect.arrayContaining([
+                [NES_BUTTON.DOWN, false],
+                [NES_BUTTON.LEFT, false],
+            ]),
+        );
+    });
+
+    // -----------------------------------------------------------------------
+    // Visual feedback
+    // -----------------------------------------------------------------------
+
+    it("Given a button touch, When it starts and ends, Then the pressed class follows the button state", () => {
+        manager.handleTouchStart(fakeTouch(0, btnA));
+        expect(btnA.classList.contains("pressed")).toBe(true);
+
+        manager.handleTouchEnd(fakeTouch(0, btnA));
+        expect(btnA.classList.contains("pressed")).toBe(false);
+    });
+
+    it("Given a joystick touch, When it moves away from center and ends, Then the joystick pressed state and knob offset are updated", () => {
+        const knob = document.createElement("div");
+        knob.className = "touch-joystick-knob";
+        joystickZone.appendChild(knob);
+
+        manager.handleTouchStart(fakeTouch(0, joystickZone, 64, 64));
+        manager.handleTouchMove(fakeTouch(0, joystickZone, 118, 64));
+
+        expect(joystickZone.classList.contains("pressed")).toBe(true);
+        expect(joystickZone.style.getPropertyValue("--touch-stick-x")).not.toBe("");
+        expect(joystickZone.style.getPropertyValue("--touch-stick-y")).not.toBe("");
+
+        manager.handleTouchEnd(fakeTouch(0, joystickZone, 118, 64));
+
+        expect(joystickZone.classList.contains("pressed")).toBe(false);
+        expect(joystickZone.style.getPropertyValue("--touch-stick-x")).toBe("0px");
+        expect(joystickZone.style.getPropertyValue("--touch-stick-y")).toBe("0px");
     });
 
     // -----------------------------------------------------------------------

--- a/web/src/input/touch_controls.ts
+++ b/web/src/input/touch_controls.ts
@@ -106,6 +106,20 @@ function emitPressedButtons(callback: ButtonChangeCallback, currentButtons: numb
     }
 }
 
+function collectPressedButtons(states: Iterable<ActiveTouchState>): number[] {
+    const buttons: number[] = [];
+
+    for (const state of states) {
+        for (const button of state.buttons) {
+            if (!buttons.includes(button)) {
+                buttons.push(button);
+            }
+        }
+    }
+
+    return buttons;
+}
+
 function findTouchBindingElement(element: Element | null): Element | null {
     return element?.closest("[data-button], [data-touch-zone]") ?? null;
 }
@@ -225,6 +239,12 @@ export class TouchInputManager {
         this.callback = callback;
     }
 
+    private emitGlobalButtonChanges(previousButtons: number[]) {
+        const nextButtons = collectPressedButtons(this.activeTouches.values());
+        emitReleasedButtons(this.callback, previousButtons, nextButtons);
+        emitPressedButtons(this.callback, previousButtons, nextButtons);
+    }
+
     private refreshVisualState(changedRoots: Array<Element | null>) {
         const roots = new Set<Element>();
         for (const root of changedRoots) {
@@ -265,12 +285,14 @@ export class TouchInputManager {
         const resolved = resolveTouchState(touch);
         if (!resolved.captured) return;
 
+        const previousButtons = collectPressedButtons(this.activeTouches.values());
+
         this.activeTouches.set(touch.identifier, {
             buttons: resolved.buttons,
             visualRoot: resolved.visualRoot,
             stickOffset: resolved.stickOffset,
         });
-        emitPressedButtons(this.callback, [], resolved.buttons);
+        this.emitGlobalButtonChanges(previousButtons);
         this.refreshVisualState([resolved.visualRoot]);
     }
 
@@ -278,6 +300,8 @@ export class TouchInputManager {
     handleTouchMove(touch: Touch): void {
         const currentState = this.activeTouches.get(touch.identifier);
         const resolved = resolveTouchState(touch);
+
+        const previousButtons = collectPressedButtons(this.activeTouches.values());
 
         if (currentState === undefined) {
             if (!resolved.captured) return;
@@ -287,14 +311,14 @@ export class TouchInputManager {
                 visualRoot: resolved.visualRoot,
                 stickOffset: resolved.stickOffset,
             });
-            emitPressedButtons(this.callback, [], resolved.buttons);
+            this.emitGlobalButtonChanges(previousButtons);
             this.refreshVisualState([resolved.visualRoot]);
             return;
         }
 
         if (!resolved.captured) {
             this.activeTouches.delete(touch.identifier);
-            emitReleasedButtons(this.callback, currentState.buttons, []);
+            this.emitGlobalButtonChanges(previousButtons);
             this.refreshVisualState([currentState.visualRoot]);
             return;
         }
@@ -305,16 +329,16 @@ export class TouchInputManager {
 
         if (!buttonsChanged && !visualRootChanged && !stickOffsetChanged) return;
 
-        if (buttonsChanged) {
-            emitReleasedButtons(this.callback, currentState.buttons, resolved.buttons);
-            emitPressedButtons(this.callback, currentState.buttons, resolved.buttons);
-        }
-
         this.activeTouches.set(touch.identifier, {
             buttons: resolved.buttons,
             visualRoot: resolved.visualRoot,
             stickOffset: resolved.stickOffset,
         });
+
+        if (buttonsChanged) {
+            this.emitGlobalButtonChanges(previousButtons);
+        }
+
         this.refreshVisualState([currentState.visualRoot, resolved.visualRoot]);
     }
 
@@ -323,8 +347,10 @@ export class TouchInputManager {
         const state = this.activeTouches.get(touch.identifier);
         if (state === undefined) return;
 
+        const previousButtons = collectPressedButtons(this.activeTouches.values());
+
         this.activeTouches.delete(touch.identifier);
-        emitReleasedButtons(this.callback, state.buttons, []);
+        this.emitGlobalButtonChanges(previousButtons);
         this.refreshVisualState([state.visualRoot]);
     }
 
@@ -333,9 +359,9 @@ export class TouchInputManager {
         this.handleTouchEnd(touch);
     }
 
-    /** Get the currently pressed button for a touch identifier, if any. */
-    getButtonForTouch(identifier: number): number | undefined {
-        return this.activeTouches.get(identifier)?.buttons[0];
+    /** Get the currently pressed buttons for a touch identifier, if any. */
+    getButtonsForTouch(identifier: number): number[] {
+        return [...(this.activeTouches.get(identifier)?.buttons ?? [])];
     }
 
     /** Get count of active touches. */

--- a/web/src/input/touch_controls.ts
+++ b/web/src/input/touch_controls.ts
@@ -23,6 +23,27 @@ const BUTTON_NAME_MAP: Record<string, number> = {
 
 export type ButtonChangeCallback = (button: number, pressed: boolean) => void;
 
+type StickOffset = {
+    x: number;
+    y: number;
+};
+
+type ResolvedTouchState = {
+    captured: boolean;
+    buttons: number[];
+    visualRoot: Element | null;
+    stickOffset: StickOffset | null;
+};
+
+type ActiveTouchState = {
+    buttons: number[];
+    visualRoot: Element | null;
+    stickOffset: StickOffset | null;
+};
+
+const JOYSTICK_DEADZONE_RATIO = 0.22;
+const JOYSTICK_KNOB_OFFSET_RATIO = 0.45;
+
 /**
  * Detect whether the current device supports touch input.
  */
@@ -59,49 +80,252 @@ export function resolveButtonFromElement(element: Element | null): number | unde
     return BUTTON_NAME_MAP[name.toLowerCase()];
 }
 
+function sameButtons(left: number[], right: number[]): boolean {
+    return left.length === right.length && left.every((button, index) => button === right[index]);
+}
+
+function sameStickOffset(left: StickOffset | null, right: StickOffset | null): boolean {
+    return left?.x === right?.x && left?.y === right?.y;
+}
+
+function emitReleasedButtons(callback: ButtonChangeCallback, currentButtons: number[], nextButtons: number[]) {
+    const next = new Set(nextButtons);
+    for (const button of currentButtons) {
+        if (!next.has(button)) {
+            callback(button, false);
+        }
+    }
+}
+
+function emitPressedButtons(callback: ButtonChangeCallback, currentButtons: number[], nextButtons: number[]) {
+    const current = new Set(currentButtons);
+    for (const button of nextButtons) {
+        if (!current.has(button)) {
+            callback(button, true);
+        }
+    }
+}
+
+function findTouchBindingElement(element: Element | null): Element | null {
+    return element?.closest("[data-button], [data-touch-zone]") ?? null;
+}
+
+function togglePressedClass(element: Element | null, pressed: boolean) {
+    element?.classList.toggle("pressed", pressed);
+}
+
+function applyVisualState(element: Element, buttons: number[], stickOffset: StickOffset | null) {
+    const zone = element.getAttribute("data-touch-zone")?.toLowerCase();
+
+    switch (zone) {
+    case "joystick": {
+        togglePressedClass(element, buttons.length > 0);
+        if (element instanceof HTMLElement) {
+            element.style.setProperty("--touch-stick-x", `${Math.round(stickOffset?.x ?? 0)}px`);
+            element.style.setProperty("--touch-stick-y", `${Math.round(stickOffset?.y ?? 0)}px`);
+        }
+        return;
+    }
+    default:
+        if (resolveButtonFromElement(element) !== undefined) {
+            togglePressedClass(element, buttons.length > 0);
+        }
+    }
+}
+
+function resolveJoystickState(element: Element, touch: Touch): { buttons: number[]; stickOffset: StickOffset } {
+    const rect = element.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+        return { buttons: [], stickOffset: { x: 0, y: 0 } };
+    }
+
+    const centerX = rect.left + (rect.width / 2);
+    const centerY = rect.top + (rect.height / 2);
+    const distanceX = touch.clientX - centerX;
+    const distanceY = touch.clientY - centerY;
+    const radius = Math.min(rect.width, rect.height) / 2;
+    const distance = Math.hypot(distanceX, distanceY);
+    const clampedDistance = Math.min(distance, radius);
+    const offsetScale = distance === 0 ? 0 : (clampedDistance / distance) * (JOYSTICK_KNOB_OFFSET_RATIO);
+    const stickOffset = {
+        x: distanceX * offsetScale,
+        y: distanceY * offsetScale,
+    };
+
+    if (distance <= radius * JOYSTICK_DEADZONE_RATIO) {
+        return { buttons: [], stickOffset: { x: 0, y: 0 } };
+    }
+
+    const sector = ((Math.round(Math.atan2(distanceY, distanceX) / (Math.PI / 4)) % 8) + 8) % 8;
+
+    switch (sector) {
+    case 0:
+        return { buttons: [NES_BUTTON.RIGHT], stickOffset };
+    case 1:
+        return { buttons: [NES_BUTTON.DOWN, NES_BUTTON.RIGHT], stickOffset };
+    case 2:
+        return { buttons: [NES_BUTTON.DOWN], stickOffset };
+    case 3:
+        return { buttons: [NES_BUTTON.DOWN, NES_BUTTON.LEFT], stickOffset };
+    case 4:
+        return { buttons: [NES_BUTTON.LEFT], stickOffset };
+    case 5:
+        return { buttons: [NES_BUTTON.UP, NES_BUTTON.LEFT], stickOffset };
+    case 6:
+        return { buttons: [NES_BUTTON.UP], stickOffset };
+    case 7:
+        return { buttons: [NES_BUTTON.UP, NES_BUTTON.RIGHT], stickOffset };
+    default:
+        return { buttons: [], stickOffset };
+    }
+}
+
+function resolveTouchState(touch: Touch): ResolvedTouchState {
+    const element = findTouchBindingElement(touch.target as Element | null);
+
+    const button = resolveButtonFromElement(element);
+    if (button !== undefined) {
+        return {
+            captured: true,
+            buttons: [button],
+            visualRoot: element,
+            stickOffset: null,
+        };
+    }
+
+    const zone = element?.getAttribute("data-touch-zone")?.toLowerCase();
+    switch (zone) {
+    case "joystick": {
+        const joystickState = resolveJoystickState(element, touch);
+        return {
+            captured: true,
+            buttons: joystickState.buttons,
+            visualRoot: element,
+            stickOffset: joystickState.stickOffset,
+        };
+    }
+    default:
+        return {
+            captured: false,
+            buttons: [],
+            visualRoot: null,
+            stickOffset: null,
+        };
+    }
+}
+
 /**
  * Manages active touch state and fires callbacks on button changes.
  */
 export class TouchInputManager {
-    private activeTouches: Map<number, number> = new Map();
+    private activeTouches: Map<number, ActiveTouchState> = new Map();
     private callback: ButtonChangeCallback;
 
     constructor(callback: ButtonChangeCallback) {
         this.callback = callback;
     }
 
+    private refreshVisualState(changedRoots: Array<Element | null>) {
+        const roots = new Set<Element>();
+        for (const root of changedRoots) {
+            if (root) {
+                roots.add(root);
+            }
+        }
+        for (const state of this.activeTouches.values()) {
+            if (state.visualRoot) {
+                roots.add(state.visualRoot);
+            }
+        }
+
+        for (const root of roots) {
+            const buttons: number[] = [];
+            let stickOffset: StickOffset | null = null;
+
+            for (const state of this.activeTouches.values()) {
+                if (state.visualRoot !== root) continue;
+
+                for (const button of state.buttons) {
+                    if (!buttons.includes(button)) {
+                        buttons.push(button);
+                    }
+                }
+
+                if (state.stickOffset) {
+                    stickOffset = state.stickOffset;
+                }
+            }
+
+            applyVisualState(root, buttons, stickOffset);
+        }
+    }
+
     /** Handle a new touch starting on a button element. */
     handleTouchStart(touch: Touch): void {
-        const button = resolveButtonFromElement(touch.target as Element);
-        if (button === undefined) return;
-        this.activeTouches.set(touch.identifier, button);
-        this.callback(button, true);
+        const resolved = resolveTouchState(touch);
+        if (!resolved.captured) return;
+
+        this.activeTouches.set(touch.identifier, {
+            buttons: resolved.buttons,
+            visualRoot: resolved.visualRoot,
+            stickOffset: resolved.stickOffset,
+        });
+        emitPressedButtons(this.callback, [], resolved.buttons);
+        this.refreshVisualState([resolved.visualRoot]);
     }
 
     /** Handle a touch moving (possibly sliding between buttons). */
     handleTouchMove(touch: Touch): void {
-        const currentButton = this.activeTouches.get(touch.identifier);
-        const newButton = resolveButtonFromElement(touch.target as Element);
+        const currentState = this.activeTouches.get(touch.identifier);
+        const resolved = resolveTouchState(touch);
 
-        if (currentButton !== undefined && newButton !== currentButton) {
-            // Finger slid off the current button
+        if (currentState === undefined) {
+            if (!resolved.captured) return;
+
+            this.activeTouches.set(touch.identifier, {
+                buttons: resolved.buttons,
+                visualRoot: resolved.visualRoot,
+                stickOffset: resolved.stickOffset,
+            });
+            emitPressedButtons(this.callback, [], resolved.buttons);
+            this.refreshVisualState([resolved.visualRoot]);
+            return;
+        }
+
+        if (!resolved.captured) {
             this.activeTouches.delete(touch.identifier);
-            this.callback(currentButton, false);
+            emitReleasedButtons(this.callback, currentState.buttons, []);
+            this.refreshVisualState([currentState.visualRoot]);
+            return;
         }
 
-        if (newButton !== undefined && newButton !== currentButton) {
-            // Finger slid onto a new button
-            this.activeTouches.set(touch.identifier, newButton);
-            this.callback(newButton, true);
+        const buttonsChanged = !sameButtons(currentState.buttons, resolved.buttons);
+        const visualRootChanged = currentState.visualRoot !== resolved.visualRoot;
+        const stickOffsetChanged = !sameStickOffset(currentState.stickOffset, resolved.stickOffset);
+
+        if (!buttonsChanged && !visualRootChanged && !stickOffsetChanged) return;
+
+        if (buttonsChanged) {
+            emitReleasedButtons(this.callback, currentState.buttons, resolved.buttons);
+            emitPressedButtons(this.callback, currentState.buttons, resolved.buttons);
         }
+
+        this.activeTouches.set(touch.identifier, {
+            buttons: resolved.buttons,
+            visualRoot: resolved.visualRoot,
+            stickOffset: resolved.stickOffset,
+        });
+        this.refreshVisualState([currentState.visualRoot, resolved.visualRoot]);
     }
 
     /** Handle a touch ending. */
     handleTouchEnd(touch: Touch): void {
-        const button = this.activeTouches.get(touch.identifier);
-        if (button === undefined) return;
+        const state = this.activeTouches.get(touch.identifier);
+        if (state === undefined) return;
+
         this.activeTouches.delete(touch.identifier);
-        this.callback(button, false);
+        emitReleasedButtons(this.callback, state.buttons, []);
+        this.refreshVisualState([state.visualRoot]);
     }
 
     /** Handle a touch being cancelled. */
@@ -111,7 +335,7 @@ export class TouchInputManager {
 
     /** Get the currently pressed button for a touch identifier, if any. */
     getButtonForTouch(identifier: number): number | undefined {
-        return this.activeTouches.get(identifier);
+        return this.activeTouches.get(identifier)?.buttons[0];
     }
 
     /** Get count of active touches. */

--- a/web/src/input/touch_markup.test.ts
+++ b/web/src/input/touch_markup.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+
+import indexHtml from "../../index.html?raw";
+
+function parseTouchControls(): HTMLElement {
+    const documentRoot = new DOMParser().parseFromString(indexHtml, "text/html");
+    const touchControls = documentRoot.getElementById("touch-controls");
+    if (!touchControls) {
+        throw new Error("touch controls container should exist");
+    }
+    return touchControls;
+}
+
+describe("touch controls markup", () => {
+    it("Given touch controls markup, When reading the left controls, Then a joystick zone with a knob is present instead of segmented d-pad buttons", () => {
+        const touchControls = parseTouchControls();
+
+        expect(touchControls.querySelector('[data-touch-zone="joystick"]')).not.toBeNull();
+        expect(touchControls.querySelector(".touch-joystick-knob")).not.toBeNull();
+        expect(touchControls.querySelector(".touch-dpad-btn")).toBeNull();
+    });
+
+    it("Given touch controls markup, When reading the action area, Then A and B remain direct buttons without a shared action zone", () => {
+        const touchControls = parseTouchControls();
+
+        expect(touchControls.querySelector('[data-touch-zone="actions"]')).toBeNull();
+        expect(touchControls.querySelector('.touch-btn-a[data-button="a"]')).not.toBeNull();
+        expect(touchControls.querySelector('.touch-btn-b[data-button="b"]')).not.toBeNull();
+        expect(touchControls.querySelector('.touch-meta-btn[data-button="select"]')).not.toBeNull();
+        expect(touchControls.querySelector('.touch-meta-btn[data-button="start"]')).not.toBeNull();
+    });
+});

--- a/web/src/input/touch_styles.test.ts
+++ b/web/src/input/touch_styles.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const mainCss = readFileSync(resolve(currentDir, "../../main.css"), "utf8");
+
+describe("touch controls stylesheet", () => {
+    it("Given the touch stylesheet, When styling movement controls, Then it defines joystick visuals and no longer styles segmented d-pad buttons", () => {
+        expect(mainCss).toContain(".touch-joystick");
+        expect(mainCss).toContain(".touch-joystick-knob");
+        expect(mainCss).toContain("var(--touch-stick-x)");
+        expect(mainCss).toContain("var(--touch-stick-y)");
+        expect(mainCss).not.toContain(".touch-dpad-btn");
+    });
+});


### PR DESCRIPTION
## Summary
- replace the segmented touch D-pad with a joystick-style control zone
- keep the touch work scoped to the D-pad portion only and revert the A+B overlap experiment
- add focused markup, stylesheet, and touch-manager tests for the joystick behavior

## Details
This PR keeps the new directional touch controller and its visual feedback, but intentionally leaves the A+B button redesign out of scope. The action buttons remain direct single-button touch targets for now.

## Validation
- npm test -- web/src/input/touch_controls.test.ts web/src/input/touch_markup.test.ts web/src/input/touch_styles.test.ts
- npm test

Related to #2115