### PR TITLE
Fix #2189: PPU frame_ready preservation + GB save RAM support

### DIFF
--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -256,6 +256,11 @@ impl CgbBus {
         Ok(())
     }
 
+    /// Returns `true` when the cartridge has battery-backed RAM.
+    pub fn has_battery(&self) -> bool {
+        self.cart.has_battery()
+    }
+
     /// Snapshot cartridge RAM.
     pub fn cart_ram_snapshot(&self) -> Vec<u8> {
         self.cart.ram_snapshot()

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -424,6 +424,11 @@ impl DmgBus {
         Ok(())
     }
 
+    /// Returns `true` when the cartridge has battery-backed RAM.
+    pub fn has_battery(&self) -> bool {
+        self.cart.has_battery()
+    }
+
     /// Snapshot cartridge RAM.
     pub fn cart_ram_snapshot(&self) -> Vec<u8> {
         self.cart.ram_snapshot()

--- a/src/gb/cartridge/cartridge.rs
+++ b/src/gb/cartridge/cartridge.rs
@@ -53,4 +53,11 @@ pub trait GbCartridge {
     /// Does nothing for cartridges without MBC registers or if data is
     /// malformed/empty.
     fn restore_mbc_state(&mut self, _data: &[u8]) {}
+
+    /// Returns `true` when the cartridge has battery-backed RAM.
+    ///
+    /// Used to decide whether to load/save `.sav` files.
+    fn has_battery(&self) -> bool {
+        false
+    }
 }

--- a/src/gb/cartridge/mbc1.rs
+++ b/src/gb/cartridge/mbc1.rs
@@ -48,10 +48,12 @@ pub struct Mbc1 {
     ram_enabled: bool,
     /// True when the ROM is an MBC1M multi-game compilation cart.
     multicart: bool,
+    /// True when the cartridge has battery-backed RAM.
+    battery: bool,
 }
 
 impl Mbc1 {
-    pub fn new(rom: Vec<u8>, ram: Vec<u8>) -> Self {
+    pub fn new(rom: Vec<u8>, ram: Vec<u8>, battery: bool) -> Self {
         let multicart = is_multicart_rom(&rom);
         Self {
             multicart,
@@ -61,6 +63,7 @@ impl Mbc1 {
             secondary_bank: 0,
             mode: false,
             ram_enabled: false,
+            battery,
         }
     }
 
@@ -187,6 +190,10 @@ impl GbCartridge for Mbc1 {
         }
     }
 
+    fn has_battery(&self) -> bool {
+        self.battery
+    }
+
     fn ram_snapshot(&self) -> Vec<u8> {
         self.ram.clone()
     }
@@ -239,7 +246,7 @@ mod tests {
     #[test]
     fn test_mbc1_reads_bank0_data_from_low_region_initially() {
         // Given: 4-bank ROM (banks 0–3 filled with 0x00–0x03)
-        let cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(0));
+        let cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(0), false);
         // When: reading from the $0000–$3FFF window (bank 0)
         // Then: returns bank 0 fill byte 0x00
         assert_eq!(cart.read(0x0000), 0x00);
@@ -249,7 +256,7 @@ mod tests {
     #[test]
     fn test_mbc1_reads_bank1_data_from_high_region_initially() {
         // Given: 4-bank ROM; initial bank register = 0 → effective = 1
-        let cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(0));
+        let cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(0), false);
         // When: reading from the $4000–$7FFF window
         // Then: returns bank 1 fill byte 0x01
         assert_eq!(cart.read(0x4000), 0x01);
@@ -259,7 +266,7 @@ mod tests {
     #[test]
     fn test_mbc1_rom_bank_switch_selects_correct_bank() {
         // Given: 4-bank ROM; select bank 2 by writing to $2000
-        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(0));
+        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(0), false);
         // When: writing 0x02 to $2000 and reading from high region
         cart.write(0x2000, 0x02);
         // Then: $4000 returns bank 2 fill byte 0x02
@@ -269,7 +276,7 @@ mod tests {
     #[test]
     fn test_mbc1_writing_zero_to_bank_reg_selects_bank_1() {
         // Given: 4-bank ROM; write 0x00 to $2000 (hardware corrects to bank 1)
-        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(0));
+        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(0), false);
         // When: writing 0x00
         cart.write(0x2000, 0x00);
         // Then: bank 1 (fill byte 0x01) appears at $4000
@@ -280,7 +287,7 @@ mod tests {
     fn test_mbc1_secondary_bank_shifts_to_upper_rom_bits_in_mode0() {
         // Given: 64-bank ROM (1 MB); secondary_bank = 1; rom_bank_reg = 0 → 1
         // Then: effective bank = (1 << 5) | 1 = 33; bank 33 fill = 33u8
-        let mut cart = Mbc1::new(make_mbc1_rom(64), make_mbc1_ram(0));
+        let mut cart = Mbc1::new(make_mbc1_rom(64), make_mbc1_ram(0), false);
         cart.write(0x4000, 0x01); // secondary_bank = 1
         cart.write(0x2000, 0x00); // rom_bank_reg = 0 → corrected to 1
         assert_eq!(cart.read(0x4000), 33u8);
@@ -290,7 +297,7 @@ mod tests {
     fn test_mbc1_mode1_bank0_region_uses_secondary_bank_offset() {
         // Given: 64-bank ROM; mode 1; secondary_bank = 1
         // Then: $0000–$3FFF shows bank (1 << 5) = 32; fill byte = 32u8
-        let mut cart = Mbc1::new(make_mbc1_rom(64), make_mbc1_ram(0));
+        let mut cart = Mbc1::new(make_mbc1_rom(64), make_mbc1_ram(0), false);
         cart.write(0x6000, 0x01); // mode = 1
         cart.write(0x4000, 0x01); // secondary_bank = 1
         assert_eq!(cart.read(0x0000), 32u8);
@@ -299,7 +306,7 @@ mod tests {
     #[test]
     fn test_mbc1_ram_read_returns_0xff_when_disabled() {
         // Given: cart with 1 RAM bank, RAM disabled (default)
-        let cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(1));
+        let cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(1), false);
         // Then: reads from $A000 return 0xFF
         assert_eq!(cart.read(0xA000), 0xFF);
     }
@@ -307,7 +314,7 @@ mod tests {
     #[test]
     fn test_mbc1_ram_read_write_when_enabled() {
         // Given: cart with 1 RAM bank; enable RAM
-        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(1));
+        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(1), false);
         cart.write(0x0000, 0x0A); // Enable RAM
         // When: writing 0x42 to $A000
         cart.write(0xA000, 0x42);
@@ -318,7 +325,7 @@ mod tests {
     #[test]
     fn test_mbc1_ram_bank_switching_in_mode1() {
         // Given: 4 RAM banks, mode 1; write distinct data to banks 0 and 1
-        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(4));
+        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(4), false);
         cart.write(0x0000, 0x0A); // Enable RAM
         cart.write(0x6000, 0x01); // Mode 1
 
@@ -380,7 +387,7 @@ mod tests {
         // Given: MBC1M cart; secondary=1, rom_bank=1
         // Then: bank1_index = (1 << 4) | 1 = 17 → fill byte = 17u8
         // (Standard MBC1 would give (1 << 5) | 1 = 33 → fill = 33u8)
-        let mut cart = Mbc1::new(make_mbc1m_rom(), make_mbc1_ram(0));
+        let mut cart = Mbc1::new(make_mbc1m_rom(), make_mbc1_ram(0), false);
         cart.write(0x4000, 0x01); // secondary = 1
         cart.write(0x2000, 0x01); // rom_bank = 1
         assert_eq!(cart.read(0x4000), 17u8);
@@ -391,7 +398,7 @@ mod tests {
         // Given: MBC1M cart; secondary=0, rom_bank_reg=0x11 (17; top bit set)
         // Then: effective bank uses only lower 4 bits → (0 << 4) | 1 = 1 → fill = 1u8
         // (Standard MBC1 would give (0 << 5) | 17 = 17 → fill = 17u8)
-        let mut cart = Mbc1::new(make_mbc1m_rom(), make_mbc1_ram(0));
+        let mut cart = Mbc1::new(make_mbc1m_rom(), make_mbc1_ram(0), false);
         cart.write(0x4000, 0x00); // secondary = 0
         cart.write(0x2000, 0x11); // rom_bank_reg = 0x11 = 17
         assert_eq!(cart.read(0x4000), 1u8);
@@ -402,7 +409,7 @@ mod tests {
         // Given: MBC1M cart; mode=1, secondary=1
         // Then: bank0_index = (1 << 4) = 16 → fill byte = 16u8
         // (Standard MBC1 would give (1 << 5) = 32 → fill = 32u8)
-        let mut cart = Mbc1::new(make_mbc1m_rom(), make_mbc1_ram(0));
+        let mut cart = Mbc1::new(make_mbc1m_rom(), make_mbc1_ram(0), false);
         cart.write(0x6000, 0x01); // mode = 1
         cart.write(0x4000, 0x01); // secondary = 1
         assert_eq!(cart.read(0x0000), 16u8);
@@ -415,7 +422,7 @@ mod tests {
         // Given: 1 RAM bank (8 KB, 64 Kbit); mode 1; data written to bank 0
         // When: secondary register is set to 2 (out of range for 1-bank cart)
         // Then: reads return the same data (secondary masked to bank 0)
-        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(1));
+        let mut cart = Mbc1::new(make_mbc1_rom(4), make_mbc1_ram(1), false);
         cart.write(0x0000, 0x0A); // enable RAM
         cart.write(0x6000, 0x01); // mode 1
         cart.write(0x4000, 0x00); // secondary = 0 → RAM bank 0

--- a/src/gb/cartridge/mbc2.rs
+++ b/src/gb/cartridge/mbc2.rs
@@ -16,15 +16,18 @@ pub struct Mbc2 {
     rom_bank: u8,
     /// Whether cartridge RAM is enabled.
     ram_enabled: bool,
+    /// True when the cartridge has battery-backed RAM.
+    battery: bool,
 }
 
 impl Mbc2 {
-    pub fn new(rom: Vec<u8>) -> Self {
+    pub fn new(rom: Vec<u8>, battery: bool) -> Self {
         Self {
             rom,
             ram: [0u8; 512],
             rom_bank: 0,
             ram_enabled: false,
+            battery,
         }
     }
 
@@ -94,6 +97,10 @@ impl GbCartridge for Mbc2 {
         }
     }
 
+    fn has_battery(&self) -> bool {
+        self.battery
+    }
+
     fn ram_snapshot(&self) -> Vec<u8> {
         self.ram.to_vec()
     }
@@ -138,7 +145,7 @@ mod tests {
     #[test]
     fn test_mbc2_initial_rom_bank0_readable() {
         // Bank 0 is always at $0000–$3FFF; fill byte = 0
-        let cart = Mbc2::new(make_rom(4));
+        let cart = Mbc2::new(make_rom(4), false);
         assert_eq!(cart.read(0x0000), 0x00);
         assert_eq!(cart.read(0x3FFF), 0x00);
     }
@@ -146,7 +153,7 @@ mod tests {
     #[test]
     fn test_mbc2_initial_high_region_maps_bank1() {
         // rom_bank = 0 → promotes to 1; fill byte = 1
-        let cart = Mbc2::new(make_rom(4));
+        let cart = Mbc2::new(make_rom(4), false);
         assert_eq!(cart.read(0x4000), 0x01);
         assert_eq!(cart.read(0x7FFF), 0x01);
     }
@@ -154,7 +161,7 @@ mod tests {
     #[test]
     fn test_mbc2_rom_bank_switch_selects_bank() {
         // Write 0x02 to addr with bit 8 set (e.g. $0100) → bank 2
-        let mut cart = Mbc2::new(make_rom(4));
+        let mut cart = Mbc2::new(make_rom(4), false);
         cart.write(0x0100, 0x02);
         assert_eq!(cart.read(0x4000), 0x02);
     }
@@ -162,7 +169,7 @@ mod tests {
     #[test]
     fn test_mbc2_writing_zero_bank_reg_promotes_to_bank1() {
         // Explicitly write 0 to bank reg → still maps to bank 1
-        let mut cart = Mbc2::new(make_rom(4));
+        let mut cart = Mbc2::new(make_rom(4), false);
         cart.write(0x0100, 0x00);
         assert_eq!(cart.read(0x4000), 0x01);
     }
@@ -170,7 +177,7 @@ mod tests {
     #[test]
     fn test_mbc2_bank_reg_masked_to_4_bits() {
         // Writing 0x1F → lower 4 bits = 0xF = 15
-        let mut cart = Mbc2::new(make_rom(16));
+        let mut cart = Mbc2::new(make_rom(16), false);
         cart.write(0x0100, 0x1F);
         assert_eq!(cart.read(0x4000), 0x0F);
     }
@@ -179,7 +186,7 @@ mod tests {
     fn test_mbc2_bank_wraps_to_available_banks() {
         // 4-bank ROM; requesting bank 5 → 5 & 3 = 1 (effective_rom_bank &
         // (bank_count - 1) masking); fill byte = 1
-        let mut cart = Mbc2::new(make_rom(4));
+        let mut cart = Mbc2::new(make_rom(4), false);
         cart.write(0x0100, 0x05); // lower 4 bits = 5; 5 & (4-1) = 1
         assert_eq!(cart.read(0x4000), 0x01);
     }
@@ -190,14 +197,14 @@ mod tests {
 
     #[test]
     fn test_mbc2_ram_disabled_by_default_returns_0xff() {
-        let cart = Mbc2::new(make_rom(2));
+        let cart = Mbc2::new(make_rom(2), false);
         assert_eq!(cart.read(0xA000), 0xFF);
     }
 
     #[test]
     fn test_mbc2_ram_enable_any_lower_nibble_0xa() {
         // 0x2A has lower nibble 0xA → enables; addr has bit 8 clear (0x0000)
-        let mut cart = Mbc2::new(make_rom(2));
+        let mut cart = Mbc2::new(make_rom(2), false);
         cart.write(0x0000, 0x2A);
         cart.write(0xA000, 0x05);
         assert_eq!(cart.read(0xA000), 0x05 | 0xF0);
@@ -206,7 +213,7 @@ mod tests {
     #[test]
     fn test_mbc2_ram_disable_non_0xa_lower_nibble() {
         // Enable first, then write 0x00 (lower nibble 0) → disabled
-        let mut cart = Mbc2::new(make_rom(2));
+        let mut cart = Mbc2::new(make_rom(2), false);
         cart.write(0x0000, 0x0A); // enable
         cart.write(0xA000, 0x07);
         cart.write(0x0000, 0x00); // disable
@@ -215,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_mbc2_ram_write_and_read_when_enabled() {
-        let mut cart = Mbc2::new(make_rom(2));
+        let mut cart = Mbc2::new(make_rom(2), false);
         cart.write(0x0000, 0x0A);
         cart.write(0xA000, 0x03);
         assert_eq!(cart.read(0xA000), 0x03 | 0xF0);
@@ -224,7 +231,7 @@ mod tests {
     #[test]
     fn test_mbc2_ram_read_returns_upper_nibble_0xf() {
         // Stored value 0x05; read must return 0xF5
-        let mut cart = Mbc2::new(make_rom(2));
+        let mut cart = Mbc2::new(make_rom(2), false);
         cart.write(0x0000, 0x0A);
         cart.write(0xA001, 0x05);
         assert_eq!(cart.read(0xA001), 0xF5);
@@ -233,7 +240,7 @@ mod tests {
     #[test]
     fn test_mbc2_ram_mirrors_a200_to_bfff() {
         // Write to $A000; read back at $A200 (512 bytes later, same slot)
-        let mut cart = Mbc2::new(make_rom(2));
+        let mut cart = Mbc2::new(make_rom(2), false);
         cart.write(0x0000, 0x0A);
         cart.write(0xA000, 0x09);
         assert_eq!(cart.read(0xA200), 0x09 | 0xF0);
@@ -242,7 +249,7 @@ mod tests {
     #[test]
     fn test_mbc2_writes_to_bit8_clear_addr_do_not_change_bank() {
         // Bit 8 clear → RAM gate write; should NOT change current ROM bank
-        let mut cart = Mbc2::new(make_rom(4));
+        let mut cart = Mbc2::new(make_rom(4), false);
         cart.write(0x0100, 0x03); // select bank 3 first
         cart.write(0x0000, 0x0A); // RAM enable (bit 8 clear) — must not reset bank
         assert_eq!(cart.read(0x4000), 0x03);
@@ -251,7 +258,7 @@ mod tests {
     #[test]
     fn test_mbc2_writes_to_bit8_set_addr_do_not_enable_ram() {
         // Bit 8 set → ROM bank select; should NOT change RAM enabled state
-        let mut cart = Mbc2::new(make_rom(4));
+        let mut cart = Mbc2::new(make_rom(4), false);
         // RAM disabled by default; write bank select with 0x0A value but bit 8 set
         cart.write(0x0100, 0x0A);
         // RAM should still be disabled

--- a/src/gb/cartridge/mbc5.rs
+++ b/src/gb/cartridge/mbc5.rs
@@ -28,20 +28,20 @@ pub struct Mbc5 {
     /// True for rumble cart types (0x1C–0x1E). Bit 3 of writes to $4000–$5FFF
     /// controls the rumble motor and is masked out of the RAM bank register.
     has_rumble: bool,
+    /// True when the cartridge has battery-backed RAM.
+    battery: bool,
 }
 
 impl Mbc5 {
-    pub fn new(rom: Vec<u8>, ram: Vec<u8>, has_rumble: bool) -> Self {
+    pub fn new(rom: Vec<u8>, ram: Vec<u8>, has_rumble: bool, battery: bool) -> Self {
         Self {
             rom,
             ram,
-            // MBC5 powers on with bank 1 in the switchable window — same as
-            // other MBCs.  "Writing 0 gives bank 0" describes write behaviour,
-            // not the power-on state.
             rom_bank: 1,
             ram_bank: 0,
             ram_enabled: false,
             has_rumble,
+            battery,
         }
     }
 
@@ -131,6 +131,10 @@ impl GbCartridge for Mbc5 {
         }
     }
 
+    fn has_battery(&self) -> bool {
+        self.battery
+    }
+
     fn ram_snapshot(&self) -> Vec<u8> {
         self.ram.clone()
     }
@@ -185,7 +189,7 @@ mod tests {
     #[test]
     fn test_mbc5_fixed_window_always_reads_bank0() {
         // Given: 4-bank ROM; bank 0 filled with 0x00
-        let cart = Mbc5::new(make_rom(4), make_ram(0), false);
+        let cart = Mbc5::new(make_rom(4), make_ram(0), false, false);
         // Then: $0000 and $3FFF both return bank 0 fill byte
         assert_eq!(cart.read(0x0000), 0x00);
         assert_eq!(cart.read(0x3FFF), 0x00);
@@ -194,7 +198,7 @@ mod tests {
     #[test]
     fn test_mbc5_fixed_window_unchanged_after_bank_select() {
         // Given: bank 2 is selected
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false, false);
         cart.write(0x2000, 0x02);
         // Then: $0000 still returns bank 0 data
         assert_eq!(cart.read(0x0000), 0x00);
@@ -208,7 +212,7 @@ mod tests {
     fn test_mbc5_switchable_window_initially_maps_bank1() {
         // MBC5 powers on with bank 1 in the switchable window (same as other MBCs).
         // "Writing 0 gives bank 0" applies only to explicit writes, not power-on state.
-        let cart = Mbc5::new(make_rom(4), make_ram(0), false);
+        let cart = Mbc5::new(make_rom(4), make_ram(0), false, false);
         assert_eq!(cart.read(0x4000), 0x01);
         assert_eq!(cart.read(0x7FFF), 0x01);
     }
@@ -216,7 +220,7 @@ mod tests {
     #[test]
     fn test_mbc5_writing_zero_to_bank_reg_selects_bank0() {
         // Unlike MBC1/MBC2, explicitly writing 0 selects bank 0 (no promotion).
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false, false);
         cart.write(0x2000, 0x00);
         assert_eq!(cart.read(0x4000), 0x00);
     }
@@ -224,7 +228,7 @@ mod tests {
     #[test]
     fn test_mbc5_rom_bank_switch_low_byte_selects_correct_bank() {
         // Given: 4-bank ROM; write 0x02 to $2000
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false, false);
         cart.write(0x2000, 0x02);
         // Then: $4000 returns bank 2 fill byte
         assert_eq!(cart.read(0x4000), 0x02);
@@ -233,7 +237,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_rom_bank_switch_to_bank3() {
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false, false);
         cart.write(0x2000, 0x03);
         assert_eq!(cart.read(0x4000), 0x03);
     }
@@ -242,7 +246,7 @@ mod tests {
     fn test_mbc5_9th_bit_selects_upper_bank() {
         // Given: 512-bank ROM; write 0xFF to $2000 and 0x01 to $3000 → bank 0x1FF
         // Bank 0x1FF = 511; fill byte = 511u8 = 0xFF
-        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false, false);
         cart.write(0x2000, 0xFF); // lower 8 bits = 0xFF
         cart.write(0x3000, 0x01); // bit 8 set → bank = 0x1FF
         assert_eq!(cart.read(0x4000), 0xFF);
@@ -251,7 +255,7 @@ mod tests {
     #[test]
     fn test_mbc5_9th_bit_only_lowest_bit_matters() {
         // Writing 0xFE to $3000 (bit 0 = 0) should not set bit 8
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false, false);
         cart.write(0x2000, 0x02); // bank 2
         cart.write(0x3000, 0xFE); // bit 0 = 0 → bit 8 stays 0
         assert_eq!(cart.read(0x4000), 0x02); // still bank 2
@@ -260,7 +264,7 @@ mod tests {
     #[test]
     fn test_mbc5_9th_bit_can_be_cleared() {
         // Set bit 8, then clear it by writing 0x00 to $3000
-        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false, false);
         cart.write(0x2000, 0x01); // bank 1
         cart.write(0x3000, 0x01); // bit 8 set → bank 0x101 = 257; fill byte = 1 (wraps)
         cart.write(0x3000, 0x00); // clear bit 8 → bank 1
@@ -270,7 +274,7 @@ mod tests {
     #[test]
     fn test_mbc5_low_byte_write_preserves_high_bit() {
         // Set bit 8, then change low byte; bit 8 should be preserved
-        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(512), make_ram(0), false, false);
         cart.write(0x3000, 0x01); // bit 8 set
         cart.write(0x2000, 0x05); // low byte = 5 → bank = 0x105 = 261
         // 261 & 511 = 261; fill byte = 261u8 = 5 (261 % 256 wraps, and fill = bank as u8)
@@ -280,7 +284,7 @@ mod tests {
     #[test]
     fn test_mbc5_bank_masking_wraps_to_available_banks() {
         // 4-bank ROM; requesting bank 5 → 5 & 3 = 1; fill byte = 1
-        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(4), make_ram(0), false, false);
         cart.write(0x2000, 0x05);
         assert_eq!(cart.read(0x4000), 0x01);
     }
@@ -291,13 +295,13 @@ mod tests {
 
     #[test]
     fn test_mbc5_ram_disabled_by_default_returns_0xff() {
-        let cart = Mbc5::new(make_rom(2), make_ram(1), false);
+        let cart = Mbc5::new(make_rom(2), make_ram(1), false, false);
         assert_eq!(cart.read(0xA000), 0xFF);
     }
 
     #[test]
     fn test_mbc5_ram_enable_with_0x0a() {
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false, false);
         cart.write(0x0000, 0x0A); // enable RAM
         cart.write(0xA000, 0x42);
         assert_eq!(cart.read(0xA000), 0x42);
@@ -306,7 +310,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_enable_with_any_lower_nibble_a() {
         // $1A has lower nibble 0xA → should also enable
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false, false);
         cart.write(0x0000, 0x1A);
         cart.write(0xA000, 0x55);
         assert_eq!(cart.read(0xA000), 0x55);
@@ -314,7 +318,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_ram_disable_with_0x00() {
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false, false);
         cart.write(0x0000, 0x0A); // enable
         cart.write(0xA000, 0x42);
         cart.write(0x0000, 0x00); // disable
@@ -324,7 +328,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_disable_non_0xa_lower_nibble() {
         // Lower nibble 0x0B ≠ 0x0A → disable
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false, false);
         cart.write(0x0000, 0x0A); // enable first
         cart.write(0xA000, 0x42);
         cart.write(0x0000, 0x0B); // disable
@@ -333,7 +337,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_ram_write_ignored_when_disabled() {
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false, false);
         // RAM disabled; write should be a no-op
         cart.write(0xA000, 0x42);
         // Enable and verify the write did nothing
@@ -343,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_mbc5_empty_ram_returns_0xff_even_when_enabled() {
-        let mut cart = Mbc5::new(make_rom(2), make_ram(0), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(0), false, false);
         cart.write(0x0000, 0x0A); // enable
         assert_eq!(cart.read(0xA000), 0xFF);
     }
@@ -355,7 +359,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_bank_switching() {
         // Given: 2 RAM banks; write distinct bytes to each bank
-        let mut cart = Mbc5::new(make_rom(2), make_ram(2), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(2), false, false);
         cart.write(0x0000, 0x0A); // enable RAM
 
         cart.write(0x4000, 0x00); // select RAM bank 0
@@ -374,7 +378,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_bank_register_masked_to_4_bits() {
         // Writing 0xFF → lower 4 bits = 0xF = 15; 1 RAM bank → wraps to 0
-        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(1), false, false);
         cart.write(0x0000, 0x0A);
         cart.write(0x4000, 0xFF); // 4-bit mask → ram_bank = 0xF; 1 bank → wraps to 0
         cart.write(0xA000, 0x77);
@@ -384,7 +388,7 @@ mod tests {
     #[test]
     fn test_mbc5_ram_bank_masking_wraps_to_available_banks() {
         // 2 RAM banks; select bank 3 → 3 & 1 = 1 (wraps to bank 1)
-        let mut cart = Mbc5::new(make_rom(2), make_ram(2), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(2), false, false);
         cart.write(0x0000, 0x0A);
         cart.write(0x4000, 0x01); // bank 1
         cart.write(0xA000, 0xCC);
@@ -400,7 +404,7 @@ mod tests {
     fn test_mbc5_rumble_bit3_does_not_affect_ram_bank() {
         // For rumble carts, bit 3 drives the rumble motor; writing 0x08 (only
         // bit 3 set) should leave the RAM bank at 0, not switch to bank 8.
-        let mut cart = Mbc5::new(make_rom(2), make_ram(2), true);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(2), true, false);
         cart.write(0x0000, 0x0A);
         cart.write(0x4000, 0x00); // bank 0
         cart.write(0xA000, 0xAA);
@@ -412,7 +416,7 @@ mod tests {
     fn test_mbc5_rumble_ram_bank_masked_to_3_bits() {
         // For rumble carts, the RAM bank is only 3 bits (0x00–0x07).
         // Writing 0xFF → 0xFF & 0x07 = 7, not 0x0F = 15.
-        let mut cart = Mbc5::new(make_rom(2), make_ram(8), true);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(8), true, false);
         cart.write(0x0000, 0x0A);
         cart.write(0x4000, 0x07); // bank 7
         cart.write(0xA000, 0xBB);
@@ -423,7 +427,7 @@ mod tests {
     #[test]
     fn test_mbc5_non_rumble_ram_bank_uses_full_4_bits() {
         // Non-rumble carts allow 4-bit bank (0x00–0x0F). Bit 3 is a valid bank bit.
-        let mut cart = Mbc5::new(make_rom(2), make_ram(16), false);
+        let mut cart = Mbc5::new(make_rom(2), make_ram(16), false, false);
         cart.write(0x0000, 0x0A);
         cart.write(0x4000, 0x08); // bank 8 — valid for non-rumble
         cart.write(0xA000, 0xCC);

--- a/src/gb/cartridge/mod.rs
+++ b/src/gb/cartridge/mod.rs
@@ -70,16 +70,26 @@ pub fn load_cartridge(bytes: &[u8]) -> Result<Box<dyn GbCartridge>, RomError> {
         0x00 => Ok(Box::new(Mbc0::new(bytes.to_vec()))),
         0x01..=0x03 => {
             let ram_size = ram_size_from_byte(bytes[0x0149]);
-            Ok(Box::new(Mbc1::new(bytes.to_vec(), vec![0u8; ram_size])))
+            let has_battery = mbc_type == 0x03;
+            Ok(Box::new(Mbc1::new(
+                bytes.to_vec(),
+                vec![0u8; ram_size],
+                has_battery,
+            )))
         }
-        0x05..=0x06 => Ok(Box::new(Mbc2::new(bytes.to_vec()))),
+        0x05..=0x06 => {
+            let has_battery = mbc_type == 0x06;
+            Ok(Box::new(Mbc2::new(bytes.to_vec(), has_battery)))
+        }
         0x19..=0x1E => {
             let ram_size = ram_size_from_byte(bytes[0x0149]);
             let has_rumble = mbc_type >= 0x1C;
+            let has_battery = matches!(mbc_type, 0x1B | 0x1E);
             Ok(Box::new(Mbc5::new(
                 bytes.to_vec(),
                 vec![0u8; ram_size],
                 has_rumble,
+                has_battery,
             )))
         }
         n => Err(RomError::UnsupportedMbc(n)),

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -101,6 +101,27 @@ impl GbConsole {
         }
     }
 
+    fn has_battery(&self) -> bool {
+        match self {
+            Self::Dmg(gb) => gb.cpu.bus.has_battery(),
+            Self::Cgb(gb) => gb.cpu.bus.has_battery(),
+        }
+    }
+
+    fn cart_ram_snapshot(&self) -> Vec<u8> {
+        match self {
+            Self::Dmg(gb) => gb.cpu.bus.cart_ram_snapshot(),
+            Self::Cgb(gb) => gb.cpu.bus.cart_ram_snapshot(),
+        }
+    }
+
+    fn restore_cart_ram(&mut self, data: &[u8]) {
+        match self {
+            Self::Dmg(gb) => gb.cpu.bus.restore_cart_ram(data),
+            Self::Cgb(gb) => gb.cpu.bus.restore_cart_ram(data),
+        }
+    }
+
     fn save_state_bytes(&self) -> Result<Vec<u8>, String> {
         let state = match self {
             Self::Dmg(gb) => GbSaveState {
@@ -210,6 +231,10 @@ impl GameBoy {
             GbConsole::Dmg(Box::new(Gb::new(DmgBus::new(cart, dmg_variant))))
         });
         self.rom_path = Some(PathBuf::from(name));
+
+        // Load battery-backed save RAM from disk if a .sav file exists.
+        self.load_save_ram_from_disk();
+
         Ok(())
     }
 
@@ -328,6 +353,84 @@ impl GameBoy {
     /// if no ROM is loaded.
     pub fn state_path(&self) -> Option<PathBuf> {
         self.rom_path.as_ref().map(|p| p.with_extension("state"))
+    }
+
+    /// Returns `true` when the loaded cartridge has battery-backed RAM.
+    pub fn has_battery(&self) -> bool {
+        self.gb.as_ref().is_some_and(|gb| gb.has_battery())
+    }
+
+    /// Snapshot cartridge RAM contents (battery-backed SRAM).
+    pub fn cart_ram_snapshot(&self) -> Vec<u8> {
+        self.gb
+            .as_ref()
+            .map_or_else(Vec::new, |gb| gb.cart_ram_snapshot())
+    }
+
+    /// Returns the `.sav` path derived from the ROM path, or `None`.
+    fn sav_path(&self) -> Option<PathBuf> {
+        self.rom_path.as_ref().map(|p| p.with_extension("sav"))
+    }
+
+    /// Save battery-backed cartridge RAM to a `.sav` file.
+    ///
+    /// Uses a temp file + rename for atomic writes to prevent corruption.
+    pub fn save_ram_to_disk(&self) -> Result<(), String> {
+        if !self.has_battery() {
+            return Ok(());
+        }
+        let Some(sav_path) = self.sav_path() else {
+            return Ok(());
+        };
+        let data = self.cart_ram_snapshot();
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        // Atomic write: temp file → rename
+        let mut temp_path = sav_path.clone();
+        temp_path.set_extension(format!("sav.tmp.{}", std::process::id()));
+
+        if let Some(parent) = sav_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("failed to create dir {}: {e}", parent.display()))?;
+        }
+
+        std::fs::write(&temp_path, &data)
+            .map_err(|e| format!("failed to write {}: {e}", temp_path.display()))?;
+
+        if sav_path.exists() {
+            let _ = std::fs::remove_file(&sav_path);
+        }
+
+        std::fs::rename(&temp_path, &sav_path)
+            .map_err(|e| format!("failed to rename to {}: {e}", sav_path.display()))
+    }
+
+    /// Load battery-backed cartridge RAM from a `.sav` file if one exists.
+    fn load_save_ram_from_disk(&mut self) {
+        if !self.has_battery() {
+            return;
+        }
+        let Some(sav_path) = self.sav_path() else {
+            return;
+        };
+        if !sav_path.exists() {
+            return;
+        }
+        match std::fs::read(&sav_path) {
+            Ok(data) => {
+                if let Some(gb) = &mut self.gb {
+                    gb.restore_cart_ram(&data);
+                }
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: failed to read save file {}: {e}",
+                    sav_path.display()
+                );
+            }
+        }
     }
 
     // ── Debugger support ───────────────────────────────────────────────
@@ -575,7 +678,7 @@ impl Emulator for GameBoy {
     }
 
     fn save_ram(&self) -> Result<(), String> {
-        Ok(())
+        self.save_ram_to_disk()
     }
 
     fn app_context(&self) -> &SharedAppContext {
@@ -644,6 +747,19 @@ mod tests {
         config.gb.hardware = Some(hardware);
         let app_context = AppContext::new_with_config(config).into_shared();
         GameBoy::new(app_context)
+    }
+
+    /// Build a ROM with MBC5+RAM+BATTERY (type 0x1B), 8 KB RAM.
+    fn mbc5_battery_rom() -> Vec<u8> {
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0147] = 0x1B; // MBC5+RAM+BATTERY
+        rom[0x0148] = 0x00; // 32 KB ROM
+        rom[0x0149] = 0x02; // 8 KB RAM
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+        rom
     }
 
     // ── safety before ROM load ──────────────────────────────────────────────
@@ -1400,5 +1516,99 @@ mod tests {
         gb.apply_ui_action_with_controller(&mut controller, action);
 
         // If we got here without panicking, test passes
+    }
+
+    // ── Save RAM persistence ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_has_battery_returns_true_for_mbc5_battery_cart() {
+        // Given: a GameBoy loaded with an MBC5+RAM+BATTERY ROM
+        let mut gb = make_gameboy();
+        gb.load_rom(&mbc5_battery_rom(), "test.gb").unwrap();
+
+        // Then: has_battery reports true
+        assert!(
+            gb.has_battery(),
+            "MBC5+RAM+BATTERY cart should report has_battery=true"
+        );
+    }
+
+    #[test]
+    fn test_has_battery_returns_false_for_rom_only_cart() {
+        // Given: a GameBoy loaded with a ROM-only cartridge (no battery)
+        let mut gb = make_gameboy();
+        gb.load_rom(&minimal_rom(), "test.gb").unwrap();
+
+        // Then: has_battery reports false
+        assert!(
+            !gb.has_battery(),
+            "ROM-only cart should report has_battery=false"
+        );
+    }
+
+    #[test]
+    fn test_save_ram_writes_sav_file_for_battery_cart() {
+        // Given: a GameBoy with MBC5+RAM+BATTERY ROM loaded from a temp dir
+        let dir = std::env::temp_dir().join("neser_test_save_ram");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let rom_path = dir.join("test_battery.gb");
+        let sav_path = dir.join("test_battery.sav");
+        std::fs::write(&rom_path, mbc5_battery_rom()).unwrap();
+
+        let mut gb = make_gameboy();
+        gb.load_rom(
+            &std::fs::read(&rom_path).unwrap(),
+            rom_path.to_str().unwrap(),
+        )
+        .unwrap();
+
+        // When: save_ram is called
+        let result = gb.save_ram();
+
+        // Then: succeeds and .sav file exists
+        assert!(result.is_ok(), "save_ram should succeed");
+        assert!(sav_path.exists(), ".sav file should be created");
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_load_rom_restores_sav_file_for_battery_cart() {
+        // Given: a .sav file with known data exists alongside the ROM
+        let dir = std::env::temp_dir().join("neser_test_load_sav");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let rom_path = dir.join("test_battery.gb");
+        let sav_path = dir.join("test_battery.sav");
+
+        // Write a ROM and a .sav file with recognizable pattern
+        std::fs::write(&rom_path, mbc5_battery_rom()).unwrap();
+        let mut save_data = vec![0u8; 8 * 1024]; // 8 KB matching the cart RAM size
+        save_data[0] = 0xAA;
+        save_data[1] = 0xBB;
+        save_data[42] = 0xCC;
+        std::fs::write(&sav_path, &save_data).unwrap();
+
+        // When: load_rom is called with the ROM path
+        let mut gb = make_gameboy();
+        gb.load_rom(
+            &std::fs::read(&rom_path).unwrap(),
+            rom_path.to_str().unwrap(),
+        )
+        .unwrap();
+
+        // Then: cart RAM should contain the saved data
+        let ram_snapshot = gb.cart_ram_snapshot();
+        assert_eq!(ram_snapshot[0], 0xAA, "save data byte 0 should be restored");
+        assert_eq!(ram_snapshot[1], 0xBB, "save data byte 1 should be restored");
+        assert_eq!(
+            ram_snapshot[42], 0xCC,
+            "save data byte 42 should be restored"
+        );
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -425,10 +425,10 @@ impl GameBoy {
                 }
             }
             Err(e) => {
-                eprintln!(
+                crate::platform::debugging::log_info(format!(
                     "Warning: failed to read save file {}: {e}",
                     sav_path.display()
-                );
+                ));
             }
         }
     }
@@ -1549,11 +1549,9 @@ mod tests {
     #[test]
     fn test_save_ram_writes_sav_file_for_battery_cart() {
         // Given: a GameBoy with MBC5+RAM+BATTERY ROM loaded from a temp dir
-        let dir = std::env::temp_dir().join("neser_test_save_ram");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let rom_path = dir.join("test_battery.gb");
-        let sav_path = dir.join("test_battery.sav");
+        let dir = tempfile::tempdir().unwrap();
+        let rom_path = dir.path().join("test_battery.gb");
+        let sav_path = dir.path().join("test_battery.sav");
         std::fs::write(&rom_path, mbc5_battery_rom()).unwrap();
 
         let mut gb = make_gameboy();
@@ -1569,19 +1567,14 @@ mod tests {
         // Then: succeeds and .sav file exists
         assert!(result.is_ok(), "save_ram should succeed");
         assert!(sav_path.exists(), ".sav file should be created");
-
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn test_load_rom_restores_sav_file_for_battery_cart() {
         // Given: a .sav file with known data exists alongside the ROM
-        let dir = std::env::temp_dir().join("neser_test_load_sav");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-        let rom_path = dir.join("test_battery.gb");
-        let sav_path = dir.join("test_battery.sav");
+        let dir = tempfile::tempdir().unwrap();
+        let rom_path = dir.path().join("test_battery.gb");
+        let sav_path = dir.path().join("test_battery.sav");
 
         // Write a ROM and a .sav file with recognizable pattern
         std::fs::write(&rom_path, mbc5_battery_rom()).unwrap();
@@ -1607,8 +1600,5 @@ mod tests {
             ram_snapshot[42], 0xCC,
             "save data byte 42 should be restored"
         );
-
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/gb/ppu/mod.rs
+++ b/src/gb/ppu/mod.rs
@@ -934,9 +934,10 @@ mod tests {
         // Then: within two full frames of ticking, frame_ready must become true.
         // (One frame = 70,224 dots is the worst case after LCD re-enable resets timing.)
         let two_frames = (FIRST_SCANLINE_DOTS + 456 * 153) * 2;
+        let chunk: u32 = 456; // tick one scanline at a time for efficiency
         let mut became_ready = false;
-        for _ in 0..two_frames {
-            ppu.tick_dots(1);
+        for _ in (0..two_frames).step_by(chunk as usize) {
+            ppu.tick_dots(chunk);
             if ppu.is_frame_ready() {
                 became_ready = true;
                 break;

--- a/src/gb/ppu/mod.rs
+++ b/src/gb/ppu/mod.rs
@@ -410,7 +410,11 @@ impl Ppu {
         if !was_enabled && now_enabled {
             // LCD 0→1: reset timing, immediately compute LYC=LY for LY=0.
             trace_ppu!(1; "lcdc enable y={} dot={} lcdc={:02X}", self.timing.ly(), self.timing.dot(), val);
+            let pending_frame = self.timing.is_frame_ready();
             self.timing = Timing::new();
+            if pending_frame {
+                self.timing.set_frame_ready();
+            }
             self.window_line = 0;
             // Initialise prev_stat_irq_line to the LYC source state that was active
             // while the LCD was off (based on the frozen LYC=LY bit).
@@ -910,6 +914,57 @@ mod tests {
         assert!(ppu.is_frame_ready());
         ppu.clear_frame_ready();
         assert!(!ppu.is_frame_ready());
+    }
+
+    // ── LCD disable/re-enable frame_ready ─────────────────────────────────────
+
+    #[test]
+    fn test_lcd_disable_reenable_produces_frame_ready_within_two_frames() {
+        // Given: PPU mid-frame (at scanline 50), frame_ready cleared
+        let mut ppu = Ppu::new();
+        tick_dots(&mut ppu, FIRST_SCANLINE_DOTS + 456 * 49);
+        assert_eq!(ppu.timing.ly(), 50);
+        assert!(!ppu.is_frame_ready());
+
+        // When: game disables LCD, does some work, then re-enables LCD
+        ppu.write_register(0xFF40, 0x11); // LCD off (bit 7 = 0)
+        ppu.tick_dots(456 * 10); // simulate some time passing (no-op while LCD off)
+        ppu.write_register(0xFF40, 0x91); // LCD on (bit 7 = 1)
+
+        // Then: within two full frames of ticking, frame_ready must become true.
+        // (One frame = 70,224 dots is the worst case after LCD re-enable resets timing.)
+        let two_frames = (FIRST_SCANLINE_DOTS + 456 * 153) * 2;
+        let mut became_ready = false;
+        for _ in 0..two_frames {
+            ppu.tick_dots(1);
+            if ppu.is_frame_ready() {
+                became_ready = true;
+                break;
+            }
+        }
+        assert!(
+            became_ready,
+            "frame_ready must eventually become true after LCD disable/re-enable"
+        );
+    }
+
+    #[test]
+    fn test_lcd_disable_reenable_when_frame_ready_pending() {
+        // Given: PPU has completed a full frame, frame_ready is true
+        let mut ppu = Ppu::new();
+        let total = FIRST_SCANLINE_DOTS + 456 * 153;
+        tick_dots(&mut ppu, total);
+        assert!(ppu.is_frame_ready());
+
+        // When: game disables and re-enables LCD without clearing frame_ready
+        ppu.write_register(0xFF40, 0x11); // LCD off
+        ppu.write_register(0xFF40, 0x91); // LCD on
+
+        // Then: frame_ready should still be true (pending frame signal preserved)
+        assert!(
+            ppu.is_frame_ready(),
+            "LCD re-enable must not discard a pending frame_ready signal"
+        );
     }
 
     // ── Register interface ────────────────────────────────────────────────────

--- a/src/gb/ppu/timing.rs
+++ b/src/gb/ppu/timing.rs
@@ -429,6 +429,14 @@ impl Timing {
         self.frame_ready = false;
     }
 
+    /// Force the frame-ready flag to `true`.
+    ///
+    /// Used to preserve a pending frame signal across LCD disable→enable
+    /// transitions that reset the timing state.
+    pub fn set_frame_ready(&mut self) {
+        self.frame_ready = true;
+    }
+
     /// Returns the total number of completed frames since emulation started.
     ///
     /// This counter increments when LY wraps from 153 to 0 (frame boundary).


### PR DESCRIPTION
## Summary

Fixes #2189 (Sub-issue of #2187)

Two bugs found during investigation of Wario Land II freeze:

### 1. PPU LCD disable/re-enable resets frame_ready

When a game disables then re-enables the LCD (LCDC bit 7), `Timing::new()` was called which reset `frame_ready` to false. If `frame_ready` was already pending (scanline had wrapped 153 to 0), the pending frame was lost and `run_frame()` had to complete an entire additional frame.

**Fix**: Save and restore the pending `frame_ready` flag across LCD 0-to-1 transitions.

### 2. GB emulator never loads/saves .sav files

Unlike the NES emulator, the GB emulator had no `.sav` file support. Battery-backed cartridges (MBC1 type 0x03, MBC2 type 0x06, MBC5 types 0x1B/0x1E) lost all save data between sessions.

**Fix**: 
- Added `has_battery()` to cartridge types
- `save_ram_to_disk()` with atomic writes (temp file + rename)
- `load_save_ram_from_disk()` on ROM load with error logging
- Wired up `Emulator::save_ram()` trait method

### Files changed

- `src/gb/ppu/mod.rs` - Preserve frame_ready across LCD re-enable + tests
- `src/gb/ppu/timing.rs` - Added `set_frame_ready()` method
- `src/gb/cartridge/cartridge.rs` - Added `has_battery()` trait method
- `src/gb/cartridge/mbc1.rs` - Battery flag support
- `src/gb/cartridge/mbc2.rs` - Battery flag support
- `src/gb/cartridge/mbc5.rs` - Battery flag support
- `src/gb/cartridge/mod.rs` - Pass battery flag for relevant cart types
- `src/gb/bus/cgb_bus.rs` - Delegate `has_battery()`
- `src/gb/bus/dmg_bus.rs` - Delegate `has_battery()`
- `src/gb/console/gameboy.rs` - Save/load implementation + tests

### Test results

- All 8,735 library tests pass
- All 54 WASM tests pass
- All 201 Python tests pass
- All 298 npm tests pass
- Clippy clean, fmt clean

### Note

This does NOT fix the Wario Land II freeze itself. The freeze is caused by missing CGB features (HDMA, WRAM banking, double-speed mode) tracked in separate sub-issues: #2190, #2191, #2192.
