### PR TITLE
Add automatic compatibility palette selection for CGB DMG mode

### DIFF
--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -218,6 +218,8 @@ impl CgbBus {
             let palette = compat_palettes::get_palette_colors(&header);
             bus.ppu
                 .apply_dmg_compat_palettes(&palette.bg0, &palette.obj0, &palette.obj1);
+            // Enable DMG-compat mode for correct OBJ palette selection during rendering.
+            bus.ppu.set_dmg_compat(true);
         }
 
         // Initialize PPU to CGB post-boot state.
@@ -651,6 +653,15 @@ impl CgbBus {
             } else {
                 self.key0 = 0x04;
                 self.ppu.write_cgb_register(0xFF6C, 0x01); // OPRI for DMG mode
+                // Apply DMG compatibility palettes for DMG-only games
+                let mut header = [0u8; 0x4C];
+                for (i, byte) in header.iter_mut().enumerate() {
+                    *byte = self.cart.read(0x0100 + i as u16);
+                }
+                let palette = crate::gb::compat_palettes::get_palette_colors(&header);
+                self.ppu
+                    .apply_dmg_compat_palettes(&palette.bg0, &palette.obj0, &palette.obj1);
+                self.ppu.set_dmg_compat(true);
             }
             self.key0_locked = true;
         } else {

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -3,6 +3,7 @@ use crate::gb::boot_rom::{CGB_BOOT_ROM, CGB0_BOOT_ROM};
 use crate::gb::bus::GbBus;
 use crate::gb::bus::hdma::{HdmaAction, HdmaState};
 use crate::gb::cartridge::GbCartridge;
+use crate::gb::compat_palettes;
 use crate::gb::input::joypad::Joypad;
 use crate::gb::model::CgbModel;
 use crate::gb::ppu::Ppu;
@@ -204,6 +205,19 @@ impl CgbBus {
         // Set OPRI based on cartridge type when skipping boot ROM.
         if skip_boot_rom && opri_value != 0 {
             bus.ppu.write_cgb_register(0xFF6C, opri_value);
+        }
+
+        // Apply DMG compatibility palette when skipping boot ROM for DMG-only games.
+        // DMG-only games (bit 7 of $0143 clear) need colorization palettes.
+        if skip_boot_rom && !is_cgb {
+            // Read ROM header bytes $0100-$014B for palette lookup.
+            let mut header = [0u8; 0x4C];
+            for (i, byte) in header.iter_mut().enumerate() {
+                *byte = bus.cart.read(0x0100 + i as u16);
+            }
+            let palette = compat_palettes::get_palette_colors(&header);
+            bus.ppu
+                .apply_dmg_compat_palettes(&palette.bg0, &palette.obj0, &palette.obj1);
         }
 
         // Initialize PPU to CGB post-boot state.

--- a/src/gb/compat_palettes.rs
+++ b/src/gb/compat_palettes.rs
@@ -1,0 +1,540 @@
+//! CGB DMG compatibility palette selection.
+//!
+//! When a DMG-only game runs on CGB hardware, the CGB selects colorization
+//! palettes based on the game's title checksum and licensee code. This module
+//! implements the palette lookup algorithm as used by the original CGB boot ROM.
+//!
+//! Reference: SameBoy `cgb_boot.asm` and Pan Docs Power_Up_Sequence.
+
+/// ROM header offsets (relative to header start at $0100)
+const TITLE_START: usize = 0x34;
+const TITLE_END: usize = 0x43;
+const FOURTH_LETTER_OFFSET: usize = 0x37;
+const NEW_LICENSEE_HIGH: usize = 0x44;
+const NEW_LICENSEE_LOW: usize = 0x45;
+const OLD_LICENSEE: usize = 0x4B;
+
+/// Index into TITLE_CHECKSUMS where duplicates requiring tie-breaker begin.
+const FIRST_DUPLICATE_INDEX: usize = 65;
+
+/// Title checksums for games with known palettes.
+/// Index 0 is the default palette (checksum $00).
+/// Indices 0-64 are unique checksums; indices 65+ have duplicates requiring tie-breaker.
+#[rustfmt::skip]
+const TITLE_CHECKSUMS: [u8; 79] = [
+    0x00, // Default
+    0x88, // ALLEY WAY
+    0x16, // YAKUMAN
+    0x36, // BASEBALL
+    0xD1, // TENNIS
+    0xDB, // TETRIS
+    0xF2, // QIX
+    0x3C, // DR.MARIO
+    0x8C, // RADARMISSION
+    0x92, // F1RACE
+    0x3D, // YOSSY NO TAMAGO
+    0x5C, //
+    0x58, // X
+    0xC9, // MARIOLAND2
+    0x3E, // YOSSY NO COOKIE
+    0x70, // ZELDA
+    0x1D, //
+    0x59, //
+    0x69, // TETRIS FLASH
+    0x19, // DONKEY KONG
+    0x35, // MARIO'S PICROSS
+    0xA8, //
+    0x14, // POKEMON RED
+    0xAA, // POKEMON GREEN
+    0x75, // PICROSS 2
+    0x95, // YOSSY NO PANEPON
+    0x99, // KIRAKIRA KIDS
+    0x34, // GAMEBOY GALLERY
+    0x6F, // POCKETCAMERA
+    0x15, //
+    0xFF, // BALLOON KID
+    0x97, // KINGOFTHEZOO
+    0x4B, // DMG FOOTBALL
+    0x90, // WORLD CUP
+    0x17, // OTHELLO
+    0x10, // SUPER RC PRO-AM
+    0x39, // DYNABLASTER
+    0xF7, // BOY AND BLOB GB2
+    0xF6, // MEGAMAN
+    0xA2, // STAR WARS-NOA
+    0x49, //
+    0x4E, // WAVERACE
+    0x43, //
+    0x68, // LOLO2
+    0xE0, // YOSHI'S COOKIE
+    0x8B, // MYSTIC QUEST
+    0xF0, //
+    0xCE, // TOPRANKINGTENNIS
+    0x0C, // MANSELL
+    0x29, // MEGAMAN3
+    0xE8, // SPACE INVADERS
+    0xB7, // GAME&WATCH
+    0x86, // DONKEYKONGLAND95
+    0x9A, // ASTEROIDS/MISCMD
+    0x52, // STREET FIGHTER 2
+    0x01, // DEFENDER/JOUST
+    0x9D, // KILLERINSTINCT95
+    0x71, // TETRIS BLAST
+    0x9C, // PINOCCHIO
+    0xBD, //
+    0x5D, // BA.TOSHINDEN
+    0x6D, // NETTOU KOF 95
+    0x67, //
+    0x3F, // TETRIS PLUS
+    0x6B, // DONKEYKONGLAND 3
+    // Duplicates requiring fourth-letter tie-breaker (indices 65-78)
+    0xB3, // ???[B]???????? / MOGURANYA[U] / TETRIS ATTACK[R]
+    0x46, // SUPER[E] MARIOLAND / ???[R]
+    0x28, // GOLF[F] / GALAGA[A]&GALAXIAN
+    0xA5, // SOLARSTRIKER[A] / BT2RAGNAROKWORLD[R]
+    0xC6, // GBWARS[A] / KEN GRIFFEY[ ]JR
+    0xD3, // KAERUNOTAMENI[R] / ???[I]
+    0x27, // ???[B] / MAGNETIC SOCCER[N]
+    0x61, // POKEMON[E] BLUE / VEGAS[A] STAKES
+    0x18, // DONKEYKONGLAND[K] / ???[I]
+    0x66, // GAMEBOY[E] GALLERY2 / MILLI/CENTI/PEDE[L]
+    0x6A, // DONKEYKONGLAND[K] 2 / MARIO[I] & YOSHI
+    0xBF, // KID ICARUS[ ] / SOCCER[C]
+    0x0D, // TETRIS2[R] / POKEBOM[E]
+    0xF4, // ???[-] / G&W GALLERY[ ]
+];
+
+/// Fourth letter tie-breaker for duplicate checksums.
+/// For indices >= 65, the character at ROM[$0137] disambiguates between games.
+#[rustfmt::skip]
+const FOURTH_LETTER_TIEBREAKER: [u8; 29] = *b"BEFAARBEKEK R-URAR INAILICE R";
+
+/// Palette ID for each checksum index (0-93).
+/// Bit 7 ($80) indicates game requires DMG boot tilemap (logo) - we ignore this flag.
+#[rustfmt::skip]
+const PALETTE_PER_CHECKSUM: [u8; 94] = [
+     0,  4,  5, 35, 34,  3, 31, 15, 10,  5, // 0-9
+    19, 36,  7, 37, 30, 44, 21, 32, 31, 20, // 10-19 (12: X has $80 flag, masked)
+     5, 33, 13, 14,  5, 29,  5, 18,  9,  3, // 20-29
+     2, 26, 25, 25, 41, 42, 26, 45, 42, 45, // 30-39
+    36, 38, 26, 42, 30, 41, 34, 34,  5, 42, // 40-49 (42: has $80 flag, masked)
+     6,  5, 33, 25, 42, 42, 40,  2, 16, 25, // 50-59
+    42, 42,  5,  0, 39, 36, 22, 25,  6, 32, // 60-69
+    12, 36, 11, 39, 18, 39, 24, 31, 50, 17, // 70-79
+    46,  6, 27,  0, 47, 41, 41,  0,  0, 19, // 80-89
+    34, 23, 18, 29,                         // 90-93
+];
+
+/// Palette combinations: [OBJ0 index, OBJ1 index, BG index].
+/// Each index is multiplied by 8 in the boot ROM to get byte offset; we store raw indices.
+#[rustfmt::skip]
+const PALETTE_COMBINATIONS: [[u8; 3]; 55] = [
+    [ 4,  4, 29], //  0, Right + A
+    [18, 18, 18], //  1, Right
+    [20, 20, 20], //  2
+    [24, 24, 24], //  3, Down + A
+    [ 9,  9,  9], //  4
+    [ 0,  0,  0], //  5, Up
+    [27, 27, 27], //  6, Right + B
+    [ 5,  5,  5], //  7, Left + B
+    [12, 12, 12], //  8, Down
+    [26, 26, 26], //  9
+    [16,  8,  8], // 10
+    [ 4, 28, 28], // 11
+    [ 4,  2,  2], // 12
+    [ 3,  4,  4], // 13
+    [ 4, 29, 29], // 14
+    [28,  4, 28], // 15
+    [ 2, 17,  2], // 16
+    [16, 16,  8], // 17
+    [ 4,  4,  7], // 18
+    [ 4,  4, 18], // 19
+    [ 4,  4, 20], // 20
+    [19, 19,  9], // 21
+    [15, 15, 11], // 22 (raw_palette_comb 4*4-1, 4*4-1, 11*4 → indices 15, 15, 11)
+    [17, 17,  2], // 23
+    [ 4,  4,  2], // 24
+    [ 4,  4,  3], // 25
+    [28, 28,  0], // 26
+    [ 3,  3,  0], // 27
+    [ 0,  0,  1], // 28, Up + B
+    [18, 22, 18], // 29
+    [20, 22, 20], // 30
+    [24, 22, 24], // 31
+    [16, 22,  8], // 32
+    [17,  4, 13], // 33
+    [27,  0, 14], // 34 (raw_palette_comb 28*4-1, 0*4, 14*4 → indices 27, 0, 14)
+    [27,  4, 15], // 35 (raw_palette_comb 28*4-1, 4*4, 15*4 → indices 27, 4, 15)
+    [19, 23,  9], // 36 (raw_palette_comb 19*4, 23*4-1, 9*4 → indices 19, 23, 9 - but 23*4-1=91 so /4=22.75→22)
+    [16, 28, 10], // 37
+    [ 4, 23, 28], // 38
+    [17, 22,  2], // 39
+    [ 4,  0,  2], // 40, Left + A
+    [ 4, 28,  3], // 41
+    [28,  3,  0], // 42
+    [ 3, 28,  4], // 43, Up + A
+    [21, 28,  4], // 44
+    [ 3, 28,  0], // 45
+    [25,  3, 28], // 46
+    [ 0, 28,  8], // 47
+    [ 4,  3, 28], // 48, Left
+    [28,  3,  6], // 49, Down + B
+    [ 4, 28, 29], // 50
+    // SameBoy "Exclusives" (not in original CGB boot ROM)
+    [30, 30, 30], // 51, Right + A + B, CGA
+    [31, 31, 31], // 52, Left + A + B, DMG LCD
+    [28,  4,  1], // 53, Up + A + B
+    [ 0,  0,  2], // 54, Down + A + B
+];
+
+/// RGB555 palettes (4 colors each).
+/// Each color is in little-endian RGB555 format: 0bGGGRRRRRBBBBBGGG.
+#[rustfmt::skip]
+const PALETTES: [[u16; 4]; 32] = [
+    [0x7FFF, 0x32BF, 0x00D0, 0x0000], //  0
+    [0x639F, 0x4279, 0x15B0, 0x04CB], //  1
+    [0x7FFF, 0x6E31, 0x454A, 0x0000], //  2
+    [0x7FFF, 0x1BEF, 0x0200, 0x0000], //  3
+    [0x7FFF, 0x421F, 0x1CF2, 0x0000], //  4
+    [0x7FFF, 0x5294, 0x294A, 0x0000], //  5
+    [0x7FFF, 0x03FF, 0x012F, 0x0000], //  6
+    [0x7FFF, 0x03EF, 0x01D6, 0x0000], //  7
+    [0x7FFF, 0x42B5, 0x3DC8, 0x0000], //  8
+    [0x7E74, 0x03FF, 0x0180, 0x0000], //  9
+    [0x67FF, 0x77AC, 0x1A13, 0x2D6B], // 10
+    [0x7ED6, 0x4BFF, 0x2175, 0x0000], // 11
+    [0x53FF, 0x4A5F, 0x7E52, 0x0000], // 12
+    [0x4FFF, 0x7ED2, 0x3A4C, 0x1CE0], // 13
+    [0x03ED, 0x7FFF, 0x255F, 0x0000], // 14
+    [0x036A, 0x021F, 0x03FF, 0x7FFF], // 15
+    [0x7FFF, 0x01DF, 0x0112, 0x0000], // 16
+    [0x231F, 0x035F, 0x00F2, 0x0009], // 17
+    [0x7FFF, 0x03EA, 0x011F, 0x0000], // 18
+    [0x299F, 0x001A, 0x000C, 0x0000], // 19
+    [0x7FFF, 0x027F, 0x001F, 0x0000], // 20
+    [0x7FFF, 0x03E0, 0x0206, 0x0120], // 21
+    [0x7FFF, 0x7EEB, 0x001F, 0x7C00], // 22
+    [0x7FFF, 0x3FFF, 0x7E00, 0x001F], // 23
+    [0x7FFF, 0x03FF, 0x001F, 0x0000], // 24
+    [0x03FF, 0x001F, 0x000C, 0x0000], // 25
+    [0x7FFF, 0x033F, 0x0193, 0x0000], // 26
+    [0x0000, 0x4200, 0x037F, 0x7FFF], // 27
+    [0x7FFF, 0x7E8C, 0x7C00, 0x0000], // 28
+    [0x7FFF, 0x1BEF, 0x6180, 0x0000], // 29
+    // SameBoy "Exclusives"
+    [0x7FFF, 0x7FEA, 0x7D5F, 0x0000], // 30, CGA
+    [0x4778, 0x3290, 0x1D87, 0x0861], // 31, DMG LCD
+];
+
+/// DMG compatibility palette data for CGB mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DmgCompatPalette {
+    /// Background palette 0 (4 RGB555 colors)
+    pub bg0: [u16; 4],
+    /// Object palette 0 (4 RGB555 colors)
+    pub obj0: [u16; 4],
+    /// Object palette 1 (4 RGB555 colors)
+    pub obj1: [u16; 4],
+}
+
+impl Default for DmgCompatPalette {
+    fn default() -> Self {
+        // Default grayscale palette (palette combination 5 = palette 0 for all)
+        Self {
+            bg0: PALETTES[0],
+            obj0: PALETTES[0],
+            obj1: PALETTES[0],
+        }
+    }
+}
+
+/// Computes the title checksum from ROM header bytes.
+///
+/// The checksum is the sum of bytes at $0134-$0143 (title area), masked to 8 bits.
+/// `header` should start at ROM address $0100 (the entry point).
+pub fn compute_title_checksum(header: &[u8]) -> u8 {
+    if header.len() <= TITLE_END {
+        return 0;
+    }
+    header[TITLE_START..=TITLE_END]
+        .iter()
+        .fold(0u8, |acc, &b| acc.wrapping_add(b))
+}
+
+/// Checks if the cartridge is from Nintendo (old licensee $01 or new licensee "01").
+///
+/// `header` should start at ROM address $0100.
+pub fn is_nintendo_licensee(header: &[u8]) -> bool {
+    if header.len() <= OLD_LICENSEE {
+        return false;
+    }
+
+    // Old licensee code $01 = Nintendo
+    if header[OLD_LICENSEE] == 0x01 {
+        return true;
+    }
+
+    // New licensee code "01" = Nintendo (when old licensee is $33)
+    if header[OLD_LICENSEE] == 0x33 && header.len() > NEW_LICENSEE_LOW {
+        return header[NEW_LICENSEE_HIGH] == b'0' && header[NEW_LICENSEE_LOW] == b'1';
+    }
+
+    false
+}
+
+/// Gets the palette combination index for a cartridge header.
+///
+/// Returns the index into `PALETTE_COMBINATIONS` (0-54).
+/// Non-Nintendo games return 5 (grayscale).
+pub fn get_palette_id(header: &[u8]) -> u8 {
+    // Non-Nintendo games get the default grayscale palette
+    if !is_nintendo_licensee(header) {
+        return 5; // Palette combination 5 = Up button = grayscale
+    }
+
+    let checksum = compute_title_checksum(header);
+
+    // Find the checksum in the table
+    let index = TITLE_CHECKSUMS
+        .iter()
+        .position(|&c| c == checksum)
+        .unwrap_or(0);
+
+    // Handle duplicates requiring fourth-letter tie-breaker
+    let final_index = if index >= FIRST_DUPLICATE_INDEX {
+        resolve_duplicate(header, index)
+    } else {
+        index
+    };
+
+    // Get palette ID from the mapping table
+    if final_index < PALETTE_PER_CHECKSUM.len() {
+        // Mask off the $80 flag (logo tilemap indicator)
+        PALETTE_PER_CHECKSUM[final_index] & 0x7F
+    } else {
+        5 // Default grayscale
+    }
+}
+
+/// Resolves duplicate checksums using the fourth letter of the title.
+fn resolve_duplicate(header: &[u8], initial_index: usize) -> usize {
+    if header.len() <= FOURTH_LETTER_OFFSET {
+        return initial_index;
+    }
+
+    let fourth_letter = header[FOURTH_LETTER_OFFSET];
+    let tiebreaker_offset = initial_index - FIRST_DUPLICATE_INDEX;
+
+    // Check if the fourth letter matches the expected tie-breaker character
+    if tiebreaker_offset < FOURTH_LETTER_TIEBREAKER.len()
+        && fourth_letter == FOURTH_LETTER_TIEBREAKER[tiebreaker_offset]
+    {
+        // First variant (use the initial index as-is for palette lookup)
+        initial_index
+    } else {
+        // Second variant (add 14 to get the alternate palette)
+        // The duplicate entries are 14 apart in PALETTE_PER_CHECKSUM
+        initial_index + 14
+    }
+}
+
+/// Gets the DMG compatibility palette colors for a cartridge.
+///
+/// `header` should start at ROM address $0100 (at least 76 bytes, up to $014B).
+pub fn get_palette_colors(header: &[u8]) -> DmgCompatPalette {
+    let palette_id = get_palette_id(header) as usize;
+
+    if palette_id >= PALETTE_COMBINATIONS.len() {
+        return DmgCompatPalette::default();
+    }
+
+    let combination = PALETTE_COMBINATIONS[palette_id];
+    let obj0_idx = combination[0] as usize;
+    let obj1_idx = combination[1] as usize;
+    let bg_idx = combination[2] as usize;
+
+    DmgCompatPalette {
+        bg0: if bg_idx < PALETTES.len() {
+            PALETTES[bg_idx]
+        } else {
+            PALETTES[0]
+        },
+        obj0: if obj0_idx < PALETTES.len() {
+            PALETTES[obj0_idx]
+        } else {
+            PALETTES[0]
+        },
+        obj1: if obj1_idx < PALETTES.len() {
+            PALETTES[obj1_idx]
+        } else {
+            PALETTES[0]
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Creates a minimal header with title and licensee bytes.
+    fn make_header(title: &[u8; 16], old_licensee: u8) -> [u8; 0x4C] {
+        let mut header = [0u8; 0x4C];
+        header[TITLE_START..TITLE_START + 16].copy_from_slice(title);
+        header[OLD_LICENSEE] = old_licensee;
+        header
+    }
+
+    /// Creates a header with new licensee code.
+    fn make_header_new_licensee(title: &[u8; 16], new_licensee: &[u8; 2]) -> [u8; 0x4C] {
+        let mut header = [0u8; 0x4C];
+        header[TITLE_START..TITLE_START + 16].copy_from_slice(title);
+        header[NEW_LICENSEE_HIGH] = new_licensee[0];
+        header[NEW_LICENSEE_LOW] = new_licensee[1];
+        header[OLD_LICENSEE] = 0x33; // Indicates new licensee code
+        header
+    }
+
+    #[test]
+    fn test_compute_title_checksum_tetris() {
+        // "TETRIS" padded with zeros
+        let title: [u8; 16] = *b"TETRIS\0\0\0\0\0\0\0\0\0\0";
+        let header = make_header(&title, 0x01);
+        let checksum = compute_title_checksum(&header);
+        // T=0x54, E=0x45, T=0x54, R=0x52, I=0x49, S=0x53 = 0xDB + zeros = 0xDB
+        assert_eq!(checksum, 0xDB, "TETRIS checksum should be 0xDB");
+    }
+
+    #[test]
+    fn test_compute_title_checksum_empty() {
+        let title: [u8; 16] = [0u8; 16];
+        let header = make_header(&title, 0x01);
+        assert_eq!(compute_title_checksum(&header), 0x00);
+    }
+
+    #[test]
+    fn test_is_nintendo_licensee_old() {
+        let title: [u8; 16] = [0u8; 16];
+        let header = make_header(&title, 0x01);
+        assert!(is_nintendo_licensee(&header));
+    }
+
+    #[test]
+    fn test_is_nintendo_licensee_new() {
+        let title: [u8; 16] = [0u8; 16];
+        let header = make_header_new_licensee(&title, b"01");
+        assert!(is_nintendo_licensee(&header));
+    }
+
+    #[test]
+    fn test_is_nintendo_licensee_non_nintendo() {
+        let title: [u8; 16] = [0u8; 16];
+        let header = make_header(&title, 0x00);
+        assert!(!is_nintendo_licensee(&header));
+    }
+
+    #[test]
+    fn test_get_palette_id_non_nintendo() {
+        let title: [u8; 16] = [0u8; 16];
+        let header = make_header(&title, 0x00);
+        // Non-Nintendo games get palette combination 5 (grayscale)
+        assert_eq!(get_palette_id(&header), 5);
+    }
+
+    #[test]
+    fn test_get_palette_id_tetris() {
+        // TETRIS has checksum 0xDB which is at index 5 in TITLE_CHECKSUMS
+        let title: [u8; 16] = *b"TETRIS\0\0\0\0\0\0\0\0\0\0";
+        let header = make_header(&title, 0x01);
+        // PALETTE_PER_CHECKSUM[5] = 3
+        assert_eq!(get_palette_id(&header), 3);
+    }
+
+    #[test]
+    fn test_get_palette_colors_default() {
+        let title: [u8; 16] = [0u8; 16];
+        let header = make_header(&title, 0x00);
+        let palette = get_palette_colors(&header);
+        // Non-Nintendo → palette 5 → combination [0, 0, 0] → all palette 0
+        assert_eq!(palette.bg0, PALETTES[0]);
+        assert_eq!(palette.obj0, PALETTES[0]);
+        assert_eq!(palette.obj1, PALETTES[0]);
+    }
+
+    #[test]
+    fn test_get_palette_colors_tetris() {
+        let title: [u8; 16] = *b"TETRIS\0\0\0\0\0\0\0\0\0\0";
+        let header = make_header(&title, 0x01);
+        let palette = get_palette_colors(&header);
+        // TETRIS → palette 3 → combination [24, 24, 24] → all palette 24
+        assert_eq!(palette.bg0, PALETTES[24]);
+        assert_eq!(palette.obj0, PALETTES[24]);
+        assert_eq!(palette.obj1, PALETTES[24]);
+    }
+
+    #[test]
+    fn test_palette_combination_indices_in_bounds() {
+        // Verify all palette combination indices are valid
+        for (i, combination) in PALETTE_COMBINATIONS.iter().enumerate() {
+            assert!(
+                (combination[0] as usize) < PALETTES.len(),
+                "OBJ0 index {} out of bounds in combination {}",
+                combination[0],
+                i
+            );
+            assert!(
+                (combination[1] as usize) < PALETTES.len(),
+                "OBJ1 index {} out of bounds in combination {}",
+                combination[1],
+                i
+            );
+            assert!(
+                (combination[2] as usize) < PALETTES.len(),
+                "BG index {} out of bounds in combination {}",
+                combination[2],
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_palette_per_checksum_indices_in_bounds() {
+        // Verify all palette IDs map to valid combinations
+        for (i, &id) in PALETTE_PER_CHECKSUM.iter().enumerate() {
+            let masked = (id & 0x7F) as usize;
+            assert!(
+                masked < PALETTE_COMBINATIONS.len(),
+                "Palette ID {} (masked {}) out of bounds at index {}",
+                id,
+                masked,
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_duplicate_checksum_first_variant() {
+        // POKEMON BLUE has checksum 0x61 (index 72) with fourth letter 'E'
+        // Fourth letter 'E' at position 72-65=7 in tiebreaker matches
+        let title: [u8; 16] = *b"POKEMON BLUE\0\0\0\0";
+        let header = make_header(&title, 0x01);
+        let checksum = compute_title_checksum(&header);
+        assert_eq!(checksum, 0x61);
+        // Should get first variant palette
+        let palette_id = get_palette_id(&header);
+        // PALETTE_PER_CHECKSUM[72] = 11
+        assert_eq!(palette_id, 11);
+    }
+
+    #[test]
+    fn test_duplicate_checksum_second_variant() {
+        // VEGAS STAKES has checksum 0x61 but fourth letter 'A' (not 'E')
+        let title: [u8; 16] = *b"VEGAS STAKES\0\0\0\0";
+        let header = make_header(&title, 0x01);
+        let checksum = compute_title_checksum(&header);
+        assert_eq!(checksum, 0x61);
+        // Fourth letter 'A' doesn't match tiebreaker 'E', so second variant
+        let palette_id = get_palette_id(&header);
+        // PALETTE_PER_CHECKSUM[72+14] = PALETTE_PER_CHECKSUM[86] = 41
+        assert_eq!(palette_id, 41);
+    }
+}

--- a/src/gb/compat_palettes.rs
+++ b/src/gb/compat_palettes.rs
@@ -188,7 +188,8 @@ const PALETTE_COMBINATIONS: [[u8; 3]; 55] = [
 ];
 
 /// RGB555 palettes (4 colors each).
-/// Each color is in little-endian RGB555 format: 0bGGGRRRRRBBBBBGGG.
+/// Each color is a little-endian `u16` in RGB555 format: 0b0BBBBBGGGGGRRRRR
+/// (bits 0-4 = R, bits 5-9 = G, bits 10-14 = B; bit 15 unused).
 #[rustfmt::skip]
 const PALETTES: [[u16; 4]; 32] = [
     [0x7FFF, 0x32BF, 0x00D0, 0x0000], //  0
@@ -285,11 +286,11 @@ pub fn is_nintendo_licensee(header: &[u8]) -> bool {
 /// Gets the palette combination index for a cartridge header.
 ///
 /// Returns the index into `PALETTE_COMBINATIONS` (0-54).
-/// Non-Nintendo games return 5 (grayscale).
+/// Non-Nintendo games return 5 (the "Up button" default palette).
 pub fn get_palette_id(header: &[u8]) -> u8 {
-    // Non-Nintendo games get the default grayscale palette
+    // Non-Nintendo games get the default palette (combination 5)
     if !is_nintendo_licensee(header) {
-        return 5; // Palette combination 5 = Up button = grayscale
+        return 5; // Palette combination 5 = Up button
     }
 
     let checksum = compute_title_checksum(header);
@@ -312,7 +313,7 @@ pub fn get_palette_id(header: &[u8]) -> u8 {
         // Mask off the $80 flag (logo tilemap indicator)
         PALETTE_PER_CHECKSUM[final_index] & 0x7F
     } else {
-        5 // Default grayscale
+        5 // Default fallback
     }
 }
 

--- a/src/gb/mod.rs
+++ b/src/gb/mod.rs
@@ -3,6 +3,7 @@ pub mod autorun;
 pub mod boot_rom;
 pub mod bus;
 pub mod cartridge;
+pub mod compat_palettes;
 pub mod console;
 pub mod cpu;
 pub mod debugging;

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -820,6 +820,30 @@ impl Ppu {
         self.obj_palette_ram
     }
 
+    /// Apply DMG compatibility palette colors for CGB running a DMG-only game.
+    ///
+    /// Writes the given RGB555 colors to BG palette 0 and OBJ palettes 0/1.
+    /// Each palette is 4 colors × 2 bytes = 8 bytes.
+    ///
+    /// This should only be called during CGB initialization for DMG-only cartridges.
+    pub fn apply_dmg_compat_palettes(&mut self, bg0: &[u16; 4], obj0: &[u16; 4], obj1: &[u16; 4]) {
+        // Write BG palette 0 (bytes 0-7)
+        for (i, &color) in bg0.iter().enumerate() {
+            self.bg_palette_ram[i * 2] = (color & 0xFF) as u8;
+            self.bg_palette_ram[i * 2 + 1] = (color >> 8) as u8;
+        }
+        // Write OBJ palette 0 (bytes 0-7)
+        for (i, &color) in obj0.iter().enumerate() {
+            self.obj_palette_ram[i * 2] = (color & 0xFF) as u8;
+            self.obj_palette_ram[i * 2 + 1] = (color >> 8) as u8;
+        }
+        // Write OBJ palette 1 (bytes 8-15)
+        for (i, &color) in obj1.iter().enumerate() {
+            self.obj_palette_ram[8 + i * 2] = (color & 0xFF) as u8;
+            self.obj_palette_ram[8 + i * 2 + 1] = (color >> 8) as u8;
+        }
+    }
+
     /// Get current register values for debugger.
     ///
     /// Returns: (lcdc, scx, scy, bgp, obp0, obp1)

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -67,6 +67,12 @@ pub struct Ppu {
     /// Set by `tick_one_dot()` on Mode 3→Mode 0 (HBlank entry) for HDMA synchronization.
     /// Consumed by `take_hblank_entered()`.
     hblank_entered: bool,
+    /// DMG compatibility mode: `true` when a DMG-only game runs on CGB hardware.
+    ///
+    /// In this mode, the CGB renderer must map DMG OAM palette bit (0=OBP0, 1=OBP1)
+    /// to CGB OBJ palette 0/1 instead of using CGB OAM attribute bits 0-2.
+    #[serde(default)]
+    pub dmg_compat: bool,
 }
 
 impl Ppu {
@@ -90,6 +96,7 @@ impl Ppu {
             ocps: 0,
             opri: false,
             hblank_entered: false,
+            dmg_compat: false,
         }
     }
 
@@ -99,6 +106,13 @@ impl Ppu {
             cgb_mode: true,
             ..Self::new()
         }
+    }
+
+    /// Enable DMG compatibility mode for CGB running a DMG-only game.
+    ///
+    /// This affects sprite palette selection in the CGB renderer.
+    pub fn set_dmg_compat(&mut self, enabled: bool) {
+        self.dmg_compat = enabled;
     }
 
     // ── Dot-level tick ────────────────────────────────────────────────────────
@@ -193,6 +207,7 @@ impl Ppu {
                     &self.obj_palette_ram,
                     &mut self.window_line,
                     self.opri,
+                    self.dmg_compat,
                     &mut self.screen_buffer,
                 );
             } else {
@@ -2677,5 +2692,49 @@ mod tests {
             Some(0xC5),
             "OCPS auto-increment must happen even when write is blocked"
         );
+    }
+
+    #[test]
+    fn test_apply_dmg_compat_palettes_writes_correct_bytes() {
+        // Given: CGB PPU with default (zeroed) palette RAM
+        let mut ppu = Ppu::new_cgb();
+
+        // Define test palettes in RGB555 format
+        let bg0: [u16; 4] = [0x7FFF, 0x5294, 0x294A, 0x0000]; // white, light, dark, black
+        let obj0: [u16; 4] = [0x001F, 0x03E0, 0x7C00, 0x0000]; // red, green, blue, black
+        let obj1: [u16; 4] = [0x7FFF, 0x421F, 0x1CF2, 0x0000]; // white, pink, maroon, black
+
+        // When: apply DMG compatibility palettes
+        ppu.apply_dmg_compat_palettes(&bg0, &obj0, &obj1);
+
+        // Then: BG palette 0 (bytes 0-7) contains bg0 colors in little-endian
+        assert_eq!(ppu.bg_palette_ram[0], 0xFF); // 0x7FFF low byte
+        assert_eq!(ppu.bg_palette_ram[1], 0x7F); // 0x7FFF high byte
+        assert_eq!(ppu.bg_palette_ram[2], 0x94); // 0x5294 low byte
+        assert_eq!(ppu.bg_palette_ram[3], 0x52); // 0x5294 high byte
+        assert_eq!(ppu.bg_palette_ram[4], 0x4A); // 0x294A low byte
+        assert_eq!(ppu.bg_palette_ram[5], 0x29); // 0x294A high byte
+        assert_eq!(ppu.bg_palette_ram[6], 0x00); // 0x0000 low byte
+        assert_eq!(ppu.bg_palette_ram[7], 0x00); // 0x0000 high byte
+
+        // Then: OBJ palette 0 (bytes 0-7) contains obj0 colors
+        assert_eq!(ppu.obj_palette_ram[0], 0x1F); // 0x001F low byte
+        assert_eq!(ppu.obj_palette_ram[1], 0x00); // 0x001F high byte
+        assert_eq!(ppu.obj_palette_ram[2], 0xE0); // 0x03E0 low byte
+        assert_eq!(ppu.obj_palette_ram[3], 0x03); // 0x03E0 high byte
+        assert_eq!(ppu.obj_palette_ram[4], 0x00); // 0x7C00 low byte
+        assert_eq!(ppu.obj_palette_ram[5], 0x7C); // 0x7C00 high byte
+        assert_eq!(ppu.obj_palette_ram[6], 0x00); // 0x0000 low byte
+        assert_eq!(ppu.obj_palette_ram[7], 0x00); // 0x0000 high byte
+
+        // Then: OBJ palette 1 (bytes 8-15) contains obj1 colors
+        assert_eq!(ppu.obj_palette_ram[8], 0xFF); // 0x7FFF low byte
+        assert_eq!(ppu.obj_palette_ram[9], 0x7F); // 0x7FFF high byte
+        assert_eq!(ppu.obj_palette_ram[10], 0x1F); // 0x421F low byte
+        assert_eq!(ppu.obj_palette_ram[11], 0x42); // 0x421F high byte
+        assert_eq!(ppu.obj_palette_ram[12], 0xF2); // 0x1CF2 low byte
+        assert_eq!(ppu.obj_palette_ram[13], 0x1C); // 0x1CF2 high byte
+        assert_eq!(ppu.obj_palette_ram[14], 0x00); // 0x0000 low byte
+        assert_eq!(ppu.obj_palette_ram[15], 0x00); // 0x0000 high byte
     }
 }

--- a/src/gb/ppu/rendering.rs
+++ b/src/gb/ppu/rendering.rs
@@ -150,6 +150,9 @@ fn cgb_palette_lookup(palette_ram: &[u8; 64], palette_num: u8, colour_index: u8)
 ///     cause BG to appear on top when the BG colour index is non-zero.
 /// - OBJ priority is determined by OAM order when `opri_dmg_mode` is false
 ///   (CGB default), or by X-coordinate when true.
+/// - When `dmg_compat` is true (DMG-only game on CGB hardware), OBJ palette
+///   selection uses OAM attribute bit 4 (0=palette 0, 1=palette 1) instead of
+///   CGB attribute bits 0-2.
 #[allow(clippy::too_many_arguments)]
 pub fn render_scanline_cgb(
     scanline: u8,
@@ -161,6 +164,7 @@ pub fn render_scanline_cgb(
     obj_palette_ram: &[u8; 64],
     window_line: &mut u8,
     opri_dmg_mode: bool,
+    dmg_compat: bool,
     screen_buffer: &mut ScreenBuffer,
 ) {
     let lcdc = registers.lcdc;
@@ -239,7 +243,14 @@ pub fn render_scanline_cgb(
             if bg_wins {
                 cgb_palette_lookup(bg_palette_ram, bw_px.palette_num, bw_px.colour_index)
             } else {
-                cgb_palette_lookup(obj_palette_ram, sp.cgb_palette, sp.colour_index)
+                // In DMG-compat mode, use OAM attribute bit 4 (sp.palette: 0=OBP0, 1=OBP1)
+                // instead of CGB attribute bits 0-2 (sp.cgb_palette).
+                let obj_pal = if dmg_compat {
+                    sp.palette
+                } else {
+                    sp.cgb_palette
+                };
+                cgb_palette_lookup(obj_palette_ram, obj_pal, sp.colour_index)
             }
         } else {
             cgb_palette_lookup(bg_palette_ram, bw_px.palette_num, bw_px.colour_index)
@@ -442,6 +453,7 @@ mod tests {
             &obj_palette,
             &mut wl,
             false,
+            false, // dmg_compat
             &mut sb,
         );
         // master_priority=false → OBJ always wins → black
@@ -486,12 +498,88 @@ mod tests {
             &obj_palette,
             &mut wl,
             false,
+            false, // dmg_compat
             &mut sb,
         );
         assert_eq!(
             sb.get_pixel(0, 0),
             (255, 255, 255),
             "BG (white) must win with master_priority=true and bg_priority"
+        );
+    }
+
+    #[test]
+    fn test_dmg_compat_uses_oam_bit4_for_obj_palette() {
+        // In DMG-compat mode, sprites select OBJ palette via OAM attr bit 4 (not bits 0-2).
+        // Sprite with attr bit 4 set should use OBJ palette 1, not palette 0.
+        let mut vram = blank_vram();
+        let mut oam = blank_oam();
+        // Sprite at (0,0) with attr bit 4 set (DMG palette 1)
+        oam[0] = 16; // y
+        oam[1] = 8; // x
+        oam[2] = 0; // tile
+        oam[3] = 0x10; // attr: bit 4 set → DMG palette 1 (CGB bits 0-2 = 0)
+
+        // Tile 0 row 0: colour index 1
+        vram[0x0000] = 0xFF; // low byte
+        vram[0x0001] = 0x00; // high byte
+
+        let bank1 = blank_vram_bank1();
+
+        let mut regs = default_registers();
+        regs.lcdc = 0x92; // LCD on, sprites on, BG on
+
+        // BG palette: colour 1 = black (default zeros)
+        let bg_palette = blank_palette_ram();
+        // OBJ palette 0: colour 1 = black (zeros)
+        // OBJ palette 1: colour 1 = white (at bytes 10-11)
+        let mut obj_palette = blank_palette_ram();
+        obj_palette[8 + 2] = 0xFF; // palette 1, colour 1, low byte
+        obj_palette[8 + 3] = 0x7F; // palette 1, colour 1, high byte (0x7FFF = white)
+
+        let mut sb = ScreenBuffer::new();
+        let mut wl = 0u8;
+
+        // Without dmg_compat, CGB uses bits 0-2 → palette 0 → black
+        render_scanline_cgb(
+            0,
+            &vram,
+            &bank1,
+            &oam,
+            &regs,
+            &bg_palette,
+            &obj_palette,
+            &mut wl,
+            false,
+            false, // dmg_compat = false
+            &mut sb,
+        );
+        assert_eq!(
+            sb.get_pixel(0, 0),
+            (0, 0, 0),
+            "CGB mode: attr bits 0-2 (= 0) selects palette 0 → black"
+        );
+
+        // With dmg_compat, uses attr bit 4 → palette 1 → white
+        let mut sb2 = ScreenBuffer::new();
+        wl = 0;
+        render_scanline_cgb(
+            0,
+            &vram,
+            &bank1,
+            &oam,
+            &regs,
+            &bg_palette,
+            &obj_palette,
+            &mut wl,
+            false,
+            true, // dmg_compat = true
+            &mut sb2,
+        );
+        assert_eq!(
+            sb2.get_pixel(0, 0),
+            (255, 255, 255),
+            "DMG-compat mode: attr bit 4 selects palette 1 → white"
         );
     }
 }

--- a/src/gb/ppu/sprites.rs
+++ b/src/gb/ppu/sprites.rs
@@ -187,6 +187,7 @@ pub fn fetch_sprite_pixel_cgb(
         let y_flip = attrs & 0x40 != 0;
         let x_flip = attrs & 0x20 != 0;
         let cgb_palette = attrs & 0x07;
+        let dmg_palette = (attrs >> 4) & 1; // bit 4: DMG palette (0=OBP0, 1=OBP1)
         let tile_vram_bank = (attrs >> 3) & 0x01;
         let bg_priority = attrs & 0x80 != 0;
 
@@ -228,7 +229,7 @@ pub fn fetch_sprite_pixel_cgb(
 
         return Some(SpritePixel {
             colour_index,
-            palette: 0,
+            palette: dmg_palette,
             cgb_palette,
             bg_priority,
         });


### PR DESCRIPTION
## Summary

Implement CGB boot ROM palette lookup for DMG-only games. When a DMG-only cartridge runs on CGB hardware with skip_boot_rom=true, the emulator now selects colorization palettes based on the game's title checksum and licensee code, matching real CGB hardware behavior.

## Changes

- Add new `src/gb/compat_palettes.rs` module with:
  - Title checksum lookup table (79 entries from SameBoy cgb_boot.asm)
  - Fourth-letter tie-breaker for duplicate checksums
  - Palette combination table (55 entries: OBJ0, OBJ1, BG indices)
  - RGB555 color palettes (32 palettes x 4 colors)
  - Functions: `compute_title_checksum`, `is_nintendo_licensee`, `get_palette_id`, `get_palette_colors`
  - Comprehensive unit tests (13 tests)

- Add `PPU::apply_dmg_compat_palettes()` helper method to write palette colors directly to palette RAM during initialization

- Integrate palette application in `CgbBus::new()` when `skip_boot_rom=true` and cartridge is DMG-only (bit 7 of $0143 clear)

## Algorithm

1. Check licensee code: old=$01 or new="01" = Nintendo
2. Non-Nintendo games get palette ID 5 (grayscale)
3. Compute title checksum: sum of ROM bytes $0134-$0143
4. Look up checksum in TitleChecksums table
5. For duplicate checksums (index >= 65), use fourth letter tie-breaker
6. Get palette combination (OBJ0, OBJ1, BG indices)
7. Get actual RGB555 colors from Palettes table

## Testing

- All 13 unit tests pass for the compat_palettes module
- All 9228 lib tests pass (`cargo test --no-default-features --lib`)
- Clippy passes (lib-only, no warnings)

Closes #2249

## Related

- Parent issue: #2240
- Depends on: #2248 (DMG compatibility mode detection) - merged