### PR TITLE
CGB post-boot register initialization (partial fix for #2242)

### DIFF
--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -236,6 +236,25 @@ impl CgbBus {
         bus.ppu.write_register(0xFF4A, 0x00);
         bus.ppu.write_register(0xFF4B, 0x00);
 
+        // When skipping the boot ROM, initialize additional registers to post-boot state.
+        // These values match what the official CGB boot ROM leaves at PC=$0100.
+        // Reference: Mooneye boot_hwio-C test (verified on real CGB hardware).
+        //
+        // Note: KEY1 is NOT initialized here because:
+        // - KEY1=$81 would put the system in double-speed mode (bit 7 set)
+        // - Pan Docs states "CGB is operating in Normal Speed Mode when first turned on"
+        // - The Mooneye boot_hwio-C test's KEY1=$FF expectation may be for a specific
+        //   scenario that doesn't apply to standard post-boot state.
+        if skip_boot_rom {
+            // SVBK ($FF70): reads as $FF when svbk = $07
+            //   (read formula: svbk | 0xF8 = 0x07 | 0xF8 = $FF)
+            bus.svbk = 0x07;
+            // BCPS ($FF68): $C8 (auto-increment + index $48)
+            // OCPS ($FF6A): $D0 (auto-increment + index $50)
+            bus.ppu.write_cgb_register(0xFF68, 0xC8);
+            bus.ppu.write_cgb_register(0xFF6A, 0xD0);
+        }
+
         // Initialize DIV to post-boot value for CGB models.
         // The internal 16-bit counter value must be precisely set for Mooneye
         // boot_div tests to pass. These tests verify the exact phase alignment
@@ -1126,7 +1145,17 @@ mod tests {
         load_cartridge(&rom).expect("valid ROM")
     }
 
+    /// Create a CgbBus with boot ROM active (skip_boot_rom=false).
+    /// This tests hardware DEFAULT values, not post-boot values.
+    /// Use this for unit tests that verify register defaults and hardware functionality.
     fn make_bus() -> CgbBus {
+        CgbBus::new(cgb_rom_only_cart(), CgbModel::default(), false)
+    }
+
+    /// Create a CgbBus with post-boot state (skip_boot_rom=true).
+    /// Use this for tests that verify post-boot register values.
+    #[allow(dead_code)]
+    fn make_bus_post_boot() -> CgbBus {
         CgbBus::new(cgb_rom_only_cart(), CgbModel::default(), true)
     }
 
@@ -1162,12 +1191,11 @@ mod tests {
     }
 
     #[test]
-    fn test_hdma5_read_80_when_inactive() {
-        // Given: CgbBus with no transfer started
+    fn test_hdma5_read_ff_when_never_started() {
+        // Given: CgbBus with no transfer ever started (make_bus uses boot ROM active)
         let mut bus = make_bus();
-        // Then: $FF55 reads $80 (inactive + 0 remaining)
-        // Note: remaining_blocks initialized to 0, so read returns $80
-        assert_eq!(bus.read(0xFF55), 0x80);
+        // Then: $FF55 reads $FF (never_started flag set, per Mooneye boot_hwio-C)
+        assert_eq!(bus.read(0xFF55), 0xFF);
     }
 
     // ── GDMA tests ──────────────────────────────────────────────────────────

--- a/src/gb/bus/hdma.rs
+++ b/src/gb/bus/hdma.rs
@@ -31,6 +31,14 @@ pub struct HdmaState {
     /// `true` when HDMA has been requested but not yet activated.
     /// Set when bit 7=1 is written to FF55; cleared when transfer starts or is cancelled.
     hdma_on_hblank: bool,
+    /// `true` until the first write to HDMA5 ($FF55).
+    /// Per Mooneye boot_hwio-C: HDMA5 reads $FF when no transfer has ever been started.
+    #[serde(default = "default_never_started")]
+    never_started: bool,
+}
+
+fn default_never_started() -> bool {
+    true
 }
 
 impl Default for HdmaState {
@@ -49,6 +57,7 @@ impl HdmaState {
             active: false,
             hblank_mode: false,
             hdma_on_hblank: false,
+            never_started: true,
         }
     }
 
@@ -81,6 +90,9 @@ impl HdmaState {
     /// - Bit 7 = 1 → `StartHdma` (length = lower 7 bits, marks as requested)
     /// - Bit 7 = 0, active HDMA → `CancelHdma`
     pub fn write_control(&mut self, val: u8) -> HdmaAction {
+        // Clear the never_started flag on first write.
+        self.never_started = false;
+
         let length = val & 0x7F;
         let start_hblank = val & 0x80 != 0;
 
@@ -113,9 +125,12 @@ impl HdmaState {
     /// Read the control register ($FF55 — HDMA5).
     ///
     /// Returns remaining blocks in bits 0–6, and bit 7 = 1 when **inactive** (0 when active).
-    /// Returns $FF when no transfer has ever been started or after GDMA completion.
+    /// Returns $FF when no transfer has ever been started (per Mooneye boot_hwio-C).
     pub fn read_control(&self) -> u8 {
-        if self.active {
+        if self.never_started {
+            // Per Mooneye boot_hwio-C: HDMA5 reads $FF when no transfer has ever been started.
+            0xFF
+        } else if self.active {
             // Bit 7 = 0 (active), lower 7 bits = remaining blocks.
             self.remaining_blocks & 0x7F
         } else {
@@ -356,11 +371,28 @@ mod tests {
     // ── Control register read tests ─────────────────────────────────────────
 
     #[test]
-    fn test_read_control_when_inactive_returns_80() {
-        // Given: no transfer ever started
-        // Note: remaining_blocks initialized to 0, so read returns $80 (inactive + 0 remaining)
+    fn test_read_control_when_never_started_returns_ff() {
+        // Given: no transfer ever started (per Mooneye boot_hwio-C)
         let hdma = HdmaState::new();
-        // Then: $80 (bit 7 set = inactive, lower bits = 0)
+        // Then: $FF (never_started flag is set)
+        assert_eq!(hdma.read_control(), 0xFF);
+    }
+
+    #[test]
+    fn test_read_control_when_inactive_after_start_returns_80() {
+        // Given: a transfer was started and completed
+        let mut hdma = HdmaState::new();
+        hdma.write_source_high(0x80);
+        hdma.write_dest_high(0x00);
+        // Start a 1-block GDMA (length = 0 means 1 block)
+        hdma.write_control(0x00);
+        // Complete the transfer
+        let mock_read = |_| 0u8;
+        let mock_write = |_, _| {};
+        let mut read_fn = mock_read;
+        let mut write_fn = mock_write;
+        hdma.transfer_block(&mut read_fn, &mut write_fn);
+        // Then: $80 (inactive after transfer, 0 remaining)
         assert_eq!(hdma.read_control(), 0x80);
     }
 

--- a/src/gb/integration_tests/boot_tests.rs
+++ b/src/gb/integration_tests/boot_tests.rs
@@ -1085,8 +1085,8 @@ fn test_cgb_production_boot_io_registers() {
     assert_eq!(read_cgb_bus(&mut gb, 0xFF52), 0xFF, "HDMA2 ($FF52)");
     assert_eq!(read_cgb_bus(&mut gb, 0xFF53), 0xFF, "HDMA3 ($FF53)");
     assert_eq!(read_cgb_bus(&mut gb, 0xFF54), 0xFF, "HDMA4 ($FF54)");
-    // HDMA5 bit 7 = not active; $80 indicates no DMA in progress
-    assert_eq!(read_cgb_bus(&mut gb, 0xFF55), 0x80, "HDMA5 ($FF55)");
+    // HDMA5 reads $FF when no DMA has ever been started (per Mooneye)
+    assert_eq!(read_cgb_bus(&mut gb, 0xFF55), 0xFF, "HDMA5 ($FF55)");
     // RP ($FF56 - infrared) not implemented in CGB bus; skipped
     assert_eq!(read_cgb_bus(&mut gb, 0xFF70), 0xF8, "SVBK ($FF70)");
 
@@ -1159,8 +1159,8 @@ fn test_cgb0_boot_io_registers() {
     assert_eq!(read_cgb_bus(&mut gb, 0xFF52), 0xFF, "HDMA2 ($FF52)");
     assert_eq!(read_cgb_bus(&mut gb, 0xFF53), 0xFF, "HDMA3 ($FF53)");
     assert_eq!(read_cgb_bus(&mut gb, 0xFF54), 0xFF, "HDMA4 ($FF54)");
-    // HDMA5 bit 7 = not active; $80 indicates no DMA in progress
-    assert_eq!(read_cgb_bus(&mut gb, 0xFF55), 0x80, "HDMA5 ($FF55)");
+    // HDMA5 reads $FF when no DMA has ever been started (per Mooneye)
+    assert_eq!(read_cgb_bus(&mut gb, 0xFF55), 0xFF, "HDMA5 ($FF55)");
     // RP ($FF56 - infrared) not implemented in CGB bus; skipped
     assert_eq!(read_cgb_bus(&mut gb, 0xFF70), 0xF8, "SVBK ($FF70)");
 


### PR DESCRIPTION
## Summary

Adds post-boot register initialization for non-APU CGB registers when skip_boot_rom=true. This is a **partial fix** for issue #2242.

## Changes

### Post-boot register initialization (skip_boot_rom=true)
- **SVBK ($FF70)**: Set to $07 so it reads $FF (per Mooneye boot_hwio-C)
- **BCPS ($FF68)**: Set to $C8 (auto-increment + index $48)
- **OCPS ($FF6A)**: Set to $D0 (auto-increment + index $50)

### HDMA5 never_started flag
- HDMA5 ($FF55) now returns $FF when no transfer has ever been started
- Previously returned $80; updated to match Mooneye boot_hwio-C verification

### Test infrastructure
- Fixed `make_bus()` helper to use `skip_boot_rom=false` for unit tests
- Added `make_bus_post_boot()` helper for tests needing post-boot state
- Updated boot test expectations for HDMA5 ($FF when never started)

## What's NOT included

The following are deliberately omitted because they break existing tests:

1. **KEY1 ($FF4D)** - Setting KEY1=$81 puts the system in double-speed mode, which breaks SameSuite APU tests (APU runs at half rate in double-speed mode)

2. **APU post-boot registers (NR50, NR51, NR52, NR12, NR21)** - Setting CH1 as "active" for correct NR52 read affects channel timing behavior and breaks SameSuite APU tests

## Test status

- Mooneye boot_hwio-C: Still ignored (requires APU post-boot state)
- Mooneye unused_hwio-C: Still ignored (requires APU post-boot state)
- All SameSuite APU tests: Passing
- All existing tests: Passing

Fixes: partial fix for #2242