### PR TITLE
Restrict available shaders per emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ test-results/
 *.sym
 obj
 
+test.state

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Options:
   --fullscreen          Run emulator in fullscreen mode
   --display <N>         Select display index for fullscreen (default: 0)
   --nes-filter <name>   Specify NES shader filter (crt|ntsc|smooth|pal|none)
-  --gb-filter <name>    Specify Game Boy shader filter (gameboy|none)
+  --gb-filter <name>    Specify Game Boy shader filter (dmg|none)
   --config <path>       Specify config file path (overrides default locations)
   --window-height <N>   Window height in pixels, windowed mode only (e.g., 720)
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Options:
   --load-state <path>   Load a save state on startup
   --fullscreen          Run emulator in fullscreen mode
   --display <N>         Select display index for fullscreen (default: 0)
-  --filter <name>       Specify shader filter (crt|ntsc|smooth|none)
+  --nes-filter <name>   Specify NES shader filter (crt|ntsc|smooth|pal|none)
+  --gb-filter <name>    Specify Game Boy shader filter (gameboy|none)
   --config <path>       Specify config file path (overrides default locations)
   --window-height <N>   Window height in pixels, windowed mode only (e.g., 720)
 ```
@@ -358,7 +359,7 @@ NESER supports shader filters for visual effects:
 Example:
 
 ```bash
-neser --filter crt
+neser --nes-filter crt
 ```
 
 Or in config file:

--- a/neser.conf.example
+++ b/neser.conf.example
@@ -84,15 +84,23 @@ fullscreen=false
 # Only used when fullscreen=true.
 display=0
 
-# Shader/filter preset.
+# Shader/filter preset (NES).
 # Applies visual effects like CRT simulation or pixel scaling.
 # Valid values:
 #   - crt    : CRT simulation with scanlines, shadow mask, bloom
 #   - ntsc   : NTSC composite video simulation
 #   - smooth : Smooth pixel upscaling (xBRZ)
+#   - pal    : PAL composite video simulation
 #   - none   : No filter, raw pixels
 # Leave empty or comment out for no shader.
-#filter=crt
+#nes-filter=crt
+
+# Shader/filter preset (Game Boy).
+# Valid values:
+#   - gameboy : DMG dot-matrix green-tint LCD simulation
+#   - none    : No filter, raw pixels
+# Leave empty or comment out for no shader.
+#gb-filter=gameboy
 
 # -----------------------------------------------------------------------------
 # Input Settings

--- a/neser.conf.example
+++ b/neser.conf.example
@@ -97,10 +97,10 @@ display=0
 
 # Shader/filter preset (Game Boy).
 # Valid values:
-#   - gameboy : DMG dot-matrix green-tint LCD simulation
+#   - dmg    : DMG dot-matrix green-tint LCD simulation
 #   - none    : No filter, raw pixels
 # Leave empty or comment out for no shader.
-#gb-filter=gameboy
+#gb-filter=dmg
 
 # -----------------------------------------------------------------------------
 # Input Settings

--- a/shaders/README.md
+++ b/shaders/README.md
@@ -32,7 +32,7 @@ neser rom.nes --nes-filter crt     # CRT simulation
 neser rom.nes --nes-filter ntsc    # NTSC composite
 neser rom.nes --nes-filter smooth  # Smooth upscaling
 neser rom.nes --nes-filter none    # No filter
-neser rom.gb  --gb-filter gameboy  # DMG dot-matrix LCD
+neser rom.gb  --gb-filter dmg  # DMG dot-matrix LCD
 ```
 
 Or set in config file:

--- a/shaders/README.md
+++ b/shaders/README.md
@@ -25,19 +25,20 @@ git clone --recurse-submodules https://github.com/rmstdope/neser
 
 ## Usage
 
-Use the `--filter` flag with a simplified name:
+Use the `--nes-filter` flag for NES or `--gb-filter` for Game Boy:
 
 ```bash
-neser rom.nes --filter crt     # CRT simulation
-neser rom.nes --filter ntsc    # NTSC composite
-neser rom.nes --filter smooth  # Smooth upscaling
-neser rom.nes --filter none    # No filter
+neser rom.nes --nes-filter crt     # CRT simulation
+neser rom.nes --nes-filter ntsc    # NTSC composite
+neser rom.nes --nes-filter smooth  # Smooth upscaling
+neser rom.nes --nes-filter none    # No filter
+neser rom.gb  --gb-filter gameboy  # DMG dot-matrix LCD
 ```
 
 Or set in config file:
 
 ```text
-filter=crt
+nes-filter=crt
 ```
 
 You can also cycle through shaders at runtime with F6.

--- a/src/frontends/native/app_state.rs
+++ b/src/frontends/native/app_state.rs
@@ -285,7 +285,7 @@ Space: Pause\n\
 Ctrl+F: Toggle fullscreen\n\
 Ctrl+O: Switch cartridge\n\
 F2/F3: Volume up/down\n\
-F4: Cycle shader\n\
+F4: Cycle visual filter\n\
 F5: Debugger (open/continue)\n\
 F10/F11: Step over/into\n\
 F6/F7: Save/Load state";

--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -589,6 +589,7 @@ impl ApplicationHandler for NativeEventLoop {
             event_loop,
             self.app_context.clone(),
             self.console.system_type(),
+            self.console.allowed_shaders(),
         ) {
             Ok(gl) => {
                 self.gl_wrapper = Some(gl);
@@ -918,7 +919,7 @@ impl ApplicationHandler for NativeEventLoop {
                     // Record timestamp for FPS counter (only real emulation frames).
                     self.frame_timestamps.push_back(self.last_frame_rendered);
                     let window = std::time::Duration::from_secs(1);
-                    while self.frame_timestamps.front().map_or(false, |t| {
+                    while self.frame_timestamps.front().is_some_and(|t| {
                         self.last_frame_rendered.saturating_duration_since(*t) > window
                     }) {
                         self.frame_timestamps.pop_front();

--- a/src/frontends/native/gl_backend.rs
+++ b/src/frontends/native/gl_backend.rs
@@ -351,6 +351,7 @@ impl GlBackend {
         proc_address: ProcAddressLoader,
         shader_path: Option<&str>,
         app_context: SharedAppContext,
+        allowed_shaders: &[&str],
     ) -> Result<Self, String> {
         unsafe {
             gl::Disable(gl::DEPTH_TEST);
@@ -427,7 +428,7 @@ impl GlBackend {
             )
         };
 
-        let mut shader_manager = ShaderManager::new();
+        let mut shader_manager = ShaderManager::new(allowed_shaders);
 
         // Load shader preset if specified
         if let Some(path) = shader_path

--- a/src/frontends/native/gl_backend.rs
+++ b/src/frontends/native/gl_backend.rs
@@ -768,29 +768,35 @@ impl GlBackend {
 
     /// Cycles through available shader presets, if any.
     ///
-    /// Returns the name of the newly active preset on success, or `None` when
-    /// no shader is active (e.g. cycling landed on "no shader" / no presets).
+    /// Returns the short preset name (e.g. `"crt"`, `"dmg"`) of the newly
+    /// active preset, or `None` when cycling has landed on stock (no shader).
     pub fn cycle_shader(&mut self) -> Option<String> {
         if let Err(e) = self.shader_manager.cycle_shader(self.glow_context.clone()) {
             log_info(format!("Error cycling shader: {}", e));
         }
-        let name = self.shader_manager.current_preset_name().map(str::to_owned);
+        let path = self.shader_manager.current_preset_name();
+        let short_name = path.and_then(|p| {
+            crate::platform::shaders::SHADER_PRESETS
+                .iter()
+                .find(|(_, preset_path)| *preset_path == p)
+                .map(|(name, _)| (*name).to_owned())
+        });
         log_info(format!(
-            "Switched to shader: {}",
-            name.as_deref().unwrap_or("off")
+            "Switched to filter: {}",
+            short_name.as_deref().unwrap_or("off")
         ));
-        name
+        short_name
     }
 }
 
-/// Returns the toast message to display when the shader preset changes.
+/// Returns the toast message to display when the visual filter changes.
 ///
-/// * `Some(name)` → `"Shader: <name>"`
-/// * `None`       → `"Shader: off"`
+/// * `Some(name)` → `"Visual Filter: <NAME>"` (short preset name, uppercased)
+/// * `None`       → `"Visual Filter: off"`
 pub fn shader_toast_message(preset_name: Option<&str>) -> String {
     match preset_name {
-        Some(name) => format!("Shader: {name}"),
-        None => "Shader: off".to_owned(),
+        Some(name) => format!("Visual Filter: {}", name.to_uppercase()),
+        None => "Visual Filter: off".to_owned(),
     }
 }
 
@@ -1207,16 +1213,16 @@ mod tests {
 
     #[test]
     fn test_shader_toast_message_with_name_shows_shader_name() {
-        // When cycle_shader returns Some(name), the toast should name the shader.
+        // cycle_shader returns the short preset name; the toast uppercases it.
         assert_eq!(
-            super::shader_toast_message(Some("ntsc-256px-composite")),
-            "Shader: ntsc-256px-composite"
+            super::shader_toast_message(Some("ntsc")),
+            "Visual Filter: NTSC"
         );
     }
 
     #[test]
     fn test_shader_toast_message_with_none_shows_no_shader() {
         // When no shader is active (cycled to "no shader"), the toast says so.
-        assert_eq!(super::shader_toast_message(None), "Shader: off");
+        assert_eq!(super::shader_toast_message(None), "Visual Filter: off");
     }
 }

--- a/src/frontends/native/gl_wrapper.rs
+++ b/src/frontends/native/gl_wrapper.rs
@@ -39,6 +39,7 @@ impl NativeGlWrapper {
         event_loop: &winit::event_loop::ActiveEventLoop,
         app_context: SharedAppContext,
         system_type: SystemType,
+        allowed_shaders: &'static [&'static str],
     ) -> Result<Self, String> {
         let (fullscreen, vsync_enabled, shader_path, debugger_alpha, fullscreen_display, height) = {
             let ctx = app_context.borrow();
@@ -157,6 +158,7 @@ impl NativeGlWrapper {
             proc_address,
             shader_path.as_deref(),
             app_context,
+            allowed_shaders,
         )?;
         gl_backend.set_debugger_alpha(debugger_alpha);
 

--- a/src/frontends/native/shader_manager.rs
+++ b/src/frontends/native/shader_manager.rs
@@ -17,8 +17,8 @@ pub struct ShaderManager {
 }
 
 impl ShaderManager {
-    pub fn new() -> Self {
-        let available_presets = Self::discover_presets();
+    pub fn new(allowed_names: &[&str]) -> Self {
+        let available_presets = Self::discover_presets_filtered(allowed_names);
         let current_index = Self::initial_current_index(&available_presets);
 
         ShaderManager {
@@ -97,17 +97,29 @@ impl ShaderManager {
         Ok(self.output_texture.expect("output texture must be set"))
     }
 
-    fn discover_presets() -> Vec<PathBuf> {
-        // Derived from the canonical SHADER_PRESETS list in platform::shaders.
-        // Presets that don't exist on disk (e.g. submodule not initialised)
-        // are silently skipped.
-        let mut presets: Vec<PathBuf> = SHADER_PRESETS
-            .iter()
-            .map(|(_, path)| PathBuf::from(path))
+    fn discover_presets_filtered(allowed_names: &[&str]) -> Vec<PathBuf> {
+        // Like discover_presets but restricted to names allowed for the active emulator.
+        let mut presets: Vec<PathBuf> = Self::presets_for_names(allowed_names, SHADER_PRESETS)
+            .into_iter()
             .filter(|p| p.exists())
             .collect();
         presets.sort();
         presets
+    }
+
+    /// Returns the paths from `all_presets` whose short names appear in `allowed_names`.
+    ///
+    /// This is the pure, disk-free subset of `discover_presets` used to restrict
+    /// the cycling list to the shaders relevant to the active emulator.
+    pub(crate) fn presets_for_names(
+        allowed_names: &[&str],
+        all_presets: &[(&str, &str)],
+    ) -> Vec<PathBuf> {
+        all_presets
+            .iter()
+            .filter(|(name, _)| allowed_names.contains(name))
+            .map(|(_, path)| PathBuf::from(path))
+            .collect()
     }
 
     pub fn load_preset(
@@ -321,6 +333,51 @@ mod tests {
             PathBuf::from("vendor/slang-shaders/crt/crt-lottes.slangp"),
             "first F4 from 'no shader' state should land on crt, not index {}",
             next_index
+        );
+    }
+
+    #[test]
+    fn test_presets_for_names_returns_only_allowed_presets() {
+        let all: &[(&str, &str)] = &[
+            ("none", "shaders/stock.slangp"),
+            ("crt", "vendor/slang-shaders/crt/crt-lottes.slangp"),
+            (
+                "smooth",
+                "vendor/slang-shaders/edge-smoothing/xbrz/xbrz-freescale-multipass.slangp",
+            ),
+            (
+                "ntsc",
+                "vendor/slang-shaders/ntsc/ntsc-256px-composite.slangp",
+            ),
+            (
+                "pal",
+                "vendor/slang-shaders/pal/decoupled-guest-advanced-pal 3-RF.slangp",
+            ),
+            ("gameboy", "vendor/slang-shaders/handheld/gameboy.slangp"),
+        ];
+
+        let gb_allowed = &["none", "gameboy"];
+        let gb_presets = ShaderManager::presets_for_names(gb_allowed, all);
+        assert_eq!(gb_presets.len(), 2, "GB should have exactly 2 presets");
+        assert!(gb_presets.contains(&PathBuf::from("shaders/stock.slangp")));
+        assert!(gb_presets.contains(&PathBuf::from(
+            "vendor/slang-shaders/handheld/gameboy.slangp"
+        )));
+        assert!(
+            !gb_presets
+                .iter()
+                .any(|p| p.to_str().unwrap_or("").contains("crt")),
+            "GB must not include crt"
+        );
+
+        let nes_allowed = &["none", "crt", "smooth", "ntsc", "pal"];
+        let nes_presets = ShaderManager::presets_for_names(nes_allowed, all);
+        assert_eq!(nes_presets.len(), 5, "NES should have exactly 5 presets");
+        assert!(
+            !nes_presets
+                .iter()
+                .any(|p| p.to_str().unwrap_or("").contains("gameboy")),
+            "NES must not include gameboy"
         );
     }
 }

--- a/src/frontends/native/shader_manager.rs
+++ b/src/frontends/native/shader_manager.rs
@@ -353,10 +353,10 @@ mod tests {
                 "pal",
                 "vendor/slang-shaders/pal/decoupled-guest-advanced-pal 3-RF.slangp",
             ),
-            ("gameboy", "vendor/slang-shaders/handheld/gameboy.slangp"),
+            ("dmg", "vendor/slang-shaders/handheld/gameboy.slangp"),
         ];
 
-        let gb_allowed = &["none", "gameboy"];
+        let gb_allowed = &["none", "dmg"];
         let gb_presets = ShaderManager::presets_for_names(gb_allowed, all);
         assert_eq!(gb_presets.len(), 2, "GB should have exactly 2 presets");
         assert!(gb_presets.contains(&PathBuf::from("shaders/stock.slangp")));
@@ -377,7 +377,7 @@ mod tests {
             !nes_presets
                 .iter()
                 .any(|p| p.to_str().unwrap_or("").contains("gameboy")),
-            "NES must not include gameboy"
+            "NES must not include dmg"
         );
     }
 }

--- a/src/gb/console/config.rs
+++ b/src/gb/console/config.rs
@@ -9,11 +9,18 @@ use crate::platform::config::CliFlag;
 /// GB-specific CLI flags, defined here so that the GB module owns its flag
 /// declarations and parsing logic. These are chained into the global flag list
 /// by the platform config parser for validation and help-text generation.
-pub(crate) const GB_CLI_FLAGS: &[CliFlag] = &[CliFlag {
-    flag: "--gb-dmg-variant",
-    help: Some("DMG hardware variant: dmg-0, dmg-a, dmg-b, dmg-c (default: dmg-b)"),
-    has_value: true,
-}];
+pub(crate) const GB_CLI_FLAGS: &[CliFlag] = &[
+    CliFlag {
+        flag: "--gb-filter",
+        help: Some("Game Boy shader filter: gameboy or none"),
+        has_value: true,
+    },
+    CliFlag {
+        flag: "--gb-dmg-variant",
+        help: Some("DMG hardware variant: dmg-0, dmg-a, dmg-b, dmg-c (default: dmg-b)"),
+        has_value: true,
+    },
+];
 
 /// Valid values for the `gb-dmg-variant` option (used in error messages).
 const VALID_DMG_VARIANTS: &str = "dmg-0, dmg-a, dmg-b, dmg-c";

--- a/src/gb/console/config.rs
+++ b/src/gb/console/config.rs
@@ -12,7 +12,7 @@ use crate::platform::config::CliFlag;
 pub(crate) const GB_CLI_FLAGS: &[CliFlag] = &[
     CliFlag {
         flag: "--gb-filter",
-        help: Some("Game Boy shader filter: gameboy or none"),
+        help: Some("Game Boy shader filter: dmg or none"),
         has_value: true,
     },
     CliFlag {

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -308,6 +308,10 @@ impl Emulator for GameBoy {
         SystemType::GameBoy
     }
 
+    fn allowed_shaders(&self) -> &'static [&'static str] {
+        &["none", "gameboy"]
+    }
+
     fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String> {
         GameBoy::load_rom(self, bytes, name)
     }
@@ -831,6 +835,37 @@ mod tests {
             emu.get_joypad_button_states(1),
             0,
             "setting a button via port 1 must update the GB joypad"
+        );
+    }
+
+    #[test]
+    fn test_gb_allowed_shaders_includes_expected_presets() {
+        use crate::platform::emulator::Emulator;
+        let gb = make_gameboy();
+        let shaders = gb.allowed_shaders();
+        assert!(
+            shaders.contains(&"none"),
+            "GB must allow the 'none' (stock) shader"
+        );
+        assert!(
+            shaders.contains(&"gameboy"),
+            "GB must allow the 'gameboy' shader"
+        );
+        assert!(
+            !shaders.contains(&"crt"),
+            "GB must NOT allow the 'crt' shader"
+        );
+        assert!(
+            !shaders.contains(&"ntsc"),
+            "GB must NOT allow the 'ntsc' shader"
+        );
+        assert!(
+            !shaders.contains(&"pal"),
+            "GB must NOT allow the 'pal' shader"
+        );
+        assert!(
+            !shaders.contains(&"smooth"),
+            "GB must NOT allow the 'smooth' shader"
         );
     }
 }

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -309,7 +309,7 @@ impl Emulator for GameBoy {
     }
 
     fn allowed_shaders(&self) -> &'static [&'static str] {
-        &["none", "gameboy"]
+        &["none", "dmg"]
     }
 
     fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String> {
@@ -847,10 +847,7 @@ mod tests {
             shaders.contains(&"none"),
             "GB must allow the 'none' (stock) shader"
         );
-        assert!(
-            shaders.contains(&"gameboy"),
-            "GB must allow the 'gameboy' shader"
-        );
+        assert!(shaders.contains(&"dmg"), "GB must allow the 'dmg' shader");
         assert!(
             !shaders.contains(&"crt"),
             "GB must NOT allow the 'crt' shader"

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -1041,10 +1041,8 @@ impl Config {
 
         // GB shader path
         if let Some(filter_name) = Self::parse_named_arg(args, "--gb-filter") {
-            self.frontend.shader_path = Some(Self::map_filter_name_for(
-                &filter_name,
-                &["none", "gameboy"],
-            )?);
+            self.frontend.shader_path =
+                Some(Self::map_filter_name_for(&filter_name, &["none", "dmg"])?);
         }
 
         if let Some(path) = Self::parse_rom_arg(args)? {
@@ -1565,8 +1563,8 @@ impl Config {
     /// # Shader/filter
     /// # NES valid values: crt, ntsc, smooth, pal, none
     /// nes-filter=crt
-    /// # GB valid values: gameboy, none
-    /// gb-filter=gameboy
+    /// # GB valid values: dmg, none
+    /// gb-filter=dmg
     ///
     /// # APU channel toggles
     /// pulse1=true
@@ -1679,7 +1677,7 @@ impl Config {
             "gb-filter" => {
                 if !value.is_empty() {
                     self.frontend.shader_path =
-                        Some(Self::map_filter_name_for(value, &["none", "gameboy"])?);
+                        Some(Self::map_filter_name_for(value, &["none", "dmg"])?);
                 }
             }
             "debugger" => {
@@ -6217,17 +6215,17 @@ nes-filter=invalid-shader
     }
 
     #[test]
-    fn test_config_cmdline_nes_filter_rejects_gameboy_shader() {
+    fn test_config_cmdline_nes_filter_rejects_dmg_shader() {
         let args = vec![
             "neser".to_string(),
             "--nes-filter".to_string(),
-            "gameboy".to_string(),
+            "dmg".to_string(),
         ];
         let result = config_new(args);
         assert!(result.is_err());
         let msg = result.unwrap_err();
         assert!(
-            msg.contains("gameboy"),
+            msg.contains("dmg"),
             "Error should mention the invalid value: {msg}"
         );
     }
@@ -6252,11 +6250,11 @@ nes-filter=invalid-shader
     // --gb-filter CLI flag tests
 
     #[test]
-    fn test_config_cmdline_gb_filter_gameboy_sets_shader_path() {
+    fn test_config_cmdline_gb_filter_dmg_sets_shader_path() {
         let args = vec![
             "neser".to_string(),
             "--gb-filter".to_string(),
-            "gameboy".to_string(),
+            "dmg".to_string(),
         ];
         let config = parse_config(args);
         assert_eq!(
@@ -6308,13 +6306,13 @@ nes-filter=invalid-shader
     }
 
     #[test]
-    fn test_config_file_nes_filter_rejects_gameboy_shader() {
+    fn test_config_file_nes_filter_rejects_dmg_shader() {
         let mut config = Config::default();
-        let result = config.apply_config_value("nes-filter", "gameboy");
+        let result = config.apply_config_value("nes-filter", "dmg");
         assert!(result.is_err());
         let msg = result.unwrap_err();
         assert!(
-            msg.contains("gameboy"),
+            msg.contains("dmg"),
             "Error should mention the invalid value: {msg}"
         );
     }
@@ -6329,9 +6327,9 @@ nes-filter=invalid-shader
     // gb-filter= config file key tests
 
     #[test]
-    fn test_config_file_gb_filter_gameboy_sets_shader_path() {
+    fn test_config_file_gb_filter_dmg_sets_shader_path() {
         let mut config = Config::default();
-        config.apply_config_value("gb-filter", "gameboy").unwrap();
+        config.apply_config_value("gb-filter", "dmg").unwrap();
         assert_eq!(
             config.frontend.shader_path,
             Some("vendor/slang-shaders/handheld/gameboy.slangp".to_string())

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -74,8 +74,8 @@ const CLI_FLAGS: &[CliFlag] = &[
         has_value: true,
     },
     CliFlag {
-        flag: "--filter",
-        help: Some("Specify shader filter: crt, ntsc, smooth, or none"),
+        flag: "--nes-filter",
+        help: Some("NES shader filter: crt, ntsc, smooth, pal, or none"),
         has_value: true,
     },
     CliFlag {
@@ -742,7 +742,8 @@ impl Config {
             flag,
             "--fullscreen"
                 | "--display"
-                | "--filter"
+                | "--nes-filter"
+                | "--gb-filter"
                 | "--window-height"
                 | "--vsync"
                 | "--no-vsync"
@@ -1030,9 +1031,20 @@ impl Config {
             self.frontend.fullscreen_display = Some(display);
         }
 
-        // Shader path
-        if let Some(filter_name) = Self::parse_shader_arg(args) {
-            self.frontend.shader_path = Some(Self::map_filter_name(&filter_name)?);
+        // NES shader path
+        if let Some(filter_name) = Self::parse_named_arg(args, "--nes-filter") {
+            self.frontend.shader_path = Some(Self::map_filter_name_for(
+                &filter_name,
+                &["none", "crt", "smooth", "ntsc", "pal"],
+            )?);
+        }
+
+        // GB shader path
+        if let Some(filter_name) = Self::parse_named_arg(args, "--gb-filter") {
+            self.frontend.shader_path = Some(Self::map_filter_name_for(
+                &filter_name,
+                &["none", "gameboy"],
+            )?);
         }
 
         if let Some(path) = Self::parse_rom_arg(args)? {
@@ -1372,10 +1384,10 @@ impl Config {
         Ok(None)
     }
 
-    /// Parse the --filter argument from command-line args.
-    fn parse_shader_arg(args: &[String]) -> Option<String> {
+    /// Parse a named flag argument (e.g., `--nes-filter`) from command-line args.
+    fn parse_named_arg(args: &[String], flag: &str) -> Option<String> {
         for i in 0..args.len() {
-            if args[i] == "--filter" && i + 1 < args.len() {
+            if args[i] == flag && i + 1 < args.len() {
                 return Some(args[i + 1].clone());
             }
         }
@@ -1551,8 +1563,10 @@ impl Config {
     /// window_height=896
     ///
     /// # Shader/filter
-    /// # Valid values: crt, ntsc, smooth, none
-    /// filter=crt
+    /// # NES valid values: crt, ntsc, smooth, pal, none
+    /// nes-filter=crt
+    /// # GB valid values: gameboy, none
+    /// gb-filter=gameboy
     ///
     /// # APU channel toggles
     /// pulse1=true
@@ -1585,22 +1599,22 @@ impl Config {
         Ok(())
     }
 
-    /// Map simplified filter names to shader paths.
+    /// Map a filter name to a shader path, validating against an allowed list.
     ///
-    /// Valid names and paths are defined in [`crate::platform::shaders::SHADER_PRESETS`].
-    fn map_filter_name(name: &str) -> Result<String, String> {
+    /// `allowed` must be a subset of names defined in [`crate::platform::shaders::SHADER_PRESETS`].
+    fn map_filter_name_for(name: &str, allowed: &[&str]) -> Result<String, String> {
+        if !allowed.contains(&name) {
+            return Err(format!(
+                "Invalid filter name: '{}'. Valid options are: {}",
+                name,
+                allowed.join(", ")
+            ));
+        }
         SHADER_PRESETS
             .iter()
             .find(|(n, _)| *n == name)
             .map(|(_, path)| (*path).to_string())
-            .ok_or_else(|| {
-                let valid: Vec<&str> = SHADER_PRESETS.iter().map(|(n, _)| *n).collect();
-                format!(
-                    "Invalid filter name: '{}'. Valid options are: {}",
-                    name,
-                    valid.join(", ")
-                )
-            })
+            .ok_or_else(|| format!("Filter '{}' has no shader path defined", name))
     }
 
     /// Apply a single config file key-value pair.
@@ -1654,9 +1668,18 @@ impl Config {
                     self.frontend.fullscreen_display = Some(d);
                 }
             }
-            "filter" => {
+            "nes-filter" => {
                 if !value.is_empty() {
-                    self.frontend.shader_path = Some(Self::map_filter_name(value)?);
+                    self.frontend.shader_path = Some(Self::map_filter_name_for(
+                        value,
+                        &["none", "crt", "smooth", "ntsc", "pal"],
+                    )?);
+                }
+            }
+            "gb-filter" => {
+                if !value.is_empty() {
+                    self.frontend.shader_path =
+                        Some(Self::map_filter_name_for(value, &["none", "gameboy"])?);
                 }
             }
             "debugger" => {
@@ -2797,19 +2820,14 @@ mod tests {
     fn test_config_cmdline_filter_invalid_errors() {
         let args = vec![
             "neser".to_string(),
-            "--filter".to_string(),
+            "--nes-filter".to_string(),
             "invalid-filter".to_string(),
         ];
         let result = config_new(args);
         assert!(result.is_err());
-        let valid = crate::platform::shaders::SHADER_PRESETS
-            .iter()
-            .map(|(n, _)| *n)
-            .collect::<Vec<_>>()
-            .join(", ");
         assert_eq!(
             result.unwrap_err(),
-            format!("Invalid filter name: 'invalid-filter'. Valid options are: {valid}")
+            "Invalid filter name: 'invalid-filter'. Valid options are: none, crt, smooth, ntsc, pal"
         );
     }
 
@@ -3329,30 +3347,25 @@ mod tests {
     #[test]
     fn test_config_file_filter_invalid_errors() {
         let mut config = Config::default();
-        let result = config.apply_config_value("filter", "invalid-filter");
+        let result = config.apply_config_value("nes-filter", "invalid-filter");
         assert!(result.is_err());
-        let valid = crate::platform::shaders::SHADER_PRESETS
-            .iter()
-            .map(|(n, _)| *n)
-            .collect::<Vec<_>>()
-            .join(", ");
         assert_eq!(
             result.unwrap_err(),
-            format!("Invalid filter name: 'invalid-filter'. Valid options are: {valid}")
+            "Invalid filter name: 'invalid-filter'. Valid options are: none, crt, smooth, ntsc, pal"
         );
     }
 
     #[test]
     fn test_config_file_filter_empty_ignored() {
         let mut config = Config::default();
-        config.apply_config_value("filter", "").unwrap();
+        config.apply_config_value("nes-filter", "").unwrap();
         assert_eq!(config.frontend.shader_path, None);
     }
 
     #[test]
     fn test_config_file_filter_crt() {
         let mut config = Config::default();
-        config.apply_config_value("filter", "crt").unwrap();
+        config.apply_config_value("nes-filter", "crt").unwrap();
         assert_eq!(
             config.frontend.shader_path,
             Some("vendor/slang-shaders/crt/crt-lottes.slangp".to_string())
@@ -3362,7 +3375,7 @@ mod tests {
     #[test]
     fn test_config_file_filter_ntsc() {
         let mut config = Config::default();
-        config.apply_config_value("filter", "ntsc").unwrap();
+        config.apply_config_value("nes-filter", "ntsc").unwrap();
         assert_eq!(
             config.frontend.shader_path,
             Some("vendor/slang-shaders/ntsc/ntsc-256px-composite.slangp".to_string())
@@ -3372,7 +3385,7 @@ mod tests {
     #[test]
     fn test_config_file_filter_smooth() {
         let mut config = Config::default();
-        config.apply_config_value("filter", "smooth").unwrap();
+        config.apply_config_value("nes-filter", "smooth").unwrap();
         assert_eq!(
             config.frontend.shader_path,
             Some(
@@ -3385,7 +3398,7 @@ mod tests {
     #[test]
     fn test_config_file_filter_none() {
         let mut config = Config::default();
-        config.apply_config_value("filter", "none").unwrap();
+        config.apply_config_value("nes-filter", "none").unwrap();
         assert_eq!(
             config.frontend.shader_path,
             Some("shaders/stock.slangp".to_string())
@@ -3396,7 +3409,7 @@ mod tests {
     fn test_config_cmdline_filter_crt() {
         let args = vec![
             "neser".to_string(),
-            "--filter".to_string(),
+            "--nes-filter".to_string(),
             "crt".to_string(),
         ];
         let config = parse_config(args);
@@ -3410,7 +3423,7 @@ mod tests {
     fn test_config_cmdline_filter_ntsc() {
         let args = vec![
             "neser".to_string(),
-            "--filter".to_string(),
+            "--nes-filter".to_string(),
             "ntsc".to_string(),
         ];
         let config = parse_config(args);
@@ -3424,7 +3437,7 @@ mod tests {
     fn test_config_cmdline_filter_smooth() {
         let args = vec![
             "neser".to_string(),
-            "--filter".to_string(),
+            "--nes-filter".to_string(),
             "smooth".to_string(),
         ];
         let config = parse_config(args);
@@ -3441,7 +3454,7 @@ mod tests {
     fn test_config_cmdline_filter_none() {
         let args = vec![
             "neser".to_string(),
-            "--filter".to_string(),
+            "--nes-filter".to_string(),
             "none".to_string(),
         ];
         let config = parse_config(args);
@@ -3762,7 +3775,7 @@ nes-hardware=nes-pal
 audio=false
 fullscreen=true
 display=2
-filter=crt
+nes-filter=crt
 nes-pulse1=false
 "#;
 
@@ -3898,7 +3911,7 @@ nes-controller_port2=arkanoid
 
         let content = r#"
     hardware=nes-pal
-filter=invalid-shader
+nes-filter=invalid-shader
 "#;
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(content.as_bytes()).unwrap();
@@ -3910,14 +3923,9 @@ filter=invalid-shader
         ];
         let result = Config::new(&args);
         assert!(result.is_err());
-        let valid = crate::platform::shaders::SHADER_PRESETS
-            .iter()
-            .map(|(n, _)| *n)
-            .collect::<Vec<_>>()
-            .join(", ");
         assert_eq!(
             result.unwrap_err(),
-            format!("Invalid filter name: 'invalid-shader'. Valid options are: {valid}")
+            "Invalid filter name: 'invalid-shader'. Valid options are: none, crt, smooth, ntsc, pal"
         );
     }
 
@@ -6190,5 +6198,162 @@ filter=invalid-shader
         ];
         let result = config_new(args);
         assert!(result.is_err());
+    }
+
+    // --nes-filter CLI flag tests
+
+    #[test]
+    fn test_config_cmdline_nes_filter_crt_sets_shader_path() {
+        let args = vec![
+            "neser".to_string(),
+            "--nes-filter".to_string(),
+            "crt".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/crt/crt-lottes.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_cmdline_nes_filter_rejects_gameboy_shader() {
+        let args = vec![
+            "neser".to_string(),
+            "--nes-filter".to_string(),
+            "gameboy".to_string(),
+        ];
+        let result = config_new(args);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("gameboy"),
+            "Error should mention the invalid value: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_config_cmdline_nes_filter_accepts_smooth() {
+        let args = vec![
+            "neser".to_string(),
+            "--nes-filter".to_string(),
+            "smooth".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(
+            config.frontend.shader_path,
+            Some(
+                "vendor/slang-shaders/edge-smoothing/xbrz/xbrz-freescale-multipass.slangp"
+                    .to_string()
+            )
+        );
+    }
+
+    // --gb-filter CLI flag tests
+
+    #[test]
+    fn test_config_cmdline_gb_filter_gameboy_sets_shader_path() {
+        let args = vec![
+            "neser".to_string(),
+            "--gb-filter".to_string(),
+            "gameboy".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/gameboy.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_cmdline_gb_filter_rejects_crt_shader() {
+        let args = vec![
+            "neser".to_string(),
+            "--gb-filter".to_string(),
+            "crt".to_string(),
+        ];
+        let result = config_new(args);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("crt"),
+            "Error should mention the invalid value: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_config_cmdline_gb_filter_none_sets_stock_shader() {
+        let args = vec![
+            "neser".to_string(),
+            "--gb-filter".to_string(),
+            "none".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("shaders/stock.slangp".to_string())
+        );
+    }
+
+    // nes-filter= config file key tests
+
+    #[test]
+    fn test_config_file_nes_filter_ntsc_sets_shader_path() {
+        let mut config = Config::default();
+        config.apply_config_value("nes-filter", "ntsc").unwrap();
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/ntsc/ntsc-256px-composite.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_file_nes_filter_rejects_gameboy_shader() {
+        let mut config = Config::default();
+        let result = config.apply_config_value("nes-filter", "gameboy");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("gameboy"),
+            "Error should mention the invalid value: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_config_file_nes_filter_empty_ignored() {
+        let mut config = Config::default();
+        config.apply_config_value("nes-filter", "").unwrap();
+        assert_eq!(config.frontend.shader_path, None);
+    }
+
+    // gb-filter= config file key tests
+
+    #[test]
+    fn test_config_file_gb_filter_gameboy_sets_shader_path() {
+        let mut config = Config::default();
+        config.apply_config_value("gb-filter", "gameboy").unwrap();
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/gameboy.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_file_gb_filter_rejects_crt_shader() {
+        let mut config = Config::default();
+        let result = config.apply_config_value("gb-filter", "crt");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("crt"),
+            "Error should mention the invalid value: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_config_file_gb_filter_empty_ignored() {
+        let mut config = Config::default();
+        config.apply_config_value("gb-filter", "").unwrap();
+        assert_eq!(config.frontend.shader_path, None);
     }
 }

--- a/src/nes/console/nes.rs
+++ b/src/nes/console/nes.rs
@@ -1207,6 +1207,10 @@ impl Emulator for Nes {
         SystemType::Nes
     }
 
+    fn allowed_shaders(&self) -> &'static [&'static str] {
+        &["none", "crt", "smooth", "ntsc", "pal"]
+    }
+
     fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String> {
         Nes::load_rom(self, bytes, name)
     }
@@ -3009,6 +3013,33 @@ mod tests {
         assert!(
             nes.save_ram().is_ok(),
             "save_ram with no cartridge must return Ok"
+        );
+    }
+
+    #[test]
+    fn test_nes_allowed_shaders_includes_expected_presets() {
+        use crate::platform::emulator::Emulator;
+        let nes = Nes::new(crate::platform::app_context::AppContext::new_with_config(
+            Config::default(),
+        ));
+        let shaders = nes.allowed_shaders();
+        assert!(
+            shaders.contains(&"none"),
+            "NES must allow the 'none' (stock) shader"
+        );
+        assert!(shaders.contains(&"crt"), "NES must allow the 'crt' shader");
+        assert!(
+            shaders.contains(&"smooth"),
+            "NES must allow the 'smooth' shader"
+        );
+        assert!(
+            shaders.contains(&"ntsc"),
+            "NES must allow the 'ntsc' shader"
+        );
+        assert!(shaders.contains(&"pal"), "NES must allow the 'pal' shader");
+        assert!(
+            !shaders.contains(&"gameboy"),
+            "NES must NOT allow the 'gameboy' shader"
         );
     }
 }

--- a/src/nes/console/nes.rs
+++ b/src/nes/console/nes.rs
@@ -3038,8 +3038,8 @@ mod tests {
         );
         assert!(shaders.contains(&"pal"), "NES must allow the 'pal' shader");
         assert!(
-            !shaders.contains(&"gameboy"),
-            "NES must NOT allow the 'gameboy' shader"
+            !shaders.contains(&"dmg"),
+            "NES must NOT allow the 'dmg' shader"
         );
     }
 }

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -24,6 +24,11 @@ use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
 /// [`Console`] variant.
 pub trait Emulator {
     fn system_type(&self) -> SystemType;
+    /// Short names of shader presets permitted for this emulator.
+    ///
+    /// Names correspond to the first element of each entry in
+    /// [`crate::platform::shaders::SHADER_PRESETS`].
+    fn allowed_shaders(&self) -> &'static [&'static str];
     fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String>;
     fn run_tick(&mut self) -> u8;
     fn is_ready_to_render(&self) -> bool;
@@ -100,6 +105,11 @@ impl Console {
     /// Which system this console is emulating.
     pub fn system_type(&self) -> SystemType {
         self.as_core().system_type()
+    }
+
+    /// Short names of shader presets permitted for this console's emulator.
+    pub fn allowed_shaders(&self) -> &'static [&'static str] {
+        self.as_core().allowed_shaders()
     }
 
     /// Load a ROM into the emulator.

--- a/src/platform/shaders.rs
+++ b/src/platform/shaders.rs
@@ -1,7 +1,7 @@
 /// Single source of truth for all available shader presets.
 ///
 /// Each entry is `(short_name, relative_path_to_slangp)`.
-/// - `short_name` is used in the CLI (`--nes-filter crt`, `--gb-filter gameboy`) and config file (`nes-filter=crt`, `gb-filter=gameboy`).
+/// - `short_name` is used in the CLI (`--nes-filter crt`, `--gb-filter dmg`) and config file (`nes-filter=crt`, `gb-filter=dmg`).
 /// - `path` is relative to the working directory when neser runs.
 ///
 /// To add or remove a shader preset, edit this list only.
@@ -20,5 +20,5 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
         "pal",
         "vendor/slang-shaders/pal/decoupled-guest-advanced-pal 3-RF.slangp",
     ),
-    ("gameboy", "vendor/slang-shaders/handheld/gameboy.slangp"),
+    ("dmg", "vendor/slang-shaders/handheld/gameboy.slangp"),
 ];

--- a/src/platform/shaders.rs
+++ b/src/platform/shaders.rs
@@ -1,7 +1,7 @@
 /// Single source of truth for all available shader presets.
 ///
 /// Each entry is `(short_name, relative_path_to_slangp)`.
-/// - `short_name` is used in the CLI (`--filter crt`) and config file (`filter=crt`).
+/// - `short_name` is used in the CLI (`--nes-filter crt`, `--gb-filter gameboy`) and config file (`nes-filter=crt`, `gb-filter=gameboy`).
 /// - `path` is relative to the working directory when neser runs.
 ///
 /// To add or remove a shader preset, edit this list only.


### PR DESCRIPTION
Add `allowed_shaders()` to the `Emulator` trait so each emulator declares its own permitted shader preset names.

- **NES** allows: `none`, `crt`, `smooth`, `ntsc`, `pal`
- **Game Boy** allows: `none`, `gameboy`

Thread the allowed list from `Console.allowed_shaders()` through `NativeGlWrapper::new()` → `GlBackend::new()` → `ShaderManager::new()`, where `discover_presets_filtered()` restricts the cycling list to only the on-disk presets that are permitted for the active emulator.

Also adds a pure `presets_for_names()` helper for disk-free, unit-testable filtering logic, and fixes a pre-existing clippy warning (`map_or(false, ...)` → `is_some_and(...)`) in the FPS counter code.

Tests:
- `test_nes_allowed_shaders_includes_expected_presets`
- `test_gb_allowed_shaders_includes_expected_presets`
- `test_presets_for_names_returns_only_allowed_presets`

Closes #2151
