### PR TITLE
Fix #2190: Implement CGB HDMA (HBlank DMA)

### DIFF
--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -1,5 +1,6 @@
 use crate::gb::apu::Apu;
 use crate::gb::bus::GbBus;
+use crate::gb::bus::hdma::{HdmaAction, HdmaState};
 use crate::gb::cartridge::GbCartridge;
 use crate::gb::input::joypad::Joypad;
 use crate::gb::ppu::Ppu;
@@ -16,8 +17,11 @@ use crate::gb::timer::Timer;
 /// - CGB-mode PPU (`Ppu::new_cgb()`): VRAM bank 1, color palette RAM.
 /// - `$FF4F`, `$FF68`–`$FF6B`, `$FF6C` route to CGB PPU helpers.
 /// - `$FF6C` OPRI: object priority mode register.
-/// - Double-speed, WRAM banking, and HDMA are **not** implemented (not required for
+/// - Double-speed, WRAM banking are **not** implemented (not required for
 ///   cgb-acid2).
+///
+/// HDMA ($FF51–$FF55) supports both GDMA (immediate bulk transfer) and
+/// HDMA (HBlank DMA: 16 bytes per HBlank, synchronized with PPU Mode 3→0).
 ///
 /// Memory map (same as DMG unless noted):
 /// - `$0000–$7FFF`: Cartridge ROM
@@ -50,6 +54,8 @@ pub struct CgbBus {
     dma_position: u8,
     /// Whether OAM access is blocked by an active DMA transfer.
     dma_oam_blocked: bool,
+    /// CGB VRAM DMA (HDMA/GDMA) state for registers $FF51–$FF55.
+    hdma: HdmaState,
 }
 
 impl CgbBus {
@@ -74,6 +80,7 @@ impl CgbBus {
             dma_source: 0,
             dma_position: 0,
             dma_oam_blocked: false,
+            hdma: HdmaState::new(),
         };
         // Start with LCD disabled; the cartridge code will enable it.
         bus.ppu.write_register(0xFF40, 0x00);
@@ -113,6 +120,69 @@ impl CgbBus {
         }
         self.ppu.tick_dots(u32::from(m_cycles) * 4);
         self.apu.tick(m_cycles);
+
+        // HDMA: transfer one 16-byte block per HBlank (Mode 3→0).
+        if self.hdma.is_active() && self.hdma.is_hblank_mode() && self.ppu.take_hblank_entered() {
+            self.do_hdma_block_transfer();
+            // Tick subsystems forward by 8 M-cycles (the transfer duration).
+            self.tick_subsystems_for_hdma(8);
+        }
+    }
+
+    /// Execute one HDMA block transfer (16 bytes from source to VRAM).
+    fn do_hdma_block_transfer(&mut self) {
+        let vbk = self.ppu.vbk;
+        let source = self.hdma.source();
+        let dest = self.hdma.destination();
+
+        // Transfer 16 bytes: read from source via read_raw, write directly to VRAM.
+        for i in 0u16..16 {
+            let byte = self.read_raw(source.wrapping_add(i));
+            let vram_offset = dest.wrapping_add(i) as usize;
+            if vram_offset < 0x2000 {
+                if vbk & 0x01 != 0 {
+                    self.ppu.vram_bank1[vram_offset] = byte;
+                } else {
+                    self.ppu.vram[vram_offset] = byte;
+                }
+            }
+        }
+
+        // Advance addresses and decrement remaining blocks.
+        self.hdma.advance_after_block();
+    }
+
+    /// Execute a GDMA (General-Purpose DMA) — transfer all blocks at once.
+    /// Called when $FF55 is written with bit 7 = 0 and no HDMA is active.
+    fn do_gdma_transfer(&mut self) {
+        let total_blocks = self.hdma.remaining_blocks() as u32 + 1;
+
+        for _ in 0..total_blocks {
+            self.do_hdma_block_transfer();
+        }
+
+        // Tick subsystems forward by 8 M-cycles per block.
+        self.tick_subsystems_for_hdma(8 * total_blocks);
+    }
+
+    /// Tick PPU, timer, and APU forward (used during HDMA/GDMA transfers).
+    fn tick_subsystems_for_hdma(&mut self, m_cycles: u32) {
+        for _ in 0..m_cycles {
+            self.timer.tick(1);
+            if self.timer.interrupt_pending {
+                self.if_reg |= 0x04;
+                self.timer.interrupt_pending = false;
+            }
+        }
+        self.ppu.tick_dots(m_cycles * 4);
+        self.if_reg |= self.ppu.take_pending_interrupts();
+        // APU tick takes u8, so tick in chunks for large GDMA transfers.
+        let mut remaining = m_cycles;
+        while remaining > 0 {
+            let chunk = remaining.min(255) as u8;
+            self.apu.tick(chunk);
+            remaining -= u32::from(chunk);
+        }
     }
 
     /// Raw read bypassing PPU access blocking (used by OAM DMA).
@@ -196,6 +266,7 @@ impl CgbBus {
         self.dma_source = 0;
         self.dma_position = 0;
         self.dma_oam_blocked = false;
+        self.hdma = HdmaState::new();
     }
 
     // ── Save-state capture / restore ───────────────────────────────────────
@@ -217,6 +288,7 @@ impl CgbBus {
             dma_source: self.dma_source,
             dma_position: self.dma_position,
             dma_oam_blocked: self.dma_oam_blocked,
+            hdma: Some(self.hdma.clone()),
             boot_rom_active: None,
             sb: None,
             sc: None,
@@ -253,6 +325,7 @@ impl CgbBus {
         self.dma_source = state.dma_source;
         self.dma_position = state.dma_position;
         self.dma_oam_blocked = state.dma_oam_blocked;
+        self.hdma = state.hdma.clone().unwrap_or_else(HdmaState::new);
         Ok(())
     }
 
@@ -305,6 +378,9 @@ impl GbBus for CgbBus {
             0xFF10..=0xFF3F => self.apu.read_register(addr),
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B => self.ppu.read_register(addr),
             0xFF46 => self.dma_source,
+            // CGB HDMA registers
+            0xFF51..=0xFF54 => 0xFF, // HDMA1-4 are write-only
+            0xFF55 => self.hdma.read_control(),
             // CGB-specific registers
             0xFF4F | 0xFF68..=0xFF6C => self.ppu.read_cgb_register(addr).unwrap_or(0xFF),
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
@@ -342,6 +418,15 @@ impl GbBus for CgbBus {
                 self.if_reg |= self.ppu.take_pending_interrupts();
             }
             0xFF46 => self.do_oam_dma(val),
+            // CGB HDMA registers
+            0xFF51 => self.hdma.write_source_high(val),
+            0xFF52 => self.hdma.write_source_low(val),
+            0xFF53 => self.hdma.write_dest_high(val),
+            0xFF54 => self.hdma.write_dest_low(val),
+            0xFF55 => match self.hdma.write_control(val) {
+                HdmaAction::StartGdma => self.do_gdma_transfer(),
+                HdmaAction::StartHdma | HdmaAction::CancelHdma => {}
+            },
             // CGB-specific registers
             0xFF4F | 0xFF68..=0xFF6C => {
                 self.ppu.write_cgb_register(addr, val);
@@ -393,11 +478,271 @@ impl GbBus for CgbBus {
             0xFF10..=0xFF3F => self.apu.read_register(addr),
             0xFF40..=0xFF45 | 0xFF47..=0xFF4B => self.ppu.read_register(addr),
             0xFF46 => self.dma_source,
+            // CGB HDMA registers
+            0xFF51..=0xFF54 => 0xFF, // HDMA1-4 are write-only
+            0xFF55 => self.hdma.read_control(),
             // CGB-specific registers
             0xFF4F | 0xFF68..=0xFF6C => self.ppu.read_cgb_register(addr).unwrap_or(0xFF),
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
             0xFFFF => self.ie_reg,
             _ => 0xFF,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gb::cartridge::load_cartridge;
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// Build a minimal CGB ROM-only cartridge.
+    fn cgb_rom_only_cart() -> Box<dyn GbCartridge> {
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0143] = 0x80; // CGB compatible
+        rom[0x0147] = 0x00; // ROM only
+        rom[0x0148] = 0x00; // 32 KB
+        rom[0x0149] = 0x00; // no RAM
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+        load_cartridge(&rom).expect("valid ROM")
+    }
+
+    /// Build a CGB ROM-only cartridge with specific data at given addresses.
+    fn cgb_rom_with_data(data: &[(u16, u8)]) -> Box<dyn GbCartridge> {
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0143] = 0x80; // CGB compatible
+        rom[0x0147] = 0x00; // ROM only
+        rom[0x0148] = 0x00; // 32 KB
+        rom[0x0149] = 0x00; // no RAM
+        for &(addr, val) in data {
+            rom[addr as usize] = val;
+        }
+        let chk = rom[0x0134..=0x014C]
+            .iter()
+            .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+        rom[0x014D] = chk;
+        load_cartridge(&rom).expect("valid ROM")
+    }
+
+    fn make_bus() -> CgbBus {
+        CgbBus::new(cgb_rom_only_cart())
+    }
+
+    /// Enable LCD (needed for PPU to tick and reach HBlank).
+    fn enable_lcd(bus: &mut CgbBus) {
+        bus.write(0xFF40, 0x91); // LCD on, BG enabled
+    }
+
+    // ── HDMA register read/write through bus ─────────────────────────────────
+
+    #[test]
+    fn test_hdma_source_registers_are_write_only() {
+        // Given: CgbBus
+        let mut bus = make_bus();
+        // When: write to $FF51/$FF52, then read
+        bus.write(0xFF51, 0xC0);
+        bus.write(0xFF52, 0x50);
+        // Then: reads return $FF (write-only)
+        assert_eq!(bus.read(0xFF51), 0xFF);
+        assert_eq!(bus.read(0xFF52), 0xFF);
+    }
+
+    #[test]
+    fn test_hdma_dest_registers_are_write_only() {
+        // Given: CgbBus
+        let mut bus = make_bus();
+        // When: write to $FF53/$FF54, then read
+        bus.write(0xFF53, 0x80);
+        bus.write(0xFF54, 0x00);
+        // Then: reads return $FF (write-only)
+        assert_eq!(bus.read(0xFF53), 0xFF);
+        assert_eq!(bus.read(0xFF54), 0xFF);
+    }
+
+    #[test]
+    fn test_hdma5_read_ff_when_inactive() {
+        // Given: CgbBus with no transfer started
+        let mut bus = make_bus();
+        // Then: $FF55 reads $FF (inactive)
+        assert_eq!(bus.read(0xFF55), 0xFF);
+    }
+
+    // ── GDMA tests ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_gdma_transfers_data_from_wram_to_vram() {
+        // Given: CgbBus with data in WRAM at $C000-$C00F
+        let mut bus = make_bus();
+        for i in 0u8..16 {
+            bus.write(0xC000 + i as u16, i + 1);
+        }
+        // Configure HDMA: source=$C000, dest=$8000, length=0 (1 block of 16 bytes)
+        bus.write(0xFF51, 0xC0); // Source high
+        bus.write(0xFF52, 0x00); // Source low
+        bus.write(0xFF53, 0x80); // Dest high ($8000)
+        bus.write(0xFF54, 0x00); // Dest low
+        // When: trigger GDMA (bit 7=0, length=0)
+        bus.write(0xFF55, 0x00);
+        // Then: VRAM at $8000-$800F contains the transferred data
+        // Read directly from PPU VRAM (bypass PPU blocking)
+        for i in 0u8..16 {
+            assert_eq!(
+                bus.ppu.vram[i as usize],
+                i + 1,
+                "VRAM byte {} should be {}",
+                i,
+                i + 1
+            );
+        }
+        // And $FF55 reads $FF (transfer complete)
+        assert_eq!(bus.read(0xFF55), 0xFF);
+    }
+
+    #[test]
+    fn test_gdma_transfers_multiple_blocks() {
+        // Given: 2 blocks (32 bytes) of data in WRAM
+        let mut bus = make_bus();
+        for i in 0u8..32 {
+            bus.write(0xC000 + i as u16, i + 1);
+        }
+        bus.write(0xFF51, 0xC0);
+        bus.write(0xFF52, 0x00);
+        bus.write(0xFF53, 0x80);
+        bus.write(0xFF54, 0x00);
+        // When: GDMA with length=1 (2 blocks)
+        bus.write(0xFF55, 0x01);
+        // Then: 32 bytes transferred
+        for i in 0u8..32 {
+            assert_eq!(bus.ppu.vram[i as usize], i + 1);
+        }
+        assert_eq!(bus.read(0xFF55), 0xFF);
+    }
+
+    #[test]
+    fn test_gdma_transfers_from_rom_to_vram() {
+        // Given: ROM data at $0100-$010F
+        let data: Vec<(u16, u8)> = (0..16).map(|i| (0x0100 + i as u16, 0xA0 + i)).collect();
+        let cart = cgb_rom_with_data(&data);
+        let mut bus = CgbBus::new(cart);
+        // Configure HDMA: source=$0100, dest=$8000, 1 block
+        bus.write(0xFF51, 0x01); // Source high
+        bus.write(0xFF52, 0x00); // Source low
+        bus.write(0xFF53, 0x80); // Dest high
+        bus.write(0xFF54, 0x00); // Dest low
+        // When: GDMA
+        bus.write(0xFF55, 0x00);
+        // Then: data transferred from ROM to VRAM
+        for i in 0u8..16 {
+            assert_eq!(bus.ppu.vram[i as usize], 0xA0 + i);
+        }
+    }
+
+    #[test]
+    fn test_gdma_respects_vram_bank_selection() {
+        // Given: VBK=1 (VRAM bank 1), data in WRAM
+        let mut bus = make_bus();
+        for i in 0u8..16 {
+            bus.write(0xC000 + i as u16, 0xBB);
+        }
+        bus.write(0xFF4F, 0x01); // Select VRAM bank 1
+        bus.write(0xFF51, 0xC0);
+        bus.write(0xFF52, 0x00);
+        bus.write(0xFF53, 0x80);
+        bus.write(0xFF54, 0x00);
+        // When: GDMA
+        bus.write(0xFF55, 0x00);
+        // Then: data written to VRAM bank 1
+        for i in 0u8..16 {
+            assert_eq!(bus.ppu.vram_bank1[i as usize], 0xBB);
+        }
+        // And VRAM bank 0 untouched
+        for i in 0u8..16 {
+            assert_eq!(bus.ppu.vram[i as usize], 0x00);
+        }
+    }
+
+    // ── HDMA (HBlank DMA) tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_hdma_start_marks_active() {
+        // Given: CgbBus with HDMA configured
+        let mut bus = make_bus();
+        bus.write(0xFF51, 0xC0);
+        bus.write(0xFF52, 0x00);
+        bus.write(0xFF53, 0x80);
+        bus.write(0xFF54, 0x00);
+        // When: start HDMA (bit 7=1, length=1 → 2 blocks)
+        bus.write(0xFF55, 0x81);
+        // Then: $FF55 reads 0x01 (active, 2 blocks remaining)
+        assert_eq!(bus.read(0xFF55), 0x01);
+    }
+
+    #[test]
+    fn test_hdma_transfers_on_hblank() {
+        // Given: HDMA configured with source=$C000, dest=$8000, 1 block
+        let mut bus = make_bus();
+        enable_lcd(&mut bus);
+        for i in 0u8..16 {
+            bus.write(0xC000 + i as u16, 0x50 + i);
+        }
+        bus.write(0xFF51, 0xC0);
+        bus.write(0xFF52, 0x00);
+        bus.write(0xFF53, 0x80);
+        bus.write(0xFF54, 0x00);
+        bus.write(0xFF55, 0x80); // HDMA, 1 block (length=0)
+
+        // When: tick enough to reach HBlank on the first scanline
+        // First scanline: Mode 3→0 at dot 256, so 252 dots = 63 M-cycles from LCD enable
+        for _ in 0..64 {
+            bus.tick(1);
+        }
+
+        // Then: after HBlank, 16 bytes should be transferred to VRAM
+        for i in 0u8..16 {
+            assert_eq!(
+                bus.ppu.vram[i as usize],
+                0x50 + i,
+                "VRAM byte {} should be transferred",
+                i
+            );
+        }
+        // And transfer should be complete ($FF55 = $FF)
+        assert_eq!(bus.read(0xFF55), 0xFF);
+    }
+
+    #[test]
+    fn test_hdma_cancel_stops_transfer() {
+        // Given: active HDMA with 3 blocks
+        let mut bus = make_bus();
+        bus.write(0xFF51, 0xC0);
+        bus.write(0xFF52, 0x00);
+        bus.write(0xFF53, 0x80);
+        bus.write(0xFF54, 0x00);
+        bus.write(0xFF55, 0x82); // HDMA, 3 blocks (remaining=2)
+
+        // When: cancel by writing bit 7=0 to $FF55
+        bus.write(0xFF55, 0x00);
+
+        // Then: $FF55 reads $FF (inactive)
+        assert_eq!(bus.read(0xFF55), 0xFF);
+    }
+
+    // ── Debugger read ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_debugger_reads_hdma5() {
+        // Given: active HDMA
+        let mut bus = make_bus();
+        bus.write(0xFF51, 0xC0);
+        bus.write(0xFF52, 0x00);
+        bus.write(0xFF53, 0x80);
+        bus.write(0xFF54, 0x00);
+        bus.write(0xFF55, 0x83); // HDMA, 4 blocks
+        // Then: debugger read matches normal read
+        assert_eq!(bus.read_for_debugger(0xFF55), bus.read(0xFF55));
     }
 }

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -325,7 +325,7 @@ impl CgbBus {
         self.dma_source = state.dma_source;
         self.dma_position = state.dma_position;
         self.dma_oam_blocked = state.dma_oam_blocked;
-        self.hdma = state.hdma.clone().unwrap_or_else(HdmaState::new);
+        self.hdma = state.hdma.clone().unwrap_or_default();
         Ok(())
     }
 

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -360,6 +360,7 @@ impl DmgBus {
             dma_source: self.dma_source,
             dma_position: self.dma_position,
             dma_oam_blocked: self.dma_oam_blocked,
+            hdma: None,
             boot_rom_active: Some(self.boot_rom_active),
             sb: Some(self.sb),
             sc: Some(self.sc),

--- a/src/gb/bus/hdma.rs
+++ b/src/gb/bus/hdma.rs
@@ -30,6 +30,12 @@ pub struct HdmaState {
     hblank_mode: bool,
 }
 
+impl Default for HdmaState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HdmaState {
     /// Create a new HDMA state with all registers cleared and no active transfer.
     pub fn new() -> Self {
@@ -317,7 +323,7 @@ mod tests {
         hdma.write_dest_low(0x00);
         hdma.write_control(0x00); // GDMA, 1 block
         // When: transfer the single block
-        let mut dummy_mem = [0u8; 0x10000];
+        let dummy_mem = [0u8; 0x10000];
         let complete =
             hdma.transfer_block(&mut |addr| dummy_mem[addr as usize], &mut |_addr, _val| {});
         // Then: transfer complete, read returns $FF

--- a/src/gb/bus/hdma.rs
+++ b/src/gb/bus/hdma.rs
@@ -1,0 +1,401 @@
+use serde::{Deserialize, Serialize};
+
+/// Action requested by a write to $FF55 (HDMA5 control register).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HdmaAction {
+    /// Start a general-purpose DMA (bit 7 = 0, no active HDMA).
+    StartGdma,
+    /// Start an HBlank DMA (bit 7 = 1).
+    StartHdma,
+    /// Cancel an active HBlank DMA (bit 7 = 0 while HDMA is active).
+    CancelHdma,
+}
+
+/// CGB VRAM DMA (HDMA) state for registers $FF51–$FF55.
+///
+/// Supports two transfer modes:
+/// - **GDMA** (General-Purpose DMA): transfers all blocks at once, CPU halted.
+/// - **HDMA** (HBlank DMA): transfers one 16-byte block per HBlank (LY 0–143).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HdmaState {
+    /// Source address (full 16-bit, lower 4 bits forced to 0).
+    source: u16,
+    /// Destination offset within VRAM ($0000–$1FF0, lower 4 bits forced to 0).
+    destination: u16,
+    /// Remaining block count (0-based: 0 = 1 block of 16 bytes, 0x7F = 128 blocks).
+    remaining_blocks: u8,
+    /// Whether a transfer is currently active.
+    active: bool,
+    /// `true` for HBlank DMA, `false` for GDMA.
+    hblank_mode: bool,
+}
+
+impl HdmaState {
+    /// Create a new HDMA state with all registers cleared and no active transfer.
+    pub fn new() -> Self {
+        Self {
+            source: 0,
+            destination: 0,
+            remaining_blocks: 0,
+            active: false,
+            hblank_mode: false,
+        }
+    }
+
+    /// Write the high byte of the source address ($FF51 — HDMA1).
+    pub fn write_source_high(&mut self, val: u8) {
+        self.source = (self.source & 0x00F0) | (u16::from(val) << 8);
+    }
+
+    /// Write the low byte of the source address ($FF52 — HDMA2).
+    /// Lower 4 bits are ignored (forced to 0).
+    pub fn write_source_low(&mut self, val: u8) {
+        self.source = (self.source & 0xFF00) | u16::from(val & 0xF0);
+    }
+
+    /// Write the high byte of the destination address ($FF53 — HDMA3).
+    /// Only bits 4–0 of the high byte matter (destination is $8000–$9FF0).
+    pub fn write_dest_high(&mut self, val: u8) {
+        self.destination = (self.destination & 0x00F0) | (u16::from(val & 0x1F) << 8);
+    }
+
+    /// Write the low byte of the destination address ($FF54 — HDMA4).
+    /// Lower 4 bits are ignored (forced to 0).
+    pub fn write_dest_low(&mut self, val: u8) {
+        self.destination = (self.destination & 0xFF00) | u16::from(val & 0xF0);
+    }
+
+    /// Write to the control register ($FF55 — HDMA5) and return the requested action.
+    ///
+    /// - Bit 7 = 0, no active HDMA → `StartGdma` (length = lower 7 bits)
+    /// - Bit 7 = 1 → `StartHdma` (length = lower 7 bits)
+    /// - Bit 7 = 0, active HDMA → `CancelHdma`
+    pub fn write_control(&mut self, val: u8) -> HdmaAction {
+        let length = val & 0x7F;
+        let start_hblank = val & 0x80 != 0;
+
+        if self.active && self.hblank_mode && !start_hblank {
+            // Writing bit 7 = 0 while HDMA is active cancels the transfer.
+            self.active = false;
+            return HdmaAction::CancelHdma;
+        }
+
+        self.remaining_blocks = length;
+        self.active = true;
+
+        if start_hblank {
+            self.hblank_mode = true;
+            HdmaAction::StartHdma
+        } else {
+            self.hblank_mode = false;
+            HdmaAction::StartGdma
+        }
+    }
+
+    /// Read the control register ($FF55 — HDMA5).
+    ///
+    /// Returns remaining blocks in bits 0–6, and bit 7 = 1 when **inactive** (0 when active).
+    /// Returns $FF when no transfer has ever been started or after GDMA completion.
+    pub fn read_control(&self) -> u8 {
+        if self.active {
+            // Bit 7 = 0 (active), lower 7 bits = remaining blocks.
+            self.remaining_blocks & 0x7F
+        } else {
+            // Bit 7 = 1 (not active). After GDMA completion or cancellation,
+            // returns $FF (bit 7 set + lower 7 bits = $7F).
+            0xFF
+        }
+    }
+
+    /// Transfer one 16-byte block using the provided read/write closures.
+    ///
+    /// Reads 16 bytes from `source`, writes to `destination` (VRAM offset),
+    /// advances both addresses by 16, and decrements `remaining_blocks`.
+    /// Returns `true` if the transfer is now complete (no more blocks remaining).
+    pub fn transfer_block(
+        &mut self,
+        read_fn: &mut dyn FnMut(u16) -> u8,
+        write_fn: &mut dyn FnMut(u16, u8),
+    ) -> bool {
+        for i in 0u16..16 {
+            let byte = read_fn(self.source.wrapping_add(i));
+            write_fn(self.destination.wrapping_add(i), byte);
+        }
+        self.source = self.source.wrapping_add(16);
+        self.destination = self.destination.wrapping_add(16);
+
+        if self.remaining_blocks == 0 {
+            self.active = false;
+            true
+        } else {
+            self.remaining_blocks -= 1;
+            false
+        }
+    }
+
+    /// Returns `true` if a transfer (GDMA or HDMA) is active.
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Advance source/destination addresses and decrement remaining blocks
+    /// after one 16-byte block has been transferred externally.
+    ///
+    /// Used by `CgbBus` which handles the actual memory reads/writes directly
+    /// (to avoid borrow-checker issues with closures over `&mut self`).
+    /// Returns `true` if the transfer is now complete.
+    pub fn advance_after_block(&mut self) -> bool {
+        self.source = self.source.wrapping_add(16);
+        self.destination = self.destination.wrapping_add(16);
+
+        if self.remaining_blocks == 0 {
+            self.active = false;
+            true
+        } else {
+            self.remaining_blocks -= 1;
+            false
+        }
+    }
+
+    /// Returns `true` if the active transfer is HBlank DMA.
+    pub fn is_hblank_mode(&self) -> bool {
+        self.hblank_mode
+    }
+
+    /// Returns the current source address.
+    pub fn source(&self) -> u16 {
+        self.source
+    }
+
+    /// Returns the current VRAM destination offset.
+    pub fn destination(&self) -> u16 {
+        self.destination
+    }
+
+    /// Returns the number of remaining blocks (0-based).
+    pub fn remaining_blocks(&self) -> u8 {
+        self.remaining_blocks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Source register tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_write_source_high_sets_upper_byte() {
+        // Given: fresh HdmaState
+        let mut hdma = HdmaState::new();
+        // When: write $C0 to HDMA1 (source high)
+        hdma.write_source_high(0xC0);
+        // Then: source address upper byte is $C0
+        assert_eq!(hdma.source() & 0xFF00, 0xC000);
+    }
+
+    #[test]
+    fn test_write_source_low_masks_lower_4_bits() {
+        // Given: fresh HdmaState
+        let mut hdma = HdmaState::new();
+        // When: write $3F to HDMA2 (source low)
+        hdma.write_source_low(0x3F);
+        // Then: lower 4 bits are forced to 0, so source low byte is $30
+        assert_eq!(hdma.source() & 0x00FF, 0x0030);
+    }
+
+    #[test]
+    fn test_write_source_preserves_other_byte() {
+        // Given: HdmaState with source high set to $C0
+        let mut hdma = HdmaState::new();
+        hdma.write_source_high(0xC0);
+        // When: write $50 to source low
+        hdma.write_source_low(0x50);
+        // Then: full source is $C050
+        assert_eq!(hdma.source(), 0xC050);
+    }
+
+    // ── Destination register tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_write_dest_high_masks_upper_3_bits() {
+        // Given: fresh HdmaState
+        let mut hdma = HdmaState::new();
+        // When: write $9F to HDMA3 (dest high)
+        hdma.write_dest_high(0x9F);
+        // Then: upper 3 bits ignored, only bits 4–0 preserved → $1F
+        assert_eq!(hdma.destination() >> 8, 0x1F);
+    }
+
+    #[test]
+    fn test_write_dest_low_masks_lower_4_bits() {
+        // Given: fresh HdmaState
+        let mut hdma = HdmaState::new();
+        // When: write $AB to HDMA4 (dest low)
+        hdma.write_dest_low(0xAB);
+        // Then: lower 4 bits forced to 0 → $A0
+        assert_eq!(hdma.destination() & 0x00FF, 0x00A0);
+    }
+
+    #[test]
+    fn test_write_dest_preserves_other_byte() {
+        // Given: HdmaState with dest high set to $80
+        let mut hdma = HdmaState::new();
+        hdma.write_dest_high(0x80);
+        // When: write $F0 to dest low
+        hdma.write_dest_low(0xF0);
+        // Then: full destination is $00F0 (high bits masked: $80 & $1F = $00)
+        assert_eq!(hdma.destination(), 0x00F0);
+    }
+
+    // ── Control register write tests ────────────────────────────────────────
+
+    #[test]
+    fn test_write_control_bit7_clear_starts_gdma() {
+        // Given: no active transfer
+        let mut hdma = HdmaState::new();
+        // When: write $0F to HDMA5 (bit 7=0, length=0x0F → 16 blocks)
+        let action = hdma.write_control(0x0F);
+        // Then: GDMA started
+        assert_eq!(action, HdmaAction::StartGdma);
+        assert!(hdma.is_active());
+        assert!(!hdma.is_hblank_mode());
+        assert_eq!(hdma.remaining_blocks(), 0x0F);
+    }
+
+    #[test]
+    fn test_write_control_bit7_set_starts_hdma() {
+        // Given: no active transfer
+        let mut hdma = HdmaState::new();
+        // When: write $83 to HDMA5 (bit 7=1, length=$03 → 4 blocks)
+        let action = hdma.write_control(0x83);
+        // Then: HDMA started
+        assert_eq!(action, HdmaAction::StartHdma);
+        assert!(hdma.is_active());
+        assert!(hdma.is_hblank_mode());
+        assert_eq!(hdma.remaining_blocks(), 0x03);
+    }
+
+    #[test]
+    fn test_write_control_bit7_clear_during_active_hdma_cancels() {
+        // Given: active HDMA transfer
+        let mut hdma = HdmaState::new();
+        hdma.write_control(0x83); // Start HDMA
+        // When: write $00 to HDMA5 (bit 7=0 while HDMA active)
+        let action = hdma.write_control(0x00);
+        // Then: HDMA cancelled
+        assert_eq!(action, HdmaAction::CancelHdma);
+        assert!(!hdma.is_active());
+    }
+
+    // ── Control register read tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_read_control_when_inactive_returns_ff() {
+        // Given: no transfer ever started
+        let hdma = HdmaState::new();
+        // Then: $FF (bit 7 set = inactive, lower bits all 1)
+        assert_eq!(hdma.read_control(), 0xFF);
+    }
+
+    #[test]
+    fn test_read_control_during_active_hdma_returns_remaining() {
+        // Given: active HDMA with 4 blocks remaining (remaining_blocks = 3)
+        let mut hdma = HdmaState::new();
+        hdma.write_control(0x83); // Start HDMA, length=$03
+        // Then: bit 7 = 0 (active), lower 7 bits = 3
+        assert_eq!(hdma.read_control(), 0x03);
+    }
+
+    #[test]
+    fn test_read_control_after_gdma_completion_returns_ff() {
+        // Given: GDMA with 1 block (length=0)
+        let mut hdma = HdmaState::new();
+        hdma.write_source_high(0xC0);
+        hdma.write_source_low(0x00);
+        hdma.write_dest_high(0x80);
+        hdma.write_dest_low(0x00);
+        hdma.write_control(0x00); // GDMA, 1 block
+        // When: transfer the single block
+        let mut dummy_mem = [0u8; 0x10000];
+        let complete =
+            hdma.transfer_block(&mut |addr| dummy_mem[addr as usize], &mut |_addr, _val| {});
+        // Then: transfer complete, read returns $FF
+        assert!(complete);
+        assert_eq!(hdma.read_control(), 0xFF);
+    }
+
+    // ── Transfer block tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_transfer_block_copies_16_bytes() {
+        // Given: source at $C000, destination at $0000 (VRAM offset)
+        let mut hdma = HdmaState::new();
+        hdma.write_source_high(0xC0);
+        hdma.write_source_low(0x00);
+        hdma.write_dest_high(0x80);
+        hdma.write_dest_low(0x00);
+        hdma.write_control(0x00); // GDMA, 1 block
+
+        let mut src_mem = [0u8; 0x10000];
+        for i in 0..16u8 {
+            src_mem[0xC000 + i as usize] = i + 1;
+        }
+        let mut dest_writes: Vec<(u16, u8)> = Vec::new();
+
+        // When: transfer one block
+        hdma.transfer_block(&mut |addr| src_mem[addr as usize], &mut |addr, val| {
+            dest_writes.push((addr, val))
+        });
+
+        // Then: 16 bytes written to VRAM offsets $0000–$000F
+        assert_eq!(dest_writes.len(), 16);
+        for i in 0..16u16 {
+            assert_eq!(dest_writes[i as usize], (i, (i + 1) as u8));
+        }
+    }
+
+    #[test]
+    fn test_transfer_block_advances_addresses() {
+        // Given: source at $C000, dest at $0000, 2 blocks
+        let mut hdma = HdmaState::new();
+        hdma.write_source_high(0xC0);
+        hdma.write_source_low(0x00);
+        hdma.write_dest_high(0x80);
+        hdma.write_dest_low(0x00);
+        hdma.write_control(0x01); // GDMA, 2 blocks (remaining=1)
+
+        let dummy_mem = [0u8; 0x10000];
+        // When: transfer first block
+        let complete =
+            hdma.transfer_block(&mut |addr| dummy_mem[addr as usize], &mut |_addr, _val| {});
+        // Then: not complete, addresses advanced by 16
+        assert!(!complete);
+        assert_eq!(hdma.source(), 0xC010);
+        assert_eq!(hdma.destination(), 0x0010);
+        assert_eq!(hdma.remaining_blocks(), 0x00);
+
+        // When: transfer second block
+        let complete =
+            hdma.transfer_block(&mut |addr| dummy_mem[addr as usize], &mut |_addr, _val| {});
+        // Then: complete
+        assert!(complete);
+    }
+
+    #[test]
+    fn test_transfer_block_returns_true_on_last_block() {
+        // Given: GDMA with 1 block
+        let mut hdma = HdmaState::new();
+        hdma.write_source_high(0xC0);
+        hdma.write_source_low(0x00);
+        hdma.write_dest_high(0x80);
+        hdma.write_dest_low(0x00);
+        hdma.write_control(0x00); // 1 block (remaining=0)
+
+        let dummy_mem = [0u8; 0x10000];
+        let complete =
+            hdma.transfer_block(&mut |addr| dummy_mem[addr as usize], &mut |_addr, _val| {});
+        assert!(complete);
+        assert!(!hdma.is_active());
+    }
+}

--- a/src/gb/bus/mod.rs
+++ b/src/gb/bus/mod.rs
@@ -7,3 +7,4 @@ pub use dmg_bus::DmgBus;
 mod bus;
 mod cgb_bus;
 mod dmg_bus;
+pub mod hdma;

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -1019,7 +1019,11 @@ mod tests {
         let mut state = gb.save_state_bytes().unwrap();
         // Corrupt the version field in the JSON
         let json_str = String::from_utf8(state).unwrap();
-        let corrupted = json_str.replacen("\"version\":1", "\"version\":9999", 1);
+        let corrupted = json_str.replacen(
+            &format!("\"version\":{}", GB_SAVESTATE_VERSION),
+            "\"version\":9999",
+            1,
+        );
         state = corrupted.into_bytes();
         let result = gb.load_state_bytes(&state);
         assert!(result.is_err());

--- a/src/gb/console/save_state.rs
+++ b/src/gb/console/save_state.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
 use crate::gb::apu::Apu;
+use crate::gb::bus::hdma::HdmaState;
 use crate::gb::cpu::{Registers, Sm83};
 use crate::gb::input::joypad::Joypad;
 use crate::gb::model::DmgModel;
@@ -20,7 +21,7 @@ use crate::gb::timer::Timer;
 
 /// Current save-state format version for Game Boy.
 /// Increment this when making breaking changes to the state format.
-pub const GB_SAVESTATE_VERSION: u32 = 1;
+pub const GB_SAVESTATE_VERSION: u32 = 2;
 
 /// Identifies which bus variant was active when the state was saved.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,6 +60,8 @@ pub struct BusState {
     pub dma_source: u8,
     pub dma_position: u8,
     pub dma_oam_blocked: bool,
+    // CGB HDMA state (None for DMG)
+    pub hdma: Option<HdmaState>,
     // DMG-only fields (None for CGB)
     pub boot_rom_active: Option<bool>,
     pub sb: Option<u8>,
@@ -231,8 +234,8 @@ mod tests {
     // ── Version checks ─────────────────────────────────────────────────────
 
     #[test]
-    fn test_gb_savestate_version_is_1() {
-        assert_eq!(GB_SAVESTATE_VERSION, 1);
+    fn test_gb_savestate_version_is_2() {
+        assert_eq!(GB_SAVESTATE_VERSION, 2);
     }
 
     // ── DMG round-trip ─────────────────────────────────────────────────────

--- a/src/gb/ppu/mod.rs
+++ b/src/gb/ppu/mod.rs
@@ -72,6 +72,9 @@ pub struct Ppu {
     pub ocps: u8,
     /// `$FF6C` OPRI bit 0 — Object priority mode: `false`=OAM order (CGB), `true`=X-coord (DMG).
     pub opri: bool,
+    /// Set by `tick_one_dot()` on Mode 3→Mode 0 (HBlank entry) for HDMA synchronization.
+    /// Consumed by `take_hblank_entered()`.
+    hblank_entered: bool,
 }
 
 impl Ppu {
@@ -94,6 +97,7 @@ impl Ppu {
             bcps: 0,
             ocps: 0,
             opri: false,
+            hblank_entered: false,
         }
     }
 
@@ -184,6 +188,7 @@ impl Ppu {
 
         // Render the current visible scanline when Mode 3→Mode 0 transition fires.
         if events.render_scanline {
+            self.hblank_entered = true;
             let scanline = self.timing.ly();
             if self.cgb_mode {
                 rendering::render_scanline_cgb(
@@ -520,6 +525,17 @@ impl Ppu {
         let flags = self.pending_interrupts;
         self.pending_interrupts = 0;
         flags
+    }
+
+    // ── HDMA interface ────────────────────────────────────────────────────────
+
+    /// Returns `true` if HBlank was entered since the last call, then clears the flag.
+    ///
+    /// Used by `CgbBus` to synchronize HDMA transfers with Mode 3→Mode 0 transitions.
+    pub fn take_hblank_entered(&mut self) -> bool {
+        let entered = self.hblank_entered;
+        self.hblank_entered = false;
+        entered
     }
 
     // ── Frame output ──────────────────────────────────────────────────────────
@@ -1671,5 +1687,83 @@ mod tests {
         tick_dots(&mut ppu, 10);
         // Then: dot() returns 14
         assert_eq!(ppu.dot(), 14);
+    }
+
+    // ── HBlank-entered flag (HDMA synchronization) ───────────────────────────
+
+    #[test]
+    fn test_hblank_entered_flag_set_on_mode3_to_mode0_transition() {
+        // Given: PPU at start (first scanline, dot=4, Mode 0 — but no Mode 3→0 yet)
+        let mut ppu = Ppu::new();
+        // Clear any initial state
+        ppu.take_hblank_entered();
+
+        // First scanline after LCD enable: Mode 0 [4,84), Mode 3 [84,256), Mode 0 [256,456)
+        // Mode 3→0 transition fires at dot=256, which is 252 dots from dot=4.
+        tick_dots(&mut ppu, 252); // dot=4 + 252 = dot=256, Mode 3→0 transition
+        // Then: hblank_entered is set
+        assert!(
+            ppu.take_hblank_entered(),
+            "hblank_entered should be set after Mode 3→Mode 0 transition"
+        );
+    }
+
+    #[test]
+    fn test_take_hblank_entered_clears_flag() {
+        // Given: PPU has entered HBlank (flag is set)
+        let mut ppu = Ppu::new();
+        tick_dots(&mut ppu, 252); // advance to HBlank on first scanline (dot=256)
+
+        // When: take the flag once
+        let first = ppu.take_hblank_entered();
+        // Then: first take returns true
+        assert!(first);
+
+        // When: take again without further ticks
+        let second = ppu.take_hblank_entered();
+        // Then: second take returns false (flag was cleared)
+        assert!(
+            !second,
+            "take_hblank_entered should clear the flag after first read"
+        );
+    }
+
+    #[test]
+    fn test_hblank_entered_not_set_before_mode3_ends() {
+        // Given: PPU in Mode 3 (Pixel Transfer) on first scanline
+        let mut ppu = Ppu::new();
+        tick_dots(&mut ppu, 80); // dot=84, Mode 3
+        assert_eq!(ppu.timing.mode(), PpuMode::PixelTransfer);
+
+        // Then: hblank_entered should NOT be set
+        assert!(
+            !ppu.take_hblank_entered(),
+            "hblank_entered should not be set during Mode 3"
+        );
+    }
+
+    #[test]
+    fn test_hblank_entered_fires_each_visible_scanline() {
+        // Given: PPU starting fresh
+        let mut ppu = Ppu::new();
+        ppu.take_hblank_entered(); // clear initial state
+
+        // When: advance through first scanline (452 dots)
+        tick_dots(&mut ppu, FIRST_SCANLINE_DOTS);
+
+        // Then: hblank should have fired on the first scanline
+        // (We can't be sure it's still set since the scanline wrap might have cleared it,
+        //  but let's check a normal scanline)
+        let first = ppu.take_hblank_entered();
+
+        // Advance through scanline 1 (456 dots)
+        tick_dots(&mut ppu, 456);
+        let second = ppu.take_hblank_entered();
+
+        // At least one of these should have been set (if both fire, even better)
+        assert!(
+            first || second,
+            "hblank_entered should fire at least once during visible scanlines"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements CGB VRAM DMA (registers $FF51-$FF55) with both transfer modes, fixing the Wario Land II freeze where the game busy-waits on $FF55 bit 7 for HDMA completion.

Closes #2190

## Changes

### New: `src/gb/bus/hdma.rs`
- `HdmaState` struct managing source/destination addresses, block count, active/hblank flags
- `HdmaAction` enum: `StartGdma`, `StartHdma`, `CancelHdma`
- Register masking per Pan Docs: source lower 4 bits, dest upper 3 + lower 4 bits
- `write_control()` / `read_control()` with correct bit 7 semantics
- `advance_after_block()` for CgbBus direct VRAM writes (avoids borrow-checker issues)
- 15 unit tests

### Modified: `src/gb/ppu/mod.rs`
- `hblank_entered` flag set on Mode 3 -> Mode 0 transition
- `take_hblank_entered()` read-and-clear accessor for CgbBus polling
- 4 tests

### Modified: `src/gb/bus/cgb_bus.rs`
- Register dispatch for $FF51-$FF55 in `read()`, `write()`, `read_for_debugger()`
- `do_gdma_transfer()`: immediate bulk transfer of all blocks with subsystem ticking
- `do_hdma_block_transfer()`: per-HBlank 16-byte transfer with direct VRAM writes
- `tick_subsystems_for_hdma()`: ticks timer/PPU/APU during transfers (u32 to avoid overflow)
- Save state capture/restore with `HdmaState`
- 11 integration tests

### Modified: `src/gb/console/save_state.rs`
- `GB_SAVESTATE_VERSION` bumped to 2
- `HdmaState` field added to `BusState`

### Modified: `src/gb/bus/dmg_bus.rs`
- `hdma: None` in DMG `capture_bus_state`

## Testing

- 30 new tests (15 unit + 4 PPU + 11 bus integration)
- All 789 GB tests passing
