### PR TITLE
Add minimal CGB boot ROM (Production variant)

### DIFF
--- a/src/gb/boot_rom.rs
+++ b/src/gb/boot_rom.rs
@@ -292,8 +292,10 @@ pub const DMG0_BOOT_ROM: [u8; 256] = [
 
 /// Minimal CGB boot ROM (Production variant: CGB-A through CGB-E).
 ///
-/// Sets up the post-boot hardware state for CGB-native mode without animation
-/// or sound, then hands off to the cartridge at $0100.
+/// Sets up the post-boot hardware state for CGB-native mode without a boot
+/// animation or intentional startup jingle. To match required post-boot APU
+/// state, it may still perform minimal audio register initialization before
+/// handing off to the cartridge at $0100.
 ///
 /// ## Post-boot CPU state (Mooneye-verified)
 ///

--- a/src/gb/boot_rom.rs
+++ b/src/gb/boot_rom.rs
@@ -290,6 +290,152 @@ pub const DMG0_BOOT_ROM: [u8; 256] = [
     0xE0, 0x50, // LDH [$FF50], A  (unmap boot ROM → execute $0100)
 ];
 
+/// Minimal CGB boot ROM (Production variant: CGB-A through CGB-E).
+///
+/// Sets up the post-boot hardware state for CGB-native mode without animation
+/// or sound, then hands off to the cartridge at $0100.
+///
+/// ## Post-boot CPU state (Mooneye-verified)
+///
+/// | Register | Value |
+/// |----------|-------|
+/// | A        | $11   |
+/// | F        | $80 (Z=1, N=0, H=0, C=0) |
+/// | B        | $00   |
+/// | C        | $00   |
+/// | D        | $00   |
+/// | E        | $08   |
+/// | H        | $00   |
+/// | L        | $7C   |
+/// | SP       | $FFFE |
+/// | PC       | $0100 |
+///
+/// Note: Pan Docs lists different values (D=$FF, E=$56, L=$0D) but Mooneye's
+/// `misc/boot_regs-cgb.s` test verifies the above values against real hardware.
+///
+/// ## Post-boot IO state
+///
+/// | Address | Register | Value |
+/// |---------|----------|-------|
+/// | $FF26   | NR52     | $F1 (APU on, channel 1 active) |
+/// | $FF24   | NR50     | $77   |
+/// | $FF25   | NR51     | $F3   |
+/// | $FF40   | LCDC     | $91   |
+/// | $FF47   | BGP      | $FC   |
+///
+/// ## Memory layout
+///
+/// The CGB boot ROM is 2048 bytes, split into two mapped regions:
+/// - $0000-$00FF: Early initialization (256 bytes) → array indices [0..256]
+/// - $0100-$01FF: Cartridge header (NOT in boot ROM; reads go to cartridge)
+/// - $0200-$08FF: Main boot ROM code (1792 bytes) → array indices [256..2048]
+///
+/// This minimal implementation uses only the first 256 bytes.
+pub const CGB_BOOT_ROM: [u8; 2048] = {
+    let mut rom = [0u8; 2048];
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // $0000-$00FF: First mapped region (256 bytes)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── $0000: Initialize stack pointer ────────────────────────────────────
+    rom[0x00] = 0x31; // LD SP, $FFFE
+    rom[0x01] = 0xFE;
+    rom[0x02] = 0xFF;
+
+    // ── $0003: APU initialization ──────────────────────────────────────────
+    // Turn on APU
+    rom[0x03] = 0x3E; // LD A, $80
+    rom[0x04] = 0x80;
+    rom[0x05] = 0xE0; // LDH [$26], A  ; NR52 = $80 (APU on)
+    rom[0x06] = 0x26;
+
+    // Set channel 1 duty (50%) - writes $80, reads back as $BF due to mask
+    rom[0x07] = 0xE0; // LDH [$11], A  ; NR11 = $80 (reuse A=$80)
+    rom[0x08] = 0x11;
+
+    // Set channel 1 envelope
+    rom[0x09] = 0x3E; // LD A, $F3
+    rom[0x0A] = 0xF3;
+    rom[0x0B] = 0xE0; // LDH [$12], A  ; NR12 = $F3
+    rom[0x0C] = 0x12;
+
+    // Set sound panning (reuse A=$F3)
+    rom[0x0D] = 0xE0; // LDH [$25], A  ; NR51 = $F3
+    rom[0x0E] = 0x25;
+
+    // Set master volume
+    rom[0x0F] = 0x3E; // LD A, $77
+    rom[0x10] = 0x77;
+    rom[0x11] = 0xE0; // LDH [$24], A  ; NR50 = $77
+    rom[0x12] = 0x24;
+
+    // Trigger channel 1 (makes NR52 read as $F1)
+    rom[0x13] = 0x3E; // LD A, $87
+    rom[0x14] = 0x87;
+    rom[0x15] = 0xE0; // LDH [$14], A  ; NR14 = $87 (trigger, length=0, period=7)
+    rom[0x16] = 0x14;
+
+    // ── $0017: PPU initialization ──────────────────────────────────────────
+    rom[0x17] = 0x3E; // LD A, $91
+    rom[0x18] = 0x91;
+    rom[0x19] = 0xE0; // LDH [$40], A  ; LCDC = $91
+    rom[0x1A] = 0x40;
+
+    rom[0x1B] = 0x3E; // LD A, $FC
+    rom[0x1C] = 0xFC;
+    rom[0x1D] = 0xE0; // LDH [$47], A  ; BGP = $FC
+    rom[0x1E] = 0x47;
+
+    // ── $001F: Set CPU registers ───────────────────────────────────────────
+    // Set AF = $1180 (A=$11, F=$80) using HL trick:
+    // PUSH HL pushes H first, then L. POP AF pops to F first, then A.
+    // So for A=$11, F=$80: set H=$11, L=$80, PUSH HL, POP AF.
+    rom[0x1F] = 0x26; // LD H, $11
+    rom[0x20] = 0x11;
+    rom[0x21] = 0x2E; // LD L, $80
+    rom[0x22] = 0x80;
+    rom[0x23] = 0xE5; // PUSH HL
+    rom[0x24] = 0xF1; // POP AF  ; Now A=$11, F=$80
+
+    // Set B, C, D, E
+    rom[0x25] = 0x06; // LD B, $00
+    rom[0x26] = 0x00;
+    rom[0x27] = 0x0E; // LD C, $00
+    rom[0x28] = 0x00;
+    rom[0x29] = 0x16; // LD D, $00
+    rom[0x2A] = 0x00;
+    rom[0x2B] = 0x1E; // LD E, $08
+    rom[0x2C] = 0x08;
+
+    // Set H, L to final values
+    rom[0x2D] = 0x26; // LD H, $00
+    rom[0x2E] = 0x00;
+    rom[0x2F] = 0x2E; // LD L, $7C
+    rom[0x30] = 0x7C;
+
+    // ── $0031: Jump to boot exit ───────────────────────────────────────────
+    rom[0x31] = 0xC3; // JP $00FE
+    rom[0x32] = 0xFE;
+    rom[0x33] = 0x00;
+
+    // ── $0034-$00FD: Padding (zeros) ───────────────────────────────────────
+    // (already zero-initialized)
+
+    // ── $00FE: Boot exit ───────────────────────────────────────────────────
+    // Write to $FF50 to unmap boot ROM. A=$11 from earlier.
+    // After this instruction completes, PC=$0100 = cartridge entry point.
+    rom[0xFE] = 0xE0; // LDH [$50], A
+    rom[0xFF] = 0x50;
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // $0200-$08FF: Second mapped region (1792 bytes) - unused in minimal ROM
+    // ═══════════════════════════════════════════════════════════════════════
+    // (already zero-initialized)
+
+    rom
+};
+
 /// Placeholder CGB boot ROM for infrastructure testing.
 ///
 /// This is a minimal boot ROM that immediately disables itself and jumps to

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -1,5 +1,5 @@
 use crate::gb::apu::Apu;
-use crate::gb::boot_rom::CGB_PLACEHOLDER_BOOT_ROM;
+use crate::gb::boot_rom::CGB_BOOT_ROM;
 use crate::gb::bus::GbBus;
 use crate::gb::bus::hdma::{HdmaAction, HdmaState};
 use crate::gb::cartridge::GbCartridge;
@@ -162,7 +162,7 @@ impl CgbBus {
             ff73: 0x00,
             ff74: 0xFF, // Value on reset per Mooneye test and Pan Docs
             ff75: 0x00,
-            boot_rom: CGB_PLACEHOLDER_BOOT_ROM,
+            boot_rom: CGB_BOOT_ROM,
             boot_rom_active: !skip_boot_rom,
             skip_boot_rom,
         };
@@ -1590,14 +1590,12 @@ mod tests {
         // Given: CgbBus with boot ROM active
         let bus = CgbBus::new(cgb_rom_only_cart(), CgbModel::default(), false);
         // Then: $0000 should read from boot ROM
-        // Placeholder: LD A, $01 ($3E $01); LDH [$FF50], A ($E0 $50); JP $0100 ($C3 $00 $01)
-        assert_eq!(bus.read_for_debugger(0x0000), 0x3E); // LD A, n8
-        assert_eq!(bus.read_for_debugger(0x0001), 0x01); // $01
-        assert_eq!(bus.read_for_debugger(0x0002), 0xE0); // LDH [n8], A
-        assert_eq!(bus.read_for_debugger(0x0003), 0x50); // $50
-        assert_eq!(bus.read_for_debugger(0x0004), 0xC3); // JP
-        assert_eq!(bus.read_for_debugger(0x0005), 0x00); // $00
-        assert_eq!(bus.read_for_debugger(0x0006), 0x01); // $01
+        // CGB_BOOT_ROM starts with: LD SP, $FFFE ($31 $FE $FF); LD A, $80 ($3E $80)
+        assert_eq!(bus.read_for_debugger(0x0000), 0x31); // LD SP, nn
+        assert_eq!(bus.read_for_debugger(0x0001), 0xFE); // low byte of $FFFE
+        assert_eq!(bus.read_for_debugger(0x0002), 0xFF); // high byte of $FFFE
+        assert_eq!(bus.read_for_debugger(0x0003), 0x3E); // LD A, n8
+        assert_eq!(bus.read_for_debugger(0x0004), 0x80); // $80
     }
 
     #[test]
@@ -1726,6 +1724,7 @@ mod tests {
         // Given: CgbBus with boot ROM active
         let bus = CgbBus::new(cgb_rom_only_cart(), CgbModel::default(), false);
         // Then: read_raw should also return boot ROM data
-        assert_eq!(bus.read_raw(0x0000), 0x3E); // LD A, n8 opcode
+        // CGB_BOOT_ROM starts with LD SP, $FFFE (0x31)
+        assert_eq!(bus.read_raw(0x0000), 0x31); // LD SP, nn opcode
     }
 }

--- a/src/gb/integration_tests/boot_tests.rs
+++ b/src/gb/integration_tests/boot_tests.rs
@@ -312,3 +312,191 @@ fn test_dmg0_boot_sets_correct_register_state() {
     assert_eq!(gb.cpu.regs.sp, 0xFFFE, "SP after DMG-0 boot");
     assert_eq!(gb.cpu.regs.pc, 0x0100, "PC after DMG-0 boot");
 }
+
+// ============================================================================
+// CGB boot ROM tests
+// ============================================================================
+
+use crate::gb::bus::CgbBus;
+use crate::gb::model::CgbModel;
+
+/// Build a minimal 32 KiB ROM for CGB boot tests.
+///
+/// Places a `JR $-2` infinite loop at $0100 and sets the CGB compatibility
+/// flag at $0143 to indicate CGB-native mode.
+fn build_cgb_test_rom() -> Vec<u8> {
+    let mut rom = vec![0u8; 0x8000];
+    rom[0x0100] = 0x18; // JR opcode
+    rom[0x0101] = 0xFE; // offset -2 → jumps back to $0100
+    // CGB compatibility flag: $80 = CGB-compatible, $C0 = CGB-only
+    rom[0x0143] = 0x80;
+    // Cartridge type / ROM+RAM size
+    rom[0x0147] = 0x00; // ROM only
+    rom[0x0148] = 0x00; // 32 KiB
+    rom[0x0149] = 0x00; // no RAM
+    // Header checksum over $0134–$014C
+    let chk = rom[0x0134..=0x014C]
+        .iter()
+        .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+    rom[0x014D] = chk;
+    rom
+}
+
+/// Step CGB until PC reaches $0100 or cycle limit is exceeded.
+fn run_cgb_until_cartridge_entry(gb: &mut Gb<CgbBus>) -> bool {
+    let start = gb.cycles();
+    loop {
+        if gb.cpu.regs.pc == 0x0100 {
+            return true;
+        }
+        if gb.cycles().saturating_sub(start) >= BOOT_CYCLE_LIMIT {
+            return false;
+        }
+        gb.step();
+    }
+}
+
+/// Helper: boot a fresh CGB with the given model and return it at PC=$0100.
+fn boot_cgb_to_cartridge_entry(model: CgbModel) -> Gb<CgbBus> {
+    let rom = build_cgb_test_rom();
+    let cart = load_cartridge(&rom).expect("valid ROM");
+    // skip_boot_rom=false to actually run the boot ROM
+    let mut gb = Gb::new(CgbBus::new(cart, model, false));
+    let reached = run_cgb_until_cartridge_entry(&mut gb);
+    assert!(reached, "Boot ROM must reach $0100 for model {:?}", model);
+    gb
+}
+
+/// Helper: read an IO register from CGB bus.
+fn read_cgb_io(gb: &mut Gb<CgbBus>, addr: u16) -> u8 {
+    gb.cpu.bus.read(addr)
+}
+
+/// After the CGB boot ROM completes, the CPU registers must match the
+/// Mooneye-verified post-boot-ROM state.
+///
+/// Reference: Mooneye test `misc/boot_regs-cgb.s` (verified on real CGB hardware)
+#[test]
+fn test_cgb_boot_sets_correct_register_state() {
+    let gb = boot_cgb_to_cartridge_entry(CgbModel::CgbE);
+
+    assert_eq!(gb.cpu.regs.a, 0x11, "A register after CGB boot");
+    assert_eq!(gb.cpu.regs.f, 0x80, "F register after CGB boot (Z=1)");
+    assert_eq!(gb.cpu.regs.b, 0x00, "B register after CGB boot");
+    assert_eq!(gb.cpu.regs.c, 0x00, "C register after CGB boot");
+    assert_eq!(gb.cpu.regs.d, 0x00, "D register after CGB boot");
+    assert_eq!(gb.cpu.regs.e, 0x08, "E register after CGB boot");
+    assert_eq!(gb.cpu.regs.h, 0x00, "H register after CGB boot");
+    assert_eq!(gb.cpu.regs.l, 0x7C, "L register after CGB boot");
+    assert_eq!(gb.cpu.regs.sp, 0xFFFE, "SP after CGB boot");
+    assert_eq!(gb.cpu.regs.pc, 0x0100, "PC after CGB boot");
+}
+
+/// Verify key IO registers after CGB boot ROM completes.
+///
+/// Reference: Pan Docs Power Up Sequence hardware registers table
+#[test]
+fn test_cgb_boot_sets_correct_io_registers() {
+    let mut gb = boot_cgb_to_cartridge_entry(CgbModel::CgbE);
+
+    // APU registers
+    assert_eq!(read_cgb_io(&mut gb, 0xFF24), 0x77, "NR50 ($FF24)");
+    assert_eq!(read_cgb_io(&mut gb, 0xFF25), 0xF3, "NR51 ($FF25)");
+    assert_eq!(
+        read_cgb_io(&mut gb, 0xFF26),
+        0xF1,
+        "NR52 ($FF26) - APU on, CH1 active"
+    );
+
+    // PPU registers
+    assert_eq!(read_cgb_io(&mut gb, 0xFF40), 0x91, "LCDC ($FF40)");
+    assert_eq!(read_cgb_io(&mut gb, 0xFF47), 0xFC, "BGP ($FF47)");
+}
+
+/// The boot ROM must unmap itself after writing to $FF50.
+/// Subsequent reads from $0000-$00FF should return cartridge data.
+#[test]
+fn test_cgb_boot_rom_unmaps_after_completion() {
+    let mut gb = boot_cgb_to_cartridge_entry(CgbModel::CgbE);
+
+    // Boot ROM should be inactive after reaching $0100
+    assert!(
+        !gb.cpu.bus.is_boot_rom_active(),
+        "Boot ROM should be unmapped after boot completion"
+    );
+
+    // Read from $0000 should return cartridge data (all zeros in our test ROM)
+    assert_eq!(
+        read_cgb_io(&mut gb, 0x0000),
+        0x00,
+        "Read from $0000 should return cartridge data after boot"
+    );
+
+    // Read from $0100-$0101 should return our JR -2 loop
+    assert_eq!(
+        read_cgb_io(&mut gb, 0x0100),
+        0x18,
+        "Read from $0100 should return JR opcode"
+    );
+    assert_eq!(
+        read_cgb_io(&mut gb, 0x0101),
+        0xFE,
+        "Read from $0101 should return -2 offset"
+    );
+}
+
+/// CGB-A through CGB-E should produce identical post-boot state.
+///
+/// All production CGB models share the same boot ROM and should produce
+/// identical CPU register values and IO register values at $0100.
+#[test]
+fn test_cgb_a_through_e_produce_identical_post_boot_state() {
+    let mut gb_a = boot_cgb_to_cartridge_entry(CgbModel::CgbA);
+    let mut gb_e = boot_cgb_to_cartridge_entry(CgbModel::CgbE);
+
+    // CPU registers
+    assert_eq!(gb_a.cpu.regs.af(), gb_e.cpu.regs.af(), "AF: CGB-A vs CGB-E");
+    assert_eq!(gb_a.cpu.regs.bc(), gb_e.cpu.regs.bc(), "BC: CGB-A vs CGB-E");
+    assert_eq!(gb_a.cpu.regs.de(), gb_e.cpu.regs.de(), "DE: CGB-A vs CGB-E");
+    assert_eq!(gb_a.cpu.regs.hl(), gb_e.cpu.regs.hl(), "HL: CGB-A vs CGB-E");
+    assert_eq!(gb_a.cpu.regs.sp, gb_e.cpu.regs.sp, "SP: CGB-A vs CGB-E");
+
+    // Key IO registers
+    let io_addrs: &[u16] = &[0xFF24, 0xFF25, 0xFF26, 0xFF40, 0xFF47];
+    for &addr in io_addrs {
+        let a = read_cgb_io(&mut gb_a, addr);
+        let e = read_cgb_io(&mut gb_e, addr);
+        assert_eq!(
+            a, e,
+            "IO ${:04X}: CGB-A (${:02X}) vs CGB-E (${:02X})",
+            addr, a, e
+        );
+    }
+}
+
+/// The CGB boot ROM accepts any cartridge without logo verification.
+///
+/// Unlike the real Nintendo boot ROM, our IPR-free implementation does not
+/// verify the Nintendo logo, so any cartridge data is accepted.
+#[test]
+fn test_cgb_boot_accepts_any_cartridge() {
+    let mut rom = build_cgb_test_rom();
+    // Put garbage in the logo area
+    for (i, byte) in rom[0x0104..0x0134].iter_mut().enumerate() {
+        *byte = (((0x0104 + i) * 17) & 0xFF) as u8;
+    }
+    // Recompute header checksum
+    let chk = rom[0x0134..=0x014C]
+        .iter()
+        .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
+    rom[0x014D] = chk;
+
+    let cart = load_cartridge(&rom).expect("valid ROM");
+    let mut gb = Gb::new(CgbBus::new(cart, CgbModel::CgbE, false));
+    let reached = run_cgb_until_cartridge_entry(&mut gb);
+
+    assert!(
+        reached,
+        "Boot ROM must accept any cartridge and reach $0100"
+    );
+}

--- a/src/gb/integration_tests/boot_tests.rs
+++ b/src/gb/integration_tests/boot_tests.rs
@@ -10,6 +10,13 @@ use crate::gb::model::DmgModel;
 /// headroom without running forever on a lock-up scenario.
 const BOOT_CYCLE_LIMIT: u64 = 8_000_000;
 
+/// Compute the header checksum for $0134–$014C.
+fn compute_header_checksum(rom: &[u8]) -> u8 {
+    rom[0x0134..=0x014C]
+        .iter()
+        .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1))
+}
+
 /// Build a minimal 32 KiB ROM for boot tests.
 ///
 /// Places a `JR $-2` infinite loop at $0100 so the running test can detect
@@ -18,19 +25,24 @@ const BOOT_CYCLE_LIMIT: u64 = 8_000_000;
 /// verification.
 /// The header checksum at $014D is recomputed from $0134–$014C.
 fn build_test_rom(logo: [u8; 48]) -> Vec<u8> {
+    let mut rom = build_base_test_rom();
+    rom[0x0104..0x0134].copy_from_slice(&logo);
+    rom[0x014D] = compute_header_checksum(&rom);
+    rom
+}
+
+/// Build a base 32 KiB test ROM with common setup.
+///
+/// Places a `JR $-2` infinite loop at $0100 and sets cartridge type/size fields.
+/// The header checksum is NOT set; callers must set it after customizing the ROM.
+fn build_base_test_rom() -> Vec<u8> {
     let mut rom = vec![0u8; 0x8000];
     rom[0x0100] = 0x18; // JR opcode
     rom[0x0101] = 0xFE; // offset -2 → jumps back to $0100
-    rom[0x0104..0x0134].copy_from_slice(&logo);
     // Cartridge type / ROM+RAM size
     rom[0x0147] = 0x00; // ROM only
     rom[0x0148] = 0x00; // 32 KiB
     rom[0x0149] = 0x00; // no RAM
-    // Header checksum over $0134–$014C (all zero in this ROM)
-    let chk = rom[0x0134..=0x014C]
-        .iter()
-        .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
-    rom[0x014D] = chk;
     rom
 }
 
@@ -325,20 +337,10 @@ use crate::gb::model::CgbModel;
 /// Places a `JR $-2` infinite loop at $0100 and sets the CGB compatibility
 /// flag at $0143 to indicate CGB-native mode.
 fn build_cgb_test_rom() -> Vec<u8> {
-    let mut rom = vec![0u8; 0x8000];
-    rom[0x0100] = 0x18; // JR opcode
-    rom[0x0101] = 0xFE; // offset -2 → jumps back to $0100
+    let mut rom = build_base_test_rom();
     // CGB compatibility flag: $80 = CGB-compatible, $C0 = CGB-only
     rom[0x0143] = 0x80;
-    // Cartridge type / ROM+RAM size
-    rom[0x0147] = 0x00; // ROM only
-    rom[0x0148] = 0x00; // 32 KiB
-    rom[0x0149] = 0x00; // no RAM
-    // Header checksum over $0134–$014C
-    let chk = rom[0x0134..=0x014C]
-        .iter()
-        .fold(0u8, |acc, &b| acc.wrapping_sub(b).wrapping_sub(1));
-    rom[0x014D] = chk;
+    rom[0x014D] = compute_header_checksum(&rom);
     rom
 }
 
@@ -367,8 +369,8 @@ fn boot_cgb_to_cartridge_entry(model: CgbModel) -> Gb<CgbBus> {
     gb
 }
 
-/// Helper: read an IO register from CGB bus.
-fn read_cgb_io(gb: &mut Gb<CgbBus>, addr: u16) -> u8 {
+/// Helper: read a value from the CGB bus.
+fn read_cgb_bus(gb: &mut Gb<CgbBus>, addr: u16) -> u8 {
     gb.cpu.bus.read(addr)
 }
 
@@ -400,17 +402,17 @@ fn test_cgb_boot_sets_correct_io_registers() {
     let mut gb = boot_cgb_to_cartridge_entry(CgbModel::CgbE);
 
     // APU registers
-    assert_eq!(read_cgb_io(&mut gb, 0xFF24), 0x77, "NR50 ($FF24)");
-    assert_eq!(read_cgb_io(&mut gb, 0xFF25), 0xF3, "NR51 ($FF25)");
+    assert_eq!(read_cgb_bus(&mut gb, 0xFF24), 0x77, "NR50 ($FF24)");
+    assert_eq!(read_cgb_bus(&mut gb, 0xFF25), 0xF3, "NR51 ($FF25)");
     assert_eq!(
-        read_cgb_io(&mut gb, 0xFF26),
+        read_cgb_bus(&mut gb, 0xFF26),
         0xF1,
         "NR52 ($FF26) - APU on, CH1 active"
     );
 
     // PPU registers
-    assert_eq!(read_cgb_io(&mut gb, 0xFF40), 0x91, "LCDC ($FF40)");
-    assert_eq!(read_cgb_io(&mut gb, 0xFF47), 0xFC, "BGP ($FF47)");
+    assert_eq!(read_cgb_bus(&mut gb, 0xFF40), 0x91, "LCDC ($FF40)");
+    assert_eq!(read_cgb_bus(&mut gb, 0xFF47), 0xFC, "BGP ($FF47)");
 }
 
 /// The boot ROM must unmap itself after writing to $FF50.
@@ -427,19 +429,19 @@ fn test_cgb_boot_rom_unmaps_after_completion() {
 
     // Read from $0000 should return cartridge data (all zeros in our test ROM)
     assert_eq!(
-        read_cgb_io(&mut gb, 0x0000),
+        read_cgb_bus(&mut gb, 0x0000),
         0x00,
         "Read from $0000 should return cartridge data after boot"
     );
 
     // Read from $0100-$0101 should return our JR -2 loop
     assert_eq!(
-        read_cgb_io(&mut gb, 0x0100),
+        read_cgb_bus(&mut gb, 0x0100),
         0x18,
         "Read from $0100 should return JR opcode"
     );
     assert_eq!(
-        read_cgb_io(&mut gb, 0x0101),
+        read_cgb_bus(&mut gb, 0x0101),
         0xFE,
         "Read from $0101 should return -2 offset"
     );
@@ -464,8 +466,8 @@ fn test_cgb_a_through_e_produce_identical_post_boot_state() {
     // Key IO registers
     let io_addrs: &[u16] = &[0xFF24, 0xFF25, 0xFF26, 0xFF40, 0xFF47];
     for &addr in io_addrs {
-        let a = read_cgb_io(&mut gb_a, addr);
-        let e = read_cgb_io(&mut gb_e, addr);
+        let a = read_cgb_bus(&mut gb_a, addr);
+        let e = read_cgb_bus(&mut gb_e, addr);
         assert_eq!(
             a, e,
             "IO ${:04X}: CGB-A (${:02X}) vs CGB-E (${:02X})",


### PR DESCRIPTION
## Summary

Implements issue #2245: Minimal CGB boot ROM (Production) for CGB-A through CGB-E models.

## Changes

### New CGB_BOOT_ROM constant in boot_rom.rs

SM83 assembly that sets up the correct post-boot hardware state:

**CPU Registers (Mooneye-verified):**
| Register | Value |
|----------|-------|
| A | $11 |
| F | $80 (Z=1) |
| B | $00 |
| C | $00 |
| D | $00 |
| E | $08 |
| H | $00 |
| L | $7C |
| SP | $FFFE |

**Note:** Pan Docs lists different values (D=$FF, E=$56, L=$0D) but Mooneye's `misc/boot_regs-cgb.s` test is authoritative as it's verified against real CGB hardware.

**IO Registers:**
- NR52 = $F1 (APU on, channel 1 active)
- NR50 = $77 (master volume)
- NR51 = $F3 (sound panning)
- LCDC = $91 (LCD enabled)
- BGP = $FC (BG palette)

### Updated cgb_bus.rs

- Uses `CGB_BOOT_ROM` instead of placeholder
- Updated tests to match new boot ROM bytes

### New CGB boot tests in boot_tests.rs

- `test_cgb_boot_sets_correct_register_state` - CPU registers
- `test_cgb_boot_sets_correct_io_registers` - IO registers  
- `test_cgb_boot_rom_unmaps_after_completion` - Boot ROM unmapping
- `test_cgb_a_through_e_produce_identical_post_boot_state` - Model consistency
- `test_cgb_boot_accepts_any_cartridge` - No logo verification

## Testing

- All 8968 unit tests pass
- All 54 WASM tests pass
- Clippy passes with no warnings
- Python and npm tests pass

## Out of Scope

- Boot animation and sound (sub-issue #2247)
- DMG compatibility mode (sub-issue #2248)
- CGB-0 variant (sub-issue #2246)

Closes #2245