### PR TITLE
Add GB debugger native UI integration

### DIFF
--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -10,6 +10,7 @@ use crate::frontends::native::gl_wrapper::NativeGlWrapper;
 use crate::frontends::native::keyboard::{self, KeyOutcome};
 use crate::frontends::native::mouse;
 use crate::frontends::native::sleep_inhibitor::SleepInhibitor;
+use crate::gb::debugging::control::GbDebuggerController;
 use crate::nes::debugging::control::DebuggerController;
 use crate::platform::app_context::SharedAppContext;
 use crate::platform::audio::{EmulatorAudio, normalize_nes_sample};
@@ -37,6 +38,7 @@ pub struct NativeEventLoop {
     tracing: Tracing,
     state: NativeAppState,
     debugger_controller: DebuggerController,
+    gb_debugger_controller: GbDebuggerController,
     /// Whether the user had manually paused before the debugger opened,
     /// so we can restore pause state when the debugger closes.
     paused_before_debugger: bool,
@@ -78,9 +80,20 @@ impl NativeEventLoop {
         tracing: Tracing,
         headless: bool,
     ) -> Self {
-        let (gamepads_enabled, four_score, fullscreen, vsync_enabled, debugger_controller) = {
+        let (
+            gamepads_enabled,
+            four_score,
+            fullscreen,
+            vsync_enabled,
+            debugger_controller,
+            gb_debugger_controller,
+        ) = {
             let config = app_context.borrow().config().clone();
             let dc = DebuggerController::new(
+                &config.frontend.breakpoints,
+                config.frontend.debugger_enabled,
+            );
+            let gb_dc = GbDebuggerController::new(
                 &config.frontend.breakpoints,
                 config.frontend.debugger_enabled,
             );
@@ -90,6 +103,7 @@ impl NativeEventLoop {
                 config.frontend.fullscreen,
                 config.frontend.vsync_enabled,
                 dc,
+                gb_dc,
             )
         };
 
@@ -125,6 +139,7 @@ impl NativeEventLoop {
                 ..NativeAppState::default()
             },
             debugger_controller,
+            gb_debugger_controller,
             paused_before_debugger: false,
             paused_before_cart_switch: false,
             gamepad,
@@ -169,7 +184,11 @@ impl NativeEventLoop {
     }
 
     fn run_frame(&mut self) {
-        if self.state.paused && !self.debugger_controller.is_paused() {
+        let debugger_paused = match &self.console {
+            Console::Nes(_) => self.debugger_controller.is_paused(),
+            Console::GameBoy(_) => self.gb_debugger_controller.is_paused(),
+        };
+        if self.state.paused && !debugger_paused {
             // Manually paused (not debugger) — skip frame
             return;
         }
@@ -206,17 +225,7 @@ impl NativeEventLoop {
                     });
             }
             Console::GameBoy(gb) => {
-                // Run ticks until a full frame is ready, draining audio samples.
-                while !gb.is_frame_ready() {
-                    gb.run_tick();
-                    if let Some(ref mut audio) = *audio_cell.borrow_mut() {
-                        while gb.sample_ready() {
-                            if let Some(sample) = gb.get_sample() {
-                                audio.queue_sample(sample);
-                            }
-                        }
-                    }
-                }
+                gb.run_frame_with_debugger(&mut self.gb_debugger_controller, &audio_cell);
             }
         }
         self.audio = audio_cell.into_inner();
@@ -257,7 +266,12 @@ impl NativeEventLoop {
 
     /// Sync frontend state from the debugger controller.
     fn sync_from_controller(&mut self) {
-        if self.debugger_controller.is_debugger_open() {
+        let debugger_open = match &self.console {
+            Console::Nes(_) => self.debugger_controller.is_debugger_open(),
+            Console::GameBoy(_) => self.gb_debugger_controller.is_debugger_open(),
+        };
+
+        if debugger_open {
             if !self.state.debugger_open {
                 // Debugger just opened — remember manual pause state.
                 self.paused_before_debugger = self.state.paused;
@@ -734,30 +748,38 @@ impl ApplicationHandler for NativeEventLoop {
                             }
                         }
                         KeyOutcome::ToggleDebugger => {
-                            let Console::Nes(nes) = &self.console else {
-                                panic!(
-                                    "NES-only event loop: unexpected non-NES console in ToggleDebugger"
-                                );
-                            };
-                            self.debugger_controller.toggle_debugger(nes);
+                            match &self.console {
+                                Console::Nes(nes) => {
+                                    self.debugger_controller.toggle_debugger(nes);
+                                }
+                                Console::GameBoy(gb) => {
+                                    gb.toggle_debugger_with_controller(
+                                        &mut self.gb_debugger_controller,
+                                    );
+                                }
+                            }
                             self.sync_from_controller();
                         }
                         KeyOutcome::StepOver => {
-                            let Console::Nes(nes) = &mut self.console else {
-                                panic!(
-                                    "NES-only event loop: unexpected non-NES console in StepOver"
-                                );
-                            };
-                            self.debugger_controller.step_over(nes);
+                            match &mut self.console {
+                                Console::Nes(nes) => {
+                                    self.debugger_controller.step_over(nes);
+                                }
+                                Console::GameBoy(gb) => {
+                                    gb.step_over_with_controller(&mut self.gb_debugger_controller);
+                                }
+                            }
                             self.sync_from_controller();
                         }
                         KeyOutcome::StepInto => {
-                            let Console::Nes(nes) = &mut self.console else {
-                                panic!(
-                                    "NES-only event loop: unexpected non-NES console in StepInto"
-                                );
-                            };
-                            self.debugger_controller.step_into(nes);
+                            match &mut self.console {
+                                Console::Nes(nes) => {
+                                    self.debugger_controller.step_into(nes);
+                                }
+                                Console::GameBoy(gb) => {
+                                    gb.step_into_with_controller(&mut self.gb_debugger_controller);
+                                }
+                            }
                             self.sync_from_controller();
                         }
                         KeyOutcome::SwitchCartridge(path) => {
@@ -941,7 +963,14 @@ impl ApplicationHandler for NativeEventLoop {
 
                 // Render and apply debugger UI actions
                 let action = if let Some(ref mut gl) = self.gl_wrapper {
-                    gl.update_breakpoints(self.debugger_controller.breakpoints());
+                    match &self.console {
+                        Console::Nes(_) => {
+                            gl.update_breakpoints(self.debugger_controller.breakpoints());
+                        }
+                        Console::GameBoy(_) => {
+                            gl.update_gb_breakpoints(self.gb_debugger_controller.breakpoints());
+                        }
+                    }
                     let crosshair =
                         mouse::zapper_crosshair(&self.console, self.state.last_zapper_position);
                     let overlay = self
@@ -961,8 +990,19 @@ impl ApplicationHandler for NativeEventLoop {
                 } else {
                     Default::default()
                 };
-                if let Console::Nes(nes) = &mut self.console {
-                    self.debugger_controller.apply_ui_action(nes, action);
+                match &mut self.console {
+                    Console::Nes(nes) => {
+                        self.debugger_controller.apply_ui_action(nes, action);
+                    }
+                    Console::GameBoy(gb) => {
+                        if let Some(ref mut gl) = self.gl_wrapper {
+                            let gb_action = gl.take_gb_debugger_action();
+                            gb.apply_ui_action_with_controller(
+                                &mut self.gb_debugger_controller,
+                                gb_action,
+                            );
+                        }
+                    }
                 }
                 self.sync_from_controller();
             }

--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -748,7 +748,7 @@ impl ApplicationHandler for NativeEventLoop {
                             }
                         }
                         KeyOutcome::ToggleDebugger => {
-                            match &self.console {
+                            match &mut self.console {
                                 Console::Nes(nes) => {
                                     self.debugger_controller.toggle_debugger(nes);
                                 }

--- a/src/frontends/native/gl_backend.rs
+++ b/src/frontends/native/gl_backend.rs
@@ -1,5 +1,7 @@
 use crate::frontends::native::input::{InputEvent, apply_input};
 use crate::frontends::native::shader_manager::ShaderManager;
+use crate::gb::debugging::GbDebuggerViewState;
+use crate::gb::debugging::debugger_ui as gb_debugger_ui;
 use crate::nes::console::Nes;
 use crate::nes::debugging::DebuggerViewState;
 use crate::nes::debugging::ppu_viewer::{
@@ -23,6 +25,17 @@ const PPU_VIEWER_TILES_TEXTURE_HEIGHT: i32 = 128;
 
 const PPU_VIEWER_WINDOW_INITIAL_WIDTH: f32 = 560.0;
 const PPU_VIEWER_WINDOW_INITIAL_HEIGHT: f32 = 854.0;
+
+// GB PPU viewer texture dimensions
+const GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_DMG: i32 = 256;
+const GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_DMG: i32 = 128;
+const GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_CGB: i32 = 512;
+const GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_CGB: i32 = 128;
+const GB_PPU_VIEWER_BG_MAPS_TEXTURE_WIDTH: i32 = 512;
+const GB_PPU_VIEWER_BG_MAPS_TEXTURE_HEIGHT: i32 = 256;
+
+const GB_PPU_VIEWER_WINDOW_INITIAL_WIDTH: f32 = 560.0;
+const GB_PPU_VIEWER_WINDOW_INITIAL_HEIGHT: f32 = 600.0;
 
 /// Backend-agnostic surface for presenting rendered frames.
 ///
@@ -72,12 +85,25 @@ pub struct GlBackend {
     app_context: SharedAppContext,
     framebuffer: Vec<u8>,
     last_frame: Instant,
+    // NES debugger state
     debugger_view_state: DebuggerViewState,
     debugger_alpha: f32,
     breakpoints: BreakpointList,
     bp_add_state: BreakpointAddUiState,
     hexdump_ui_state: HexdumpUiState,
     watchlist_ui_state: WatchlistUiState,
+    // GB debugger state
+    gb_debugger_view_state: GbDebuggerViewState,
+    gb_debugger_alpha: f32,
+    gb_breakpoints: BreakpointList,
+    gb_bp_add_state: gb_debugger_ui::BreakpointAddUiState,
+    gb_hexdump_ui_state: gb_debugger_ui::HexdumpUiState,
+    gb_watchlist_ui_state: gb_debugger_ui::WatchlistUiState,
+    // GB PPU viewer textures
+    gb_ppu_viewer_tiles_texture: gl::types::GLuint,
+    gb_ppu_viewer_tiles_texture_id: imgui::TextureId,
+    gb_ppu_viewer_bg_maps_texture: gl::types::GLuint,
+    gb_ppu_viewer_bg_maps_texture_id: imgui::TextureId,
     shader_manager: ShaderManager,
     /// Current GL texture width (updated when console type changes).
     tex_w: u32,
@@ -428,6 +454,20 @@ impl GlBackend {
             )
         };
 
+        // GB PPU viewer textures
+        let (gb_ppu_viewer_tiles_texture, gb_ppu_viewer_tiles_texture_id) = unsafe {
+            create_rgba_texture(
+                GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_CGB,
+                GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_CGB,
+            )
+        };
+        let (gb_ppu_viewer_bg_maps_texture, gb_ppu_viewer_bg_maps_texture_id) = unsafe {
+            create_rgba_texture(
+                GB_PPU_VIEWER_BG_MAPS_TEXTURE_WIDTH,
+                GB_PPU_VIEWER_BG_MAPS_TEXTURE_HEIGHT,
+            )
+        };
+
         let mut shader_manager = ShaderManager::new(allowed_shaders);
 
         // Load shader preset if specified
@@ -457,12 +497,25 @@ impl GlBackend {
             app_context,
             framebuffer: Vec::new(),
             last_frame: Instant::now(),
+            // NES debugger state
             debugger_view_state: DebuggerViewState::default(),
             debugger_alpha: 1.0,
             breakpoints: BreakpointList::default(),
             bp_add_state: BreakpointAddUiState::default(),
             hexdump_ui_state: HexdumpUiState::default(),
             watchlist_ui_state: WatchlistUiState::default(),
+            // GB debugger state
+            gb_debugger_view_state: GbDebuggerViewState::default(),
+            gb_debugger_alpha: 1.0,
+            gb_breakpoints: BreakpointList::default(),
+            gb_bp_add_state: gb_debugger_ui::BreakpointAddUiState::default(),
+            gb_hexdump_ui_state: gb_debugger_ui::HexdumpUiState::default(),
+            gb_watchlist_ui_state: gb_debugger_ui::WatchlistUiState::default(),
+            // GB PPU viewer textures
+            gb_ppu_viewer_tiles_texture,
+            gb_ppu_viewer_tiles_texture_id,
+            gb_ppu_viewer_bg_maps_texture,
+            gb_ppu_viewer_bg_maps_texture_id,
             shader_manager,
             tex_w: 1,
             tex_h: 1,
@@ -490,6 +543,20 @@ impl GlBackend {
     /// Updates the breakpoint list used by the debugger UI.
     pub fn update_breakpoints(&mut self, breakpoints: &BreakpointList) {
         self.breakpoints = breakpoints.clone();
+    }
+
+    // GB debugger methods
+
+    /// Sets the GB debugger window background opacity (clamped to 0.1–1.0).
+    #[allow(dead_code)] // Used by debugger controller, not yet wired up
+    pub fn set_gb_debugger_alpha(&mut self, alpha: f32) {
+        self.gb_debugger_alpha = alpha.clamp(0.1, 1.0);
+    }
+
+    /// Updates the GB breakpoint list used by the GB debugger UI.
+    #[allow(dead_code)] // Used by debugger controller, not yet wired up
+    pub fn update_gb_breakpoints(&mut self, breakpoints: &BreakpointList) {
+        self.gb_breakpoints = breakpoints.clone();
     }
 
     /// Returns a copy of the watch addresses currently tracked in the debugger.
@@ -747,6 +814,64 @@ impl GlBackend {
                         self.ppu_viewer_nt_texture_id,
                         self.ppu_viewer_tiles_texture_id,
                         scroll,
+                    );
+                }
+            } else if show_debugger && let Console::GameBoy(gb) = console {
+                let snapshot = gb.create_debugger_snapshot(&mut self.gb_debugger_view_state);
+                let gb_action = gb_debugger_ui::render(
+                    ui,
+                    &snapshot,
+                    self.gb_debugger_alpha,
+                    &self.gb_breakpoints,
+                    &mut self.gb_bp_add_state,
+                    &mut self.gb_hexdump_ui_state,
+                    &mut self.gb_watchlist_ui_state,
+                );
+                if gb_action.toggle_ppu_viewer {
+                    self.gb_debugger_view_state.toggle_ppu_viewer();
+                }
+                if let Some(base) = gb_action.set_wram_hexdump_base {
+                    self.gb_debugger_view_state.set_wram_hexdump_base(base);
+                }
+                if let Some(delta) = gb_action.nudge_wram_hexdump_base_by_bytes {
+                    self.gb_debugger_view_state
+                        .nudge_wram_hexdump_base_by_bytes_from(snapshot.wram_hexdump_base, delta);
+                }
+                if let Some(base) = gb_action.set_vram_hexdump_base {
+                    self.gb_debugger_view_state.set_vram_hexdump_base(base);
+                }
+                if let Some(delta) = gb_action.nudge_vram_hexdump_base_by_bytes {
+                    self.gb_debugger_view_state
+                        .nudge_vram_hexdump_base_by_bytes_from(snapshot.vram_hexdump_base, delta);
+                }
+                if let Some(address) = gb_action.add_watch_address {
+                    self.gb_debugger_view_state.add_watch_address(address);
+                }
+                if let Some(index) = gb_action.remove_watch_address {
+                    self.gb_debugger_view_state.remove_watch_address(index);
+                }
+                if let Some(update) = gb_action.update_watch_address {
+                    self.gb_debugger_view_state
+                        .update_watch_address(update.index, update.address);
+                }
+                if gb_action.increase_opacity {
+                    self.gb_debugger_alpha = (self.gb_debugger_alpha + 0.1).min(1.0);
+                }
+                if gb_action.decrease_opacity {
+                    self.gb_debugger_alpha = (self.gb_debugger_alpha - 0.1).max(0.1);
+                }
+                if self.gb_debugger_view_state.is_ppu_viewer_visible() {
+                    let ppu_snap = gb.create_ppu_viewer_snapshot();
+                    update_gb_ppu_viewer_textures_from_snapshot(
+                        &ppu_snap,
+                        self.gb_ppu_viewer_tiles_texture,
+                        self.gb_ppu_viewer_bg_maps_texture,
+                    );
+                    draw_gb_ppu_viewer_window(
+                        ui,
+                        self.gb_ppu_viewer_tiles_texture_id,
+                        self.gb_ppu_viewer_bg_maps_texture_id,
+                        gb.is_cgb_mode(),
                     );
                 }
             }
@@ -1107,6 +1232,91 @@ fn update_ppu_viewer_textures(
     ppu_snap.scroll
 }
 
+/// Update GB PPU viewer textures with a snapshot.
+fn update_gb_ppu_viewer_textures_from_snapshot(
+    ppu_snap: &crate::gb::debugging::ppu_viewer::GbPpuViewerSnapshot,
+    tiles_texture: gl::types::GLuint,
+    bg_maps_texture: gl::types::GLuint,
+) {
+    use crate::gb::debugging::ppu_viewer::{render_bg_maps_rgba, render_tiles_rgba};
+    let tiles_pixels = render_tiles_rgba(
+        &ppu_snap.vram,
+        &ppu_snap.vram_bank1,
+        ppu_snap.bgp,
+        &ppu_snap.bg_palette_ram,
+        ppu_snap.cgb_mode,
+    );
+    let bg_maps_pixels = render_bg_maps_rgba(
+        &ppu_snap.vram,
+        &ppu_snap.vram_bank1,
+        ppu_snap.lcdc,
+        ppu_snap.bgp,
+        &ppu_snap.bg_palette_ram,
+        ppu_snap.cgb_mode,
+    );
+
+    let (tiles_width, tiles_height) = if ppu_snap.cgb_mode {
+        (
+            GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_CGB,
+            GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_CGB,
+        )
+    } else {
+        (
+            GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_DMG,
+            GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_DMG,
+        )
+    };
+
+    unsafe {
+        upload_rgba_texture(tiles_texture, tiles_width, tiles_height, &tiles_pixels);
+        upload_rgba_texture(
+            bg_maps_texture,
+            GB_PPU_VIEWER_BG_MAPS_TEXTURE_WIDTH,
+            GB_PPU_VIEWER_BG_MAPS_TEXTURE_HEIGHT,
+            &bg_maps_pixels,
+        );
+    }
+}
+
+/// Render the GB PPU viewer ImGui window showing tiles and BG maps.
+fn draw_gb_ppu_viewer_window(
+    ui: &imgui::Ui,
+    tiles_texture_id: imgui::TextureId,
+    bg_maps_texture_id: imgui::TextureId,
+    is_cgb: bool,
+) {
+    // Aspect ratios for GB PPU viewer textures
+    let tiles_aspect = if is_cgb {
+        GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_CGB as f32 / GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_CGB as f32
+    } else {
+        GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_DMG as f32 / GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_DMG as f32
+    };
+    const BG_MAPS_ASPECT: f32 =
+        GB_PPU_VIEWER_BG_MAPS_TEXTURE_HEIGHT as f32 / GB_PPU_VIEWER_BG_MAPS_TEXTURE_WIDTH as f32;
+
+    ui.window("GB PPU Viewer")
+        .size(
+            [
+                GB_PPU_VIEWER_WINDOW_INITIAL_WIDTH,
+                GB_PPU_VIEWER_WINDOW_INITIAL_HEIGHT,
+            ],
+            imgui::Condition::FirstUseEver,
+        )
+        .build(|| {
+            let mode_label = if is_cgb { "CGB" } else { "DMG" };
+            ui.text(format!("Tiles ({})", mode_label));
+            ui.separator();
+            let avail_w = ui.content_region_avail()[0];
+            imgui::Image::new(tiles_texture_id, [avail_w, avail_w * tiles_aspect]).build(ui);
+
+            ui.dummy([0.0, 6.0]);
+            ui.text("BG Maps (0x9800 | 0x9C00)");
+            ui.separator();
+            let avail_w = ui.content_region_avail()[0];
+            imgui::Image::new(bg_maps_texture_id, [avail_w, avail_w * BG_MAPS_ASPECT]).build(ui);
+        });
+}
+
 impl Drop for GlBackend {
     fn drop(&mut self) {
         // Best-effort: make current and clean up GL resources.
@@ -1116,6 +1326,8 @@ impl Drop for GlBackend {
                 gl::DeleteTextures(1, &self.nes_texture);
                 gl::DeleteTextures(1, &self.ppu_viewer_nt_texture);
                 gl::DeleteTextures(1, &self.ppu_viewer_tiles_texture);
+                gl::DeleteTextures(1, &self.gb_ppu_viewer_tiles_texture);
+                gl::DeleteTextures(1, &self.gb_ppu_viewer_bg_maps_texture);
             }
         }
     }

--- a/src/frontends/native/gl_backend.rs
+++ b/src/frontends/native/gl_backend.rs
@@ -99,6 +99,7 @@ pub struct GlBackend {
     gb_bp_add_state: gb_debugger_ui::BreakpointAddUiState,
     gb_hexdump_ui_state: gb_debugger_ui::HexdumpUiState,
     gb_watchlist_ui_state: gb_debugger_ui::WatchlistUiState,
+    last_gb_action: gb_debugger_ui::GbDebuggerUiAction,
     // GB PPU viewer textures
     gb_ppu_viewer_tiles_texture: gl::types::GLuint,
     gb_ppu_viewer_tiles_texture_id: imgui::TextureId,
@@ -511,6 +512,7 @@ impl GlBackend {
             gb_bp_add_state: gb_debugger_ui::BreakpointAddUiState::default(),
             gb_hexdump_ui_state: gb_debugger_ui::HexdumpUiState::default(),
             gb_watchlist_ui_state: gb_debugger_ui::WatchlistUiState::default(),
+            last_gb_action: gb_debugger_ui::GbDebuggerUiAction::default(),
             // GB PPU viewer textures
             gb_ppu_viewer_tiles_texture,
             gb_ppu_viewer_tiles_texture_id,
@@ -554,9 +556,13 @@ impl GlBackend {
     }
 
     /// Updates the GB breakpoint list used by the GB debugger UI.
-    #[allow(dead_code)] // Used by debugger controller, not yet wired up
     pub fn update_gb_breakpoints(&mut self, breakpoints: &BreakpointList) {
         self.gb_breakpoints = breakpoints.clone();
+    }
+
+    /// Takes the last GB debugger UI action, replacing it with default.
+    pub fn take_gb_debugger_action(&mut self) -> gb_debugger_ui::GbDebuggerUiAction {
+        std::mem::take(&mut self.last_gb_action)
     }
 
     /// Returns a copy of the watch addresses currently tracked in the debugger.
@@ -860,6 +866,8 @@ impl GlBackend {
                 if gb_action.decrease_opacity {
                     self.gb_debugger_alpha = (self.gb_debugger_alpha - 0.1).max(0.1);
                 }
+                // Store action for processing by controller
+                self.last_gb_action = gb_action;
                 if self.gb_debugger_view_state.is_ppu_viewer_visible() {
                     let ppu_snap = gb.create_ppu_viewer_snapshot();
                     update_gb_ppu_viewer_textures_from_snapshot(
@@ -871,7 +879,7 @@ impl GlBackend {
                         ui,
                         self.gb_ppu_viewer_tiles_texture_id,
                         self.gb_ppu_viewer_bg_maps_texture_id,
-                        gb.is_cgb_mode(),
+                        &ppu_snap,
                     );
                 }
             }
@@ -1255,20 +1263,36 @@ fn update_gb_ppu_viewer_textures_from_snapshot(
         ppu_snap.cgb_mode,
     );
 
-    let (tiles_width, tiles_height) = if ppu_snap.cgb_mode {
-        (
-            GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_CGB,
-            GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_CGB,
-        )
+    // Pad DMG tiles to full CGB texture size to avoid stale data
+    let tiles_upload_width = GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_CGB;
+    let tiles_upload_height = GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_CGB;
+    let tiles_upload_pixels = if ppu_snap.cgb_mode {
+        tiles_pixels
     } else {
-        (
-            GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_DMG,
-            GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_DMG,
-        )
+        let src_width = GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_DMG as usize;
+        let src_height = GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_DMG as usize;
+        let dst_width = GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_CGB as usize;
+        let dst_height = GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_CGB as usize;
+        let mut padded_pixels = vec![0u8; dst_width * dst_height * 4];
+
+        for row in 0..src_height {
+            let src_start = row * src_width * 4;
+            let src_end = src_start + src_width * 4;
+            let dst_start = row * dst_width * 4;
+            let dst_end = dst_start + src_width * 4;
+            padded_pixels[dst_start..dst_end].copy_from_slice(&tiles_pixels[src_start..src_end]);
+        }
+
+        padded_pixels
     };
 
     unsafe {
-        upload_rgba_texture(tiles_texture, tiles_width, tiles_height, &tiles_pixels);
+        upload_rgba_texture(
+            tiles_texture,
+            tiles_upload_width,
+            tiles_upload_height,
+            &tiles_upload_pixels,
+        );
         upload_rgba_texture(
             bg_maps_texture,
             GB_PPU_VIEWER_BG_MAPS_TEXTURE_WIDTH,
@@ -1278,13 +1302,16 @@ fn update_gb_ppu_viewer_textures_from_snapshot(
     }
 }
 
-/// Render the GB PPU viewer ImGui window showing tiles and BG maps.
+/// Render the GB PPU viewer ImGui window showing tiles, BG maps, OAM, and palettes.
 fn draw_gb_ppu_viewer_window(
     ui: &imgui::Ui,
     tiles_texture_id: imgui::TextureId,
     bg_maps_texture_id: imgui::TextureId,
-    is_cgb: bool,
+    ppu_snap: &crate::gb::debugging::ppu_viewer::GbPpuViewerSnapshot,
 ) {
+    use crate::gb::debugging::ppu_viewer::{format_oam_entries, format_palette_info};
+
+    let is_cgb = ppu_snap.cgb_mode;
     // Aspect ratios for GB PPU viewer textures
     let tiles_aspect = if is_cgb {
         GB_PPU_VIEWER_TILES_TEXTURE_HEIGHT_CGB as f32 / GB_PPU_VIEWER_TILES_TEXTURE_WIDTH_CGB as f32
@@ -1307,13 +1334,43 @@ fn draw_gb_ppu_viewer_window(
             ui.text(format!("Tiles ({})", mode_label));
             ui.separator();
             let avail_w = ui.content_region_avail()[0];
-            imgui::Image::new(tiles_texture_id, [avail_w, avail_w * tiles_aspect]).build(ui);
+            let tiles_uv1 = if is_cgb { [1.0, 1.0] } else { [0.5, 1.0] };
+            imgui::Image::new(tiles_texture_id, [avail_w, avail_w * tiles_aspect])
+                .uv0([0.0, 0.0])
+                .uv1(tiles_uv1)
+                .build(ui);
 
             ui.dummy([0.0, 6.0]);
             ui.text("BG Maps (0x9800 | 0x9C00)");
             ui.separator();
             let avail_w = ui.content_region_avail()[0];
             imgui::Image::new(bg_maps_texture_id, [avail_w, avail_w * BG_MAPS_ASPECT]).build(ui);
+
+            ui.dummy([0.0, 6.0]);
+            ui.text("OAM Sprites");
+            ui.separator();
+            let oam_lines = format_oam_entries(&ppu_snap.oam, is_cgb);
+            for line in oam_lines.iter().take(10) {
+                ui.text(line);
+            }
+            if oam_lines.len() > 10 {
+                ui.text(format!("... {} more sprites", oam_lines.len() - 10));
+            }
+
+            ui.dummy([0.0, 6.0]);
+            ui.text("Palettes");
+            ui.separator();
+            let palette_lines = format_palette_info(
+                ppu_snap.bgp,
+                ppu_snap.obp0,
+                ppu_snap.obp1,
+                &ppu_snap.bg_palette_ram,
+                &ppu_snap.obj_palette_ram,
+                is_cgb,
+            );
+            for line in palette_lines {
+                ui.text(line);
+            }
         });
 }
 

--- a/src/frontends/native/gl_wrapper.rs
+++ b/src/frontends/native/gl_wrapper.rs
@@ -203,6 +203,16 @@ impl NativeGlWrapper {
         self.gl_backend.update_breakpoints(breakpoints);
     }
 
+    /// Updates the GB breakpoint list used by the GB debugger UI.
+    pub fn update_gb_breakpoints(&mut self, breakpoints: &BreakpointList) {
+        self.gl_backend.update_gb_breakpoints(breakpoints);
+    }
+
+    /// Takes the last GB debugger UI action, replacing it with default.
+    pub fn take_gb_debugger_action(&mut self) -> crate::gb::debugging::ui::GbDebuggerUiAction {
+        self.gl_backend.take_gb_debugger_action()
+    }
+
     /// Returns the current watch addresses from the debugger.
     pub fn watch_addresses(&self) -> Vec<u16> {
         self.gl_backend.watch_addresses()

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -220,11 +220,6 @@ fn handle_gameboy_key_pressed(
         return outcome;
     }
 
-    // Skip debugger shortcuts (F10/F11) when debugger is open, as ImGui handles them through UI buttons
-    if app_state.debugger_open && matches!(key_code, KeyCode::F10 | KeyCode::F11) {
-        return KeyOutcome::Continue;
-    }
-
     match key_code {
         KeyCode::KeyH => app_state.help_overlay_visible = !app_state.help_overlay_visible,
         KeyCode::F5 => return KeyOutcome::ToggleDebugger,
@@ -277,11 +272,6 @@ fn handle_unmodified_key(
 ) -> KeyOutcome {
     if let Some(outcome) = handle_common_hotkey(key_code, app_state, audio) {
         return outcome;
-    }
-
-    // Skip debugger shortcuts (F10/F11) when debugger is open, as ImGui handles them through UI buttons
-    if app_state.debugger_open && matches!(key_code, KeyCode::F10 | KeyCode::F11) {
-        return KeyOutcome::Continue;
     }
 
     match key_code {

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -42,9 +42,9 @@ pub enum KeyOutcome {
 /// on actions that require access to the GL wrapper (e.g. shader cycling,
 /// fullscreen toggle).
 ///
-/// For [`Console::GameBoy`], only generic actions (pause, fullscreen toggle,
-/// directional/A/B/Start/Select keys) are dispatched; NES-specific features
-/// such as the debugger, save states, SNES buttons, and Power Pad are ignored.
+/// For [`Console::GameBoy`], NES-specific features such as SNES buttons and
+/// Power Pad are ignored, but generic features including the debugger work for
+/// both systems.
 pub fn handle_key_pressed(
     console: &mut Console,
     key_code: KeyCode,
@@ -192,7 +192,8 @@ fn handle_common_hotkey(
 /// Handles a key-press event for a [`Console::GameBoy`].
 ///
 /// Dispatches generic hotkeys (pause, fullscreen, Ctrl+Q, Ctrl+R, shader cycling,
-/// save/load state) and maps standard button keys to Game Boy buttons on port 0.
+/// debugger controls, save/load state) and maps standard button keys to Game Boy
+/// buttons on port 0.
 fn handle_gameboy_key_pressed(
     console: &mut Console,
     key_code: KeyCode,
@@ -221,6 +222,7 @@ fn handle_gameboy_key_pressed(
 
     match key_code {
         KeyCode::KeyH => app_state.help_overlay_visible = !app_state.help_overlay_visible,
+        KeyCode::F5 => return KeyOutcome::ToggleDebugger,
         KeyCode::F6 => {
             crate::nes::console::save_state_io::save_state_to_disk(console);
         }
@@ -230,6 +232,8 @@ fn handle_gameboy_key_pressed(
                 audio.drain_buffer();
             }
         }
+        KeyCode::F10 => return KeyOutcome::StepOver,
+        KeyCode::F11 => return KeyOutcome::StepInto,
         _ => {
             if let Some(btn_id) = gameboy_key_to_button_id(key_code) {
                 console.set_button(0, btn_id, true);

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -220,6 +220,11 @@ fn handle_gameboy_key_pressed(
         return outcome;
     }
 
+    // Skip debugger shortcuts (F10/F11) when debugger is open, as ImGui handles them through UI buttons
+    if app_state.debugger_open && matches!(key_code, KeyCode::F10 | KeyCode::F11) {
+        return KeyOutcome::Continue;
+    }
+
     match key_code {
         KeyCode::KeyH => app_state.help_overlay_visible = !app_state.help_overlay_visible,
         KeyCode::F5 => return KeyOutcome::ToggleDebugger,
@@ -272,6 +277,11 @@ fn handle_unmodified_key(
 ) -> KeyOutcome {
     if let Some(outcome) = handle_common_hotkey(key_code, app_state, audio) {
         return outcome;
+    }
+
+    // Skip debugger shortcuts (F10/F11) when debugger is open, as ImGui handles them through UI buttons
+    if app_state.debugger_open && matches!(key_code, KeyCode::F10 | KeyCode::F11) {
+        return KeyOutcome::Continue;
     }
 
     match key_code {

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -597,7 +597,10 @@ impl GbBus for DmgBus {
         // Debugger reads mirror normal read() address decoding (including register
         // readback behavior like `if_reg | 0xE0` and `sc | 0x7E`) but avoid side
         // effects such as OAM corruption or serial transfer state changes.
-        // Boot ROM check is skipped — debugger should see actual cartridge ROM.
+        // Boot ROM is checked — debugger should see what CPU will actually execute.
+        if self.boot_rom_active && addr <= 0x00FF {
+            return self.boot_rom[addr as usize];
+        }
         match addr {
             0x0000..=0x7FFF => self.cart.read(addr),
             0x8000..=0x9FFF => self.ppu.read_vram(addr),

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -1157,4 +1157,248 @@ mod tests {
         gb.load_rom(&minimal_cgb_rom(), "test.gbc").unwrap();
         assert!(matches!(gb.gb, Some(GbConsole::Cgb(_))));
     }
+
+    // ── Debugger wrapper tests ──────────────────────────────────────────────
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_create_debugger_snapshot_with_no_rom_returns_default() {
+        let gb = make_gameboy();
+        let mut view_state = crate::gb::debugging::GbDebuggerViewState::default();
+
+        let snapshot = gb.create_debugger_snapshot(&mut view_state);
+
+        // Should return default snapshot with zeroed CPU regs
+        assert_eq!(snapshot.cpu_regs.pc, 0);
+        assert_eq!(snapshot.cpu_regs.sp, 0);
+        assert_eq!(snapshot.wram_hexdump_base, 0xC000);
+        assert_eq!(snapshot.vram_hexdump_base, 0x8000);
+        // Hexdump bytes should be allocated but zeroed
+        assert_eq!(snapshot.wram_hexdump_bytes.len(), 256);
+        assert_eq!(snapshot.vram_hexdump_bytes.len(), 256);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_create_debugger_snapshot_with_rom_captures_state() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        // Run a few cycles to get non-zero state
+        for _ in 0..10 {
+            gb.run_tick();
+        }
+
+        let mut view_state = crate::gb::debugging::GbDebuggerViewState::default();
+        let snapshot = gb.create_debugger_snapshot(&mut view_state);
+
+        // Should have captured actual emulator state
+        // PC should have advanced from boot (or be at a valid address)
+        assert!(snapshot.cpu_regs.pc > 0 || snapshot.cpu_regs.cycles > 0);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_create_ppu_viewer_snapshot_with_no_rom_returns_defaults() {
+        let gb = make_gameboy();
+
+        let snapshot = gb.create_ppu_viewer_snapshot();
+
+        // Should return default snapshot with zeroed VRAM
+        assert_eq!(snapshot.vram, [0; 0x2000]);
+        assert_eq!(snapshot.vram_bank1, [0; 0x2000]);
+        assert_eq!(snapshot.oam, [0; 0xA0]);
+        assert_eq!(snapshot.lcdc, 0);
+        assert!(!snapshot.cgb_mode);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_create_ppu_viewer_snapshot_with_rom_captures_ppu_state() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        // Run to get some PPU state
+        for _ in 0..100 {
+            gb.run_tick();
+        }
+
+        let snapshot = gb.create_ppu_viewer_snapshot();
+
+        // Should have created snapshot successfully
+        // Check that we got valid arrays (not just the check would be that they're allocated)
+        assert_eq!(snapshot.vram.len(), 0x2000);
+        assert_eq!(snapshot.oam.len(), 0xA0);
+        // cgb_mode should match the ROM type (DMG in this case)
+        assert!(!snapshot.cgb_mode);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_is_cgb_mode_with_no_rom_returns_false() {
+        let gb = make_gameboy();
+        assert!(!gb.is_cgb_mode());
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_is_cgb_mode_with_dmg_rom_returns_false() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+        assert!(!gb.is_cgb_mode());
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_is_cgb_mode_with_cgb_rom_returns_true() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_cgb_rom(), "test.gbc").unwrap();
+        assert!(gb.is_cgb_mode());
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_toggle_debugger_with_controller_opens_when_closed() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], false);
+        assert!(!controller.is_debugger_open());
+
+        gb.toggle_debugger_with_controller(&mut controller);
+
+        assert!(controller.is_debugger_open());
+        assert!(controller.is_paused());
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_toggle_debugger_with_controller_closes_when_open() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], true);
+        assert!(controller.is_debugger_open());
+
+        gb.toggle_debugger_with_controller(&mut controller);
+
+        assert!(!controller.is_debugger_open());
+        assert!(!controller.is_paused());
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_toggle_debugger_with_no_rom_does_not_panic() {
+        let gb = make_gameboy();
+        let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], false);
+
+        // Should not panic even without ROM loaded
+        gb.toggle_debugger_with_controller(&mut controller);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_step_into_with_controller_advances_instruction() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], true);
+
+        let mut view_state = crate::gb::debugging::GbDebuggerViewState::default();
+        let snapshot_before = gb.create_debugger_snapshot(&mut view_state);
+        let pc_before = snapshot_before.cpu_regs.pc;
+
+        gb.step_into_with_controller(&mut controller);
+
+        let snapshot_after = gb.create_debugger_snapshot(&mut view_state);
+        let pc_after = snapshot_after.cpu_regs.pc;
+
+        // PC should have advanced by at least 1
+        assert!(
+            pc_after != pc_before
+                || snapshot_after.cpu_regs.cycles > snapshot_before.cpu_regs.cycles
+        );
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_step_over_with_controller_executes_instruction() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], true);
+
+        let mut view_state = crate::gb::debugging::GbDebuggerViewState::default();
+        let snapshot_before = gb.create_debugger_snapshot(&mut view_state);
+        let cycles_before = snapshot_before.cpu_regs.cycles;
+
+        gb.step_over_with_controller(&mut controller);
+
+        let snapshot_after = gb.create_debugger_snapshot(&mut view_state);
+        let cycles_after = snapshot_after.cpu_regs.cycles;
+
+        // Cycles should have progressed
+        assert!(cycles_after > cycles_before);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_apply_ui_action_step_into_advances_execution() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], true);
+
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            step_into: true,
+            ..Default::default()
+        };
+
+        let mut view_state = crate::gb::debugging::GbDebuggerViewState::default();
+        let cycles_before = gb.create_debugger_snapshot(&mut view_state).cpu_regs.cycles;
+
+        gb.apply_ui_action_with_controller(&mut controller, action);
+
+        let cycles_after = gb.create_debugger_snapshot(&mut view_state).cpu_regs.cycles;
+
+        // Should have stepped
+        assert!(cycles_after > cycles_before);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_apply_ui_action_continue_unpauses_execution() {
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], true);
+        assert!(controller.is_paused());
+
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            continue_run: true,
+            ..Default::default()
+        };
+
+        gb.apply_ui_action_with_controller(&mut controller, action);
+
+        // Should be unpaused after continue
+        assert!(!controller.is_paused());
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_wrapper_methods_with_no_rom_do_not_panic() {
+        let mut gb = make_gameboy();
+        let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], false);
+
+        // All methods should handle no-ROM case gracefully
+        gb.toggle_debugger_with_controller(&mut controller);
+        gb.step_into_with_controller(&mut controller);
+        gb.step_over_with_controller(&mut controller);
+
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction::default();
+        gb.apply_ui_action_with_controller(&mut controller, action);
+
+        // If we got here without panicking, test passes
+    }
 }

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -329,6 +329,104 @@ impl GameBoy {
     pub fn state_path(&self) -> Option<PathBuf> {
         self.rom_path.as_ref().map(|p| p.with_extension("state"))
     }
+
+    // ── Debugger support ───────────────────────────────────────────────
+
+    #[cfg(feature = "native")]
+    /// Create a GB debugger snapshot from the current state.
+    pub fn create_debugger_snapshot(
+        &self,
+        view_state: &mut crate::gb::debugging::GbDebuggerViewState,
+    ) -> crate::gb::debugging::GbDebuggerSnapshot {
+        self.gb.as_ref().map_or_else(
+            || {
+                // Return a default snapshot when no ROM is loaded
+                crate::gb::debugging::GbDebuggerSnapshot {
+                    cpu_regs: crate::gb::debugging::GbCpuRegsSnapshot {
+                        a: 0,
+                        f: 0,
+                        b: 0,
+                        c: 0,
+                        d: 0,
+                        e: 0,
+                        h: 0,
+                        l: 0,
+                        af: 0,
+                        bc: 0,
+                        de: 0,
+                        hl: 0,
+                        sp: 0,
+                        pc: 0,
+                        z_flag: false,
+                        n_flag: false,
+                        h_flag: false,
+                        c_flag: false,
+                        cycles: 0,
+                        frame_count: 0,
+                        scanline: 0,
+                        dot: 0,
+                        ppu_mode: 0,
+                        ime: false,
+                        halted: false,
+                        halt_bug: false,
+                        ie: 0,
+                        if_reg: 0,
+                    },
+                    wram_hexdump_base: 0xC000,
+                    wram_hexdump_bytes: vec![0; 256],
+                    vram_hexdump_base: 0x8000,
+                    vram_hexdump_bytes: vec![0; 256],
+                    cpu_disasm: vec![],
+                    cpu: String::new(),
+                    watch_values: vec![],
+                    recent_trace: vec![],
+                }
+            },
+            |gb_console| match gb_console {
+                GbConsole::Dmg(gb) => view_state.snapshot(gb.as_ref()),
+                GbConsole::Cgb(gb) => view_state.snapshot(gb.as_ref()),
+            },
+        )
+    }
+
+    #[cfg(feature = "native")]
+    /// Create a GB PPU viewer snapshot from the current state.
+    pub fn create_ppu_viewer_snapshot(
+        &self,
+    ) -> crate::gb::debugging::ppu_viewer::GbPpuViewerSnapshot {
+        use crate::gb::debugging::ppu_viewer::GbPpuViewerSnapshot;
+        self.gb.as_ref().map_or_else(
+            || {
+                // Return a default snapshot when no ROM is loaded
+                GbPpuViewerSnapshot {
+                    vram: [0; 0x2000],
+                    vram_bank1: [0; 0x2000],
+                    oam: [0; 0xA0],
+                    bg_palette_ram: [0; 64],
+                    obj_palette_ram: [0; 64],
+                    lcdc: 0,
+                    scx: 0,
+                    scy: 0,
+                    bgp: 0,
+                    obp0: 0,
+                    obp1: 0,
+                    cgb_mode: false,
+                }
+            },
+            |gb_console| match gb_console {
+                GbConsole::Dmg(gb) => GbPpuViewerSnapshot::from_gb(gb.as_ref()),
+                GbConsole::Cgb(gb) => GbPpuViewerSnapshot::from_gb(gb.as_ref()),
+            },
+        )
+    }
+
+    #[cfg(feature = "native")]
+    /// Check if the emulator is running in CGB mode.
+    pub fn is_cgb_mode(&self) -> bool {
+        self.gb
+            .as_ref()
+            .is_some_and(|gb_console| matches!(gb_console, GbConsole::Cgb(_)))
+    }
 }
 
 impl Emulator for GameBoy {

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -341,46 +341,8 @@ impl GameBoy {
         self.gb.as_ref().map_or_else(
             || {
                 // Return a default snapshot when no ROM is loaded
-                crate::gb::debugging::GbDebuggerSnapshot {
-                    cpu_regs: crate::gb::debugging::GbCpuRegsSnapshot {
-                        a: 0,
-                        f: 0,
-                        b: 0,
-                        c: 0,
-                        d: 0,
-                        e: 0,
-                        h: 0,
-                        l: 0,
-                        af: 0,
-                        bc: 0,
-                        de: 0,
-                        hl: 0,
-                        sp: 0,
-                        pc: 0,
-                        z_flag: false,
-                        n_flag: false,
-                        h_flag: false,
-                        c_flag: false,
-                        cycles: 0,
-                        frame_count: 0,
-                        scanline: 0,
-                        dot: 0,
-                        ppu_mode: 0,
-                        ime: false,
-                        halted: false,
-                        halt_bug: false,
-                        ie: 0,
-                        if_reg: 0,
-                    },
-                    wram_hexdump_base: 0xC000,
-                    wram_hexdump_bytes: vec![0; 256],
-                    vram_hexdump_base: 0x8000,
-                    vram_hexdump_bytes: vec![0; 256],
-                    cpu_disasm: vec![],
-                    cpu: String::new(),
-                    watch_values: vec![],
-                    recent_trace: vec![],
-                }
+                // Use Default to avoid per-frame Vec allocations
+                crate::gb::debugging::GbDebuggerSnapshot::default()
             },
             |gb_console| match gb_console {
                 GbConsole::Dmg(gb) => view_state.snapshot(gb.as_ref()),
@@ -426,6 +388,100 @@ impl GameBoy {
         self.gb
             .as_ref()
             .is_some_and(|gb_console| matches!(gb_console, GbConsole::Cgb(_)))
+    }
+
+    #[cfg(feature = "native")]
+    /// Run one frame with the debugger controller.
+    pub fn run_frame_with_debugger(
+        &mut self,
+        controller: &mut crate::gb::debugging::control::GbDebuggerController,
+        audio_cell: &std::cell::RefCell<Option<crate::frontends::native::NativeAudio>>,
+    ) {
+        use crate::platform::audio::EmulatorAudio;
+
+        if let Some(gb_console) = self.gb.as_mut() {
+            match gb_console {
+                GbConsole::Dmg(gb) => {
+                    controller.run_frame(gb.as_mut(), &mut |gb| {
+                        if let Some(ref mut audio) = *audio_cell.borrow_mut() {
+                            while gb.cpu.bus.sample_ready() {
+                                if let Some(sample) = gb.cpu.bus.take_sample() {
+                                    audio.queue_sample(sample);
+                                }
+                            }
+                        }
+                    });
+                }
+                GbConsole::Cgb(gb) => {
+                    controller.run_frame(gb.as_mut(), &mut |gb| {
+                        if let Some(ref mut audio) = *audio_cell.borrow_mut() {
+                            while gb.cpu.bus.sample_ready() {
+                                if let Some(sample) = gb.cpu.bus.take_sample() {
+                                    audio.queue_sample(sample);
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "native")]
+    /// Toggle the debugger open/closed.
+    pub fn toggle_debugger_with_controller(
+        &self,
+        controller: &mut crate::gb::debugging::control::GbDebuggerController,
+    ) {
+        if let Some(gb_console) = self.gb.as_ref() {
+            match gb_console {
+                GbConsole::Dmg(gb) => controller.toggle_debugger(gb.as_ref()),
+                GbConsole::Cgb(gb) => controller.toggle_debugger(gb.as_ref()),
+            }
+        }
+    }
+
+    #[cfg(feature = "native")]
+    /// Step over the current instruction.
+    pub fn step_over_with_controller(
+        &mut self,
+        controller: &mut crate::gb::debugging::control::GbDebuggerController,
+    ) {
+        if let Some(gb_console) = self.gb.as_mut() {
+            match gb_console {
+                GbConsole::Dmg(gb) => controller.step_over(gb.as_mut()),
+                GbConsole::Cgb(gb) => controller.step_over(gb.as_mut()),
+            }
+        }
+    }
+
+    #[cfg(feature = "native")]
+    /// Step into the current instruction.
+    pub fn step_into_with_controller(
+        &mut self,
+        controller: &mut crate::gb::debugging::control::GbDebuggerController,
+    ) {
+        if let Some(gb_console) = self.gb.as_mut() {
+            match gb_console {
+                GbConsole::Dmg(gb) => controller.step_into(gb.as_mut()),
+                GbConsole::Cgb(gb) => controller.step_into(gb.as_mut()),
+            }
+        }
+    }
+
+    #[cfg(feature = "native")]
+    /// Apply UI action from the debugger.
+    pub fn apply_ui_action_with_controller(
+        &mut self,
+        controller: &mut crate::gb::debugging::control::GbDebuggerController,
+        action: crate::gb::debugging::ui::GbDebuggerUiAction,
+    ) {
+        if let Some(gb_console) = self.gb.as_mut() {
+            match gb_console {
+                GbConsole::Dmg(gb) => controller.apply_ui_action(gb.as_mut(), action),
+                GbConsole::Cgb(gb) => controller.apply_ui_action(gb.as_mut(), action),
+            }
+        }
     }
 }
 

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -430,13 +430,13 @@ impl GameBoy {
     #[cfg(feature = "native")]
     /// Toggle the debugger open/closed.
     pub fn toggle_debugger_with_controller(
-        &self,
+        &mut self,
         controller: &mut crate::gb::debugging::control::GbDebuggerController,
     ) {
-        if let Some(gb_console) = self.gb.as_ref() {
+        if let Some(gb_console) = self.gb.as_mut() {
             match gb_console {
-                GbConsole::Dmg(gb) => controller.toggle_debugger(gb.as_ref()),
-                GbConsole::Cgb(gb) => controller.toggle_debugger(gb.as_ref()),
+                GbConsole::Dmg(gb) => controller.toggle_debugger(gb.as_mut()),
+                GbConsole::Cgb(gb) => controller.toggle_debugger(gb.as_mut()),
             }
         }
     }
@@ -1289,7 +1289,7 @@ mod tests {
     #[cfg(feature = "native")]
     #[test]
     fn test_toggle_debugger_with_no_rom_does_not_panic() {
-        let gb = make_gameboy();
+        let mut gb = make_gameboy();
         let mut controller = crate::gb::debugging::control::GbDebuggerController::new(&[], false);
 
         // Should not panic even without ROM loaded

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -939,6 +939,50 @@ mod tests {
         assert!(ctrl.breakpoints().iter().next().unwrap().enabled);
     }
 
+    // ── PC advancement tests ───────────────────────────────────────────
+
+    #[test]
+    fn test_step_into_advances_pc_by_one_instruction() {
+        let mut gb = gb_with_nop_loop();
+        let mut ctrl = default_controller();
+        ctrl.enter_debugger();
+
+        // Set PC to 0x0000 (NOP instruction, 1 byte)
+        gb.cpu.regs.pc = 0x0000;
+        let pc_before = gb.cpu.regs.pc;
+
+        // Step one instruction
+        ctrl.step_into(&mut gb);
+
+        // Should advance by exactly 1 byte (NOP is 1 byte)
+        assert_eq!(
+            gb.cpu.regs.pc,
+            pc_before + 1,
+            "step_into should execute exactly one NOP instruction"
+        );
+    }
+
+    #[test]
+    fn test_step_over_non_call_advances_pc_by_one_instruction() {
+        let mut gb = gb_with_nop_loop();
+        let mut ctrl = default_controller();
+        ctrl.enter_debugger();
+
+        // Set PC to 0x0000 (NOP instruction, 1 byte)
+        gb.cpu.regs.pc = 0x0000;
+        let pc_before = gb.cpu.regs.pc;
+
+        // Step over (NOP is not a CALL, so should behave like step_into)
+        ctrl.step_over(&mut gb);
+
+        // Should advance by exactly 1 byte
+        assert_eq!(
+            gb.cpu.regs.pc,
+            pc_before + 1,
+            "step_over on NOP should execute exactly one instruction"
+        );
+    }
+
     // ── View state tests ───────────────────────────────────────────────
 
     #[test]

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -98,6 +98,8 @@ impl GbDebuggerController {
 
     /// Open the debugger and pause emulation.
     pub fn enter_debugger<B: GbBus>(&mut self, gb: &mut Gb<B>) {
+        // Clear any leftover temporary breakpoints from previous run-to operations
+        self.clear_temporary_breakpoint();
         gb.set_cpu_trace_enabled(true);
         self.paused = true;
         self.debugger_open = true;
@@ -214,13 +216,12 @@ impl GbDebuggerController {
     }
 
     /// Run until specific interrupt is about to fire.
-    pub fn run_to_interrupt<B: GbBus>(&mut self, gb: &mut Gb<B>, kind: GbInterruptKind) {
+    pub fn run_to_interrupt<B: GbBus>(&mut self, _gb: &mut Gb<B>, kind: GbInterruptKind) {
         if !self.paused {
             return;
         }
 
         self.breakpoints.add(BreakpointKind::GbInterrupt(kind));
-        self.set_temporary_breakpoint_for_interrupt(gb.cpu.regs.pc, kind);
     }
 
     /// Apply UI actions from the debugger interface.
@@ -507,33 +508,6 @@ impl GbDebuggerController {
             required_interrupt: None,
             has_exited_required_interrupt: true,
             ignore_other_breakpoints: false,
-        });
-    }
-
-    fn set_temporary_breakpoint_for_interrupt(
-        &mut self,
-        pc: u16,
-        required_interrupt: GbInterruptKind,
-    ) {
-        self.clear_temporary_breakpoint();
-
-        let already_present = self.breakpoints.has_pc_breakpoint_at(pc);
-        let was_enabled_before = if already_present {
-            self.breakpoints
-                .force_enable_pc_breakpoint_at(pc)
-                .unwrap_or(false)
-        } else {
-            self.add_pc_breakpoint(pc);
-            true
-        };
-
-        self.temporary_breakpoint = Some(TemporaryBreakpoint {
-            pc,
-            already_present,
-            was_enabled_before,
-            required_interrupt: Some(required_interrupt),
-            has_exited_required_interrupt: false,
-            ignore_other_breakpoints: true,
         });
     }
 
@@ -866,10 +840,16 @@ mod tests {
 
         ctrl.apply_ui_action(&mut gb, action);
 
-        // Should have set temporary breakpoint for VBlank interrupt
-        assert!(ctrl.temporary_breakpoint.is_some());
-        let temp_bp = ctrl.temporary_breakpoint.as_ref().unwrap();
-        assert_eq!(temp_bp.required_interrupt, Some(GbInterruptKind::VBlank));
+        // Should have added a GbInterrupt breakpoint (not a temporary PC breakpoint)
+        assert!(
+            ctrl.breakpoints().iter().any(|bp| matches!(
+                bp.kind,
+                BreakpointKind::GbInterrupt(GbInterruptKind::VBlank)
+            )),
+            "should have added VBlank interrupt breakpoint"
+        );
+        assert!(!ctrl.is_paused(), "should be running");
+        assert!(!ctrl.is_debugger_open(), "debugger should be closed");
     }
 
     #[test]

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -306,7 +306,7 @@ impl GbDebuggerController {
         while !gb.is_frame_ready() {
             // Check pre-instruction breakpoints (PC, interrupt)
             if self.check_breakpoint_hit_pre_instruction(gb) {
-                self.paused = true;
+                self.enter_debugger();
                 return;
             }
 
@@ -315,7 +315,7 @@ impl GbDebuggerController {
 
             // Check post-instruction breakpoints (cycle, frame, write)
             if self.check_post_instruction_breakpoints(gb) {
-                self.paused = true;
+                self.enter_debugger();
                 return;
             }
 
@@ -710,6 +710,10 @@ mod tests {
 
         assert_eq!(gb.cpu.regs.pc, 0x0001);
         assert!(ctrl.is_paused());
+        assert!(
+            ctrl.is_debugger_open(),
+            "Debugger should open when breakpoint is hit"
+        );
     }
 
     #[test]

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -180,6 +180,7 @@ impl GbDebuggerController {
 
             self.set_temporary_breakpoint(return_addr);
             self.paused = false;
+            self.debugger_open = false;
         } else {
             // Not a call - just step into
             self.step_into(gb);
@@ -765,6 +766,9 @@ mod tests {
         assert!(ctrl.temporary_breakpoint.is_some());
         let temp_bp = ctrl.temporary_breakpoint.as_ref().unwrap();
         assert_eq!(temp_bp.pc, 0x0003);
+        // Should unpause and close debugger UI to run until breakpoint
+        assert!(!ctrl.is_paused());
+        assert!(!ctrl.is_debugger_open());
     }
 
     #[test]
@@ -798,6 +802,9 @@ mod tests {
         assert!(ctrl.temporary_breakpoint.is_some());
         let temp_bp = ctrl.temporary_breakpoint.as_ref().unwrap();
         assert_eq!(temp_bp.pc, 0x0001);
+        // Should unpause and close debugger UI to run until breakpoint
+        assert!(!ctrl.is_paused());
+        assert!(!ctrl.is_debugger_open());
     }
 
     // ── UI Action tests ────────────────────────────────────────────────

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -48,6 +48,8 @@ pub struct GbDebuggerController {
     view_state: GbDebuggerViewState,
     breakpoints: BreakpointList,
     temporary_breakpoint: Option<TemporaryBreakpoint>,
+    /// Tracks breakpoints added by run_to operations that should be removed after hitting
+    run_to_breakpoint: Option<BreakpointKind>,
     breakpoint_ignore_once_at_pc: Option<u16>,
     last_post_instruction_cycles: u64,
     last_post_instruction_frame: u64,
@@ -66,6 +68,7 @@ impl GbDebuggerController {
             view_state: GbDebuggerViewState::default(),
             breakpoints,
             temporary_breakpoint: None,
+            run_to_breakpoint: None,
             breakpoint_ignore_once_at_pc: None,
             last_post_instruction_cycles: 0,
             last_post_instruction_frame: 0,
@@ -100,6 +103,10 @@ impl GbDebuggerController {
     pub fn enter_debugger<B: GbBus>(&mut self, gb: &mut Gb<B>) {
         // Clear any leftover temporary breakpoints from previous run-to operations
         self.clear_temporary_breakpoint();
+        // Remove run_to breakpoint if it was hit
+        if let Some(kind) = self.run_to_breakpoint.take() {
+            self.breakpoints.remove_first_matching(&kind);
+        }
         gb.set_cpu_trace_enabled(true);
         self.paused = true;
         self.debugger_open = true;
@@ -198,7 +205,9 @@ impl GbDebuggerController {
         }
 
         let target_frame = gb.cpu.bus.ppu().frame_count() + 1;
-        self.breakpoints.add(BreakpointKind::Frame(target_frame));
+        let kind = BreakpointKind::Frame(target_frame);
+        self.breakpoints.add(kind);
+        self.run_to_breakpoint = Some(kind);
     }
 
     /// Run until next scanline.
@@ -221,7 +230,9 @@ impl GbDebuggerController {
             return;
         }
 
-        self.breakpoints.add(BreakpointKind::GbInterrupt(kind));
+        let bp_kind = BreakpointKind::GbInterrupt(kind);
+        self.breakpoints.add(bp_kind);
+        self.run_to_breakpoint = Some(bp_kind);
     }
 
     /// Apply UI actions from the debugger interface.

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -97,13 +97,14 @@ impl GbDebuggerController {
     // ── Debugger open/close ────────────────────────────────────────────
 
     /// Open the debugger and pause emulation.
-    pub fn enter_debugger(&mut self) {
+    pub fn enter_debugger<B: GbBus>(&mut self, gb: &mut Gb<B>) {
+        gb.set_cpu_trace_enabled(true);
         self.paused = true;
         self.debugger_open = true;
     }
 
     /// Close the debugger and resume emulation.
-    pub fn continue_from_debugger<B: GbBus>(&mut self, gb: &Gb<B>) {
+    pub fn continue_from_debugger<B: GbBus>(&mut self, gb: &mut Gb<B>) {
         if self
             .breakpoints
             .has_enabled_pc_breakpoint_at(gb.cpu.regs.pc)
@@ -114,16 +115,17 @@ impl GbDebuggerController {
         self.last_post_instruction_cycles = gb.cpu.cycles();
         self.last_post_instruction_frame = gb.cpu.bus.ppu().frame_count();
 
+        gb.set_cpu_trace_enabled(false);
         self.paused = false;
         self.debugger_open = false;
     }
 
     /// Toggle the debugger: open+pause if closed, continue if open.
-    pub fn toggle_debugger<B: GbBus>(&mut self, gb: &Gb<B>) {
+    pub fn toggle_debugger<B: GbBus>(&mut self, gb: &mut Gb<B>) {
         if self.debugger_open {
             self.continue_from_debugger(gb);
         } else {
-            self.enter_debugger();
+            self.enter_debugger(gb);
         }
     }
 
@@ -197,6 +199,7 @@ impl GbDebuggerController {
         self.breakpoints.add(BreakpointKind::Frame(target_frame));
         self.set_temporary_breakpoint(gb.cpu.regs.pc);
         self.paused = false;
+        self.debugger_open = false;
     }
 
     /// Run until next scanline.
@@ -222,6 +225,7 @@ impl GbDebuggerController {
         self.breakpoints.add(BreakpointKind::GbInterrupt(kind));
         self.set_temporary_breakpoint_for_interrupt(gb.cpu.regs.pc, kind);
         self.paused = false;
+        self.debugger_open = false;
     }
 
     /// Apply UI actions from the debugger interface.
@@ -307,7 +311,7 @@ impl GbDebuggerController {
         while !gb.is_frame_ready() {
             // Check pre-instruction breakpoints (PC, interrupt)
             if self.check_breakpoint_hit_pre_instruction(gb) {
-                self.enter_debugger();
+                self.enter_debugger(gb);
                 return;
             }
 
@@ -316,7 +320,7 @@ impl GbDebuggerController {
 
             // Check post-instruction breakpoints (cycle, frame, write)
             if self.check_post_instruction_breakpoints(gb) {
-                self.enter_debugger();
+                self.enter_debugger(gb);
                 return;
             }
 
@@ -623,7 +627,8 @@ mod tests {
     #[test]
     fn test_enter_debugger_sets_paused_and_open() {
         let mut ctrl = default_controller();
-        ctrl.enter_debugger();
+        let mut gb = gb_with_nop_loop();
+        ctrl.enter_debugger(&mut gb);
         assert!(ctrl.is_paused());
         assert!(ctrl.is_debugger_open());
     }
@@ -631,10 +636,10 @@ mod tests {
     #[test]
     fn test_continue_from_debugger_clears_paused_and_open() {
         let mut ctrl = default_controller();
-        let gb = gb_with_nop_loop();
+        let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger();
-        ctrl.continue_from_debugger(&gb);
+        ctrl.enter_debugger(&mut gb);
+        ctrl.continue_from_debugger(&mut gb);
 
         assert!(!ctrl.is_paused());
         assert!(!ctrl.is_debugger_open());
@@ -643,9 +648,9 @@ mod tests {
     #[test]
     fn test_toggle_debugger_opens_when_closed() {
         let mut ctrl = default_controller();
-        let gb = gb_with_nop_loop();
+        let mut gb = gb_with_nop_loop();
 
-        ctrl.toggle_debugger(&gb);
+        ctrl.toggle_debugger(&mut gb);
         assert!(ctrl.is_paused());
         assert!(ctrl.is_debugger_open());
     }
@@ -653,10 +658,10 @@ mod tests {
     #[test]
     fn test_toggle_debugger_closes_when_open() {
         let mut ctrl = default_controller();
-        let gb = gb_with_nop_loop();
+        let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger();
-        ctrl.toggle_debugger(&gb);
+        ctrl.enter_debugger(&mut gb);
+        ctrl.toggle_debugger(&mut gb);
 
         assert!(!ctrl.is_paused());
         assert!(!ctrl.is_debugger_open());
@@ -669,7 +674,7 @@ mod tests {
         let mut ctrl = default_controller();
         let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
         let initial_pc = gb.cpu.regs.pc;
 
         ctrl.step_into(&mut gb);
@@ -684,7 +689,7 @@ mod tests {
         let mut ctrl = default_controller();
         let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
         let initial_pc = gb.cpu.regs.pc;
 
         ctrl.step_over(&mut gb);
@@ -726,8 +731,8 @@ mod tests {
         gb.cpu.regs.pc = 0x0001;
         ctrl.breakpoints_mut().add(BreakpointKind::Pc(0x0001));
 
-        ctrl.enter_debugger();
-        ctrl.continue_from_debugger(&gb);
+        ctrl.enter_debugger(&mut gb);
+        ctrl.continue_from_debugger(&mut gb);
 
         // Should set ignore flag so we don't immediately re-trigger
         assert!(ctrl.breakpoint_ignore_once_at_pc.is_some());
@@ -759,7 +764,7 @@ mod tests {
         gb.cpu.bus.write(0xFF50, 0x01); // Disable boot ROM
         gb.cpu.regs.pc = 0x0000;
 
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
         ctrl.step_over(&mut gb);
 
         // Should have set temporary breakpoint at return address (PC + 3)
@@ -795,7 +800,7 @@ mod tests {
         gb.cpu.bus.write(0xFF50, 0x01);
         gb.cpu.regs.pc = 0x0000;
 
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
         ctrl.step_over(&mut gb);
 
         // Should have set temporary breakpoint at return address (PC + 1)
@@ -814,7 +819,7 @@ mod tests {
         let mut ctrl = default_controller();
         let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
 
         let action = crate::gb::debugging::ui::GbDebuggerUiAction {
             run_to_next_scanline: true,
@@ -832,7 +837,7 @@ mod tests {
         let mut ctrl = default_controller();
         let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
 
         let action = crate::gb::debugging::ui::GbDebuggerUiAction {
             run_to_next_frame: true,
@@ -853,7 +858,7 @@ mod tests {
         let mut ctrl = default_controller();
         let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
 
         let action = crate::gb::debugging::ui::GbDebuggerUiAction {
             run_to_vblank: true,
@@ -873,7 +878,7 @@ mod tests {
         let mut ctrl = default_controller();
         let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger(); // Open debugger
+        ctrl.enter_debugger(&mut gb); // Open debugger
 
         let action = crate::gb::debugging::ui::GbDebuggerUiAction {
             add_breakpoint: Some(BreakpointKind::Pc(0xC000)),
@@ -896,7 +901,7 @@ mod tests {
         let mut ctrl = default_controller();
         let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger(); // Open debugger
+        ctrl.enter_debugger(&mut gb); // Open debugger
 
         // Add a breakpoint first
         ctrl.breakpoints_mut().add(BreakpointKind::Pc(0xC000));
@@ -923,7 +928,7 @@ mod tests {
         let mut ctrl = default_controller();
         let mut gb = gb_with_nop_loop();
 
-        ctrl.enter_debugger(); // Open debugger
+        ctrl.enter_debugger(&mut gb); // Open debugger
 
         // Add a breakpoint
         ctrl.breakpoints_mut().add(BreakpointKind::Pc(0xC000));
@@ -956,7 +961,7 @@ mod tests {
     fn test_step_into_advances_pc_by_one_instruction() {
         let mut gb = gb_with_nop_loop();
         let mut ctrl = default_controller();
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
 
         // Set PC to 0x0000 (NOP instruction, 1 byte)
         gb.cpu.regs.pc = 0x0000;
@@ -977,7 +982,7 @@ mod tests {
     fn test_step_over_non_call_advances_pc_by_one_instruction() {
         let mut gb = gb_with_nop_loop();
         let mut ctrl = default_controller();
-        ctrl.enter_debugger();
+        ctrl.enter_debugger(&mut gb);
 
         // Set PC to 0x0000 (NOP instruction, 1 byte)
         gb.cpu.regs.pc = 0x0000;

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -198,8 +198,6 @@ impl GbDebuggerController {
         let target_frame = gb.cpu.bus.ppu().frame_count() + 1;
         self.breakpoints.add(BreakpointKind::Frame(target_frame));
         self.set_temporary_breakpoint(gb.cpu.regs.pc);
-        self.paused = false;
-        self.debugger_open = false;
     }
 
     /// Run until next scanline.
@@ -224,8 +222,6 @@ impl GbDebuggerController {
 
         self.breakpoints.add(BreakpointKind::GbInterrupt(kind));
         self.set_temporary_breakpoint_for_interrupt(gb.cpu.regs.pc, kind);
-        self.paused = false;
-        self.debugger_open = false;
     }
 
     /// Apply UI actions from the debugger interface.
@@ -254,7 +250,7 @@ impl GbDebuggerController {
 
         if action.run_to_next_frame {
             self.run_to_next_frame(gb);
-            should_continue = false; // run_to methods unpause internally
+            should_continue = true; // will call continue_from_debugger
         }
 
         if action.run_to_next_scanline {
@@ -264,21 +260,21 @@ impl GbDebuggerController {
 
         if action.run_to_vblank {
             self.run_to_interrupt(gb, GbInterruptKind::VBlank);
-            should_continue = false;
+            should_continue = true; // will call continue_from_debugger
         }
 
         if action.run_to_stat {
             self.run_to_interrupt(gb, GbInterruptKind::Stat);
-            should_continue = false;
+            should_continue = true; // will call continue_from_debugger
         }
 
         if action.run_to_timer {
             self.run_to_interrupt(gb, GbInterruptKind::Timer);
-            should_continue = false;
+            should_continue = true; // will call continue_from_debugger
         }
 
         if should_continue {
-            self.paused = false;
+            self.continue_from_debugger(gb);
         }
 
         if let Some(kind) = action.add_breakpoint {

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -197,7 +197,6 @@ impl GbDebuggerController {
 
         let target_frame = gb.cpu.bus.ppu().frame_count() + 1;
         self.breakpoints.add(BreakpointKind::Frame(target_frame));
-        self.set_temporary_breakpoint(gb.cpu.regs.pc);
     }
 
     /// Run until next scanline.
@@ -842,11 +841,15 @@ mod tests {
 
         ctrl.apply_ui_action(&mut gb, action);
 
-        // Should have set temporary breakpoint for next frame
-        // Note: The temporary breakpoint is stored as PC-based, not frame-based
-        // We just check that a temporary breakpoint was set
-        assert!(ctrl.temporary_breakpoint.is_some());
-        assert!(!ctrl.is_paused()); // Should be running
+        // Should have added a Frame breakpoint (not a temporary PC breakpoint)
+        assert!(
+            ctrl.breakpoints()
+                .iter()
+                .any(|bp| matches!(bp.kind, BreakpointKind::Frame(_))),
+            "should have added Frame breakpoint"
+        );
+        assert!(!ctrl.is_paused(), "should be running");
+        assert!(!ctrl.is_debugger_open(), "debugger should be closed");
     }
 
     #[test]

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -728,6 +728,217 @@ mod tests {
         assert!(ctrl.breakpoint_ignore_once_at_pc.is_some());
     }
 
+    #[test]
+    fn test_step_over_on_call_sets_temporary_breakpoint() {
+        let mut ctrl = default_controller();
+
+        // Create ROM with CALL instruction
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0000] = 0xCD; // CALL n16
+        rom[0x0001] = 0x10; // target low
+        rom[0x0002] = 0xC0; // target high -> CALL $C010
+        rom[0x0010] = 0xC9; // RET at target
+        // Cartridge header
+        rom[0x0147] = 0x00;
+        rom[0x0148] = 0x00;
+        rom[0x0149] = 0x00;
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+
+        let cart = load_cartridge(&rom).expect("valid ROM");
+        let bus = DmgBus::new(cart, DmgModel::DmgB);
+        let mut gb = Gb::new(bus);
+
+        gb.cpu.bus.write(0xFF50, 0x01); // Disable boot ROM
+        gb.cpu.regs.pc = 0x0000;
+
+        ctrl.enter_debugger();
+        ctrl.step_over(&mut gb);
+
+        // Should have set temporary breakpoint at return address (PC + 3)
+        assert!(ctrl.temporary_breakpoint.is_some());
+        let temp_bp = ctrl.temporary_breakpoint.as_ref().unwrap();
+        assert_eq!(temp_bp.pc, 0x0003);
+    }
+
+    #[test]
+    fn test_step_over_on_rst_sets_temporary_breakpoint() {
+        let mut ctrl = default_controller();
+
+        // Create ROM with RST instruction
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0000] = 0xC7; // RST $00
+        rom[0x0001] = 0x00; // next instruction
+        // Cartridge header
+        rom[0x0147] = 0x00;
+        rom[0x0148] = 0x00;
+        rom[0x0149] = 0x00;
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+
+        let cart = load_cartridge(&rom).expect("valid ROM");
+        let bus = DmgBus::new(cart, DmgModel::DmgB);
+        let mut gb = Gb::new(bus);
+
+        gb.cpu.bus.write(0xFF50, 0x01);
+        gb.cpu.regs.pc = 0x0000;
+
+        ctrl.enter_debugger();
+        ctrl.step_over(&mut gb);
+
+        // Should have set temporary breakpoint at return address (PC + 1)
+        assert!(ctrl.temporary_breakpoint.is_some());
+        let temp_bp = ctrl.temporary_breakpoint.as_ref().unwrap();
+        assert_eq!(temp_bp.pc, 0x0001);
+    }
+
+    // ── UI Action tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_apply_ui_action_run_to_next_scanline() {
+        let mut ctrl = default_controller();
+        let mut gb = gb_with_nop_loop();
+
+        ctrl.enter_debugger();
+
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            run_to_next_scanline: true,
+            ..Default::default()
+        };
+
+        ctrl.apply_ui_action(&mut gb, action);
+
+        // Currently run_to_next_scanline is a no-op, so should stay paused
+        assert!(ctrl.is_paused());
+    }
+
+    #[test]
+    fn test_apply_ui_action_run_to_next_frame() {
+        let mut ctrl = default_controller();
+        let mut gb = gb_with_nop_loop();
+
+        ctrl.enter_debugger();
+
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            run_to_next_frame: true,
+            ..Default::default()
+        };
+
+        ctrl.apply_ui_action(&mut gb, action);
+
+        // Should have set temporary breakpoint for next frame
+        // Note: The temporary breakpoint is stored as PC-based, not frame-based
+        // We just check that a temporary breakpoint was set
+        assert!(ctrl.temporary_breakpoint.is_some());
+        assert!(!ctrl.is_paused()); // Should be running
+    }
+
+    #[test]
+    fn test_apply_ui_action_run_to_vblank() {
+        let mut ctrl = default_controller();
+        let mut gb = gb_with_nop_loop();
+
+        ctrl.enter_debugger();
+
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            run_to_vblank: true,
+            ..Default::default()
+        };
+
+        ctrl.apply_ui_action(&mut gb, action);
+
+        // Should have set temporary breakpoint for VBlank interrupt
+        assert!(ctrl.temporary_breakpoint.is_some());
+        let temp_bp = ctrl.temporary_breakpoint.as_ref().unwrap();
+        assert_eq!(temp_bp.required_interrupt, Some(GbInterruptKind::VBlank));
+    }
+
+    #[test]
+    fn test_apply_ui_action_add_breakpoint() {
+        let mut ctrl = default_controller();
+        let mut gb = gb_with_nop_loop();
+
+        ctrl.enter_debugger(); // Open debugger
+
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            add_breakpoint: Some(BreakpointKind::Pc(0xC000)),
+            ..Default::default()
+        };
+
+        ctrl.apply_ui_action(&mut gb, action);
+
+        // Should have added breakpoint
+        assert_eq!(ctrl.breakpoints().len(), 1);
+        assert!(
+            ctrl.breakpoints()
+                .iter()
+                .any(|b| b.kind == BreakpointKind::Pc(0xC000))
+        );
+    }
+
+    #[test]
+    fn test_apply_ui_action_remove_breakpoint() {
+        let mut ctrl = default_controller();
+        let mut gb = gb_with_nop_loop();
+
+        ctrl.enter_debugger(); // Open debugger
+
+        // Add a breakpoint first
+        ctrl.breakpoints_mut().add(BreakpointKind::Pc(0xC000));
+        ctrl.breakpoints_mut().add(BreakpointKind::Cycle(1000));
+
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            remove_breakpoint: Some(0),
+            ..Default::default()
+        };
+
+        ctrl.apply_ui_action(&mut gb, action);
+
+        // Should have removed first breakpoint
+        assert_eq!(ctrl.breakpoints().len(), 1);
+        assert!(
+            ctrl.breakpoints()
+                .iter()
+                .any(|b| b.kind == BreakpointKind::Cycle(1000))
+        );
+    }
+
+    #[test]
+    fn test_apply_ui_action_enable_disable_breakpoint() {
+        let mut ctrl = default_controller();
+        let mut gb = gb_with_nop_loop();
+
+        ctrl.enter_debugger(); // Open debugger
+
+        // Add a breakpoint
+        ctrl.breakpoints_mut().add(BreakpointKind::Pc(0xC000));
+        assert!(ctrl.breakpoints().iter().next().unwrap().enabled);
+
+        // Disable it
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            disable_breakpoint: Some(0),
+            ..Default::default()
+        };
+        ctrl.apply_ui_action(&mut gb, action);
+
+        // Should have disabled breakpoint
+        assert!(!ctrl.breakpoints().iter().next().unwrap().enabled);
+
+        // Enable it again
+        let action = crate::gb::debugging::ui::GbDebuggerUiAction {
+            enable_breakpoint: Some(0),
+            ..Default::default()
+        };
+        ctrl.apply_ui_action(&mut gb, action);
+
+        // Should be enabled again
+        assert!(ctrl.breakpoints().iter().next().unwrap().enabled);
+    }
+
     // ── View state tests ───────────────────────────────────────────────
 
     #[test]

--- a/src/gb/debugging/control.rs
+++ b/src/gb/debugging/control.rs
@@ -223,6 +223,73 @@ impl GbDebuggerController {
         self.paused = false;
     }
 
+    /// Apply UI actions from the debugger interface.
+    ///
+    /// Handles step over, step into, continue, run-to commands, and breakpoint management.
+    pub fn apply_ui_action<B: GbBus>(
+        &mut self,
+        gb: &mut Gb<B>,
+        action: super::ui::GbDebuggerUiAction,
+    ) {
+        if !self.debugger_open {
+            return;
+        }
+
+        let mut should_continue = action.continue_run;
+
+        if action.step_over {
+            self.step_over(gb);
+            should_continue = false; // step_over unpauses internally
+        }
+
+        if action.step_into {
+            self.step_into(gb);
+            should_continue = false; // step_into unpauses internally
+        }
+
+        if action.run_to_next_frame {
+            self.run_to_next_frame(gb);
+            should_continue = false; // run_to methods unpause internally
+        }
+
+        if action.run_to_next_scanline {
+            self.run_to_next_scanline(gb);
+            // Note: currently a no-op, leaves debugger paused
+        }
+
+        if action.run_to_vblank {
+            self.run_to_interrupt(gb, GbInterruptKind::VBlank);
+            should_continue = false;
+        }
+
+        if action.run_to_stat {
+            self.run_to_interrupt(gb, GbInterruptKind::Stat);
+            should_continue = false;
+        }
+
+        if action.run_to_timer {
+            self.run_to_interrupt(gb, GbInterruptKind::Timer);
+            should_continue = false;
+        }
+
+        if should_continue {
+            self.paused = false;
+        }
+
+        if let Some(kind) = action.add_breakpoint {
+            self.breakpoints.add(kind);
+        }
+        if let Some(index) = action.remove_breakpoint {
+            self.breakpoints.remove(index);
+        }
+        if let Some(index) = action.enable_breakpoint {
+            self.breakpoints.enable(index);
+        }
+        if let Some(index) = action.disable_breakpoint {
+            self.breakpoints.disable(index);
+        }
+    }
+
     // ── Main execution loop ────────────────────────────────────────────
 
     /// Run the emulator until frame ready or debugger pause.

--- a/src/gb/debugging/mod.rs
+++ b/src/gb/debugging/mod.rs
@@ -15,6 +15,8 @@ pub mod ppu_viewer;
 pub mod snapshot;
 #[cfg(feature = "native")]
 pub mod types;
+#[cfg(feature = "native")]
+pub mod ui;
 
 #[cfg(feature = "native")]
 pub use control::GbDebuggerController;
@@ -36,3 +38,14 @@ pub use ppu_viewer::{
     GbPpuViewerSnapshot, format_oam_entries, format_palette_info, render_bg_maps_rgba,
     render_tiles_rgba,
 };
+
+// Export UI types (native-only)
+#[cfg(feature = "native")]
+pub use ui::{
+    BreakpointAddUiState, GbDebuggerUiAction, HexdumpUiState, WatchAddressUpdate, WatchlistUiState,
+};
+
+#[cfg(feature = "native")]
+pub mod debugger_ui {
+    pub use super::ui::*;
+}

--- a/src/gb/debugging/types.rs
+++ b/src/gb/debugging/types.rs
@@ -8,7 +8,7 @@ use super::disasm::GbCpuDisasmLineSnapshot;
 /// CPU register snapshot for SM83.
 ///
 /// Captures all CPU registers, flags, timing information, and interrupt state at a point in time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct GbCpuRegsSnapshot {
     // 8-bit registers
     pub a: u8,
@@ -99,4 +99,20 @@ pub struct GbDebuggerSnapshot {
 
     /// Recent executed instructions (ring buffer tail, typically last 32)
     pub recent_trace: Vec<GbCpuTraceLineSnapshot>,
+}
+
+impl Default for GbDebuggerSnapshot {
+    fn default() -> Self {
+        Self {
+            cpu_regs: GbCpuRegsSnapshot::default(),
+            wram_hexdump_base: 0xC000,
+            wram_hexdump_bytes: vec![0; 256],
+            vram_hexdump_base: 0x8000,
+            vram_hexdump_bytes: vec![0; 256],
+            cpu_disasm: Vec::new(),
+            cpu: String::new(),
+            watch_values: Vec::new(),
+            recent_trace: Vec::new(),
+        }
+    }
 }

--- a/src/gb/debugging/ui.rs
+++ b/src/gb/debugging/ui.rs
@@ -218,52 +218,46 @@ fn render_cpu_window(
 
 #[cfg(feature = "native")]
 fn render_cpu_controls(ui: &imgui::Ui, action: &mut GbDebuggerUiAction) {
-    if ui.small_button("Step") {
-        action.step_into = true;
-    }
-    ui.same_line();
-    if ui.small_button("Next") {
+    if ui.button("Step over") {
         action.step_over = true;
     }
     ui.same_line();
-    if ui.small_button("Continue") {
-        action.continue_run = true;
+    if ui.button("Step into") {
+        action.step_into = true;
     }
     ui.same_line();
-    ui.text("│");
-    ui.same_line();
-    if ui.small_button("Frame") {
+    if ui.button("Continue") {
+        action.continue_run = true;
+    }
+
+    if ui.button("Run to next frame") {
         action.run_to_next_frame = true;
     }
     ui.same_line();
-    ui.text_disabled("Scanline (unimpl)");
+    ui.text_disabled("Run to next scanline");
     ui.same_line();
-    ui.text("│");
-    ui.same_line();
-    if ui.small_button("VBlank") {
+    if ui.button("Run to VBlank") {
         action.run_to_vblank = true;
     }
     ui.same_line();
-    if ui.small_button("STAT") {
+    if ui.button("Run to STAT") {
         action.run_to_stat = true;
     }
     ui.same_line();
-    if ui.small_button("Timer") {
+    if ui.button("Run to Timer") {
         action.run_to_timer = true;
     }
     ui.same_line();
-    ui.text("│");
-    ui.same_line();
-    if ui.small_button("PPU") {
+    if ui.button("PPU Viewer") {
         action.toggle_ppu_viewer = true;
     }
     ui.same_line();
-    if ui.small_button("+α") {
-        action.increase_opacity = true;
+    if ui.button("α-") {
+        action.decrease_opacity = true;
     }
     ui.same_line();
-    if ui.small_button("−α") {
-        action.decrease_opacity = true;
+    if ui.button("α+") {
+        action.increase_opacity = true;
     }
 }
 
@@ -406,6 +400,9 @@ fn render_cpu_code_panel(ui: &imgui::Ui, snapshot: &GbDebuggerSnapshot, size: [f
             .build(|| {
                 for line in &snapshot.cpu_disasm {
                     let is_current = line.is_current;
+                    let bytes = format_disasm_bytes(&line.bytes);
+                    let text = format!("{:04X}: {:<8} {}", line.addr, bytes, line.text);
+
                     if is_current {
                         let draw_list = ui.get_window_draw_list();
                         let pos = ui.cursor_screen_pos();
@@ -419,7 +416,7 @@ fn render_cpu_code_panel(ui: &imgui::Ui, snapshot: &GbDebuggerSnapshot, size: [f
                             .filled(true)
                             .build();
                     }
-                    ui.text(&line.text);
+                    ui.text(text);
                 }
             });
 
@@ -432,10 +429,21 @@ fn render_cpu_code_panel(ui: &imgui::Ui, snapshot: &GbDebuggerSnapshot, size: [f
             .size([size[0], trace_height])
             .build(|| {
                 for line in &snapshot.recent_trace {
-                    ui.text(&line.text);
+                    let bytes = format_disasm_bytes(&line.bytes);
+                    let text = format!("{:04X}: {:<8} {}", line.addr, bytes, line.text);
+                    ui.text(text);
                 }
             });
     });
+}
+
+fn format_disasm_bytes(bytes: &[u8]) -> String {
+    match bytes.len() {
+        0 => String::new(),
+        1 => format!("{:02X}", bytes[0]),
+        2 => format!("{:02X} {:02X}", bytes[0], bytes[1]),
+        _ => format!("{:02X} {:02X} {:02X}", bytes[0], bytes[1], bytes[2]),
+    }
 }
 
 #[cfg(feature = "native")]

--- a/src/gb/debugging/ui.rs
+++ b/src/gb/debugging/ui.rs
@@ -385,56 +385,63 @@ fn parse_breakpoint_kind(kind_idx: usize, value_str: &str) -> Option<BreakpointK
 
 #[cfg(feature = "native")]
 fn render_cpu_code_panel(ui: &imgui::Ui, snapshot: &GbDebuggerSnapshot, size: [f32; 2]) {
-    ui.group(|| {
-        ui.text("Disassembly");
-        ui.separator();
+    ui.child_window("cpu_code")
+        .size(size)
+        .border(true)
+        .build(|| {
+            apply_debugger_ui_font_scale(ui);
+            ui.text("Disassembly");
+            ui.separator();
 
-        let line_height = ui.text_line_height_with_spacing();
-        let desired_height = code_panel_disasm_height_for_line_height(line_height);
-        let disasm_height = desired_height
-            .min(size[1] - ui.cursor_pos()[1] - 100.0)
-            .max(100.0);
+            let line_height = ui.text_line_height_with_spacing();
+            let desired_height = code_panel_disasm_height_for_line_height(line_height);
+            let disasm_height = desired_height.min(ui.content_region_avail()[1].max(0.0));
 
-        ui.child_window("disasm_window")
-            .size([size[0], disasm_height])
-            .build(|| {
-                for line in &snapshot.cpu_disasm {
-                    let is_current = line.is_current;
-                    let bytes = format_disasm_bytes(&line.bytes);
-                    let text = format!("{:04X}: {:<8} {}", line.addr, bytes, line.text);
+            ui.child_window("disasm_window")
+                .size([0.0, disasm_height])
+                .border(false)
+                .build(|| {
+                    apply_debugger_ui_font_scale(ui);
+                    for line in &snapshot.cpu_disasm {
+                        let is_current = line.is_current;
+                        let bytes = format_disasm_bytes(&line.bytes);
+                        let text = format!("{:04X}: {:<8} {}", line.addr, bytes, line.text);
 
-                    if is_current {
-                        let draw_list = ui.get_window_draw_list();
-                        let pos = ui.cursor_screen_pos();
-                        let size = [size[0], line_height];
-                        draw_list
-                            .add_rect(
-                                pos,
-                                [pos[0] + size[0], pos[1] + size[1]],
-                                [0.0, 1.0, 0.0, 0.3],
-                            )
-                            .filled(true)
-                            .build();
+                        if is_current {
+                            let cursor = ui.cursor_screen_pos();
+                            let draw_w = ui.content_region_avail()[0];
+                            let draw_h = ui.text_line_height();
+
+                            ui.get_window_draw_list()
+                                .add_rect(
+                                    cursor,
+                                    [cursor[0] + draw_w, cursor[1] + draw_h],
+                                    [0.0, 1.0, 0.0, 0.3],
+                                )
+                                .filled(true)
+                                .build();
+                        }
+                        ui.text(text);
                     }
-                    ui.text(text);
-                }
-            });
+                });
 
-        ui.dummy([0.0, 8.0]);
-        ui.text("CPU Trace");
-        ui.separator();
+            ui.separator();
+            ui.text("CPU Trace");
+            ui.separator();
 
-        let trace_height = (size[1] - ui.cursor_pos()[1]).max(50.0);
-        ui.child_window("trace_window")
-            .size([size[0], trace_height])
-            .build(|| {
-                for line in &snapshot.recent_trace {
-                    let bytes = format_disasm_bytes(&line.bytes);
-                    let text = format!("{:04X}: {:<8} {}", line.addr, bytes, line.text);
-                    ui.text(text);
-                }
-            });
-    });
+            let trace_height = ui.content_region_avail()[1].max(0.0);
+            ui.child_window("trace_window")
+                .size([0.0, trace_height])
+                .border(false)
+                .build(|| {
+                    apply_debugger_ui_font_scale(ui);
+                    for line in &snapshot.recent_trace {
+                        let bytes = format_disasm_bytes(&line.bytes);
+                        let text = format!("{:04X}: {:<8} {}", line.addr, bytes, line.text);
+                        ui.text(text);
+                    }
+                });
+        });
 }
 
 fn format_disasm_bytes(bytes: &[u8]) -> String {

--- a/src/gb/debugging/ui.rs
+++ b/src/gb/debugging/ui.rs
@@ -5,7 +5,7 @@
 
 #[cfg(feature = "native")]
 use super::GbDebuggerSnapshot;
-use crate::platform::debugging::breakpoints::{Breakpoint, BreakpointKind, BreakpointList};
+use crate::platform::debugging::breakpoints::{BreakpointKind, BreakpointList};
 
 const DEBUGGER_OUTER_MARGIN: f32 = 10.0;
 pub(crate) const DEBUGGER_UI_FONT_SCALE: f32 = 0.85;
@@ -236,9 +236,7 @@ fn render_cpu_controls(ui: &imgui::Ui, action: &mut GbDebuggerUiAction) {
         action.run_to_next_frame = true;
     }
     ui.same_line();
-    if ui.small_button("Scanline") {
-        action.run_to_next_scanline = true;
-    }
+    ui.text_disabled("Scanline (unimpl)");
     ui.same_line();
     ui.text("│");
     ui.same_line();
@@ -356,11 +354,14 @@ fn parse_breakpoint_kind(kind_idx: usize, value_str: &str) -> Option<BreakpointK
     let value_str = value_str.trim();
     match kind_idx {
         0 => {
-            // PC
+            // PC - parse as hex by default (addresses are displayed in hex)
             let value = if value_str.starts_with("0x") || value_str.starts_with("0X") {
                 u16::from_str_radix(&value_str[2..], 16).ok()?
             } else {
-                value_str.parse::<u16>().ok()?
+                // Accept plain hex like "C000" or decimal like "49152"
+                u16::from_str_radix(value_str, 16)
+                    .or_else(|_| value_str.parse::<u16>())
+                    .ok()?
             };
             Some(BreakpointKind::Pc(value))
         }
@@ -369,11 +370,14 @@ fn parse_breakpoint_kind(kind_idx: usize, value_str: &str) -> Option<BreakpointK
             Some(BreakpointKind::Cycle(value_str.parse().ok()?))
         }
         2 => {
-            // Write
+            // Write - parse as hex by default (addresses are displayed in hex)
             let value = if value_str.starts_with("0x") || value_str.starts_with("0X") {
                 u16::from_str_radix(&value_str[2..], 16).ok()?
             } else {
-                value_str.parse::<u16>().ok()?
+                // Accept plain hex like "C000" or decimal like "60000"
+                u16::from_str_radix(value_str, 16)
+                    .or_else(|_| value_str.parse::<u16>())
+                    .ok()?
             };
             Some(BreakpointKind::WriteAddress(value))
         }
@@ -512,7 +516,6 @@ fn render_memory_watch(
     }
 
     // Display existing watch entries
-    let mut entries_to_remove = Vec::new();
     for (index, entry) in snapshot.watch_values.iter().enumerate() {
         if watch_state.row_inputs[index].is_empty() {
             watch_state.row_inputs[index] = format!("{:04X}", entry.address);
@@ -543,17 +546,13 @@ fn render_memory_watch(
         ui.text(format!("= {:02X}", entry.value));
         ui.same_line();
         if ui.small_button(format!("X##watch_rm_{}", index)) {
-            entries_to_remove.push(index);
+            action.remove_watch_address = Some(index);
         }
 
         if let Some(ref err) = watch_state.row_errors[index] {
             ui.same_line();
             ui.text_colored([1.0, 0.0, 0.0, 1.0], err);
         }
-    }
-
-    for index in entries_to_remove.iter().rev() {
-        action.remove_watch_address = Some(*index);
     }
 
     // Add new watch entry
@@ -606,49 +605,45 @@ fn render_hexdump_panel(
     action: &mut GbDebuggerUiAction,
     size: [f32; 2],
 ) {
-    if !ui.collapsing_header("WRAM Hexdump##wram_header", imgui::TreeNodeFlags::empty()) {
-        return;
+    if ui.collapsing_header("WRAM Hexdump##wram_header", imgui::TreeNodeFlags::empty()) {
+        render_hexdump_controls(
+            ui,
+            "WRAM",
+            snapshot.wram_hexdump_base,
+            &mut hexdump_state.wram_address_input,
+            &mut hexdump_state.wram_error,
+            |addr| action.set_wram_hexdump_base = Some(addr),
+            |delta| action.nudge_wram_hexdump_base_by_bytes = Some(delta),
+        );
+
+        render_hexdump_bytes(
+            ui,
+            snapshot.wram_hexdump_base,
+            &snapshot.wram_hexdump_bytes,
+            size[0],
+        );
+
+        ui.dummy([0.0, 8.0]);
     }
 
-    render_hexdump_controls(
-        ui,
-        "WRAM",
-        snapshot.wram_hexdump_base,
-        &mut hexdump_state.wram_address_input,
-        &mut hexdump_state.wram_error,
-        |addr| action.set_wram_hexdump_base = Some(addr),
-        |delta| action.nudge_wram_hexdump_base_by_bytes = Some(delta),
-    );
+    if ui.collapsing_header("VRAM Hexdump##vram_header", imgui::TreeNodeFlags::empty()) {
+        render_hexdump_controls(
+            ui,
+            "VRAM",
+            snapshot.vram_hexdump_base,
+            &mut hexdump_state.vram_address_input,
+            &mut hexdump_state.vram_error,
+            |addr| action.set_vram_hexdump_base = Some(addr),
+            |delta| action.nudge_vram_hexdump_base_by_bytes = Some(delta),
+        );
 
-    render_hexdump_bytes(
-        ui,
-        snapshot.wram_hexdump_base,
-        &snapshot.wram_hexdump_bytes,
-        size[0],
-    );
-
-    ui.dummy([0.0, 8.0]);
-
-    if !ui.collapsing_header("VRAM Hexdump##vram_header", imgui::TreeNodeFlags::empty()) {
-        return;
+        render_hexdump_bytes(
+            ui,
+            snapshot.vram_hexdump_base,
+            &snapshot.vram_hexdump_bytes,
+            size[0],
+        );
     }
-
-    render_hexdump_controls(
-        ui,
-        "VRAM",
-        snapshot.vram_hexdump_base,
-        &mut hexdump_state.vram_address_input,
-        &mut hexdump_state.vram_error,
-        |addr| action.set_vram_hexdump_base = Some(addr),
-        |delta| action.nudge_vram_hexdump_base_by_bytes = Some(delta),
-    );
-
-    render_hexdump_bytes(
-        ui,
-        snapshot.vram_hexdump_base,
-        &snapshot.vram_hexdump_bytes,
-        size[0],
-    );
 }
 
 #[cfg(feature = "native")]
@@ -708,5 +703,116 @@ fn render_hexdump_bytes(ui: &imgui::Ui, base: u16, bytes: &[u8], _width: f32) {
             .collect::<Vec<_>>()
             .join(" ");
         ui.text(format!("{:04X}: {}", addr, hex_str));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_address_accepts_decimal_and_hex() {
+        assert_eq!(parse_address("4660"), Some(4660));
+        assert_eq!(parse_address("0x1234"), Some(0x1234));
+        assert_eq!(parse_address("0X00ff"), Some(0x00ff));
+        assert_eq!(parse_address("  0x00a0  "), Some(0x00a0));
+    }
+
+    #[test]
+    fn parse_address_rejects_invalid_input() {
+        assert_eq!(parse_address(""), None);
+        assert_eq!(parse_address("xyz"), None);
+        assert_eq!(parse_address("0x"), None);
+        assert_eq!(parse_address("70000"), None);
+        assert_eq!(parse_address("0x10000"), None);
+    }
+
+    #[test]
+    fn parse_breakpoint_kind_pc_accepts_hex_and_decimal() {
+        assert_eq!(
+            parse_breakpoint_kind(0, "0x1234"),
+            Some(BreakpointKind::Pc(0x1234))
+        );
+        // Without 0x prefix, parse as hex by default (per review comment)
+        assert_eq!(
+            parse_breakpoint_kind(0, "1234"),
+            Some(BreakpointKind::Pc(0x1234))
+        );
+        assert_eq!(
+            parse_breakpoint_kind(0, "  0x00FF  "),
+            Some(BreakpointKind::Pc(0x00FF))
+        );
+        // Pure hex like "C000" works without 0x prefix
+        assert_eq!(
+            parse_breakpoint_kind(0, "C000"),
+            Some(BreakpointKind::Pc(0xC000))
+        );
+        // Decimal values that don't look like hex still work as fallback
+        assert_eq!(
+            parse_breakpoint_kind(0, "60000"),
+            Some(BreakpointKind::Pc(60000))
+        );
+    }
+
+    #[test]
+    fn parse_breakpoint_kind_cycle() {
+        assert_eq!(
+            parse_breakpoint_kind(1, "12345"),
+            Some(BreakpointKind::Cycle(12345))
+        );
+        assert_eq!(
+            parse_breakpoint_kind(1, "  999  "),
+            Some(BreakpointKind::Cycle(999))
+        );
+    }
+
+    #[test]
+    fn parse_breakpoint_kind_write() {
+        assert_eq!(
+            parse_breakpoint_kind(2, "0xC000"),
+            Some(BreakpointKind::WriteAddress(0xC000))
+        );
+        // Without 0x prefix, parse as hex by default (per review comment)
+        assert_eq!(
+            parse_breakpoint_kind(2, "C000"),
+            Some(BreakpointKind::WriteAddress(0xC000))
+        );
+        // Decimal values that don't look like hex still work as fallback
+        assert_eq!(
+            parse_breakpoint_kind(2, "60000"),
+            Some(BreakpointKind::WriteAddress(60000))
+        );
+    }
+
+    #[test]
+    fn parse_breakpoint_kind_frame() {
+        assert_eq!(
+            parse_breakpoint_kind(3, "100"),
+            Some(BreakpointKind::Frame(100))
+        );
+    }
+
+    #[test]
+    fn parse_breakpoint_kind_rejects_invalid_input() {
+        assert_eq!(parse_breakpoint_kind(0, ""), None);
+        assert_eq!(parse_breakpoint_kind(0, "invalid"), None);
+        assert_eq!(parse_breakpoint_kind(1, "not_a_number"), None);
+        assert_eq!(parse_breakpoint_kind(4, "100"), None); // Invalid kind index
+    }
+
+    #[test]
+    fn debugger_ui_action_default_has_no_pending_actions() {
+        let action = GbDebuggerUiAction::default();
+
+        assert!(!action.step_over);
+        assert!(!action.step_into);
+        assert!(!action.continue_run);
+        assert_eq!(action.add_watch_address, None);
+        assert_eq!(action.set_wram_hexdump_base, None);
+        assert_eq!(action.nudge_wram_hexdump_base_by_bytes, None);
+        assert_eq!(action.set_vram_hexdump_base, None);
+        assert_eq!(action.nudge_vram_hexdump_base_by_bytes, None);
+        assert_eq!(action.add_breakpoint, None);
+        assert_eq!(action.remove_breakpoint, None);
     }
 }

--- a/src/gb/debugging/ui.rs
+++ b/src/gb/debugging/ui.rs
@@ -711,6 +711,22 @@ mod tests {
     use super::*;
 
     #[test]
+    fn layout_model_applies_margins() {
+        let (title, pos, size) = layout_model([800.0, 600.0]);
+        assert_eq!(title, "GB CPU/PPU Data");
+        assert_eq!(pos, [10.0, 10.0]); // DEBUGGER_OUTER_MARGIN
+        assert_eq!(size, [780.0, 580.0]); // display - 2*margin
+    }
+
+    #[test]
+    fn layout_model_handles_small_display() {
+        let (title, pos, size) = layout_model([10.0, 10.0]);
+        assert_eq!(title, "GB CPU/PPU Data");
+        assert_eq!(pos, [10.0, 10.0]);
+        assert_eq!(size, [0.0, 0.0]); // clamped to 0
+    }
+
+    #[test]
     fn parse_address_accepts_decimal_and_hex() {
         assert_eq!(parse_address("4660"), Some(4660));
         assert_eq!(parse_address("0x1234"), Some(0x1234));

--- a/src/gb/debugging/ui.rs
+++ b/src/gb/debugging/ui.rs
@@ -1,0 +1,712 @@
+//! Game Boy debugger UI using ImGui.
+//!
+//! Renders CPU registers, disassembly, breakpoints, memory hexdumps, and watch list.
+//! Follows the same pattern as the NES debugger UI.
+
+#[cfg(feature = "native")]
+use super::GbDebuggerSnapshot;
+use crate::platform::debugging::breakpoints::{Breakpoint, BreakpointKind, BreakpointList};
+
+const DEBUGGER_OUTER_MARGIN: f32 = 10.0;
+pub(crate) const DEBUGGER_UI_FONT_SCALE: f32 = 0.85;
+const CODE_VIEW_LONGEST_LINE_CHARS: f32 = 28.0;
+const CODE_VIEW_PREFIX_CHARS: f32 = 15.0;
+const CODE_VIEW_CHAR_WIDTH_AT_SCALE_ONE: f32 = 8.0;
+const CODE_VIEW_CHILD_WINDOW_HORIZONTAL_PADDING: f32 = 16.0;
+const CODE_VIEW_SCROLLBAR_GUTTER: f32 = 16.0;
+const CODE_VIEW_HIGHLIGHT_OVERDRAW_MARGIN: f32 = 4.0;
+const CPU_RIGHT_PANEL_MIN_WIDTH: f32 = 320.0;
+const CODE_PANEL_VISIBLE_LINES: usize = 20;
+
+fn debugger_ui_font_scale() -> f32 {
+    DEBUGGER_UI_FONT_SCALE
+}
+
+fn apply_debugger_ui_font_scale(ui: &imgui::Ui) {
+    ui.set_window_font_scale(debugger_ui_font_scale());
+}
+
+/// Actions that can be triggered from the debugger UI.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct GbDebuggerUiAction {
+    pub step_over: bool,
+    pub step_into: bool,
+    pub continue_run: bool,
+    pub run_to_next_frame: bool,
+    pub run_to_next_scanline: bool,
+    pub run_to_vblank: bool,
+    pub run_to_stat: bool,
+    pub run_to_timer: bool,
+    pub toggle_ppu_viewer: bool,
+    pub increase_opacity: bool,
+    pub decrease_opacity: bool,
+    /// Add a new breakpoint of this kind.
+    pub add_breakpoint: Option<BreakpointKind>,
+    /// Remove the breakpoint at this list index.
+    pub remove_breakpoint: Option<usize>,
+    /// Enable the breakpoint at this list index.
+    pub enable_breakpoint: Option<usize>,
+    /// Disable the breakpoint at this list index.
+    pub disable_breakpoint: Option<usize>,
+    /// Set WRAM hexdump base address.
+    pub set_wram_hexdump_base: Option<u16>,
+    /// Move WRAM hexdump base by byte delta.
+    pub nudge_wram_hexdump_base_by_bytes: Option<i16>,
+    /// Set VRAM hexdump base address.
+    pub set_vram_hexdump_base: Option<u16>,
+    /// Move VRAM hexdump base by byte delta.
+    pub nudge_vram_hexdump_base_by_bytes: Option<i16>,
+    /// Add a memory watch address.
+    pub add_watch_address: Option<u16>,
+    /// Remove memory watch entry by index.
+    pub remove_watch_address: Option<usize>,
+    /// Update memory watch entry address by index.
+    pub update_watch_address: Option<WatchAddressUpdate>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct WatchAddressUpdate {
+    pub index: usize,
+    pub address: u16,
+}
+
+/// Persistent state for the "add breakpoint" row in the breakpoint panel.
+#[derive(Debug, Default)]
+pub struct BreakpointAddUiState {
+    /// Index into the kind combo: 0=PC, 1=Cycle, 2=Write, 3=Frame
+    pub kind_idx: usize,
+    /// Text input buffer for the breakpoint value.
+    pub value: String,
+    /// Validation error shown inline when Add/Enter input is invalid.
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct HexdumpUiState {
+    pub wram_address_input: String,
+    pub wram_error: Option<String>,
+    pub vram_address_input: String,
+    pub vram_error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct WatchlistUiState {
+    pub add_input: String,
+    pub add_error: Option<String>,
+    pub row_inputs: Vec<String>,
+    pub row_errors: Vec<Option<String>>,
+}
+
+pub fn layout_model(display_size: [f32; 2]) -> (&'static str, [f32; 2], [f32; 2]) {
+    let [display_w, display_h] = display_size;
+    let margin = DEBUGGER_OUTER_MARGIN;
+    let available_w = (display_w - 2.0 * margin).max(0.0);
+    let available_h = (display_h - 2.0 * margin).max(0.0);
+    (
+        "GB CPU/PPU Data",
+        [margin, margin],
+        [available_w, available_h],
+    )
+}
+
+#[cfg(feature = "native")]
+pub fn render(
+    ui: &imgui::Ui,
+    snapshot: &GbDebuggerSnapshot,
+    alpha: f32,
+    breakpoints: &BreakpointList,
+    add_state: &mut BreakpointAddUiState,
+    hexdump_state: &mut HexdumpUiState,
+    watch_state: &mut WatchlistUiState,
+) -> GbDebuggerUiAction {
+    let mut action = GbDebuggerUiAction::default();
+    let (title, pos, size) = layout_model(ui.io().display_size);
+
+    ui.window(title)
+        .position(pos, imgui::Condition::Always)
+        .size(size, imgui::Condition::Always)
+        .bring_to_front_on_focus(false)
+        .bg_alpha(alpha)
+        .build(|| {
+            apply_debugger_ui_font_scale(ui);
+            render_cpu_window(
+                ui,
+                snapshot,
+                breakpoints,
+                add_state,
+                hexdump_state,
+                watch_state,
+                &mut action,
+            );
+        });
+
+    action
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CpuWindowLayout {
+    left_w: f32,
+    right_w: f32,
+    gap: f32,
+    left_pos: [f32; 2],
+    right_pos: [f32; 2],
+}
+
+#[cfg(feature = "native")]
+fn cpu_window_layout(avail: [f32; 2], cursor: [f32; 2]) -> CpuWindowLayout {
+    let gap = 8.0;
+    let target_left_w = code_view_target_width_for_font_scale(debugger_ui_font_scale());
+    let max_left_w = (avail[0] - gap - CPU_RIGHT_PANEL_MIN_WIDTH).max(0.0);
+    let left_w = target_left_w.min(max_left_w);
+    let right_w = (avail[0] - left_w - gap).max(0.0);
+
+    let left_pos = cursor;
+    let right_pos = [cursor[0] + left_w + gap, cursor[1]];
+
+    CpuWindowLayout {
+        left_w,
+        right_w,
+        gap,
+        left_pos,
+        right_pos,
+    }
+}
+
+fn code_view_target_width_for_font_scale(font_scale: f32) -> f32 {
+    let total_line_chars = CODE_VIEW_PREFIX_CHARS + CODE_VIEW_LONGEST_LINE_CHARS;
+    (total_line_chars * CODE_VIEW_CHAR_WIDTH_AT_SCALE_ONE * font_scale)
+        + CODE_VIEW_CHILD_WINDOW_HORIZONTAL_PADDING
+        + CODE_VIEW_SCROLLBAR_GUTTER
+        + CODE_VIEW_HIGHLIGHT_OVERDRAW_MARGIN
+}
+
+fn code_panel_disasm_height_for_line_height(line_height_with_spacing: f32) -> f32 {
+    line_height_with_spacing * CODE_PANEL_VISIBLE_LINES as f32
+}
+
+#[cfg(feature = "native")]
+fn render_cpu_window(
+    ui: &imgui::Ui,
+    snapshot: &GbDebuggerSnapshot,
+    breakpoints: &BreakpointList,
+    add_state: &mut BreakpointAddUiState,
+    hexdump_state: &mut HexdumpUiState,
+    watch_state: &mut WatchlistUiState,
+    action: &mut GbDebuggerUiAction,
+) {
+    render_cpu_controls(ui, action);
+    render_breakpoint_panel(ui, breakpoints, add_state, action);
+    ui.separator();
+
+    let avail = ui.content_region_avail();
+    let layout = cpu_window_layout(avail, ui.cursor_pos());
+
+    ui.set_cursor_pos(layout.left_pos);
+    render_cpu_code_panel(ui, snapshot, [layout.left_w, avail[1]]);
+
+    ui.set_cursor_pos(layout.right_pos);
+    render_cpu_right_panel(
+        ui,
+        snapshot,
+        [layout.right_w, avail[1]],
+        layout.gap,
+        hexdump_state,
+        watch_state,
+        action,
+    );
+}
+
+#[cfg(feature = "native")]
+fn render_cpu_controls(ui: &imgui::Ui, action: &mut GbDebuggerUiAction) {
+    if ui.small_button("Step") {
+        action.step_into = true;
+    }
+    ui.same_line();
+    if ui.small_button("Next") {
+        action.step_over = true;
+    }
+    ui.same_line();
+    if ui.small_button("Continue") {
+        action.continue_run = true;
+    }
+    ui.same_line();
+    ui.text("│");
+    ui.same_line();
+    if ui.small_button("Frame") {
+        action.run_to_next_frame = true;
+    }
+    ui.same_line();
+    if ui.small_button("Scanline") {
+        action.run_to_next_scanline = true;
+    }
+    ui.same_line();
+    ui.text("│");
+    ui.same_line();
+    if ui.small_button("VBlank") {
+        action.run_to_vblank = true;
+    }
+    ui.same_line();
+    if ui.small_button("STAT") {
+        action.run_to_stat = true;
+    }
+    ui.same_line();
+    if ui.small_button("Timer") {
+        action.run_to_timer = true;
+    }
+    ui.same_line();
+    ui.text("│");
+    ui.same_line();
+    if ui.small_button("PPU") {
+        action.toggle_ppu_viewer = true;
+    }
+    ui.same_line();
+    if ui.small_button("+α") {
+        action.increase_opacity = true;
+    }
+    ui.same_line();
+    if ui.small_button("−α") {
+        action.decrease_opacity = true;
+    }
+}
+
+#[cfg(feature = "native")]
+fn render_breakpoint_panel(
+    ui: &imgui::Ui,
+    breakpoints: &BreakpointList,
+    add_state: &mut BreakpointAddUiState,
+    action: &mut GbDebuggerUiAction,
+) {
+    if !ui.collapsing_header("Breakpoints##bp_header", imgui::TreeNodeFlags::empty()) {
+        return;
+    }
+
+    render_existing_breakpoints(ui, breakpoints, action);
+    ui.separator();
+    render_add_breakpoint_row(ui, add_state, action);
+}
+
+#[cfg(feature = "native")]
+fn render_existing_breakpoints(
+    ui: &imgui::Ui,
+    breakpoints: &BreakpointList,
+    action: &mut GbDebuggerUiAction,
+) {
+    for (index, bp) in breakpoints.iter().enumerate() {
+        let mut enabled = bp.enabled;
+        if ui.checkbox(format!("##bp_enable_{}", index), &mut enabled) {
+            if enabled {
+                action.enable_breakpoint = Some(index);
+            } else {
+                action.disable_breakpoint = Some(index);
+            }
+        }
+        ui.same_line();
+        ui.text(format!("{}", bp.kind));
+        ui.same_line();
+        if ui.small_button(format!("X##bp_remove_{}", index)) {
+            action.remove_breakpoint = Some(index);
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+fn render_add_breakpoint_row(
+    ui: &imgui::Ui,
+    add_state: &mut BreakpointAddUiState,
+    action: &mut GbDebuggerUiAction,
+) {
+    let kinds = ["PC", "Cycle", "Write", "Frame"];
+    ui.set_next_item_width(80.0);
+    ui.combo_simple_string("##bp_kind", &mut add_state.kind_idx, &kinds);
+
+    ui.same_line();
+    ui.set_next_item_width(120.0);
+    if ui
+        .input_text("##bp_value", &mut add_state.value)
+        .flags(imgui::InputTextFlags::ENTER_RETURNS_TRUE)
+        .build()
+    {
+        if let Some(kind) = parse_breakpoint_kind(add_state.kind_idx, &add_state.value) {
+            action.add_breakpoint = Some(kind);
+            add_state.value.clear();
+            add_state.error = None;
+        } else {
+            add_state.error = Some("Invalid value".to_string());
+        }
+    }
+
+    ui.same_line();
+    if ui.small_button("Add##bp_add") {
+        if let Some(kind) = parse_breakpoint_kind(add_state.kind_idx, &add_state.value) {
+            action.add_breakpoint = Some(kind);
+            add_state.value.clear();
+            add_state.error = None;
+        } else {
+            add_state.error = Some("Invalid value".to_string());
+        }
+    }
+
+    if let Some(ref err) = add_state.error {
+        ui.same_line();
+        ui.text_colored([1.0, 0.0, 0.0, 1.0], err);
+    }
+}
+
+fn parse_breakpoint_kind(kind_idx: usize, value_str: &str) -> Option<BreakpointKind> {
+    let value_str = value_str.trim();
+    match kind_idx {
+        0 => {
+            // PC
+            let value = if value_str.starts_with("0x") || value_str.starts_with("0X") {
+                u16::from_str_radix(&value_str[2..], 16).ok()?
+            } else {
+                value_str.parse::<u16>().ok()?
+            };
+            Some(BreakpointKind::Pc(value))
+        }
+        1 => {
+            // Cycle
+            Some(BreakpointKind::Cycle(value_str.parse().ok()?))
+        }
+        2 => {
+            // Write
+            let value = if value_str.starts_with("0x") || value_str.starts_with("0X") {
+                u16::from_str_radix(&value_str[2..], 16).ok()?
+            } else {
+                value_str.parse::<u16>().ok()?
+            };
+            Some(BreakpointKind::WriteAddress(value))
+        }
+        3 => {
+            // Frame
+            Some(BreakpointKind::Frame(value_str.parse().ok()?))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(feature = "native")]
+fn render_cpu_code_panel(ui: &imgui::Ui, snapshot: &GbDebuggerSnapshot, size: [f32; 2]) {
+    ui.group(|| {
+        ui.text("Disassembly");
+        ui.separator();
+
+        let line_height = ui.text_line_height_with_spacing();
+        let desired_height = code_panel_disasm_height_for_line_height(line_height);
+        let disasm_height = desired_height
+            .min(size[1] - ui.cursor_pos()[1] - 100.0)
+            .max(100.0);
+
+        ui.child_window("disasm_window")
+            .size([size[0], disasm_height])
+            .build(|| {
+                for line in &snapshot.cpu_disasm {
+                    let is_current = line.is_current;
+                    if is_current {
+                        let draw_list = ui.get_window_draw_list();
+                        let pos = ui.cursor_screen_pos();
+                        let size = [size[0], line_height];
+                        draw_list
+                            .add_rect(
+                                pos,
+                                [pos[0] + size[0], pos[1] + size[1]],
+                                [0.0, 1.0, 0.0, 0.3],
+                            )
+                            .filled(true)
+                            .build();
+                    }
+                    ui.text(&line.text);
+                }
+            });
+
+        ui.dummy([0.0, 8.0]);
+        ui.text("CPU Trace");
+        ui.separator();
+
+        let trace_height = (size[1] - ui.cursor_pos()[1]).max(50.0);
+        ui.child_window("trace_window")
+            .size([size[0], trace_height])
+            .build(|| {
+                for line in &snapshot.recent_trace {
+                    ui.text(&line.text);
+                }
+            });
+    });
+}
+
+#[cfg(feature = "native")]
+fn render_cpu_right_panel(
+    ui: &imgui::Ui,
+    snapshot: &GbDebuggerSnapshot,
+    size: [f32; 2],
+    _gap: f32,
+    hexdump_state: &mut HexdumpUiState,
+    watch_state: &mut WatchlistUiState,
+    action: &mut GbDebuggerUiAction,
+) {
+    ui.group(|| {
+        render_cpu_registers(ui, snapshot);
+        ui.dummy([0.0, 8.0]);
+        render_memory_watch(ui, snapshot, watch_state, action);
+        ui.dummy([0.0, 8.0]);
+        render_hexdump_panel(ui, snapshot, hexdump_state, action, size);
+    });
+}
+
+#[cfg(feature = "native")]
+fn render_cpu_registers(ui: &imgui::Ui, snapshot: &GbDebuggerSnapshot) {
+    ui.text("Registers");
+    ui.separator();
+
+    let regs = &snapshot.cpu_regs;
+
+    // AF, BC, DE, HL
+    ui.text(format!("AF: {:04X}  BC: {:04X}", regs.af, regs.bc));
+    ui.text(format!("DE: {:04X}  HL: {:04X}", regs.de, regs.hl));
+    ui.text(format!("SP: {:04X}  PC: {:04X}", regs.sp, regs.pc));
+
+    ui.dummy([0.0, 4.0]);
+
+    // Flags
+    let z = if regs.z_flag { 'Z' } else { '-' };
+    let n = if regs.n_flag { 'N' } else { '-' };
+    let h = if regs.h_flag { 'H' } else { '-' };
+    let c = if regs.c_flag { 'C' } else { '-' };
+    ui.text(format!("Flags: {}{}{}{}", z, n, h, c));
+
+    ui.dummy([0.0, 4.0]);
+
+    // Timing
+    ui.text(format!("Cycles: {}", regs.cycles));
+    ui.text(format!("Frame: {}", regs.frame_count));
+    ui.text(format!("Scanline: {}  Dot: {}", regs.scanline, regs.dot));
+    ui.text(format!("PPU Mode: {}", regs.ppu_mode));
+
+    ui.dummy([0.0, 4.0]);
+
+    // CPU state
+    let ime = if regs.ime { "ON" } else { "OFF" };
+    let halted = if regs.halted { "HALT" } else { "RUN" };
+    ui.text(format!("IME: {}  State: {}", ime, halted));
+    ui.text(format!("IE: {:02X}  IF: {:02X}", regs.ie, regs.if_reg));
+}
+
+#[cfg(feature = "native")]
+fn render_memory_watch(
+    ui: &imgui::Ui,
+    snapshot: &GbDebuggerSnapshot,
+    watch_state: &mut WatchlistUiState,
+    action: &mut GbDebuggerUiAction,
+) {
+    ui.text("Memory Watch");
+    ui.separator();
+
+    // Ensure row_inputs and row_errors match the watch list size
+    while watch_state.row_inputs.len() < snapshot.watch_values.len() {
+        watch_state.row_inputs.push(String::new());
+        watch_state.row_errors.push(None);
+    }
+    while watch_state.row_inputs.len() > snapshot.watch_values.len() {
+        watch_state.row_inputs.pop();
+        watch_state.row_errors.pop();
+    }
+
+    // Display existing watch entries
+    let mut entries_to_remove = Vec::new();
+    for (index, entry) in snapshot.watch_values.iter().enumerate() {
+        if watch_state.row_inputs[index].is_empty() {
+            watch_state.row_inputs[index] = format!("{:04X}", entry.address);
+        }
+
+        ui.set_next_item_width(80.0);
+        if ui
+            .input_text(
+                &format!("##watch_{}", index),
+                &mut watch_state.row_inputs[index],
+            )
+            .flags(imgui::InputTextFlags::ENTER_RETURNS_TRUE)
+            .build()
+        {
+            if let Some(addr) = parse_address(&watch_state.row_inputs[index]) {
+                action.update_watch_address = Some(WatchAddressUpdate {
+                    index,
+                    address: addr,
+                });
+                watch_state.row_inputs[index] = format!("{:04X}", addr);
+                watch_state.row_errors[index] = None;
+            } else {
+                watch_state.row_errors[index] = Some("Invalid".to_string());
+            }
+        }
+
+        ui.same_line();
+        ui.text(format!("= {:02X}", entry.value));
+        ui.same_line();
+        if ui.small_button(format!("X##watch_rm_{}", index)) {
+            entries_to_remove.push(index);
+        }
+
+        if let Some(ref err) = watch_state.row_errors[index] {
+            ui.same_line();
+            ui.text_colored([1.0, 0.0, 0.0, 1.0], err);
+        }
+    }
+
+    for index in entries_to_remove.iter().rev() {
+        action.remove_watch_address = Some(*index);
+    }
+
+    // Add new watch entry
+    ui.set_next_item_width(80.0);
+    if ui
+        .input_text("##watch_add", &mut watch_state.add_input)
+        .flags(imgui::InputTextFlags::ENTER_RETURNS_TRUE)
+        .build()
+    {
+        if let Some(addr) = parse_address(&watch_state.add_input) {
+            action.add_watch_address = Some(addr);
+            watch_state.add_input.clear();
+            watch_state.add_error = None;
+        } else {
+            watch_state.add_error = Some("Invalid".to_string());
+        }
+    }
+
+    ui.same_line();
+    if ui.small_button("Add##watch_add_btn") {
+        if let Some(addr) = parse_address(&watch_state.add_input) {
+            action.add_watch_address = Some(addr);
+            watch_state.add_input.clear();
+            watch_state.add_error = None;
+        } else {
+            watch_state.add_error = Some("Invalid".to_string());
+        }
+    }
+
+    if let Some(ref err) = watch_state.add_error {
+        ui.same_line();
+        ui.text_colored([1.0, 0.0, 0.0, 1.0], err);
+    }
+}
+
+fn parse_address(s: &str) -> Option<u16> {
+    let s = s.trim();
+    if s.starts_with("0x") || s.starts_with("0X") {
+        u16::from_str_radix(&s[2..], 16).ok()
+    } else {
+        s.parse::<u16>().ok()
+    }
+}
+
+#[cfg(feature = "native")]
+fn render_hexdump_panel(
+    ui: &imgui::Ui,
+    snapshot: &GbDebuggerSnapshot,
+    hexdump_state: &mut HexdumpUiState,
+    action: &mut GbDebuggerUiAction,
+    size: [f32; 2],
+) {
+    if !ui.collapsing_header("WRAM Hexdump##wram_header", imgui::TreeNodeFlags::empty()) {
+        return;
+    }
+
+    render_hexdump_controls(
+        ui,
+        "WRAM",
+        snapshot.wram_hexdump_base,
+        &mut hexdump_state.wram_address_input,
+        &mut hexdump_state.wram_error,
+        |addr| action.set_wram_hexdump_base = Some(addr),
+        |delta| action.nudge_wram_hexdump_base_by_bytes = Some(delta),
+    );
+
+    render_hexdump_bytes(
+        ui,
+        snapshot.wram_hexdump_base,
+        &snapshot.wram_hexdump_bytes,
+        size[0],
+    );
+
+    ui.dummy([0.0, 8.0]);
+
+    if !ui.collapsing_header("VRAM Hexdump##vram_header", imgui::TreeNodeFlags::empty()) {
+        return;
+    }
+
+    render_hexdump_controls(
+        ui,
+        "VRAM",
+        snapshot.vram_hexdump_base,
+        &mut hexdump_state.vram_address_input,
+        &mut hexdump_state.vram_error,
+        |addr| action.set_vram_hexdump_base = Some(addr),
+        |delta| action.nudge_vram_hexdump_base_by_bytes = Some(delta),
+    );
+
+    render_hexdump_bytes(
+        ui,
+        snapshot.vram_hexdump_base,
+        &snapshot.vram_hexdump_bytes,
+        size[0],
+    );
+}
+
+#[cfg(feature = "native")]
+fn render_hexdump_controls(
+    ui: &imgui::Ui,
+    label: &str,
+    current_base: u16,
+    input: &mut String,
+    error: &mut Option<String>,
+    set_action: impl FnOnce(u16),
+    mut nudge_action: impl FnMut(i16),
+) {
+    if input.is_empty() {
+        *input = format!("{:04X}", current_base);
+    }
+
+    ui.text(format!("{} Base:", label));
+    ui.same_line();
+    ui.set_next_item_width(80.0);
+    if ui
+        .input_text(&format!("##{}_base", label.to_lowercase()), input)
+        .flags(imgui::InputTextFlags::ENTER_RETURNS_TRUE)
+        .build()
+    {
+        if let Some(addr) = parse_address(input) {
+            set_action(addr);
+            *input = format!("{:04X}", addr);
+            *error = None;
+        } else {
+            *error = Some("Invalid".to_string());
+        }
+    }
+
+    ui.same_line();
+    if ui.small_button(format!("−16##{}_minus", label.to_lowercase())) {
+        nudge_action(-16);
+    }
+    ui.same_line();
+    if ui.small_button(format!("+16##{}_plus", label.to_lowercase())) {
+        nudge_action(16);
+    }
+
+    if let Some(err) = error {
+        ui.same_line();
+        ui.text_colored([1.0, 0.0, 0.0, 1.0], err);
+    }
+}
+
+#[cfg(feature = "native")]
+fn render_hexdump_bytes(ui: &imgui::Ui, base: u16, bytes: &[u8], _width: f32) {
+    const BYTES_PER_ROW: usize = 16;
+    for (row_idx, chunk) in bytes.chunks(BYTES_PER_ROW).enumerate() {
+        let addr = base.wrapping_add((row_idx * BYTES_PER_ROW) as u16);
+        let hex_str = chunk
+            .iter()
+            .map(|b| format!("{:02X}", b))
+            .collect::<Vec<_>>()
+            .join(" ");
+        ui.text(format!("{:04X}: {}", addr, hex_str));
+    }
+}

--- a/src/platform/debugging/breakpoints.rs
+++ b/src/platform/debugging/breakpoints.rs
@@ -250,6 +250,13 @@ impl BreakpointList {
         }
     }
 
+    /// Remove the first breakpoint that matches the given kind. No-op if not found.
+    pub fn remove_first_matching(&mut self, kind: &BreakpointKind) {
+        if let Some(index) = self.items.iter().position(|b| &b.kind == kind) {
+            self.items.remove(index);
+        }
+    }
+
     /// Enable the breakpoint at the given index. No-op if out of bounds.
     pub fn enable(&mut self, index: usize) {
         self.set_enabled(index, true);


### PR DESCRIPTION
Adds native ImGui UI integration for GB debugger, connecting CPU debugger and PPU viewer modules to create visual debugging windows in the native frontend. Implements CPU controls, breakpoint panel, register display, disassembly window, memory watch, hexdump viewers, and PPU viewer window. Follows NES debugger pattern for consistency. Closes #2179.