### PR TITLE
Automate SameSuite APU integration tests + CGB PCM registers

### DIFF
--- a/src/gb/apu/apu.rs
+++ b/src/gb/apu/apu.rs
@@ -752,4 +752,66 @@ mod tests {
             "HP filter must produce negative samples once DC is removed from an oscillating channel"
         );
     }
+
+    #[test]
+    fn test_pcm12_returns_zero_when_channels_off() {
+        let apu = powered_cgb_apu();
+        // CH1 and CH2 inactive → PCM12 should be $00
+        assert_eq!(apu.read_pcm12(), 0x00);
+    }
+
+    #[test]
+    fn test_pcm34_returns_zero_when_channels_off() {
+        let apu = powered_cgb_apu();
+        // CH3 and CH4 inactive → PCM34 should be $00
+        assert_eq!(apu.read_pcm34(), 0x00);
+    }
+
+    #[test]
+    fn test_pcm12_nibble_packing() {
+        let mut apu = powered_cgb_apu();
+        // Trigger CH1 with volume 7 and 50% duty (high state)
+        apu.write_register(0xFF12, 0x70); // vol=7, no envelope
+        apu.write_register(0xFF11, 0x80); // 50% duty
+        apu.write_register(0xFF13, 0x00);
+        apu.write_register(0xFF14, 0x87); // trigger + length disable
+        // Trigger CH2 with volume 5
+        apu.write_register(0xFF17, 0x50); // vol=5, no envelope
+        apu.write_register(0xFF16, 0x80); // 50% duty
+        apu.write_register(0xFF18, 0x00);
+        apu.write_register(0xFF19, 0x87); // trigger + length disable
+
+        // Tick a bit to ensure channels are active and output non-zero
+        apu.tick(10);
+
+        let pcm12 = apu.read_pcm12();
+        // Low nibble = CH1, high nibble = CH2
+        // Exact values depend on duty position, but both should be non-zero
+        // when active and DAC on with volume > 0
+        let ch1_out = pcm12 & 0x0F;
+        let ch2_out = (pcm12 >> 4) & 0x0F;
+
+        // At least one of them should output (depends on duty cycle position)
+        assert!(
+            ch1_out > 0 || ch2_out > 0,
+            "At least one pulse channel should output non-zero in PCM12"
+        );
+    }
+
+    #[test]
+    fn test_pcm_returns_zero_when_apu_powered_off() {
+        let mut apu = powered_cgb_apu();
+        // Trigger some channels
+        apu.write_register(0xFF12, 0xF0);
+        apu.write_register(0xFF14, 0x80);
+        apu.write_register(0xFF17, 0xF0);
+        apu.write_register(0xFF19, 0x80);
+
+        // Power off APU
+        apu.write_register(0xFF26, 0x00);
+
+        // PCM registers should return 0 when powered off
+        assert_eq!(apu.read_pcm12(), 0x00);
+        assert_eq!(apu.read_pcm34(), 0x00);
+    }
 }

--- a/src/gb/apu/apu.rs
+++ b/src/gb/apu/apu.rs
@@ -331,6 +331,24 @@ impl Apu {
         nr52
     }
 
+    /// Read PCM12 ($FF76, CGB only): digital outputs 1 & 2 [read-only].
+    ///
+    /// Low nibble = CH1 digital output (0-15), high nibble = CH2 (0-15).
+    pub fn read_pcm12(&self) -> u8 {
+        let ch1 = self.ch1.digital_output();
+        let ch2 = self.ch2.digital_output();
+        ch1 | (ch2 << 4)
+    }
+
+    /// Read PCM34 ($FF77, CGB only): digital outputs 3 & 4 [read-only].
+    ///
+    /// Low nibble = CH3 digital output (0-15), high nibble = CH4 (0-15).
+    pub fn read_pcm34(&self) -> u8 {
+        let ch3 = self.ch3.digital_output();
+        let ch4 = self.ch4.digital_output();
+        ch3 | (ch4 << 4)
+    }
+
     // ── Register write ─────────────────────────────────────────────────────
 
     /// Write an APU register.

--- a/src/gb/apu/channel1.rs
+++ b/src/gb/apu/channel1.rs
@@ -97,6 +97,15 @@ impl Channel1 {
         }
     }
 
+    /// Digital output (0-15) before DAC conversion (for PCM12 register).
+    pub fn digital_output(&self) -> u8 {
+        if !self.active || !self.dac_on {
+            return 0;
+        }
+        let bit = super::apu::DUTY_TABLE[self.duty as usize][self.duty_pos as usize];
+        if bit == 1 { self.volume } else { 0 }
+    }
+
     /// Advance the frequency timer by one M-cycle (= 4 T-cycles).
     pub fn tick(&mut self) {
         let period = (2048 - self.freq) * 4;

--- a/src/gb/apu/channel2.rs
+++ b/src/gb/apu/channel2.rs
@@ -74,6 +74,15 @@ impl Channel2 {
         }
     }
 
+    /// Digital output (0-15) before DAC conversion (for PCM12 register).
+    pub fn digital_output(&self) -> u8 {
+        if !self.active || !self.dac_on {
+            return 0;
+        }
+        let bit = super::apu::DUTY_TABLE[self.duty as usize][self.duty_pos as usize];
+        if bit == 1 { self.volume } else { 0 }
+    }
+
     pub fn tick(&mut self) {
         let period = (2048 - self.freq) * 4;
         if self.freq_timer == 0 {

--- a/src/gb/apu/channel3.rs
+++ b/src/gb/apu/channel3.rs
@@ -88,6 +88,20 @@ impl Channel3 {
         (self.current_sample >> shift) as f32 / 15.0
     }
 
+    /// Digital output (0-15) before DAC conversion (for PCM34 register).
+    pub fn digital_output(&self) -> u8 {
+        if !self.active || !self.dac_on {
+            return 0;
+        }
+        let shift = match self.output_level {
+            1 => 0,
+            2 => 1,
+            3 => 2,
+            _ => return 0, // output_level 0 = mute
+        };
+        self.current_sample >> shift
+    }
+
     /// Advance the wave frequency timer by one M-cycle (= 2 APU cycles at 2 MHz).
     /// Mirrors SameBoy's `while (cycles_left > sample_countdown)` loop exactly.
     /// The countdown is in APU cycles; reload = `freq ^ 0x7FF` = `2047 - freq`.

--- a/src/gb/apu/channel4.rs
+++ b/src/gb/apu/channel4.rs
@@ -75,6 +75,19 @@ impl Channel4 {
         }
     }
 
+    /// Digital output (0-15) before DAC conversion (for PCM34 register).
+    pub fn digital_output(&self) -> u8 {
+        if !self.active || !self.dac_on {
+            return 0;
+        }
+        // LFSR bit 0 low = channel output high.
+        if self.lfsr & 0x01 == 0 {
+            self.volume
+        } else {
+            0
+        }
+    }
+
     fn freq_timer_period(&self) -> u32 {
         DIVISORS[self.divisor_code as usize] << self.clock_shift
     }

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -523,6 +523,9 @@ impl GbBus for CgbBus {
             0xFF55 => self.hdma.read_control(),
             // CGB-specific registers
             0xFF4F | 0xFF68..=0xFF6C => self.ppu.read_cgb_register(addr).unwrap_or(0xFF),
+            // CGB PCM registers
+            0xFF76 => self.apu.read_pcm12(),
+            0xFF77 => self.apu.read_pcm34(),
             0xFF70 => self.svbk | 0xF8,
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
             0xFFFF => self.ie_reg,
@@ -646,6 +649,9 @@ impl GbBus for CgbBus {
             0xFF55 => self.hdma.read_control(),
             // CGB-specific registers
             0xFF4F | 0xFF68..=0xFF6C => self.ppu.read_cgb_register(addr).unwrap_or(0xFF),
+            // CGB PCM registers
+            0xFF76 => self.apu.read_pcm12(),
+            0xFF77 => self.apu.read_pcm34(),
             0xFF70 => self.svbk | 0xF8,
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize],
             0xFFFF => self.ie_reg,

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -587,6 +587,8 @@ impl GbBus for CgbBus {
                 self.ppu.write_cgb_register(addr, val);
             }
             0xFF50 => {} // No boot ROM to unmap on CGB bus
+            // CGB PCM registers (read-only; ignore writes)
+            0xFF76 | 0xFF77 => {}
             0xFF70 => self.svbk = val & 0x07,
             0xFF80..=0xFFFE => self.hram[(addr - 0xFF80) as usize] = val,
             0xFFFF => self.ie_reg = val,

--- a/src/gb/integration_tests/mod.rs
+++ b/src/gb/integration_tests/mod.rs
@@ -2,3 +2,4 @@ pub mod acid_tests;
 pub mod blargg_tests;
 pub mod boot_tests;
 pub mod mooneye_tests;
+pub mod samesuite_apu_tests;

--- a/src/gb/integration_tests/samesuite_apu_tests.rs
+++ b/src/gb/integration_tests/samesuite_apu_tests.rs
@@ -82,13 +82,14 @@ fn run_samesuite_apu_rom(path: &str, hardware: SameSuiteHardware) -> MooneyeResu
 
 macro_rules! assert_samesuite_pass {
     ($path:expr, $hardware:expr) => {
-        let result = run_samesuite_apu_rom($path, $hardware);
+        let path = $path;
+        let result = run_samesuite_apu_rom(path, $hardware);
         assert_eq!(
             result,
             MooneyeResult::Pass,
             "SameSuite APU test failed: {:?} — ROM: {}",
             result,
-            $path
+            path
         );
     };
 }

--- a/src/gb/integration_tests/samesuite_apu_tests.rs
+++ b/src/gb/integration_tests/samesuite_apu_tests.rs
@@ -1,0 +1,523 @@
+use crate::gb::bus::{CgbBus, DmgBus, GbBus};
+use crate::gb::cartridge::load_cartridge;
+use crate::gb::console::Gb;
+use crate::gb::integration_tests::mooneye_tests::MooneyeResult;
+use crate::gb::model::{CgbModel, DmgModel};
+
+const BASE: &str = "roms/gb/automated_tests/SameSuite/apu";
+const SAME_SUITE_CYCLE_LIMIT: u64 = 15_000_000;
+const LD_B_B: u8 = 0x40;
+const FIBO_B: u8 = 3;
+const FIBO_C: u8 = 5;
+const FIBO_D: u8 = 8;
+const FIBO_E: u8 = 13;
+const FIBO_H: u8 = 21;
+const FIBO_L: u8 = 34;
+
+#[derive(Clone, Copy)]
+enum SameSuiteHardware {
+    DmgB,
+    Cgb(CgbModel),
+}
+
+fn load_dmg_rom(path: &str) -> Gb<DmgBus> {
+    let rom = std::fs::read(path).expect("SameSuite ROM file should be present");
+    let cart = load_cartridge(&rom).expect("valid GB ROM");
+    Gb::new(DmgBus::new(cart, DmgModel::DmgB))
+}
+
+fn load_cgb_rom(path: &str, model: CgbModel) -> Gb<CgbBus> {
+    let rom = std::fs::read(path).expect("SameSuite ROM file should be present");
+    let cart = load_cartridge(&rom).expect("valid GB ROM");
+    let mut gb = Gb::new(CgbBus::new(cart, model));
+    gb.cpu.reset_registers_cgb();
+    gb
+}
+
+fn detect_samesuite_result_with_limit<B: GbBus>(gb: &mut Gb<B>, cycle_limit: u64) -> MooneyeResult {
+    let start = gb.cycles();
+    loop {
+        let opcode = gb.cpu.bus.read(gb.cpu.regs.pc);
+        if opcode == LD_B_B {
+            let r = &gb.cpu.regs;
+            if r.b == FIBO_B
+                && r.c == FIBO_C
+                && r.d == FIBO_D
+                && r.e == FIBO_E
+                && r.h == FIBO_H
+                && r.l == FIBO_L
+            {
+                return MooneyeResult::Pass;
+            }
+            return MooneyeResult::Fail {
+                b: r.b,
+                c: r.c,
+                d: r.d,
+                e: r.e,
+                h: r.h,
+                l: r.l,
+            };
+        }
+
+        if gb.cycles().saturating_sub(start) >= cycle_limit {
+            return MooneyeResult::Timeout;
+        }
+
+        gb.step();
+    }
+}
+
+fn run_samesuite_apu_rom(path: &str, hardware: SameSuiteHardware) -> MooneyeResult {
+    match hardware {
+        SameSuiteHardware::DmgB => {
+            let mut gb = load_dmg_rom(path);
+            detect_samesuite_result_with_limit(&mut gb, SAME_SUITE_CYCLE_LIMIT)
+        }
+        SameSuiteHardware::Cgb(model) => {
+            let mut gb = load_cgb_rom(path, model);
+            detect_samesuite_result_with_limit(&mut gb, SAME_SUITE_CYCLE_LIMIT)
+        }
+    }
+}
+
+macro_rules! assert_samesuite_pass {
+    ($path:expr, $hardware:expr) => {
+        let result = run_samesuite_apu_rom($path, $hardware);
+        assert_eq!(
+            result,
+            MooneyeResult::Pass,
+            "SameSuite APU test failed: {:?} — ROM: {}",
+            result,
+            $path
+        );
+    };
+}
+
+macro_rules! samesuite_apu_test {
+    ($name:ident, $path:expr, $hardware:expr, $reason:expr) => {
+        #[test]
+        #[ignore = $reason]
+        fn $name() {
+            assert_samesuite_pass!($path, $hardware);
+        }
+    };
+}
+
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_align,
+    &format!("{BASE}/channel_1/channel_1_align.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_align_cpu,
+    &format!("{BASE}/channel_1/channel_1_align_cpu.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_delay,
+    &format!("{BASE}/channel_1/channel_1_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_duty,
+    &format!("{BASE}/channel_1/channel_1_duty.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_duty_delay,
+    &format!("{BASE}/channel_1/channel_1_duty_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_extra_length_clocking_cgb0b,
+    &format!("{BASE}/channel_1/channel_1_extra_length_clocking-cgb0B.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbB),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_freq_change,
+    &format!("{BASE}/channel_1/channel_1_freq_change.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_freq_change_timing_cgb0bc,
+    &format!("{BASE}/channel_1/channel_1_freq_change_timing-cgb0BC.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbC),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_freq_change_timing_cgbde,
+    &format!("{BASE}/channel_1/channel_1_freq_change_timing-cgbDE.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbD),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_nrx2_glitch,
+    &format!("{BASE}/channel_1/channel_1_nrx2_glitch.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_nrx2_speed_change,
+    &format!("{BASE}/channel_1/channel_1_nrx2_speed_change.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_restart,
+    &format!("{BASE}/channel_1/channel_1_restart.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_restart_nrx2_glitch,
+    &format!("{BASE}/channel_1/channel_1_restart_nrx2_glitch.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_stop_div,
+    &format!("{BASE}/channel_1/channel_1_stop_div.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_stop_restart,
+    &format!("{BASE}/channel_1/channel_1_stop_restart.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_sweep,
+    &format!("{BASE}/channel_1/channel_1_sweep.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_sweep_restart,
+    &format!("{BASE}/channel_1/channel_1_sweep_restart.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_sweep_restart_2,
+    &format!("{BASE}/channel_1/channel_1_sweep_restart_2.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_volume,
+    &format!("{BASE}/channel_1/channel_1_volume.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_1_volume_div,
+    &format!("{BASE}/channel_1/channel_1_volume_div.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_align,
+    &format!("{BASE}/channel_2/channel_2_align.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_align_cpu,
+    &format!("{BASE}/channel_2/channel_2_align_cpu.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_delay,
+    &format!("{BASE}/channel_2/channel_2_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_duty,
+    &format!("{BASE}/channel_2/channel_2_duty.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_duty_delay,
+    &format!("{BASE}/channel_2/channel_2_duty_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_extra_length_clocking_cgb0b,
+    &format!("{BASE}/channel_2/channel_2_extra_length_clocking-cgb0B.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbB),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_freq_change,
+    &format!("{BASE}/channel_2/channel_2_freq_change.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_nrx2_glitch,
+    &format!("{BASE}/channel_2/channel_2_nrx2_glitch.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_nrx2_speed_change,
+    &format!("{BASE}/channel_2/channel_2_nrx2_speed_change.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_restart,
+    &format!("{BASE}/channel_2/channel_2_restart.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_restart_nrx2_glitch,
+    &format!("{BASE}/channel_2/channel_2_restart_nrx2_glitch.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_stop_div,
+    &format!("{BASE}/channel_2/channel_2_stop_div.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_stop_restart,
+    &format!("{BASE}/channel_2/channel_2_stop_restart.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_volume,
+    &format!("{BASE}/channel_2/channel_2_volume.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_2_volume_div,
+    &format!("{BASE}/channel_2/channel_2_volume_div.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_and_glitch,
+    &format!("{BASE}/channel_3/channel_3_and_glitch.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_delay,
+    &format!("{BASE}/channel_3/channel_3_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_extra_length_clocking_cgb0,
+    &format!("{BASE}/channel_3/channel_3_extra_length_clocking-cgb0.gb"),
+    SameSuiteHardware::Cgb(CgbModel::Cgb0),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_extra_length_clocking_cgbb,
+    &format!("{BASE}/channel_3/channel_3_extra_length_clocking-cgbB.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbB),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_first_sample,
+    &format!("{BASE}/channel_3/channel_3_first_sample.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_freq_change_delay,
+    &format!("{BASE}/channel_3/channel_3_freq_change_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_restart_delay,
+    &format!("{BASE}/channel_3/channel_3_restart_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_restart_during_delay,
+    &format!("{BASE}/channel_3/channel_3_restart_during_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_restart_stop_delay,
+    &format!("{BASE}/channel_3/channel_3_restart_stop_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_shift_delay,
+    &format!("{BASE}/channel_3/channel_3_shift_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_shift_skip_delay,
+    &format!("{BASE}/channel_3/channel_3_shift_skip_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_stop_delay,
+    &format!("{BASE}/channel_3/channel_3_stop_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_stop_div,
+    &format!("{BASE}/channel_3/channel_3_stop_div.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_wave_ram_dac_on_rw,
+    &format!("{BASE}/channel_3/channel_3_wave_ram_dac_on_rw.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_wave_ram_locked_write,
+    &format!("{BASE}/channel_3/channel_3_wave_ram_locked_write.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_3_wave_ram_sync,
+    &format!("{BASE}/channel_3/channel_3_wave_ram_sync.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_align,
+    &format!("{BASE}/channel_4/channel_4_align.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_delay,
+    &format!("{BASE}/channel_4/channel_4_delay.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_equivalent_frequencies,
+    &format!("{BASE}/channel_4/channel_4_equivalent_frequencies.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_extra_length_clocking_cgb0b,
+    &format!("{BASE}/channel_4/channel_4_extra_length_clocking-cgb0B.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbB),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_freq_change,
+    &format!("{BASE}/channel_4/channel_4_freq_change.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_frequency_alignment,
+    &format!("{BASE}/channel_4/channel_4_frequency_alignment.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_lfsr,
+    &format!("{BASE}/channel_4/channel_4_lfsr.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_lfsr15,
+    &format!("{BASE}/channel_4/channel_4_lfsr15.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_lfsr_15_7,
+    &format!("{BASE}/channel_4/channel_4_lfsr_15_7.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_lfsr_7_15,
+    &format!("{BASE}/channel_4/channel_4_lfsr_7_15.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_lfsr_restart,
+    &format!("{BASE}/channel_4/channel_4_lfsr_restart.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_lfsr_restart_fast,
+    &format!("{BASE}/channel_4/channel_4_lfsr_restart_fast.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_channel_4_volume_div,
+    &format!("{BASE}/channel_4/channel_4_volume_div.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+
+samesuite_apu_test!(
+    test_samesuite_apu_div_trigger_volume_10,
+    &format!("{BASE}/div_trigger_volume_10.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_div_write_trigger,
+    &format!("{BASE}/div_write_trigger.gb"),
+    SameSuiteHardware::DmgB,
+    "Known SameSuite APU failure on neser DMG-B; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_div_write_trigger_10,
+    &format!("{BASE}/div_write_trigger_10.gb"),
+    SameSuiteHardware::DmgB,
+    "Known SameSuite APU failure on neser DMG-B; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_div_write_trigger_volume,
+    &format!("{BASE}/div_write_trigger_volume.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);
+samesuite_apu_test!(
+    test_samesuite_apu_div_write_trigger_volume_10,
+    &format!("{BASE}/div_write_trigger_volume_10.gb"),
+    SameSuiteHardware::Cgb(CgbModel::CgbE),
+    "Known SameSuite APU CGB gap on neser; tracked under issue #2038"
+);


### PR DESCRIPTION
Implements issue #2225 by adding automated integration tests for all 69 SameSuite APU ROMs and implementing the CGB PCM12/PCM34 registers required for testing.

## Changes

### SameSuite APU test harness
- New `samesuite_apu_tests.rs` with all 69 ROM-backed tests
- Uses Mooneye-style `ld b,b` stop detection and register-based pass/fail oracle
- Hardware-aware test declarations (DMG vs CGB, CGB revision variants)
- All 69 tests currently `#[ignore]` with issue reference

### CGB PCM register support
- Implement $FF76 (PCM12) and $FF77 (PCM34) read-only registers
- Add `digital_output()` methods to all four GB APU channels (returns 0-15)
- Wire PCM registers into CGB bus read path

## Test status
Current classification from full 69-test sweep:
- **0 pass**
- **2 explicit fail** (`div_write_trigger`, `div_write_trigger_10`)
- **67 timeout** (blocked on deeper APU behavior gaps)

The PCM registers eliminate the previous $FF76/$FF77 unhandled-read timeouts, allowing tests to reach their natural outcomes. The timeouts and failures indicate real APU implementation gaps tracked in #2038.

## Pre-merge checklist
- [x] All Rust tests pass (`cargo test --no-default-features --lib`: 8890 passed)
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] Formatted (`cargo fmt`)
- [x] WASM tests pass (`wasm-pack test --headless --chrome`)
- [x] Python tests pass
- [x] npm tests pass

Closes #2225