### PR TITLE
fix: load ROM DB in autorun tests to match binary behavior (#2110)

### DIFF
--- a/src/nes/integration_tests/autorun_tests.rs
+++ b/src/nes/integration_tests/autorun_tests.rs
@@ -3,7 +3,7 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use crate::nes::autorun::headless_playback::run_headless_playback;
-    use crate::nes::cartridge::{Cartridge, TimingMode as CartridgeTimingMode};
+    use crate::nes::cartridge::{Cartridge, TimingMode as CartridgeTimingMode, load_rom_db};
     use crate::nes::console::{Config, HardwareModel, Nes, RamInitMode};
     use crate::platform::app_context::AppContext;
     use crate::platform::autorun::load_autorun_file;
@@ -27,7 +27,8 @@ mod tests {
     fn make_nes_for_rom(rom_path: &Path) -> Result<Nes, String> {
         let rom_data = std::fs::read(rom_path)
             .map_err(|e| format!("Failed to read ROM {}: {e}", rom_path.display()))?;
-        let cartridge = Cartridge::load_from_file(&rom_data, rom_path, None)
+        let rom_db = load_rom_db();
+        let cartridge = Cartridge::load_from_file(&rom_data, rom_path, Some(&rom_db))
             .map_err(|e| format!("Failed to parse ROM {}: {e}", rom_path.display()))?;
 
         let mut config = deterministic_config();


### PR DESCRIPTION
## Summary

Fix test_mapper_3_autorun_gradius CRC mismatch regression by loading the ROM database in autorun integration tests, matching the binary's cartridge loading behavior.

## Root Cause

Autorun tests loaded cartridges via Cartridge::load_from_file(..., None) (no ROM DB), while the binary uses Some(&rom_db). For Gradius (E), the iNES header byte 12 is 0x00 (NTSC), but the ROM DB correctly identifies it as PAL hardware (hardware type 1). Since the autorun recording was captured with the binary (PAL timing), replaying it with NTSC timing in tests caused 15 CRC mismatches at every checkpoint.

## Changes

- Load the ROM database in make_nes_for_rom() in autorun tests
- Pass Some(&rom_db) to Cartridge::load_from_file() instead of None

## Validation

- test_mapper_3_autorun_gradius now passes
- All 83 autorun tests pass
- Full test suite: 8571 passed, 0 failed
- WASM tests: 54 passed
- Python tests: 201 passed
- npm tests: 298 passed
- clippy: clean
- fmt: clean

Closes #2110
