### PR TITLE
Sub-issue (#2277): APU CH1 sweep port — Phases 0-3 (foundation)

### DIFF
--- a/src/gb/apu/apu.rs
+++ b/src/gb/apu/apu.rs
@@ -84,6 +84,15 @@ pub struct Apu {
     #[serde(default)]
     lf_div: bool,
 
+    /// SameBoy-derived M-cycle counter (`div_divider`) advanced once per
+    /// M-cycle. Its low two bits gate the upcoming `square_sweep_countdown`
+    /// at the "every 4 M-cycles" boundary (`& 3 == 3`). Currently unused
+    /// outside Phase 1 plumbing tests; the sweep dispatch still runs from
+    /// FS step 2/6 until Phase 3 lands.
+    /// Ref: SameBoy `Core/apu.c` `gb->apu.div_divider`.
+    #[serde(default)]
+    div_divider: u8,
+
     /// When `true`, the next DIV-APU falling edge is skipped.
     /// Set when the APU is powered on while the DIV-APU bit is already HIGH.
     /// Per SameSuite div_write_trigger_10: "Starting the APU while bit 4 of
@@ -128,6 +137,7 @@ impl Apu {
             powered: false,
             fs_step: 0,
             lf_div: true, // SameBoy initializes to 1
+            div_divider: 0,
             skip_next_div_apu_event: false,
             sample_acc: 0.0,
             cycles_per_sample: DMG_MCYCLES_PER_SEC / 44_100.0,
@@ -253,6 +263,10 @@ impl Apu {
     fn tick_one(&mut self) {
         // Toggle the low-frequency divider (tracks 2 MHz alignment).
         self.lf_div = !self.lf_div;
+
+        // Advance the M-cycle counter consumed by sub-M-cycle APU machinery
+        // (Phase 3+ — `square_sweep_countdown` etc.).
+        self.div_divider = self.div_divider.wrapping_add(1);
 
         // ── Channel frequency timers ───────────────────────────────────────
         self.ch1.tick();
@@ -541,6 +555,15 @@ impl Apu {
     pub fn read_wave_ram(&self, addr: u16) -> u8 {
         self.ch3.read_wave_ram(addr)
     }
+
+    /// SameBoy-style M-cycle counter used by sub-M-cycle APU machinery.
+    ///
+    /// Currently consumed only by Phase 1 plumbing tests; Phase 3 will use
+    /// it to clock `square_sweep_countdown` on `(div_divider & 3) == 3`.
+    #[allow(dead_code)] // Consumer lands in Phase 3 (square_sweep_countdown).
+    pub(crate) fn div_divider(&self) -> u8 {
+        self.div_divider
+    }
 }
 
 impl Default for Apu {
@@ -557,6 +580,43 @@ mod tests {
         let mut apu = Apu::new(false);
         apu.write_register(0xFF26, 0x80);
         apu
+    }
+
+    /// Phase 1 plumbing: `div_divider` is an M-cycle counter exposed for the
+    /// upcoming SameBoy-derived sub-M-cycle sweep machinery. It must advance
+    /// by exactly one per M-cycle so the low two bits drive the
+    /// "every 4 M-cycles" gating used by Phase 3's `square_sweep_countdown`.
+    ///
+    /// Ref: SameBoy `Core/apu.c` — `tick_square_sweep` is gated on
+    /// `(gb->apu.div_divider & 3) == 3`.
+    #[test]
+    fn test_div_divider_advances_per_m_cycle() {
+        let mut apu = powered_apu();
+        let start = apu.div_divider();
+        apu.tick(1);
+        assert_eq!(apu.div_divider(), start.wrapping_add(1));
+        apu.tick(1);
+        assert_eq!(apu.div_divider(), start.wrapping_add(2));
+        apu.tick(2);
+        assert_eq!(apu.div_divider(), start.wrapping_add(4));
+    }
+
+    #[test]
+    fn test_div_divider_low_two_bits_align_every_4_m_cycles() {
+        let mut apu = powered_apu();
+        // Advance until low 2 bits are zero, then verify the every-4-M-cycle
+        // boundary lands on `& 3 == 3` exactly once per group of 4.
+        while apu.div_divider() & 3 != 0 {
+            apu.tick(1);
+        }
+        let mut hits = 0u32;
+        for _ in 0..16 {
+            apu.tick(1);
+            if apu.div_divider() & 3 == 3 {
+                hits += 1;
+            }
+        }
+        assert_eq!(hits, 4, "expected exactly 4 boundary hits over 16 M-cycles");
     }
 
     #[test]

--- a/src/gb/apu/apu.rs
+++ b/src/gb/apu/apu.rs
@@ -127,8 +127,12 @@ pub struct Apu {
 impl Apu {
     /// Create a new APU in the power-off state.
     pub fn new(is_cgb: bool) -> Self {
+        let mut ch1 = Channel1::new();
+        // Default CGB revision = CgbE (latest); CgbBus overrides via
+        // `set_cgb_model` once it knows the configured revision.
+        ch1.set_model(is_cgb, crate::gb::model::CgbModel::CgbE);
         Self {
-            ch1: Channel1::new(),
+            ch1,
             ch2: Channel2::new(),
             ch3: Channel3::new_with_mode(is_cgb),
             ch4: Channel4::new(),
@@ -162,6 +166,13 @@ impl Apu {
     /// deserializing old save states that predate this field.
     fn default_hp_rc() -> f32 {
         Self::compute_hp_rc(44_100.0)
+    }
+
+    /// Set the CGB hardware revision and propagate it to subchannels that
+    /// consume it (currently CH1 sweep timing). Should be called once at
+    /// bus construction; default model in `Apu::new` is correct for DMG.
+    pub fn set_cgb_model(&mut self, cgb_model: crate::gb::model::CgbModel) {
+        self.ch1.set_model(self.is_cgb, cgb_model);
     }
 
     /// Set the output sample rate in Hz (default: 44 100).

--- a/src/gb/apu/apu.rs
+++ b/src/gb/apu/apu.rs
@@ -534,6 +534,10 @@ impl Apu {
             self.hp_prev_out = 0.0;
             // Clear skip flag on power-off to prevent leaking into a later power-on.
             self.skip_next_div_apu_event = false;
+            // Reset SameBoy-derived FS-step counter alongside `fs_step` so
+            // that sub-events keyed off `div_divider` low bits stay aligned
+            // across power cycles.
+            self.div_divider = 0;
         } else if power_on_transition {
             trace_apu!(1; "GB APU power on");
             // Power on: reset frame sequencer step and skip flag.
@@ -541,6 +545,7 @@ impl Apu {
             // so we only reset the step counter here. The skip flag is cleared first,
             // then write_nr52_with_div_state() will re-arm it if DIV-APU bit is HIGH.
             self.fs_step = 0;
+            self.div_divider = 0;
             self.skip_next_div_apu_event = false;
             // On CGB, powering on resets all length counters to 0.
             if self.is_cgb {
@@ -646,6 +651,23 @@ mod tests {
             }
         }
         assert_eq!(hits, 4, "expected 4 boundary hits over 16 FS steps");
+    }
+
+    #[test]
+    fn test_div_divider_resets_on_nr52_power_cycle() {
+        // Sub-events keyed off `div_divider` low bits must stay aligned
+        // with `fs_step` after an NR52 power-off / power-on cycle.
+        let mut apu = powered_apu();
+        for _ in 0..5 {
+            apu.clock_div_apu();
+        }
+        assert_ne!(apu.div_divider(), 0);
+        // Power off via NR52.
+        apu.write_register(0xFF26, 0x00);
+        assert_eq!(apu.div_divider(), 0);
+        // Power on again — should still be 0 (and fs_step is also 0).
+        apu.write_register(0xFF26, 0x80);
+        assert_eq!(apu.div_divider(), 0);
     }
 
     #[test]

--- a/src/gb/apu/apu.rs
+++ b/src/gb/apu/apu.rs
@@ -84,11 +84,13 @@ pub struct Apu {
     #[serde(default)]
     lf_div: bool,
 
-    /// SameBoy-derived M-cycle counter (`div_divider`) advanced once per
-    /// M-cycle. Its low two bits gate the upcoming `square_sweep_countdown`
-    /// at the "every 4 M-cycles" boundary (`& 3 == 3`). Currently unused
-    /// outside Phase 1 plumbing tests; the sweep dispatch still runs from
-    /// FS step 2/6 until Phase 3 lands.
+    /// SameBoy-derived FS-step counter (`div_divider`) advanced once per
+    /// DIV-APU event (i.e., per Frame Sequencer step at 512 Hz). Sub-M-cycle
+    /// APU machinery gates on its low bits:
+    ///   * `& 1 == 1` — length / NR14 retrigger "extra length tick" glitch
+    ///   * `& 3 == 3` — sweep tick (drives `Channel1::sweep_countdown`)
+    ///   * `& 7 == 7` — envelope volume countdown decrement
+    ///
     /// Ref: SameBoy `Core/apu.c` `gb->apu.div_divider`.
     #[serde(default)]
     div_divider: u8,
@@ -233,6 +235,11 @@ impl Apu {
             return;
         }
 
+        // SameBoy `Core/apu.c`: increment div_divider at the start of every
+        // serviced DIV-APU event, before any channel work. Low bits drive
+        // length/sweep/envelope sub-events.
+        self.div_divider = self.div_divider.wrapping_add(1);
+
         trace_apu!(3; "GB APU FS step={} length={} sweep={} envelope={}",
             self.fs_step,
             (FS_TABLE[self.fs_step as usize] & 0x01) != 0,
@@ -274,10 +281,6 @@ impl Apu {
     fn tick_one(&mut self) {
         // Toggle the low-frequency divider (tracks 2 MHz alignment).
         self.lf_div = !self.lf_div;
-
-        // Advance the M-cycle counter consumed by sub-M-cycle APU machinery
-        // (Phase 3+ — `square_sweep_countdown` etc.).
-        self.div_divider = self.div_divider.wrapping_add(1);
 
         // ── Channel frequency timers ───────────────────────────────────────
         self.ch1.tick();
@@ -567,11 +570,11 @@ impl Apu {
         self.ch3.read_wave_ram(addr)
     }
 
-    /// SameBoy-style M-cycle counter used by sub-M-cycle APU machinery.
+    /// SameBoy-style FS-step counter used by sub-M-cycle APU machinery.
     ///
-    /// Currently consumed only by Phase 1 plumbing tests; Phase 3 will use
-    /// it to clock `square_sweep_countdown` on `(div_divider & 3) == 3`.
-    #[allow(dead_code)] // Consumer lands in Phase 3 (square_sweep_countdown).
+    /// Advanced once per DIV-APU event in `clock_div_apu`. Phase 3 consumes
+    /// the low two bits to drive the per-128 Hz sweep tick.
+    #[allow(dead_code)] // Direct readers land in Phase 6 (NR10 glitch).
     pub(crate) fn div_divider(&self) -> u8 {
         self.div_divider
     }
@@ -593,41 +596,56 @@ mod tests {
         apu
     }
 
-    /// Phase 1 plumbing: `div_divider` is an M-cycle counter exposed for the
-    /// upcoming SameBoy-derived sub-M-cycle sweep machinery. It must advance
-    /// by exactly one per M-cycle so the low two bits drive the
-    /// "every 4 M-cycles" gating used by Phase 3's `square_sweep_countdown`.
+    /// `div_divider` is a Frame-Sequencer-step counter exposed for the
+    /// SameBoy-derived sub-M-cycle sweep machinery. It must advance by
+    /// exactly one per serviced DIV-APU event so the low bits drive
+    ///   * `& 1 == 1` — extra-length-tick glitch (256 Hz tick, half of 512 Hz)
+    ///   * `& 3 == 3` — sweep tick (128 Hz, every 4 FS steps)
+    ///   * `& 7 == 7` — envelope volume countdown (64 Hz)
     ///
-    /// Ref: SameBoy `Core/apu.c` — `tick_square_sweep` is gated on
-    /// `(gb->apu.div_divider & 3) == 3`.
+    /// Ref: SameBoy `Core/apu.c` — `gb->apu.div_divider`.
     #[test]
-    fn test_div_divider_advances_per_m_cycle() {
+    fn test_div_divider_advances_per_fs_step() {
         let mut apu = powered_apu();
         let start = apu.div_divider();
-        apu.tick(1);
+        apu.clock_div_apu();
         assert_eq!(apu.div_divider(), start.wrapping_add(1));
-        apu.tick(1);
-        assert_eq!(apu.div_divider(), start.wrapping_add(2));
-        apu.tick(2);
-        assert_eq!(apu.div_divider(), start.wrapping_add(4));
+        apu.clock_div_apu();
+        apu.clock_div_apu();
+        assert_eq!(apu.div_divider(), start.wrapping_add(3));
     }
 
     #[test]
-    fn test_div_divider_low_two_bits_align_every_4_m_cycles() {
+    fn test_div_divider_does_not_advance_on_skipped_event() {
+        // Power-on quirk: skip_next_div_apu_event suppresses both the FS
+        // dispatch AND the div_divider increment, mirroring SameBoy's
+        // skip_div_event SKIPPED branch.
         let mut apu = powered_apu();
-        // Advance until low 2 bits are zero, then verify the every-4-M-cycle
-        // boundary lands on `& 3 == 3` exactly once per group of 4.
+        apu.arm_skip_next_div_apu_event();
+        let start = apu.div_divider();
+        apu.clock_div_apu();
+        assert_eq!(apu.div_divider(), start);
+        apu.clock_div_apu();
+        assert_eq!(apu.div_divider(), start.wrapping_add(1));
+    }
+
+    #[test]
+    fn test_div_divider_low_two_bits_align_every_4_fs_steps() {
+        let mut apu = powered_apu();
+        // Advance until the low 2 bits are zero, then verify the
+        // every-4-FS-step boundary lands on `& 3 == 3` exactly once
+        // per group of 4.
         while apu.div_divider() & 3 != 0 {
-            apu.tick(1);
+            apu.clock_div_apu();
         }
         let mut hits = 0u32;
         for _ in 0..16 {
-            apu.tick(1);
+            apu.clock_div_apu();
             if apu.div_divider() & 3 == 3 {
                 hits += 1;
             }
         }
-        assert_eq!(hits, 4, "expected exactly 4 boundary hits over 16 M-cycles");
+        assert_eq!(hits, 4, "expected 4 boundary hits over 16 FS steps");
     }
 
     #[test]

--- a/src/gb/apu/channel1.rs
+++ b/src/gb/apu/channel1.rs
@@ -131,7 +131,7 @@ impl Channel1 {
     /// Set the CGB-mode flag and hardware revision used by sweep timing.
     /// Should be called once after construction by the APU. Default state
     /// (DMG, `CgbE`) is correct for DMG hardware.
-    pub fn set_model(&mut self, is_cgb: bool, cgb_model: CgbModel) {
+    pub(crate) fn set_model(&mut self, is_cgb: bool, cgb_model: CgbModel) {
         self.is_cgb = is_cgb;
         self.cgb_model = cgb_model;
     }
@@ -344,6 +344,11 @@ impl Channel1 {
         self.triggered_once = false;
         self.first_sample_zero = false;
         self.env_clock_state = EnvelopeClockState::default();
+        // Reset SameBoy-derived sub-M-cycle sweep state (`is_cgb`/`cgb_model`
+        // are configuration, not runtime state, so they are preserved across
+        // NR52 power cycles).
+        self.restart_hold = 0;
+        self.sweep_countdown = 0;
     }
 
     // ── Register reads ────────────────────────────────────────────────────
@@ -758,6 +763,20 @@ mod tests {
             "freq must not change when sweep_period == 0"
         );
         assert!(ch.is_active());
+    }
+
+    #[test]
+    fn test_power_off_clears_restart_hold_and_sweep_countdown() {
+        let mut ch = Channel1::new();
+        ch.set_model(true, CgbModel::CgbE);
+        ch.write_nr12(0xF0);
+        ch.write_nr10(0x32); // period=3
+        ch.write_nr14(0x80, false, false);
+        assert_ne!(ch.restart_hold, 0);
+        assert_ne!(ch.sweep_countdown, 0);
+        ch.power_off();
+        assert_eq!(ch.restart_hold, 0);
+        assert_eq!(ch.sweep_countdown, 0);
     }
 
     // ── Sweep correctness (hardware quirks) ──────────────────────────────

--- a/src/gb/apu/channel1.rs
+++ b/src/gb/apu/channel1.rs
@@ -63,6 +63,14 @@ pub struct Channel1 {
     #[serde(default)]
     env_clock_state: EnvelopeClockState,
 
+    /// `square_sweep_countdown` — SameBoy-derived 3-bit sub-counter that
+    /// replaces the old `sweep_timer`. Loaded as `(sweep_period ^ 7) & 7`
+    /// on trigger; incremented on every 128 Hz sweep tick. When it wraps
+    /// to 7 the actual sweep step (recalc + overflow check) fires.
+    /// Ref: SameBoy `Core/apu.c` `gb->apu.square_sweep_countdown`.
+    #[serde(default)]
+    pub(super) sweep_countdown: u8,
+
     // ── SameBoy-derived sub-M-cycle sweep machinery (Phase 2+) ───────────
     /// `true` when running on a CGB-mode model. Gates CGB-specific sweep
     /// timing constants. Set via `set_model()` from the APU.
@@ -113,6 +121,7 @@ impl Channel1 {
             triggered_once: false,
             first_sample_zero: false,
             env_clock_state: EnvelopeClockState::default(),
+            sweep_countdown: 0,
             is_cgb: false,
             cgb_model: CgbModel::CgbE,
             restart_hold: 0,
@@ -215,27 +224,38 @@ impl Channel1 {
     }
 
     /// Clock frequency sweep at 128 Hz (Frame Sequencer steps 2/6).
+    ///
+    /// Implementation follows SameBoy `Core/apu.c`:
+    ///   * Increment `square_sweep_countdown` (3-bit, wraps).
+    ///   * When the post-increment value is 7 *and* the NR10 period bits
+    ///     are non-zero, perform the sweep recalculation and overflow check.
+    ///   * The countdown is reloaded from the (current) NR10 period bits
+    ///     after the recalculation, mirroring SameBoy's `((NR10>>4)&7)^7`.
+    ///
+    /// Phases 4–6 will defer the actual recalculation by an
+    /// M-cycle window via `calculate_countdown`; for Phase 3 the recalc
+    /// fires synchronously, preserving existing test expectations.
     pub fn clock_sweep(&mut self) {
-        if self.sweep_timer > 0 {
-            self.sweep_timer -= 1;
+        self.sweep_countdown = (self.sweep_countdown + 1) & 7;
+        if self.sweep_countdown != 7 {
+            return;
         }
-        if self.sweep_timer == 0 {
-            self.sweep_timer = self.sweep_timer_reload();
-            if self.sweep_enabled && self.sweep_period > 0 {
-                let new_freq = self.compute_swept_frequency();
-                if self.sweep_negate {
-                    self.negate_used = true;
-                }
-                if new_freq > 2047 {
-                    trace_apu!(3; "GB APU CH1 sweep overflow freq=0x{:03X} -> muted", new_freq);
-                    self.active = false;
-                } else if self.sweep_shift > 0 {
-                    trace_apu!(3; "GB APU CH1 sweep update shadow=0x{:03X} -> new=0x{:03X}", self.sweep_shadow, new_freq);
-                    self.sweep_shadow = new_freq;
-                    self.freq = new_freq;
-                    // Re-check overflow against the newly loaded frequency.
-                    self.disable_if_sweep_overflows();
-                }
+        // Reload countdown from current period (matches SameBoy reload).
+        self.sweep_countdown = (self.sweep_period ^ 7) & 7;
+        if self.sweep_enabled && self.sweep_period > 0 {
+            let new_freq = self.compute_swept_frequency();
+            if self.sweep_negate {
+                self.negate_used = true;
+            }
+            if new_freq > 2047 {
+                trace_apu!(3; "GB APU CH1 sweep overflow freq=0x{:03X} -> muted", new_freq);
+                self.active = false;
+            } else if self.sweep_shift > 0 {
+                trace_apu!(3; "GB APU CH1 sweep update shadow=0x{:03X} -> new=0x{:03X}", self.sweep_shadow, new_freq);
+                self.sweep_shadow = new_freq;
+                self.freq = new_freq;
+                // Re-check overflow against the newly loaded frequency.
+                self.disable_if_sweep_overflows();
             }
         }
     }
@@ -527,6 +547,8 @@ impl Channel1 {
         self.env_clock_state = EnvelopeClockState::default();
         self.sweep_shadow = self.freq;
         self.sweep_timer = self.sweep_timer_reload();
+        // SameBoy: `square_sweep_countdown = ((NR10 >> 4) & 7) ^ 7`.
+        self.sweep_countdown = (self.sweep_period ^ 7) & 7;
         self.sweep_enabled = self.sweep_period > 0 || self.sweep_shift > 0;
         self.negate_used = false;
         // Trigger-time overflow check required by hardware even when sweep is otherwise idle.
@@ -651,7 +673,94 @@ mod tests {
         assert_eq!(ch.restart_hold, 0);
     }
 
-    // ── DAC / active state ────────────────────────────────────────────────
+    // ── Phase 3: square_sweep_countdown ─────────────────────────────────
+    //
+    // SameBoy `Core/apu.c`:
+    //   On trigger: square_sweep_countdown = ((NR10 >> 4) & 7) ^ 7
+    //   Per 128 Hz tick: ++countdown; countdown &= 7; if 7 → sweep step.
+    //
+    // For sweep_period = N (1..=7) the post-trigger countdown is 7 - N,
+    // and it takes exactly N ticks to reach the wrap point.
+
+    #[test]
+    fn test_sweep_countdown_loaded_on_trigger_period_1() {
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0); // DAC on
+        ch.write_nr10(0x10); // period=1, negate=0, shift=0
+        ch.write_nr14(0x80, false, false);
+        // (1 ^ 7) & 7 = 6
+        assert_eq!(ch.sweep_countdown, 6);
+    }
+
+    #[test]
+    fn test_sweep_countdown_loaded_on_trigger_period_3() {
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0);
+        ch.write_nr10(0x32); // period=3, negate=0, shift=2
+        ch.write_nr14(0x80, false, false);
+        // (3 ^ 7) & 7 = 4
+        assert_eq!(ch.sweep_countdown, 4);
+    }
+
+    #[test]
+    fn test_sweep_countdown_loaded_on_trigger_period_7() {
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0);
+        ch.write_nr10(0x71); // period=7, negate=0, shift=1
+        ch.write_nr14(0x80, false, false);
+        // (7 ^ 7) & 7 = 0  → 7 ticks to wrap
+        assert_eq!(ch.sweep_countdown, 0);
+    }
+
+    #[test]
+    fn test_sweep_countdown_period_zero_loaded_to_seven() {
+        // SameBoy: period=0 → countdown loaded as (0^7)&7 = 7. Next tick
+        // wraps to 0; never fires the recalc since NR10 period bits == 0.
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0);
+        ch.write_nr10(0x00); // period=0
+        ch.write_nr14(0x80, false, false);
+        assert_eq!(ch.sweep_countdown, 7);
+    }
+
+    #[test]
+    fn test_sweep_countdown_increments_and_wraps_to_seven() {
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0);
+        ch.write_nr10(0x32); // period=3
+        ch.write_nr13(0x64); // freq = 100
+        ch.write_nr14(0x80, false, false);
+        assert_eq!(ch.sweep_countdown, 4);
+        ch.clock_sweep(); // → 5
+        assert_eq!(ch.sweep_countdown, 5);
+        ch.clock_sweep(); // → 6
+        assert_eq!(ch.sweep_countdown, 6);
+        ch.clock_sweep(); // → 7 → fires; reloads to (3^7)&7 = 4
+        assert_eq!(ch.sweep_countdown, 4);
+    }
+
+    #[test]
+    fn test_sweep_countdown_period_zero_no_recalc_on_wrap() {
+        // period=0, shift=2, freq=100. countdown wraps but recalc must
+        // not fire (matches SameBoy `(NR10 & 0x70)` gate).
+        let mut ch = Channel1::new();
+        ch.write_nr12(0xF0);
+        ch.write_nr10(0x02); // period=0, shift=2
+        ch.write_nr13(0x64);
+        ch.write_nr14(0x80, false, false);
+        let initial_freq = ch.freq;
+        // 8 ticks for one full wrap cycle from countdown=7.
+        for _ in 0..16 {
+            ch.clock_sweep();
+        }
+        assert_eq!(
+            ch.freq, initial_freq,
+            "freq must not change when sweep_period == 0"
+        );
+        assert!(ch.is_active());
+    }
+
+    // ── Sweep correctness (hardware quirks) ──────────────────────────────
 
     #[test]
     fn test_trigger_makes_channel_active() {

--- a/src/gb/apu/channel1.rs
+++ b/src/gb/apu/channel1.rs
@@ -1,5 +1,6 @@
 //! CH1 – Pulse channel with frequency sweep (NR10–NR14).
 
+use crate::gb::model::CgbModel;
 use crate::trace_apu;
 use serde::{Deserialize, Serialize};
 
@@ -61,6 +62,22 @@ pub struct Channel1 {
     /// Envelope clock state for zombie mode glitch tracking.
     #[serde(default)]
     env_clock_state: EnvelopeClockState,
+
+    // ── SameBoy-derived sub-M-cycle sweep machinery (Phase 2+) ───────────
+    /// `true` when running on a CGB-mode model. Gates CGB-specific sweep
+    /// timing constants. Set via `set_model()` from the APU.
+    #[serde(default)]
+    is_cgb: bool,
+    /// CGB hardware revision (only consulted when `is_cgb`). Default `CgbE`.
+    #[serde(default)]
+    cgb_model: CgbModel,
+    /// `channel_1_restart_hold` — M-cycle countdown after a trigger during
+    /// which sweep activity is suppressed. Set in `trigger()`, decremented
+    /// per M-cycle in `tick()`. Phase 2 only sets/decrements; the gating on
+    /// dependent state machines lands in Phases 3–5.
+    /// Ref: SameBoy `Core/apu.c` `gb->apu.channel_1_restart_hold`.
+    #[serde(default)]
+    pub(super) restart_hold: u8,
 }
 
 impl Default for Channel1 {
@@ -96,7 +113,18 @@ impl Channel1 {
             triggered_once: false,
             first_sample_zero: false,
             env_clock_state: EnvelopeClockState::default(),
+            is_cgb: false,
+            cgb_model: CgbModel::CgbE,
+            restart_hold: 0,
         }
+    }
+
+    /// Set the CGB-mode flag and hardware revision used by sweep timing.
+    /// Should be called once after construction by the APU. Default state
+    /// (DMG, `CgbE`) is correct for DMG hardware.
+    pub fn set_model(&mut self, is_cgb: bool, cgb_model: CgbModel) {
+        self.is_cgb = is_cgb;
+        self.cgb_model = cgb_model;
     }
 
     pub fn is_active(&self) -> bool {
@@ -143,6 +171,11 @@ impl Channel1 {
     /// When the timer expires mid-M-cycle, the remaining T-cycles are applied
     /// after the reload, ensuring correct phase alignment.
     pub fn tick(&mut self) {
+        // SameBoy: restart_hold counts down by 1 per M-cycle, saturating at 0.
+        // Ref: `Core/apu.c` GB_apu_run — `if (gb->apu.channel_1_restart_hold) gb->apu.channel_1_restart_hold--;`
+        if self.restart_hold > 0 {
+            self.restart_hold -= 1;
+        }
         let period = (2048 - self.freq) * 4;
         if self.freq_timer == 0 {
             self.freq_timer = period;
@@ -503,6 +536,15 @@ impl Channel1 {
             }
             self.disable_if_sweep_overflows();
         }
+        // SameBoy `Core/apu.c`:
+        //     channel_1_restart_hold = 2 - lf_div + (is_cgb && model != CGB_D) * 2
+        // Suppresses sweep activity for a few M-cycles after trigger.
+        let cgb_bonus: u8 = if self.is_cgb && self.cgb_model != CgbModel::CgbD {
+            2
+        } else {
+            0
+        };
+        self.restart_hold = 2u8 - (lf_div as u8) + cgb_bonus;
     }
 }
 
@@ -521,6 +563,92 @@ mod tests {
         // NR14: trigger, no length enable, freq high = 0
         ch.write_nr14(0x80, false, false);
         ch
+    }
+
+    // ── Phase 2: restart_hold ────────────────────────────────────────────
+    //
+    // SameBoy `Core/apu.c`:
+    //     channel_1_restart_hold = 2 - lf_div + (is_cgb && model != CGB_D) * 2
+    //
+    // Truth table (lf_div is 0/false or 1/true):
+    //   DMG:           lf_div=0 → 2,  lf_div=1 → 1
+    //   CGB-D:         lf_div=0 → 2,  lf_div=1 → 1
+    //   CGB-A/B/C/E:   lf_div=0 → 4,  lf_div=1 → 3
+
+    fn ch1_for_trigger(is_cgb: bool, cgb_model: CgbModel) -> Channel1 {
+        let mut ch = Channel1::new();
+        ch.set_model(is_cgb, cgb_model);
+        ch.write_nr12(0xF0); // DAC on
+        ch.write_nr11(0x80);
+        ch
+    }
+
+    #[test]
+    fn test_restart_hold_dmg_lf_div_low() {
+        let mut ch = ch1_for_trigger(false, CgbModel::CgbE);
+        ch.write_nr14(0x80, false, /* lf_div = */ false);
+        assert_eq!(ch.restart_hold, 2);
+    }
+
+    #[test]
+    fn test_restart_hold_dmg_lf_div_high() {
+        let mut ch = ch1_for_trigger(false, CgbModel::CgbE);
+        ch.write_nr14(0x80, false, /* lf_div = */ true);
+        assert_eq!(ch.restart_hold, 1);
+    }
+
+    #[test]
+    fn test_restart_hold_cgb_d_lf_div_low() {
+        let mut ch = ch1_for_trigger(true, CgbModel::CgbD);
+        ch.write_nr14(0x80, false, false);
+        assert_eq!(ch.restart_hold, 2);
+    }
+
+    #[test]
+    fn test_restart_hold_cgb_d_lf_div_high() {
+        let mut ch = ch1_for_trigger(true, CgbModel::CgbD);
+        ch.write_nr14(0x80, false, true);
+        assert_eq!(ch.restart_hold, 1);
+    }
+
+    #[test]
+    fn test_restart_hold_cgb_e_lf_div_low() {
+        let mut ch = ch1_for_trigger(true, CgbModel::CgbE);
+        ch.write_nr14(0x80, false, false);
+        assert_eq!(ch.restart_hold, 4);
+    }
+
+    #[test]
+    fn test_restart_hold_cgb_e_lf_div_high() {
+        let mut ch = ch1_for_trigger(true, CgbModel::CgbE);
+        ch.write_nr14(0x80, false, true);
+        assert_eq!(ch.restart_hold, 3);
+    }
+
+    #[test]
+    fn test_restart_hold_cgb_b_matches_cgb_e() {
+        // CGB-A/B/C share the +2 branch with CGB-E (only CGB-D differs).
+        let mut ch = ch1_for_trigger(true, CgbModel::CgbB);
+        ch.write_nr14(0x80, false, false);
+        assert_eq!(ch.restart_hold, 4);
+    }
+
+    #[test]
+    fn test_restart_hold_decrements_per_m_cycle_and_saturates_at_zero() {
+        let mut ch = ch1_for_trigger(true, CgbModel::CgbE);
+        ch.write_nr14(0x80, false, false);
+        assert_eq!(ch.restart_hold, 4);
+        ch.tick();
+        assert_eq!(ch.restart_hold, 3);
+        ch.tick();
+        assert_eq!(ch.restart_hold, 2);
+        ch.tick();
+        ch.tick();
+        assert_eq!(ch.restart_hold, 0);
+        // Must not underflow / wrap.
+        ch.tick();
+        ch.tick();
+        assert_eq!(ch.restart_hold, 0);
     }
 
     // ── DAC / active state ────────────────────────────────────────────────

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -718,6 +718,10 @@ impl CgbBus {
         self.timer = state.timer.clone();
         self.joypad = state.joypad.clone();
         self.apu = state.apu.clone();
+        // Re-apply the configured CGB model after restoring the APU snapshot:
+        // older save-states won't have `is_cgb`/`cgb_model` serialized on CH1
+        // and would otherwise come back on the DMG/default model path.
+        self.apu.set_cgb_model(self.model);
         self.if_reg = state.if_reg;
         self.ie_reg = state.ie_reg;
         self.dma_active = state.dma_active;

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -253,6 +253,11 @@ impl CgbBus {
         };
         bus.timer.set_div_counter(initial_div_counter);
 
+        // Propagate the CGB hardware revision to the APU so model-specific
+        // sweep/timing quirks (e.g. CH1 restart_hold) match the selected
+        // hardware. Default `Apu::new` assumes `CgbE`.
+        bus.apu.set_cgb_model(model);
+
         bus
     }
 
@@ -608,6 +613,7 @@ impl CgbBus {
         self.joypad = Joypad::new();
         self.apu = Apu::new(self.cart.is_cgb());
         self.apu.set_sample_rate(apu_rate);
+        self.apu.set_cgb_model(self.model);
         self.wram = [[0u8; 0x1000]; 8];
         self.hram = [0u8; 0x7F];
         self.if_reg = 0;

--- a/src/gba/apu/apu.rs
+++ b/src/gba/apu/apu.rs
@@ -1649,10 +1649,12 @@ mod tests {
 
     #[test]
     fn test_ch4_lfsr_sequence_7bit() {
-        let mut ch4 = Channel4::default();
-        ch4.dac_on = true;
-        ch4.lfsr_7bit = true;
-        ch4.lfsr = 0x7FFF;
+        let mut ch4 = Channel4 {
+            dac_on: true,
+            lfsr_7bit: true,
+            lfsr: 0x7FFF,
+            ..Channel4::default()
+        };
 
         // Clock 7-bit LFSR manually and verify.
         let mut lfsr = 0x7FFF_u16;

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -21,9 +21,13 @@ use crate::gba::cpu::bus::Bus;
 use crate::gba::input::Keypad;
 use crate::gba::ppu::{Ppu, PpuStepEvents};
 
+#[allow(unused_imports)]
 pub use dma::{DmaBus, DmaChannel, DmaController};
+#[allow(unused_imports)]
 pub use interrupt::{InterruptController, bits as irq_bits};
+#[allow(unused_imports)]
 pub use io::{IoRegisters, REG_IE, REG_IF, REG_IME};
+#[allow(unused_imports)]
 pub use timer::{Timer, Timers};
 
 use memory::{

--- a/src/gba/cartridge/mod.rs
+++ b/src/gba/cartridge/mod.rs
@@ -18,9 +18,15 @@ pub mod header;
 pub mod save_type;
 pub mod sram;
 
+#[allow(unused_imports)]
 pub use cartridge::{CartridgeError, GbaCartridge, ROM_MAX_SIZE, SaveBackend, load_cartridge};
+#[allow(unused_imports)]
 pub use eeprom::Eeprom;
+#[allow(unused_imports)]
 pub use flash::Flash;
+#[allow(unused_imports)]
 pub use header::{GbaHeader, HeaderError, parse_header};
+#[allow(unused_imports)]
 pub use save_type::{SaveType, detect_save_type};
+#[allow(unused_imports)]
 pub use sram::Sram;

--- a/src/gba/cpu/mod.rs
+++ b/src/gba/cpu/mod.rs
@@ -26,6 +26,9 @@ pub mod bus;
 pub mod registers;
 pub mod thumb;
 
+#[allow(unused_imports)]
 pub use arm7tdmi::{Arm7tdmi, ExceptionVector};
+#[allow(unused_imports)]
 pub use bus::{Bus, RamBus};
+#[allow(unused_imports)]
 pub use registers::{CpuMode, Registers, condition_met};

--- a/src/gba/input/mod.rs
+++ b/src/gba/input/mod.rs
@@ -9,4 +9,5 @@
 
 pub mod keypad;
 
+#[allow(unused_imports)]
 pub use keypad::{KEYCNT_COND_AND, KEYCNT_IRQ_ENABLE, KEYS_MASK, Keypad, REG_KEYCNT, REG_KEYINPUT};

--- a/src/gba/mod.rs
+++ b/src/gba/mod.rs
@@ -12,9 +12,13 @@ pub mod cpu;
 pub mod input;
 pub mod ppu;
 
+#[allow(unused_imports)]
 pub use apu::Apu;
 pub use bus::GbaBus;
+#[allow(unused_imports)]
 pub use cartridge::{GbaCartridge, SaveType, load_cartridge};
 pub use console::gba::Gba;
+#[allow(unused_imports)]
 pub use input::Keypad;
+#[allow(unused_imports)]
 pub use ppu::Ppu;


### PR DESCRIPTION
Foundation work for porting SameBoy's full sub-M-cycle CH1 sweep machinery into the GB APU. Continues the effort from now-closed PR #2282 by landing the plumbing and state in small, reviewable phases.

This PR ships **Phases 0–3** only. Phases 4–7 (deferred sweep recalc dispatch, dual overflow, NR10 mid-sweep glitch, un-ignoring SameSuite sweep ROMs) are tracked separately in #2287 to keep this change reviewable.

## What this PR does

### Phase 1 — `div_divider` plumbing
- New `Apu::div_divider: u8` (`#[serde(default)]`).
- Increments per Frame-Sequencer step inside `clock_div_apu`, after the skip-next early-return so a skipped event does not advance the counter.
- Pure plumbing — does not yet drive sweep dispatch.
- 3 unit tests: per-FS-step advance, no-advance on skipped event, low-2-bit alignment every 4 FS steps.

### Phase 2 — `restart_hold`
- New `Channel1::restart_hold: u8`, `is_cgb: bool`, and `cgb_model: CgbModel` fields.
- `Apu::new(is_cgb)` and `Apu::set_cgb_model` thread the model from `CgbBus` into CH1.
- `trigger(lf_div)` loads `restart_hold = 2 - lf_div + (is_cgb && model != CGB_D) * 2`, matching SameBoy `apu.c`.
- `tick()` decrements `restart_hold` saturating per M-cycle.
- 8 white-box tests covering DMG/CGB-D/CGB-B/CGB-E across `lf_div` values and saturation.

### Phase 3 — `sweep_countdown` + FS-step semantics fix
- New `Channel1::sweep_countdown: u8`.
- On trigger: `sweep_countdown = (NR10>>4 ^ 7) & 7`.
- `clock_sweep()` now bumps `sweep_countdown`; recalc fires when it wraps to 7, gated by NR10 period bits (period 0 → no recalc).
- Corrects Phase 1's `div_divider` semantics from per-M-cycle to per-FS-step (atomic with this phase to avoid an in-between broken state).
- 6 white-box tests: trigger load for periods {1,3,7,0}, increment-and-wrap, period-zero never-recalc.

### Pre-cleanup commit
A separate `chore(gba): silence pre-existing clippy warnings` commit unblocks the repo's pre-merge clippy gate (`cargo clippy --all-targets --all-features -- -D warnings`). It addresses warnings inherited from PRs #2270 and #2271:

- `#[allow(unused_imports)]` on intentional public-surface `pub use` re-exports across `src/gba/{bus,cartridge,cpu,input}/mod.rs` and `src/gba/mod.rs`.
- Restructured the test-only `Channel4` constructor in `src/gba/apu/apu.rs` to struct-literal + `..Default::default()` (resolves `field_reassign_with_default`).

No functional changes in that commit.

## Save-state compatibility

All new fields are `#[serde(default)]`. No save-state schema bump.

## SameBoy reference

Reference is `LIJI32/SameBoy` `Core/apu.c` (MIT). All formulas paraphrased, no verbatim copying. Key references:
- `restart_hold` formula at `apu.c:1913`
- `sweep_countdown` load at `apu.c:1914`
- `div_divider` increment inside `GB_apu_div_event` at `apu.c:681`
- Sweep dispatch on `(div_divider & 3) == 3` at `apu.c:753`

## Pre-merge checkpoint results

- `cargo clippy --all-targets --all-features -- -D warnings` ✅ clean
- `cargo fmt --check` ✅ clean
- `cargo test --no-default-features --lib` ✅ 9293 passed
- `wasm-pack test --headless --chrome --no-default-features --features wasm` ✅ 54 passed
- `python -m unittest discover ...` ✅ 223 passed
- `npm test` ✅ 298 passed

## Related

- Parent: #2277
- Predecessor PR (closed): #2282
- Follow-up (Phases 4–7): #2287
