### PR TITLE
Sub-issue (2154): Move help and validation to platform

### DIFF
--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -1136,11 +1136,7 @@ pub fn should_use_manual_frame_throttle(vsync_enabled: bool, window_focused: boo
 /// - Audio disabled (`--no-audio`): when the user runs with audio disabled,
 ///   the NES ring-buffer back-pressure is absent and the emulator would
 ///   otherwise run uncapped.
-fn needs_frame_guard(
-    using_manual_throttle: bool,
-    is_game_boy: bool,
-    audio_disabled: bool,
-) -> bool {
+fn needs_frame_guard(using_manual_throttle: bool, is_game_boy: bool, audio_disabled: bool) -> bool {
     using_manual_throttle || is_game_boy || audio_disabled
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let parsed_config = match Config::new(&args)? {
         ParseResult::Help => {
-            Config::print_help();
+            crate::platform::config::print_help();
             return Ok(());
         }
         ParseResult::Config(c) => *c,

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let parsed_config = match Config::new(&args)? {
         ParseResult::Help => {
-            crate::platform::config::print_help();
+            Config::print_help();
             return Ok(());
         }
         ParseResult::Config(c) => *c,

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -16,7 +16,7 @@ use bitflags::bitflags;
 use std::fs;
 use std::path::Path;
 
-/// All supported NES and platform CLI flags.
+/// All supported NES-specific CLI flags.
 pub(crate) const CLI_FLAGS: &[CliFlag] = &[
     CliFlag {
         flag: "--trace-nestest",
@@ -197,10 +197,6 @@ pub(crate) const CLI_FLAGS: &[CliFlag] = &[
     },
 ];
 
-/// Returns an iterator over all supported CLI flags (NES/platform + GB-specific).
-///
-/// GB flags are defined in the GB config module and chained here so that
-/// validation, help text, and ROM-path parsing remain complete.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HardwareModel {
     NesNtsc,
@@ -769,6 +765,11 @@ impl Config {
         config.validate_controller_ports()?;
 
         Ok(ParseResult::Config(Box::new(config)))
+    }
+
+    /// Print help text to stdout.
+    pub fn print_help() {
+        crate::platform::config::print_help();
     }
 
     /// Apply command-line arguments to the config.

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -13,12 +13,11 @@ use crate::platform::config::ParseResult;
 use crate::platform::config::{OPTIONAL_BOOL_FLAGS, parse_bool, parse_hex_u8};
 use crate::platform::shaders::SHADER_PRESETS;
 use bitflags::bitflags;
-use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
 
 /// All supported NES and platform CLI flags.
-const CLI_FLAGS: &[CliFlag] = &[
+pub(crate) const CLI_FLAGS: &[CliFlag] = &[
     CliFlag {
         flag: "--trace-nestest",
         help: Some("Enable CPU trace output (nestest.log format)"),
@@ -202,13 +201,6 @@ const CLI_FLAGS: &[CliFlag] = &[
 ///
 /// GB flags are defined in the GB config module and chained here so that
 /// validation, help text, and ROM-path parsing remain complete.
-fn all_cli_flags() -> impl Iterator<Item = &'static CliFlag> {
-    crate::platform::config::PLATFORM_CLI_FLAGS
-        .iter()
-        .chain(CLI_FLAGS.iter())
-        .chain(crate::gb::console::config::GB_CLI_FLAGS.iter())
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HardwareModel {
     NesNtsc,
@@ -699,184 +691,6 @@ impl Config {
         Ok(())
     }
 
-    fn help_section_for_flag(flag: &str) -> &'static str {
-        if flag.starts_with("--trace")
-            || matches!(flag, "--debugger" | "--debugger-alpha" | "--breakpoint")
-        {
-            "Trace and Debugging"
-        } else if matches!(
-            flag,
-            "--nes-controller-port1"
-                | "--nes-controller-port2"
-                | "--nes-expansion-port"
-                | "--nes-zapper-detection-size"
-                | "--gamepads"
-                | "--nes-enable-4-score"
-                | "--no-nes-4-score"
-                | "--disable-nes-4-score"
-        ) {
-            "Input"
-        } else if matches!(
-            flag,
-            "--audio"
-                | "--no-audio"
-                | "--disable-audio"
-                | "--nes-pulse1"
-                | "--no-nes-pulse1"
-                | "--disable-nes-pulse1"
-                | "--nes-pulse2"
-                | "--no-nes-pulse2"
-                | "--disable-nes-pulse2"
-                | "--nes-triangle"
-                | "--no-nes-triangle"
-                | "--disable-nes-triangle"
-                | "--nes-noise"
-                | "--no-nes-noise"
-                | "--disable-nes-noise"
-                | "--nes-dmc"
-                | "--no-nes-dmc"
-                | "--disable-nes-dmc"
-        ) {
-            "Sound"
-        } else if matches!(
-            flag,
-            "--fullscreen"
-                | "--display"
-                | "--nes-filter"
-                | "--gb-filter"
-                | "--window-height"
-                | "--vsync"
-                | "--no-vsync"
-                | "--disable-vsync"
-                | "--nes-horizontal-overscan"
-                | "--nes-vertical-overscan"
-        ) {
-            "Video and Display"
-        } else if matches!(
-            flag,
-            "--create-recording"
-                | "--extend-recording"
-                | "--playback"
-                | "--playback-headless"
-                | "--playback-from-checkpoint"
-                | "--playback-headless-from-checkpoint"
-                | "--trim-checkpoints"
-                | "--convert-autorun"
-                | "--recalculate-autorun"
-        ) {
-            "Autorun"
-        } else if matches!(
-            flag,
-            "--cartridge-search-paths"
-                | "--scan-cartridges"
-                | "--no-scan-cartridges"
-                | "--rebuild-cartridge-catalog"
-        ) {
-            "Cartridge Catalog"
-        } else {
-            "General"
-        }
-    }
-
-    fn help_text() -> String {
-        const HELP_SECTIONS: [&str; 7] = [
-            "General",
-            "Input",
-            "Trace and Debugging",
-            "Sound",
-            "Video and Display",
-            "Autorun",
-            "Cartridge Catalog",
-        ];
-
-        let mut help = String::new();
-        writeln!(&mut help, "NES Emulator").unwrap();
-        writeln!(&mut help, "\nUsage: neser [OPTIONS] [ROM]").unwrap();
-
-        for section in HELP_SECTIONS {
-            let mut wrote_section = false;
-            for flag in all_cli_flags() {
-                if flag.help.is_none() || Self::help_section_for_flag(flag.flag) != section {
-                    continue;
-                }
-
-                if !wrote_section {
-                    writeln!(&mut help, "\n{section}:").unwrap();
-                    wrote_section = true;
-                }
-
-                if let Some(flag_help) = flag.help {
-                    writeln!(&mut help, "  {:<19} {}", flag.flag, flag_help).unwrap();
-                }
-            }
-        }
-
-        writeln!(&mut help, "\nExamples:").unwrap();
-        writeln!(
-            &mut help,
-            "  neser game.nes                               # Load and run a ROM"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --nes-hardware nes-pal game.nes        # Use NES PAL hardware"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --debugger game.nes                    # Enable debugger (no value = true)"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --breakpoint frame=120 game.nes           # Break on frame 120"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --audio game.nes                       # Enable audio (no value = true)"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --audio=1 game.nes                     # Enable audio (equals syntax)"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --audio false game.nes                 # Disable audio (value-based)"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --audio=0 game.nes                     # Disable audio (equals syntax)"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --no-audio game.nes                    # Disable audio (prefix negation)"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "  neser --disable-nes-pulse1 --disable-nes-pulse2 game.nes # Disable specific channels"
-        )
-        .unwrap();
-        writeln!(&mut help).unwrap();
-        writeln!(
-            &mut help,
-            "Note: Boolean flags can be used without value (defaults to true), with value (true/false/yes/no/1/0),"
-        )
-        .unwrap();
-        writeln!(
-            &mut help,
-            "      or with prefix negation (--no-*, --disable-*). All forms: --audio, --audio=1, --audio true are equivalent."
-        )
-        .unwrap();
-
-        help
-    }
-
     fn valid_controller_values() -> &'static str {
         "joypad, snes-controller, snes-mouse, zapper, arkanoid, power-pad"
     }
@@ -924,7 +738,7 @@ impl Config {
         }
 
         // Validate arguments
-        Self::validate_args(args)?;
+        crate::platform::config::validate_args(args)?;
 
         // Step 1: Start with defaults
         let mut config = Self::default();
@@ -1023,66 +837,6 @@ impl Config {
 
         Ok(())
     }
-    pub fn print_help() {
-        print!("{}", Self::help_text());
-    }
-
-    /// Validate command-line arguments.
-    fn validate_args(args: &[String]) -> Result<(), String> {
-        let mut i = 1; // Skip program name
-        let mut seen_positional = false;
-        while i < args.len() {
-            let arg = &args[i];
-
-            // Check for exact flag match
-            if let Some(flag) = all_cli_flags().find(|f| f.flag == arg) {
-                if flag.has_value {
-                    if i + 1 >= args.len() {
-                        return Err(format!("Missing value for {arg}\nTry --help for usage."));
-                    }
-                    i += 1; // Skip the value
-                }
-                // For optional boolean flags, check if next arg is a boolean value
-                else if OPTIONAL_BOOL_FLAGS.contains(&arg.as_str()) {
-                    // Peek at next argument to see if it's a boolean value
-                    if i + 1 < args.len() {
-                        let next_arg = &args[i + 1];
-                        // If next arg is a valid boolean value, skip it
-                        if parse_bool(next_arg).is_ok() {
-                            i += 1; // Skip the boolean value
-                        }
-                        // Otherwise leave it for processing as another flag or positional
-                    }
-                }
-                i += 1;
-                continue;
-            }
-
-            // Check for --flag=value syntax (e.g., --trace-cpu=2)
-            if let Some((flag_part, _)) = arg.split_once('=')
-                && all_cli_flags().any(|f| f.flag == flag_part)
-            {
-                i += 1;
-                continue;
-            }
-
-            if arg.starts_with('-') {
-                return Err(format!("Unknown argument: {arg}\nTry --help for usage."));
-            }
-
-            if seen_positional {
-                return Err(format!(
-                    "Unexpected positional argument: {arg}\nTry --help for usage."
-                ));
-            }
-
-            seen_positional = true;
-            i += 1;
-            continue;
-        }
-
-        Ok(())
-    }
 
     /// Parse the --display argument from command-line args.
     fn parse_display_arg(args: &[String]) -> Result<Option<i32>, String> {
@@ -1131,7 +885,7 @@ impl Config {
         while i < args.len() {
             let arg = &args[i];
 
-            if let Some(flag) = all_cli_flags().find(|f| f.flag == arg) {
+            if let Some(flag) = crate::platform::config::all_cli_flags().find(|f| f.flag == arg) {
                 if flag.has_value {
                     i += 2;
                 }
@@ -1149,7 +903,7 @@ impl Config {
             }
 
             if let Some((flag_part, _)) = arg.split_once('=')
-                && all_cli_flags().any(|f| f.flag == flag_part)
+                && crate::platform::config::all_cli_flags().any(|f| f.flag == flag_part)
             {
                 i += 1;
                 continue;
@@ -1673,7 +1427,7 @@ mod tests {
 
     #[test]
     fn test_help_text_groups_flags_into_readable_sections() {
-        let help = Config::help_text();
+        let help = crate::platform::config::help_text();
 
         assert!(help.contains("\nInput:"));
         assert!(help.contains("\nTrace and Debugging:"));
@@ -1697,7 +1451,7 @@ mod tests {
 
     #[test]
     fn test_help_text_load_state_is_presence_only_flag() {
-        let help = Config::help_text();
+        let help = crate::platform::config::help_text();
 
         assert!(help.contains("--load-state"));
         assert!(!help.contains("--no-load-state"));
@@ -1706,7 +1460,7 @@ mod tests {
 
     #[test]
     fn test_help_text_oam_dram_decay_shows_default_and_no_negation_aliases() {
-        let help = Config::help_text();
+        let help = crate::platform::config::help_text();
 
         assert!(help.contains("--nes-oam-dram-decay"));
         assert!(help.contains("default: false"));
@@ -1716,7 +1470,7 @@ mod tests {
 
     #[test]
     fn test_help_text_examples_use_hardware_flag() {
-        let help = Config::help_text();
+        let help = crate::platform::config::help_text();
 
         assert!(help.contains("neser --nes-hardware nes-pal game.nes"));
         assert!(!help.contains("--tv-system"));

--- a/src/nes/console/mod.rs
+++ b/src/nes/console/mod.rs
@@ -1,5 +1,5 @@
 mod cartridge_catalog;
-pub(crate) mod config;
+mod config;
 mod nes;
 mod ram_init;
 pub mod save_state_io;
@@ -16,6 +16,7 @@ pub use cartridge_catalog::{
 };
 #[allow(unused_imports)] // Used by frontend features
 pub use config::ApuChannels;
+pub(crate) use config::CLI_FLAGS;
 pub use config::ExpansionPort;
 pub use config::HardwareMode;
 #[allow(unused_imports)] // Used by integration tests and lib consumers

--- a/src/nes/console/mod.rs
+++ b/src/nes/console/mod.rs
@@ -1,5 +1,5 @@
 mod cartridge_catalog;
-mod config;
+pub(crate) mod config;
 mod nes;
 mod ram_init;
 pub mod save_state_io;

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -980,3 +980,255 @@ pub(crate) fn parse_search_paths(value: &str) -> Vec<String> {
         .map(ToString::to_string)
         .collect()
 }
+
+/// Get an iterator over all CLI flags (platform, NES, and GB).
+pub(crate) fn all_cli_flags() -> impl Iterator<Item = &'static CliFlag> {
+    PLATFORM_CLI_FLAGS
+        .iter()
+        .chain(crate::nes::console::config::CLI_FLAGS.iter())
+        .chain(crate::gb::console::config::GB_CLI_FLAGS.iter())
+}
+
+/// Categorize a flag into its help section.
+fn help_section_for_flag(flag: &str) -> &'static str {
+    if flag.starts_with("--trace")
+        || matches!(flag, "--debugger" | "--debugger-alpha" | "--breakpoint")
+    {
+        "Trace and Debugging"
+    } else if matches!(
+        flag,
+        "--nes-controller-port1"
+            | "--nes-controller-port2"
+            | "--nes-expansion-port"
+            | "--nes-zapper-detection-size"
+            | "--gamepads"
+            | "--nes-enable-4-score"
+            | "--no-nes-4-score"
+            | "--disable-nes-4-score"
+    ) {
+        "Input"
+    } else if matches!(
+        flag,
+        "--audio"
+            | "--no-audio"
+            | "--disable-audio"
+            | "--nes-pulse1"
+            | "--no-nes-pulse1"
+            | "--disable-nes-pulse1"
+            | "--nes-pulse2"
+            | "--no-nes-pulse2"
+            | "--disable-nes-pulse2"
+            | "--nes-triangle"
+            | "--no-nes-triangle"
+            | "--disable-nes-triangle"
+            | "--nes-noise"
+            | "--no-nes-noise"
+            | "--disable-nes-noise"
+            | "--nes-dmc"
+            | "--no-nes-dmc"
+            | "--disable-nes-dmc"
+    ) {
+        "Sound"
+    } else if matches!(
+        flag,
+        "--fullscreen"
+            | "--display"
+            | "--nes-filter"
+            | "--gb-filter"
+            | "--window-height"
+            | "--vsync"
+            | "--no-vsync"
+            | "--disable-vsync"
+            | "--nes-horizontal-overscan"
+            | "--nes-vertical-overscan"
+    ) {
+        "Video and Display"
+    } else if matches!(
+        flag,
+        "--create-recording"
+            | "--extend-recording"
+            | "--playback"
+            | "--playback-headless"
+            | "--playback-from-checkpoint"
+            | "--playback-headless-from-checkpoint"
+            | "--trim-checkpoints"
+            | "--convert-autorun"
+            | "--recalculate-autorun"
+    ) {
+        "Autorun"
+    } else if matches!(
+        flag,
+        "--cartridge-search-paths"
+            | "--scan-cartridges"
+            | "--no-scan-cartridges"
+            | "--rebuild-cartridge-catalog"
+    ) {
+        "Cartridge Catalog"
+    } else {
+        "General"
+    }
+}
+
+/// Generate the help text for all CLI flags.
+pub(crate) fn help_text() -> String {
+    use std::fmt::Write as _;
+
+    const HELP_SECTIONS: [&str; 7] = [
+        "General",
+        "Input",
+        "Trace and Debugging",
+        "Sound",
+        "Video and Display",
+        "Autorun",
+        "Cartridge Catalog",
+    ];
+
+    let mut help = String::new();
+    writeln!(&mut help, "NES Emulator").unwrap();
+    writeln!(&mut help, "\nUsage: neser [OPTIONS] [ROM]").unwrap();
+
+    for section in HELP_SECTIONS {
+        let mut wrote_section = false;
+        for flag in all_cli_flags() {
+            if flag.help.is_none() || help_section_for_flag(flag.flag) != section {
+                continue;
+            }
+
+            if !wrote_section {
+                writeln!(&mut help, "\n{section}:").unwrap();
+                wrote_section = true;
+            }
+
+            if let Some(flag_help) = flag.help {
+                writeln!(&mut help, "  {:<19} {}", flag.flag, flag_help).unwrap();
+            }
+        }
+    }
+
+    writeln!(&mut help, "\nExamples:").unwrap();
+    writeln!(
+        &mut help,
+        "  neser game.nes                               # Load and run a ROM"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --nes-hardware nes-pal game.nes        # Use NES PAL hardware"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --debugger game.nes                    # Enable debugger (no value = true)"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --breakpoint frame=120 game.nes           # Break on frame 120"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --audio game.nes                       # Enable audio (no value = true)"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --audio=1 game.nes                     # Enable audio (equals syntax)"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --audio false game.nes                 # Disable audio (value-based)"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --audio=0 game.nes                     # Disable audio (equals syntax)"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --no-audio game.nes                    # Disable audio (prefix negation)"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "  neser --disable-nes-pulse1 --disable-nes-pulse2 game.nes # Disable specific channels"
+    )
+    .unwrap();
+    writeln!(&mut help).unwrap();
+    writeln!(
+        &mut help,
+        "Note: Boolean flags can be used without value (defaults to true), with value (true/false/yes/no/1/0),"
+    )
+    .unwrap();
+    writeln!(
+        &mut help,
+        "      or with prefix negation (--no-*, --disable-*). All forms: --audio, --audio=1, --audio true are equivalent."
+    )
+    .unwrap();
+
+    help
+}
+
+/// Print help text to stdout.
+pub fn print_help() {
+    print!("{}", help_text());
+}
+
+/// Validate command-line arguments.
+pub(crate) fn validate_args(args: &[String]) -> Result<(), String> {
+    let mut i = 1; // Skip program name
+    let mut seen_positional = false;
+    while i < args.len() {
+        let arg = &args[i];
+
+        // Check for exact flag match
+        if let Some(flag) = all_cli_flags().find(|f| f.flag == arg) {
+            if flag.has_value {
+                if i + 1 >= args.len() {
+                    return Err(format!("Missing value for {arg}\nTry --help for usage."));
+                }
+                i += 1; // Skip the value
+            }
+            // For optional boolean flags, check if next arg is a boolean value
+            else if OPTIONAL_BOOL_FLAGS.contains(&arg.as_str()) {
+                // Peek at next argument to see if it's a boolean value
+                if i + 1 < args.len() {
+                    let next_arg = &args[i + 1];
+                    // If next arg is a valid boolean value, skip it
+                    if parse_bool(next_arg).is_ok() {
+                        i += 1; // Skip the boolean value
+                    }
+                    // Otherwise leave it for processing as another flag or positional
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        // Check for --flag=value syntax (e.g., --trace-cpu=2)
+        if let Some((flag_part, _)) = arg.split_once('=')
+            && all_cli_flags().any(|f| f.flag == flag_part)
+        {
+            i += 1;
+            continue;
+        }
+
+        if arg.starts_with('-') {
+            return Err(format!("Unknown argument: {arg}\nTry --help for usage."));
+        }
+
+        if seen_positional {
+            return Err(format!(
+                "Unexpected positional argument: {arg}\nTry --help for usage."
+            ));
+        }
+
+        seen_positional = true;
+        i += 1;
+        continue;
+    }
+
+    Ok(())
+}

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -985,7 +985,7 @@ pub(crate) fn parse_search_paths(value: &str) -> Vec<String> {
 pub(crate) fn all_cli_flags() -> impl Iterator<Item = &'static CliFlag> {
     PLATFORM_CLI_FLAGS
         .iter()
-        .chain(crate::nes::console::config::CLI_FLAGS.iter())
+        .chain(crate::nes::console::CLI_FLAGS.iter())
         .chain(crate::gb::console::config::GB_CLI_FLAGS.iter())
 }
 
@@ -1172,7 +1172,7 @@ pub(crate) fn help_text() -> String {
 }
 
 /// Print help text to stdout.
-pub fn print_help() {
+pub(crate) fn print_help() {
     print!("{}", help_text());
 }
 


### PR DESCRIPTION
Summary: Completes sub-issue #2159 by moving help/validation infrastructure from NES config to platform config.

Changes:
- Move help_section_for_flag(), help_text(), print_help(), and validate_args() to platform/config.rs
- Move all_cli_flags() to platform (chains PLATFORM + NES + GB flags)
- Make NES CLI_FLAGS pub(crate) for platform access
- Update all references in main.rs and tests
- Remove unused imports

Testing:
- All 8666 tests pass
- --help output byte-for-byte identical
- Clippy clean with -D warnings  
- WASM tests pass (54 tests)

Related: Parent issue #2154, sub-issue #2159