### PR TITLE
feat(gb): support selectable DMG hardware variants (DMG-0/A/B/C)

### DIFF
--- a/neser.conf.example
+++ b/neser.conf.example
@@ -29,7 +29,7 @@
 #   nes-pulse2=false      →  --nes-pulse2 false  OR  --nes-pulse2=0  OR  --no-nes-pulse2  OR  --disable-nes-pulse2
 #
 # NES-specific settings are prefixed with nes- (e.g., nes-hardware, nes-pulse1).
-# Game Boy-specific settings are prefixed with gb- (e.g., gb-hardware).
+# Game Boy-specific settings are prefixed with gb- (e.g., gb-dmg-variant).
 # Generic platform settings have no prefix (e.g., audio, ram_init_mode).
 #
 # CLI boolean flags:
@@ -244,7 +244,10 @@ nes-vertical_overscan=8
 # -----------------------------------------------------------------------------
 # Game Boy Settings
 # -----------------------------------------------------------------------------
-# Emulated Game Boy hardware model.
-# Valid values: dmg (original Game Boy), cgb (Game Boy Color)
-# Default: dmg
-#gb-hardware=dmg
+# DMG hardware variant to emulate.
+# Valid values: dmg-0, dmg-a, dmg-b, dmg-c
+# DMG-A, DMG-B, DMG-C share identical software-visible behavior (same boot ROM
+# and post-boot register state). DMG-0 is the first-generation variant with a
+# different boot ROM and different post-boot register values.
+# Default: dmg-b (most common hardware revision)
+#gb-dmg-variant=dmg-b

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -3,7 +3,7 @@ use crate::gb::boot_rom::{DMG_BOOT_ROM, DMG0_BOOT_ROM};
 use crate::gb::bus::GbBus;
 use crate::gb::cartridge::GbCartridge;
 use crate::gb::input::joypad::Joypad;
-use crate::gb::model::DmgModel;
+use crate::gb::model::{DmgBootVariant, DmgModel};
 use crate::gb::ppu::Ppu;
 use crate::gb::timer::Timer;
 
@@ -96,9 +96,9 @@ pub struct DmgBus {
 impl DmgBus {
     pub fn new(cart: Box<dyn GbCartridge>, model: DmgModel) -> Self {
         let is_cgb = cart.is_cgb();
-        let boot_rom = match model {
-            DmgModel::DmgAbc => DMG_BOOT_ROM,
-            DmgModel::Dmg0 => DMG0_BOOT_ROM,
+        let boot_rom = match model.boot_variant() {
+            DmgBootVariant::Production => DMG_BOOT_ROM,
+            DmgBootVariant::Dmg0 => DMG0_BOOT_ROM,
         };
         let mut bus = Self {
             cart,
@@ -149,9 +149,9 @@ impl DmgBus {
         self.hram = [0u8; 0x7F];
         self.if_reg = 1; // VBlank flag set at power-on (real DMG hardware)
         self.ie_reg = 0;
-        self.boot_rom = match self.model {
-            DmgModel::DmgAbc => DMG_BOOT_ROM,
-            DmgModel::Dmg0 => DMG0_BOOT_ROM,
+        self.boot_rom = match self.model.boot_variant() {
+            DmgBootVariant::Production => DMG_BOOT_ROM,
+            DmgBootVariant::Dmg0 => DMG0_BOOT_ROM,
         };
         self.boot_rom_active = true;
         self.sb = 0x00;
@@ -500,7 +500,7 @@ mod tests {
     }
 
     fn make_bus() -> DmgBus {
-        DmgBus::new(rom_only_cart(), DmgModel::DmgAbc)
+        DmgBus::new(rom_only_cart(), DmgModel::DmgB)
     }
 
     // ── VRAM ─────────────────────────────────────────────────────────────────

--- a/src/gb/console/config.rs
+++ b/src/gb/console/config.rs
@@ -1,53 +1,34 @@
 //! Configuration for the Game Boy emulator.
 //!
 //! [`GbConfig`] holds Game Boy-specific configuration options such as the
-//! emulated hardware variant (DMG or CGB).
+//! emulated DMG hardware variant.
 
+use crate::gb::model::DmgModel;
 use crate::platform::config::CliFlag;
 
 /// GB-specific CLI flags, defined here so that the GB module owns its flag
 /// declarations and parsing logic. These are chained into the global flag list
 /// by the platform config parser for validation and help-text generation.
 pub(crate) const GB_CLI_FLAGS: &[CliFlag] = &[CliFlag {
-    flag: "--gb-hardware",
-    help: Some("Game Boy hardware variant: dmg or cgb (default: dmg)"),
+    flag: "--gb-dmg-variant",
+    help: Some("DMG hardware variant: dmg-0, dmg-a, dmg-b, dmg-c (default: dmg-b)"),
     has_value: true,
 }];
 
-/// Game Boy hardware variant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GbHardware {
-    /// Original Game Boy (DMG).
-    Dmg,
-    /// Game Boy Color (CGB).
-    Cgb,
-}
-
-impl GbHardware {
-    /// Parse a hardware variant from a string value.
-    pub fn parse(value: &str) -> Option<Self> {
-        match value.to_ascii_lowercase().as_str() {
-            "dmg" => Some(Self::Dmg),
-            "cgb" => Some(Self::Cgb),
-            _ => None,
-        }
-    }
-}
+/// Valid values for the `gb-dmg-variant` option (used in error messages).
+const VALID_DMG_VARIANTS: &str = "dmg-0, dmg-a, dmg-b, dmg-c";
 
 /// Game Boy-specific hardware configuration.
 #[derive(Debug, Clone)]
 pub struct GbConfig {
-    /// Emulated hardware variant.
-    pub hardware: GbHardware,
-    /// Whether hardware was explicitly configured (vs. auto-detected from ROM).
-    pub hardware_explicit: bool,
+    /// Emulated DMG hardware variant.
+    pub dmg_variant: DmgModel,
 }
 
 impl Default for GbConfig {
     fn default() -> Self {
         Self {
-            hardware: GbHardware::Dmg,
-            hardware_explicit: false,
+            dmg_variant: DmgModel::DmgB,
         }
     }
 }
@@ -55,29 +36,25 @@ impl Default for GbConfig {
 impl GbConfig {
     /// Parse GB-specific CLI arguments and apply them to this config.
     pub(crate) fn apply_args(&mut self, args: &[String]) -> Result<(), String> {
-        if let Some(gb_hardware) =
-            crate::platform::config::parse_cli_string_arg(args, "--gb-hardware")
+        if let Some(variant) =
+            crate::platform::config::parse_cli_string_arg(args, "--gb-dmg-variant")
         {
-            self.hardware = GbHardware::parse(&gb_hardware).ok_or_else(|| {
+            self.dmg_variant = DmgModel::parse(&variant).ok_or_else(|| {
                 format!(
-                    "Invalid --gb-hardware value: '{}'. Valid options are: dmg, cgb",
-                    gb_hardware
+                    "Invalid --gb-dmg-variant value: '{variant}'. Valid options are: {VALID_DMG_VARIANTS}",
                 )
             })?;
-            self.hardware_explicit = true;
         }
         Ok(())
     }
 
-    /// Apply a `gb-hardware` config file value to this config.
+    /// Apply a `gb-dmg-variant` config file value to this config.
     pub(crate) fn apply_config_value(&mut self, value: &str) -> Result<(), String> {
-        self.hardware = GbHardware::parse(value).ok_or_else(|| {
+        self.dmg_variant = DmgModel::parse(value).ok_or_else(|| {
             format!(
-                "Invalid gb-hardware value: '{}'. Valid options are: dmg, cgb",
-                value
+                "Invalid gb-dmg-variant value: '{value}'. Valid options are: {VALID_DMG_VARIANTS}",
             )
         })?;
-        self.hardware_explicit = true;
         Ok(())
     }
 }

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -8,7 +8,6 @@
 //! bus is created; `.gbc` (CGB-only, 0xC0) and `.gb` CGB-compat (0x80) ROMs
 //! both get a [`CgbBus`], all others get a [`DmgBus`].
 
-use crate::gb::DmgModel;
 use crate::gb::bus::{CgbBus, DmgBus};
 use crate::gb::cartridge::load_cartridge;
 use crate::gb::console::Gb;
@@ -124,7 +123,7 @@ impl GameBoy {
     ///
     /// Automatically selects DMG or CGB bus based on the ROM's CGB flag
     /// byte at 0x0143: 0x80 (CGB+DMG) and 0xC0 (CGB-only) use [`CgbBus`];
-    /// all other values use [`DmgBus`].
+    /// all other values use [`DmgBus`] with the DMG variant from configuration.
     pub fn load_rom(&mut self, bytes: &[u8], _name: &str) -> Result<(), String> {
         let cart = load_cartridge(bytes).map_err(|e| format!("{e:?}"))?;
         self.gb = Some(if cart.is_cgb() {
@@ -132,7 +131,8 @@ impl GameBoy {
             gb.cpu.reset_registers_cgb();
             GbConsole::Cgb(Box::new(gb))
         } else {
-            GbConsole::Dmg(Box::new(Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))))
+            let dmg_variant = self.app_context.borrow().config().gb.dmg_variant;
+            GbConsole::Dmg(Box::new(Gb::new(DmgBus::new(cart, dmg_variant))))
         });
         Ok(())
     }

--- a/src/gb/console/mod.rs
+++ b/src/gb/console/mod.rs
@@ -2,6 +2,8 @@ use crate::gb::bus::CgbBus;
 use crate::gb::bus::DmgBus;
 use crate::gb::bus::GbBus;
 use crate::gb::cpu::Sm83;
+use crate::gb::model::DmgBootVariant;
+#[cfg(test)]
 use crate::gb::model::DmgModel;
 
 pub mod config;
@@ -48,20 +50,15 @@ impl Gb<DmgBus> {
     /// - `soft_reset = false`: resets CPU registers **and** all bus
     ///   state (WRAM zeroed, PPU/timer/joypad reinitialised).
     pub fn reset(&mut self, soft_reset: bool) {
-        if soft_reset {
-            // Soft reset: restore post-boot register state and continue from
-            // the cartridge entry point, preserving WRAM and bus state.
-            match self.cpu.bus.model() {
-                DmgModel::DmgAbc => self.cpu.reset_registers(),
-                DmgModel::Dmg0 => self.cpu.reset_registers_dmg0(),
-            }
-        } else {
+        // Restore post-boot register state for the configured hardware variant.
+        match self.cpu.bus.model().boot_variant() {
+            DmgBootVariant::Production => self.cpu.reset_registers(),
+            DmgBootVariant::Dmg0 => self.cpu.reset_registers_dmg0(),
+        }
+
+        if !soft_reset {
             // Hard reset: reinitialise all bus hardware and restart execution
             // from the boot ROM entry point.
-            match self.cpu.bus.model() {
-                DmgModel::DmgAbc => self.cpu.reset_registers(),
-                DmgModel::Dmg0 => self.cpu.reset_registers_dmg0(),
-            }
             self.cpu.regs.pc = 0x0000;
             self.cpu.bus.reset();
         }
@@ -148,7 +145,7 @@ mod tests {
     }
 
     fn make_dmg() -> Gb<DmgBus> {
-        Gb::new(DmgBus::new(minimal_cart(), DmgModel::DmgAbc))
+        Gb::new(DmgBus::new(minimal_cart(), DmgModel::DmgB))
     }
 
     // ── reset: CPU registers ──────────────────────────────────────────────

--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -6,7 +6,7 @@ use crate::gb::model::DmgModel;
 fn load_gb_rom(path: &str) -> Gb<DmgBus> {
     let rom = std::fs::read(path).expect("ROM file should be present");
     let cart = load_cartridge(&rom).expect("valid GB ROM");
-    Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))
+    Gb::new(DmgBus::new(cart, DmgModel::DmgB))
 }
 
 /// Generous M-cycle budget per test.

--- a/src/gb/integration_tests/boot_tests.rs
+++ b/src/gb/integration_tests/boot_tests.rs
@@ -67,7 +67,7 @@ fn run_until_cartridge_entry(gb: &mut Gb<DmgBus>) -> bool {
 fn test_dmg_boot_sets_correct_register_state() {
     let rom = build_test_rom(&NINTENDO_LOGO);
     let cart = load_cartridge(&rom).expect("valid ROM");
-    let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
+    let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgB));
 
     let reached = run_until_cartridge_entry(&mut gb);
 
@@ -97,7 +97,7 @@ fn test_dmg_boot_halts_on_corrupted_logo() {
     let bad_logo = [0u8; 48]; // all-zero logo — definitely wrong
     let rom = build_test_rom(&bad_logo);
     let cart = load_cartridge(&rom).expect("valid ROM");
-    let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
+    let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgB));
 
     let reached = run_until_cartridge_entry(&mut gb);
 

--- a/src/gb/integration_tests/mooneye_tests.rs
+++ b/src/gb/integration_tests/mooneye_tests.rs
@@ -44,11 +44,11 @@ const MOONEYE_CYCLE_LIMIT: u64 = 10_000_000;
 /// LD B,B opcode used as a Mooneye software breakpoint.
 const LD_B_B: u8 = 0x40;
 
-/// Load a GB ROM from `path` and return a ready-to-step `Gb<DmgBus>` (DMG-ABC model).
+/// Load a GB ROM from `path` and return a ready-to-step `Gb<DmgBus>` (DMG-B model).
 fn load_gb_rom(path: &str) -> Gb<DmgBus> {
     let rom = std::fs::read(path).expect("Mooneye ROM file should be present");
     let cart = load_cartridge(&rom).expect("valid GB ROM");
-    Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))
+    Gb::new(DmgBus::new(cart, DmgModel::DmgB))
 }
 
 /// Load a GB ROM from `path` and return a ready-to-step `Gb<DmgBus>` (DMG-0 model).
@@ -232,14 +232,14 @@ mod helper_tests {
     #[test]
     fn helper_detects_pass_when_fibonacci_registers_set() {
         let cart = load_cartridge(&make_pass_rom()).expect("valid test ROM");
-        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
+        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgB));
         assert_eq!(detect_mooneye_result(&mut gb), MooneyeResult::Pass);
     }
 
     #[test]
     fn helper_detects_fail_when_registers_wrong() {
         let cart = load_cartridge(&make_fail_rom()).expect("valid test ROM");
-        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
+        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgB));
         let result = detect_mooneye_result(&mut gb);
         assert!(
             matches!(result, MooneyeResult::Fail { b: 0xFF, .. }),
@@ -251,7 +251,7 @@ mod helper_tests {
     fn helper_returns_timeout_when_no_breakpoint() {
         let bytes = make_timeout_rom();
         let cart = load_cartridge(&bytes).expect("valid test ROM");
-        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgAbc));
+        let mut gb = Gb::new(DmgBus::new(cart, DmgModel::DmgB));
         assert_eq!(
             detect_mooneye_result_with_limit(&mut gb, 1_000),
             MooneyeResult::Timeout

--- a/src/gb/integration_tests/ppu_tests.rs
+++ b/src/gb/integration_tests/ppu_tests.rs
@@ -7,7 +7,7 @@ use crate::gb::model::DmgModel;
 fn load_gb_rom(path: &str) -> Gb<DmgBus> {
     let rom = std::fs::read(path).expect("ROM file should be present");
     let cart = load_cartridge(&rom).expect("valid GB ROM");
-    Gb::new(DmgBus::new(cart, DmgModel::DmgAbc))
+    Gb::new(DmgBus::new(cart, DmgModel::DmgB))
 }
 
 fn load_cgb_rom(path: &str) -> Gb<CgbBus> {

--- a/src/gb/mod.rs
+++ b/src/gb/mod.rs
@@ -10,7 +10,6 @@ pub mod ppu;
 pub mod timer;
 
 pub use console::gameboy::GameBoy;
-pub use model::DmgModel;
 
 #[cfg(test)]
 pub mod integration_tests;

--- a/src/gb/mod.rs
+++ b/src/gb/mod.rs
@@ -10,6 +10,9 @@ pub mod ppu;
 pub mod timer;
 
 pub use console::gameboy::GameBoy;
+// Re-export DmgModel so downstream library consumers can use `neser::gb::DmgModel`.
+#[allow(unused_imports)]
+pub use model::DmgModel;
 
 #[cfg(test)]
 pub mod integration_tests;

--- a/src/gb/model.rs
+++ b/src/gb/model.rs
@@ -1,21 +1,134 @@
 /// Game Boy hardware model variant.
 ///
 /// Distinguishes between the first-generation DMG-0 and the
-/// production DMG-A/B/C models.  The two variants differ in
-/// boot ROM content, post-boot CPU register values, and the
-/// DIV counter phase at boot exit.
+/// individual production DMG-A, DMG-B, DMG-C models. The DMG-0
+/// variant differs from the production variants in boot ROM content,
+/// post-boot CPU register values, and the DIV counter phase at boot
+/// exit. DMG-A, DMG-B, and DMG-C share identical software-visible
+/// behaviour.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DmgModel {
-    /// Production DMG hardware: DMG-A, DMG-B, DMG-C.
+    /// Production DMG-A hardware.
+    ///
+    /// Post-boot CPU registers: A=$01 F=$B0 B=$00 C=$13 D=$00 E=$D8 H=$01 L=$4D SP=$FFFE.
+    /// DIV=$AB at cartridge entry.
+    DmgA,
+
+    /// Production DMG-B hardware (most common revision).
     ///
     /// Post-boot CPU registers: A=$01 F=$B0 B=$00 C=$13 D=$00 E=$D8 H=$01 L=$4D SP=$FFFE.
     /// DIV=$AB at cartridge entry.
     #[default]
-    DmgAbc,
+    DmgB,
+
+    /// Production DMG-C hardware.
+    ///
+    /// Post-boot CPU registers: A=$01 F=$B0 B=$00 C=$13 D=$00 E=$D8 H=$01 L=$4D SP=$FFFE.
+    /// DIV=$AB at cartridge entry.
+    DmgC,
 
     /// First-generation DMG-0 hardware.
     ///
     /// Post-boot CPU registers: A=$01 F=$00 B=$FF C=$13 D=$00 E=$C1 H=$84 L=$03 SP=$FFFE.
     /// DIV=$18 at cartridge entry (shorter boot ROM).
     Dmg0,
+}
+
+/// Boot ROM behavior group.
+///
+/// DMG-A, DMG-B, and DMG-C all share the same boot ROM and post-boot
+/// state; DMG-0 uses a different boot ROM with different post-boot
+/// register values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DmgBootVariant {
+    /// Production DMG boot ROM (used by DMG-A, DMG-B, DMG-C).
+    Production,
+    /// First-generation DMG-0 boot ROM.
+    Dmg0,
+}
+
+impl DmgModel {
+    /// Returns the boot ROM variant for this hardware model.
+    pub fn boot_variant(self) -> DmgBootVariant {
+        match self {
+            Self::DmgA | Self::DmgB | Self::DmgC => DmgBootVariant::Production,
+            Self::Dmg0 => DmgBootVariant::Dmg0,
+        }
+    }
+
+    /// Parse a DMG model variant from a string value.
+    ///
+    /// Accepts `dmg-0`, `dmg-a`, `dmg-b`, `dmg-c` (case-insensitive).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "dmg-0" => Some(Self::Dmg0),
+            "dmg-a" => Some(Self::DmgA),
+            "dmg-b" => Some(Self::DmgB),
+            "dmg-c" => Some(Self::DmgC),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_boot_variant_dmg_a_is_production() {
+        assert_eq!(DmgModel::DmgA.boot_variant(), DmgBootVariant::Production);
+    }
+
+    #[test]
+    fn test_boot_variant_dmg_b_is_production() {
+        assert_eq!(DmgModel::DmgB.boot_variant(), DmgBootVariant::Production);
+    }
+
+    #[test]
+    fn test_boot_variant_dmg_c_is_production() {
+        assert_eq!(DmgModel::DmgC.boot_variant(), DmgBootVariant::Production);
+    }
+
+    #[test]
+    fn test_boot_variant_dmg_0_is_dmg0() {
+        assert_eq!(DmgModel::Dmg0.boot_variant(), DmgBootVariant::Dmg0);
+    }
+
+    #[test]
+    fn test_default_is_dmg_b() {
+        assert_eq!(DmgModel::default(), DmgModel::DmgB);
+    }
+
+    #[test]
+    fn test_parse_dmg_0() {
+        assert_eq!(DmgModel::parse("dmg-0"), Some(DmgModel::Dmg0));
+    }
+
+    #[test]
+    fn test_parse_dmg_a() {
+        assert_eq!(DmgModel::parse("dmg-a"), Some(DmgModel::DmgA));
+    }
+
+    #[test]
+    fn test_parse_dmg_b() {
+        assert_eq!(DmgModel::parse("dmg-b"), Some(DmgModel::DmgB));
+    }
+
+    #[test]
+    fn test_parse_dmg_c() {
+        assert_eq!(DmgModel::parse("dmg-c"), Some(DmgModel::DmgC));
+    }
+
+    #[test]
+    fn test_parse_case_insensitive() {
+        assert_eq!(DmgModel::parse("DMG-B"), Some(DmgModel::DmgB));
+        assert_eq!(DmgModel::parse("Dmg-A"), Some(DmgModel::DmgA));
+    }
+
+    #[test]
+    fn test_parse_invalid_returns_none() {
+        assert_eq!(DmgModel::parse("dmg"), None);
+        assert_eq!(DmgModel::parse("invalid"), None);
+        assert_eq!(DmgModel::parse(""), None);
+    }
 }

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -1843,7 +1843,7 @@ impl Config {
                     self.nes.vertical_overscan = v.min(16);
                 }
             }
-            "gb-hardware" => {
+            "gb-dmg-variant" => {
                 self.gb.apply_config_value(value)?;
             }
             "cartridge_search_paths" | "scan_cartridges" | "rebuild_cartridge_catalog" => {
@@ -6054,39 +6054,61 @@ filter=invalid-shader
     }
 
     #[test]
-    fn test_gb_hardware_arg_sets_gb_config() {
+    fn test_gb_dmg_variant_arg_sets_gb_config() {
         let args = vec![
             "neser".to_string(),
-            "--gb-hardware".to_string(),
-            "cgb".to_string(),
+            "--gb-dmg-variant".to_string(),
+            "dmg-0".to_string(),
         ];
         let config = parse_config(args);
-        assert_eq!(
-            config.gb.hardware,
-            crate::gb::console::config::GbHardware::Cgb
-        );
-        assert!(config.gb.hardware_explicit);
+        assert_eq!(config.gb.dmg_variant, crate::gb::model::DmgModel::Dmg0);
     }
 
     #[test]
-    fn test_gb_hardware_default_is_dmg() {
+    fn test_gb_dmg_variant_default_is_dmg_b() {
         let config = Config::with_defaults();
-        assert_eq!(
-            config.gb.hardware,
-            crate::gb::console::config::GbHardware::Dmg
-        );
-        assert!(!config.gb.hardware_explicit);
+        assert_eq!(config.gb.dmg_variant, crate::gb::model::DmgModel::DmgB);
     }
 
     #[test]
-    fn test_config_file_gb_hardware_key() {
+    fn test_config_file_gb_dmg_variant_key() {
         let mut config = Config::with_defaults();
-        config.apply_config_value("gb-hardware", "cgb").unwrap();
-        assert_eq!(
-            config.gb.hardware,
-            crate::gb::console::config::GbHardware::Cgb
+        config
+            .apply_config_value("gb-dmg-variant", "dmg-c")
+            .unwrap();
+        assert_eq!(config.gb.dmg_variant, crate::gb::model::DmgModel::DmgC);
+    }
+
+    #[test]
+    fn test_gb_dmg_variant_invalid_value_returns_error() {
+        let args = vec![
+            "neser".to_string(),
+            "--gb-dmg-variant".to_string(),
+            "invalid".to_string(),
+        ];
+        let result = Config::new(&args);
+        assert!(
+            result.is_err() || matches!(result, Ok(ParseResult::Config(c)) if false),
+            "Invalid variant should produce an error"
         );
-        assert!(config.gb.hardware_explicit);
+    }
+
+    #[test]
+    fn test_gb_dmg_variant_all_values() {
+        for (input, expected) in [
+            ("dmg-0", crate::gb::model::DmgModel::Dmg0),
+            ("dmg-a", crate::gb::model::DmgModel::DmgA),
+            ("dmg-b", crate::gb::model::DmgModel::DmgB),
+            ("dmg-c", crate::gb::model::DmgModel::DmgC),
+        ] {
+            let args = vec![
+                "neser".to_string(),
+                "--gb-dmg-variant".to_string(),
+                input.to_string(),
+            ];
+            let config = parse_config(args);
+            assert_eq!(config.gb.dmg_variant, expected, "variant={input}");
+        }
     }
 
     #[test]

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -1846,6 +1846,20 @@ impl Config {
             "gb-dmg-variant" => {
                 self.gb.apply_config_value(value)?;
             }
+            "gb-hardware" => match value.to_lowercase().as_str() {
+                "dmg" => {
+                    self.gb.apply_config_value("dmg-b")?;
+                }
+                "cgb" => {
+                    return Err("Config key 'gb-hardware=cgb' is no longer supported; \
+                         CGB mode is now auto-detected from the loaded ROM, and \
+                         'gb-dmg-variant' only applies to DMG variants."
+                        .to_string());
+                }
+                _ => {
+                    self.gb.apply_config_value(value)?;
+                }
+            },
             "cartridge_search_paths" | "scan_cartridges" | "rebuild_cartridge_catalog" => {
                 self.apply_cartridge_catalog_config_value(key, value);
             }
@@ -6080,6 +6094,27 @@ filter=invalid-shader
     }
 
     #[test]
+    fn test_config_file_legacy_gb_hardware_dmg_maps_to_dmg_b() {
+        let mut config = Config::with_defaults();
+        config.apply_config_value("gb-hardware", "dmg").unwrap();
+        assert_eq!(config.gb.dmg_variant, crate::gb::model::DmgModel::DmgB);
+    }
+
+    #[test]
+    fn test_config_file_legacy_gb_hardware_cgb_returns_error() {
+        let mut config = Config::with_defaults();
+        let result = config.apply_config_value("gb-hardware", "cgb");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_file_legacy_gb_hardware_passes_through_dmg_variants() {
+        let mut config = Config::with_defaults();
+        config.apply_config_value("gb-hardware", "dmg-a").unwrap();
+        assert_eq!(config.gb.dmg_variant, crate::gb::model::DmgModel::DmgA);
+    }
+
+    #[test]
     fn test_gb_dmg_variant_invalid_value_returns_error() {
         let args = vec![
             "neser".to_string(),
@@ -6087,10 +6122,7 @@ filter=invalid-shader
             "invalid".to_string(),
         ];
         let result = Config::new(&args);
-        assert!(
-            result.is_err() || matches!(result, Ok(ParseResult::Config(c)) if false),
-            "Invalid variant should produce an error"
-        );
+        assert!(result.is_err(), "Invalid variant should produce an error");
     }
 
     #[test]
@@ -6118,6 +6150,17 @@ filter=invalid-shader
             .apply_config_value("nes-vs_dip_switches", "0xFF")
             .unwrap();
         assert_eq!(config.nes.vs_dip_switches, 0xFF);
+    }
+
+    #[test]
+    fn test_old_gb_hardware_arg_is_rejected() {
+        let args = vec![
+            "neser".to_string(),
+            "--gb-hardware".to_string(),
+            "dmg".to_string(),
+        ];
+        let result = config_new(args);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Support selectable DMG hardware variants (DMG-0/A/B/C) via the `--gb-dmg-variant` CLI/config option. Replaces the previous `--gb-hardware` flag which only distinguished DMG vs CGB (now auto-detected from ROM header).

Closes #2123

## Changes

### DmgModel enum expansion (`src/gb/model.rs`)
- Replaced `DmgAbc` with individual `DmgA`, `DmgB`, `DmgC` variants
- Added `DmgBootVariant` enum (`Production` / `Dmg0`) to group A/B/C for boot ROM dispatch
- Added `boot_variant()` method and `parse()` for CLI/config string parsing
- Default variant: `DmgB` (most common hardware revision)
- 11 unit tests covering all variants, parsing, and boot_variant

### Config changes (`src/gb/console/config.rs`)
- Removed `GbHardware` enum, `hardware` field, and `hardware_explicit` field
- Removed `--gb-hardware` CLI flag
- Added `--gb-dmg-variant` CLI flag accepting `dmg-0`, `dmg-a`, `dmg-b`, `dmg-c`
- Added `dmg_variant: DmgModel` field to `GbConfig` (default: `DmgB`)
- Extracted `VALID_DMG_VARIANTS` constant for error messages

### Config wiring (`src/gb/console/gameboy.rs`)
- `GameBoy::load_rom()` now reads `dmg_variant` from `AppContext` config
- CGB ROMs silently ignore the DMG variant setting

### Match site updates
- `DmgBus::new()` and `reset()` now use `boot_variant()` for boot ROM selection
- `Gb<DmgBus>::reset()` refactored to eliminate duplicated boot variant match

### Test updates
- All `DmgModel::DmgAbc` references updated to `DmgModel::DmgB`
- Config tests rewritten for new `--gb-dmg-variant` flag
- All existing integration tests continue to pass

## Verification

- clippy: 0 warnings
- cargo fmt: clean
- cargo test --no-default-features --lib: 8584 passed
- wasm-pack test: 54 passed
- Python tests: 201 passed
- npm test: 298 passed
