### PR TITLE
feat(gba): implement mode 0 bg0 tile map foundations

### DIFF
--- a/src/gba/bus/io.rs
+++ b/src/gba/bus/io.rs
@@ -226,6 +226,8 @@ impl IoRegisters {
             ppu::REG_DISPCNT => ppu.write_dispcnt(value),
             ppu::REG_DISPSTAT => ppu.write_dispstat(value, ic),
             ppu::REG_VCOUNT => { /* VCOUNT is read-only */ }
+            ppu::REG_BG0HOFS => ppu.write_bg0_hofs(value),
+            ppu::REG_BG0VOFS => ppu.write_bg0_vofs(value),
             // PPU affine BG2/BG3 registers (write-only, reads fall
             // through to the I/O backing store / open-bus).
             0x0400_0020..=0x0400_003E => {
@@ -616,5 +618,103 @@ mod tests {
         );
         assert_eq!(p.read_vcount(), 0);
         assert_eq!(io.read16(ppu::REG_VCOUNT, &ic, &t, &d, &p, &k), 0);
+    }
+
+    #[test]
+    fn mode0_bg0_hofs_scroll_changes_leftmost_pixel() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let mut vram = vec![0u8; 96 * 1024];
+        let mut pram = vec![0u8; 1024];
+
+        // Mode 0 + BG0 enabled.
+        io.write16(
+            ppu::REG_DISPCNT,
+            ppu::dispcnt::BG0_ENABLE,
+            &mut ic,
+            &mut t,
+            &mut d,
+            &mut p,
+            &mut k,
+        );
+
+        // BG palette entry 1 = red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 2 has pixel (0,0) = color index 1.
+        vram[64] = 0x01;
+
+        // Map (0,0) = tile 1 (empty), (1,0) = tile 2 (red at x=0).
+        vram[0] = 0x01;
+        vram[1] = 0x00;
+        vram[2] = 0x02;
+        vram[3] = 0x00;
+
+        // BG0HOFS = 8 pixels (0x0400_0010).
+        io.write16(0x0400_0010, 8, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        p.step(
+            ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
+    fn mode0_bg0_vofs_scroll_changes_top_row_pixel() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let mut vram = vec![0u8; 96 * 1024];
+        let mut pram = vec![0u8; 1024];
+
+        // Mode 0 + BG0 enabled.
+        io.write16(
+            ppu::REG_DISPCNT,
+            ppu::dispcnt::BG0_ENABLE,
+            &mut ic,
+            &mut t,
+            &mut d,
+            &mut p,
+            &mut k,
+        );
+
+        // BG palette entry 1 = red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 3 has pixel (0,0) = color index 1.
+        vram[96] = 0x01;
+
+        // Map (0,0) = tile 1 (empty), (0,1) = tile 3 (red at y=8).
+        vram[0] = 0x01;
+        vram[1] = 0x00;
+        vram[64] = 0x03;
+        vram[65] = 0x00;
+
+        // BG0VOFS = 8 pixels (0x0400_0012).
+        io.write16(0x0400_0012, 8, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        p.step(
+            ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
     }
 }

--- a/src/gba/bus/io.rs
+++ b/src/gba/bus/io.rs
@@ -41,6 +41,7 @@ pub const REG_TM0CNT_H: u32 = 0x0400_0102;
 
 /// Address of `REG_DISPCNT` (PPU display control).
 pub const REG_DISPCNT: u32 = 0x0400_0000;
+const REG_BG0_SCROLL_END: u32 = ppu::REG_BG0VOFS + 1;
 
 /// I/O register backing store.
 ///
@@ -319,6 +320,28 @@ impl IoRegisters {
                 (current & 0x00FF) | ((value as u16) << 8)
             };
             ppu.write_affine(aligned, merged);
+            return;
+        }
+        // BG0 scroll registers are write-only as well. Merge byte writes
+        // against live PPU state instead of io.read16() (which returns
+        // backing-store/open-bus for these addresses).
+        if (ppu::REG_BG0HOFS..=REG_BG0_SCROLL_END).contains(&addr) {
+            let aligned = addr & !1;
+            let current = match aligned {
+                ppu::REG_BG0HOFS => ppu.read_bg0_hofs(),
+                ppu::REG_BG0VOFS => ppu.read_bg0_vofs(),
+                _ => unreachable!("unexpected BG0 scroll register address: {aligned:#010X}"),
+            };
+            let merged = if addr & 1 == 0 {
+                (current & 0xFF00) | value as u16
+            } else {
+                (current & 0x00FF) | ((value as u16) << 8)
+            };
+            match aligned {
+                ppu::REG_BG0HOFS => ppu.write_bg0_hofs(merged),
+                ppu::REG_BG0VOFS => ppu.write_bg0_vofs(merged),
+                _ => unreachable!("unexpected BG0 scroll register address: {aligned:#010X}"),
+            }
             return;
         }
         let aligned = addr & !1;
@@ -813,6 +836,106 @@ mod tests {
 
         // Scroll y to 256 so top pixel samples from second screenblock row.
         io.write16(0x0400_0012, 256, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        p.step(
+            ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
+    fn mode0_bg0_hofs_byte_writes_preserve_low_byte() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let mut vram = vec![0u8; 96 * 1024];
+        let mut pram = vec![0u8; 1024];
+
+        // Mode 0 + BG0 enabled.
+        io.write16(
+            ppu::REG_DISPCNT,
+            ppu::dispcnt::BG0_ENABLE,
+            &mut ic,
+            &mut t,
+            &mut d,
+            &mut p,
+            &mut k,
+        );
+
+        // BG palette entry 1 = red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 2 has pixel (0,0) = color index 1.
+        vram[64] = 0x01;
+
+        // Map (0,0) = tile 1 (empty), (1,0) = tile 2 (red at x=8).
+        vram[0] = 0x01;
+        vram[1] = 0x00;
+        vram[2] = 0x02;
+        vram[3] = 0x00;
+
+        // BG0HOFS byte writes: low=8 then high=0.
+        io.write8(0x0400_0010, 0x08, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        io.write8(0x0400_0011, 0x00, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        p.step(
+            ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
+    fn mode0_bg0_vofs_byte_writes_preserve_low_byte() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let mut vram = vec![0u8; 96 * 1024];
+        let mut pram = vec![0u8; 1024];
+
+        // Mode 0 + BG0 enabled.
+        io.write16(
+            ppu::REG_DISPCNT,
+            ppu::dispcnt::BG0_ENABLE,
+            &mut ic,
+            &mut t,
+            &mut d,
+            &mut p,
+            &mut k,
+        );
+
+        // BG palette entry 1 = red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 3 has pixel (0,0) = color index 1.
+        vram[96] = 0x01;
+
+        // Map (0,0) = tile 1 (empty), (0,1) = tile 3 (red at y=8).
+        vram[0] = 0x01;
+        vram[1] = 0x00;
+        vram[64] = 0x03;
+        vram[65] = 0x00;
+
+        // BG0VOFS byte writes: low=8 then high=0.
+        io.write8(0x0400_0012, 0x08, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        io.write8(0x0400_0013, 0x00, &mut ic, &mut t, &mut d, &mut p, &mut k);
 
         p.step(
             ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,

--- a/src/gba/bus/io.rs
+++ b/src/gba/bus/io.rs
@@ -100,6 +100,7 @@ impl IoRegisters {
             REG_IME => Some(ic.read_ime()),
             // PPU display registers.
             ppu::REG_DISPCNT => Some(ppu.read_dispcnt()),
+            ppu::REG_BG0CNT => Some(ppu.read_bg0cnt()),
             ppu::REG_DISPSTAT => Some(ppu.read_dispstat()),
             ppu::REG_VCOUNT => Some(ppu.read_vcount()),
             // Keypad.
@@ -224,6 +225,7 @@ impl IoRegisters {
             REG_IME => ic.write_ime(value),
             // PPU display registers.
             ppu::REG_DISPCNT => ppu.write_dispcnt(value),
+            ppu::REG_BG0CNT => ppu.write_bg0cnt(value),
             ppu::REG_DISPSTAT => ppu.write_dispstat(value, ic),
             ppu::REG_VCOUNT => { /* VCOUNT is read-only */ }
             ppu::REG_BG0HOFS => ppu.write_bg0_hofs(value),
@@ -707,6 +709,110 @@ mod tests {
 
         // BG0VOFS = 8 pixels (0x0400_0012).
         io.write16(0x0400_0012, 8, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        p.step(
+            ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
+    fn mode0_bg0_64x32_uses_second_screenblock_for_x_over_255() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let mut vram = vec![0u8; 96 * 1024];
+        let mut pram = vec![0u8; 1024];
+
+        // Mode 0 + BG0 enabled.
+        io.write16(
+            ppu::REG_DISPCNT,
+            ppu::dispcnt::BG0_ENABLE,
+            &mut ic,
+            &mut t,
+            &mut d,
+            &mut p,
+            &mut k,
+        );
+        // BG0CNT: screen size = 64x32 (size=1 in bits 14..15).
+        io.write16(0x0400_0008, 0x4000, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        // BG palette entry 1 = red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 3 has pixel (0,0) = color index 1.
+        vram[96] = 0x01;
+
+        // Screenblock 0 entry (0,0) = tile 1 (empty).
+        vram[0x0000] = 0x01;
+        vram[0x0001] = 0x00;
+        // Screenblock 1 entry (0,0) = tile 3 (red).
+        vram[0x0800] = 0x03;
+        vram[0x0801] = 0x00;
+
+        // Scroll x to 256 so leftmost pixel samples from second screenblock.
+        io.write16(0x0400_0010, 256, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        p.step(
+            ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
+    fn mode0_bg0_32x64_uses_lower_screenblock_for_y_over_255() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let mut vram = vec![0u8; 96 * 1024];
+        let mut pram = vec![0u8; 1024];
+
+        // Mode 0 + BG0 enabled.
+        io.write16(
+            ppu::REG_DISPCNT,
+            ppu::dispcnt::BG0_ENABLE,
+            &mut ic,
+            &mut t,
+            &mut d,
+            &mut p,
+            &mut k,
+        );
+        // BG0CNT: screen size = 32x64 (size=2 in bits 14..15).
+        io.write16(0x0400_0008, 0x8000, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        // BG palette entry 1 = red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 3 has pixel (0,0) = color index 1.
+        vram[96] = 0x01;
+
+        // Screenblock 0 entry (0,0) = tile 1 (empty).
+        vram[0x0000] = 0x01;
+        vram[0x0001] = 0x00;
+        // Screenblock 1 entry (0,0) = tile 3 (red).
+        vram[0x0800] = 0x03;
+        vram[0x0801] = 0x00;
+
+        // Scroll y to 256 so top pixel samples from second screenblock row.
+        io.write16(0x0400_0012, 256, &mut ic, &mut t, &mut d, &mut p, &mut k);
 
         p.step(
             ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,

--- a/src/gba/bus/io.rs
+++ b/src/gba/bus/io.rs
@@ -848,6 +848,59 @@ mod tests {
     }
 
     #[test]
+    fn mode0_bg0_64x64_uses_bottom_right_screenblock_for_xy_over_255() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let mut vram = vec![0u8; 96 * 1024];
+        let mut pram = vec![0u8; 1024];
+
+        // Mode 0 + BG0 enabled.
+        io.write16(
+            ppu::REG_DISPCNT,
+            ppu::dispcnt::BG0_ENABLE,
+            &mut ic,
+            &mut t,
+            &mut d,
+            &mut p,
+            &mut k,
+        );
+        // BG0CNT: screen size = 64x64 (size=3 in bits 14..15).
+        io.write16(0x0400_0008, 0xC000, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        // BG palette entry 1 = red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 3 has pixel (0,0) = color index 1.
+        vram[96] = 0x01;
+
+        // Screenblock 0 entry (0,0) = tile 1 (empty).
+        vram[0x0000] = 0x01;
+        vram[0x0001] = 0x00;
+        // Screenblock 3 entry (0,0) = tile 3 (red).
+        vram[0x1800] = 0x03;
+        vram[0x1801] = 0x00;
+
+        // Scroll to x=256, y=256 so sample lands in bottom-right block.
+        io.write16(0x0400_0010, 256, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        io.write16(0x0400_0012, 256, &mut ic, &mut t, &mut d, &mut p, &mut k);
+
+        p.step(
+            ppu::CYCLES_PER_SCANLINE * ppu::SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
     fn mode0_bg0_hofs_byte_writes_preserve_low_byte() {
         let mut io = IoRegisters::new();
         let mut ic = InterruptController::new();

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -403,6 +403,17 @@ impl GbaBus {
         ]))
     }
 
+    /// Non-mutating halfword read used by debugging/tracing paths.
+    ///
+    /// This preserves `last_bus_value` so enabling tracing does not
+    /// perturb open-bus-visible behavior.
+    pub fn peek16(&mut self, addr: u32) -> u16 {
+        let prev = self.last_bus_value;
+        let value = self.read16(addr);
+        self.last_bus_value = prev;
+        value
+    }
+
     /// Read a 32-bit little-endian word from cart ROM, respecting mirroring.
     /// Returns `None` when no cartridge is inserted.
     fn rom_u32(&self, offset: usize) -> Option<u32> {
@@ -412,6 +423,17 @@ impl GbaBus {
             self.rom_byte(offset + 2)?,
             self.rom_byte(offset + 3)?,
         ]))
+    }
+
+    /// Non-mutating word read used by debugging/tracing paths.
+    ///
+    /// This preserves `last_bus_value` so enabling tracing does not
+    /// perturb open-bus-visible behavior.
+    pub fn peek32(&mut self, addr: u32) -> u32 {
+        let prev = self.last_bus_value;
+        let value = self.read32(addr);
+        self.last_bus_value = prev;
+        value
     }
 }
 

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -13,7 +13,11 @@
 use crate::gba::GbaBus;
 use crate::gba::cartridge::load_cartridge;
 use crate::gba::cpu::Arm7tdmi;
+use crate::gba::cpu::Bus;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::gba::debugging::{disasm_arm, disasm_thumb};
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
+use crate::platform::debugging::cpu_trace_level;
 use crate::platform::emulator::{Emulator, SystemType};
 use std::time::Duration;
 
@@ -65,6 +69,45 @@ impl Gba {
     pub fn bus_mut(&mut self) -> &mut GbaBus {
         &mut self.bus
     }
+
+    fn current_instruction_trace_line(&mut self) -> Option<String> {
+        if !self.bus.has_cart() {
+            return None;
+        }
+
+        let pc = self.cpu.regs.r[15];
+        if self.cpu.thumb() {
+            let raw = self.bus.read16(pc);
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let asm = disasm_thumb(raw, pc);
+                Some(format!("GBA THUMB PC={pc:08X} RAW={raw:04X} ASM={asm}"))
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                Some(format!("GBA THUMB PC={pc:08X} RAW={raw:04X}"))
+            }
+        } else {
+            let raw = self.bus.read32(pc);
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let asm = disasm_arm(raw, pc);
+                Some(format!("GBA ARM   PC={pc:08X} RAW={raw:08X} ASM={asm}"))
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                Some(format!("GBA ARM   PC={pc:08X} RAW={raw:08X}"))
+            }
+        }
+    }
+
+    fn assert_supported_ppu_mode(&self) {
+        let mode = self.bus.ppu.mode();
+        assert!(
+            mode == 0 || mode == 3,
+            "unimplemented GBA PPU mode {mode} requested via DISPCNT; only modes 0 and 3 are currently supported"
+        );
+    }
 }
 
 impl Emulator for Gba {
@@ -87,6 +130,14 @@ impl Emulator for Gba {
     fn run_tick(&mut self) -> u8 {
         if !self.bus.has_cart() {
             return 0;
+        }
+
+        self.assert_supported_ppu_mode();
+
+        if cpu_trace_level() > 0
+            && let Some(line) = self.current_instruction_trace_line()
+        {
+            crate::trace_cpu!("{line}");
         }
         if self.bus.ic.irq_line() {
             self.cpu.raise_irq();
@@ -168,7 +219,13 @@ impl Emulator for Gba {
     }
 
     fn reset(&mut self, _soft_reset: bool) {
-        // No-op: no state to reset yet
+        // Current reset model: reset CPU core state and restart execution
+        // from cart space when a ROM is present (or BIOS reset vector with no cart).
+        self.cpu = Arm7tdmi::new();
+        if self.bus.has_cart() {
+            self.cpu.regs.r[15] = 0x0800_0000;
+        }
+        self.bus.ppu.clear_frame_ready();
     }
 
     fn save_ram(&self) -> Result<(), String> {
@@ -191,6 +248,7 @@ mod tests {
     use crate::gba::cartridge::header::{
         COMPLEMENT_CHECK_OFFSET, FIXED_BYTE_OFFSET, FIXED_BYTE_VALUE, compute_complement_check,
     };
+    use crate::gba::ppu;
     use crate::platform::app_context::AppContext;
 
     fn make_gba() -> Gba {
@@ -202,6 +260,11 @@ mod tests {
         rom[FIXED_BYTE_OFFSET] = FIXED_BYTE_VALUE;
         rom[COMPLEMENT_CHECK_OFFSET] = compute_complement_check(&rom);
         rom
+    }
+
+    fn set_mode3_bg2_enabled(gba: &mut Gba) {
+        gba.bus
+            .write16(ppu::REG_DISPCNT, 3 | ppu::dispcnt::BG2_ENABLE);
     }
 
     #[test]
@@ -247,6 +310,7 @@ mod tests {
         let mut gba = make_gba();
         let rom = make_minimal_valid_gba_rom();
         gba.load_rom(&rom, "test.gba").expect("valid GBA ROM");
+        set_mode3_bg2_enabled(&mut gba);
 
         assert!(!gba.is_ready_to_render());
 
@@ -267,12 +331,100 @@ mod tests {
         let mut gba = make_gba();
         let rom = make_minimal_valid_gba_rom();
         gba.load_rom(&rom, "test.gba").expect("valid GBA ROM");
+        set_mode3_bg2_enabled(&mut gba);
 
         let cycles = gba.run_tick();
         assert!(
             cycles <= 16,
             "run_tick should return per-instruction cycles, got {cycles}"
         );
+    }
+
+    #[test]
+    fn test_reset_with_loaded_rom_rewinds_cpu_to_cart_start() {
+        let mut gba = make_gba();
+        let rom = make_minimal_valid_gba_rom();
+        gba.load_rom(&rom, "test.gba").expect("valid GBA ROM");
+        set_mode3_bg2_enabled(&mut gba);
+
+        let _ = gba.run_tick();
+        let _ = gba.run_tick();
+        assert_ne!(gba.cpu.regs.r[15], 0x0800_0000);
+
+        gba.reset(true);
+        assert_eq!(gba.cpu.regs.r[15], 0x0800_0000);
+
+        let _ = gba.run_tick();
+        gba.reset(false);
+        assert_eq!(gba.cpu.regs.r[15], 0x0800_0000);
+    }
+
+    #[test]
+    fn test_reset_without_rom_rewinds_cpu_to_reset_vector() {
+        let mut gba = make_gba();
+
+        let _ = gba.run_tick();
+        gba.cpu.regs.r[15] = 0x0800_0000;
+        gba.reset(false);
+
+        assert_eq!(gba.cpu.regs.r[15], 0x0000_0000);
+    }
+
+    #[test]
+    fn test_current_instruction_trace_line_reports_pc_and_raw_opcode() {
+        let mut gba = make_gba();
+        let rom = make_minimal_valid_gba_rom();
+        gba.load_rom(&rom, "test.gba").expect("valid GBA ROM");
+
+        let line = gba.current_instruction_trace_line();
+        assert!(
+            line.is_some(),
+            "trace line should be available when ROM is loaded"
+        );
+        let line = line.unwrap_or_default();
+        assert!(line.contains("PC=08000000"));
+        assert!(line.contains("RAW="));
+        assert!(line.contains("ASM="));
+    }
+
+    #[test]
+    fn test_run_tick_mode0_executes_without_panicking() {
+        let mut gba = make_gba();
+        let rom = make_minimal_valid_gba_rom();
+        gba.load_rom(&rom, "test.gba").expect("valid GBA ROM");
+        // Default DISPCNT mode after reset is 0.
+
+        let cycles = gba.run_tick();
+        assert!(
+            cycles <= 16,
+            "mode 0 should execute normally, got {cycles} cycles"
+        );
+    }
+
+    #[test]
+    fn test_run_tick_mode3_executes_without_panicking() {
+        let mut gba = make_gba();
+        let rom = make_minimal_valid_gba_rom();
+        gba.load_rom(&rom, "test.gba").expect("valid GBA ROM");
+        set_mode3_bg2_enabled(&mut gba);
+
+        let cycles = gba.run_tick();
+        assert!(
+            cycles <= 16,
+            "mode 3 should execute normally, got {cycles} cycles"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "unimplemented GBA PPU mode 1")]
+    fn test_run_tick_mode1_panics_while_unimplemented() {
+        let mut gba = make_gba();
+        let rom = make_minimal_valid_gba_rom();
+        gba.load_rom(&rom, "test.gba").expect("valid GBA ROM");
+
+        // Mode 1 remains unimplemented in this increment.
+        gba.bus.write16(ppu::REG_DISPCNT, 1);
+        let _ = gba.run_tick();
     }
 
     #[test]

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -13,7 +13,6 @@
 use crate::gba::GbaBus;
 use crate::gba::cartridge::load_cartridge;
 use crate::gba::cpu::Arm7tdmi;
-use crate::gba::cpu::Bus;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::gba::debugging::{disasm_arm, disasm_thumb};
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
@@ -77,7 +76,7 @@ impl Gba {
 
         let pc = self.cpu.regs.r[15];
         if self.cpu.thumb() {
-            let raw = self.bus.read16(pc);
+            let raw = self.bus.peek16(pc);
             #[cfg(not(target_arch = "wasm32"))]
             {
                 let asm = disasm_thumb(raw, pc);
@@ -88,7 +87,7 @@ impl Gba {
                 Some(format!("GBA THUMB PC={pc:08X} RAW={raw:04X}"))
             }
         } else {
-            let raw = self.bus.read32(pc);
+            let raw = self.bus.peek32(pc);
             #[cfg(not(target_arch = "wasm32"))]
             {
                 let asm = disasm_arm(raw, pc);
@@ -248,6 +247,7 @@ mod tests {
     use crate::gba::cartridge::header::{
         COMPLEMENT_CHECK_OFFSET, FIXED_BYTE_OFFSET, FIXED_BYTE_VALUE, compute_complement_check,
     };
+    use crate::gba::cpu::bus::Bus;
     use crate::gba::ppu;
     use crate::platform::app_context::AppContext;
 
@@ -384,6 +384,7 @@ mod tests {
         let line = line.unwrap_or_default();
         assert!(line.contains("PC=08000000"));
         assert!(line.contains("RAW="));
+        #[cfg(not(target_arch = "wasm32"))]
         assert!(line.contains("ASM="));
     }
 

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -361,9 +361,19 @@ impl Ppu {
         self.bg0_scroll.0 = value & 0x01FF;
     }
 
+    /// Read BG0HOFS (0x0400_0010).
+    pub fn read_bg0_hofs(&self) -> u16 {
+        self.bg0_scroll.0
+    }
+
     /// Write BG0VOFS (0x0400_0012). Only the low 9 bits are significant.
     pub fn write_bg0_vofs(&mut self, value: u16) {
         self.bg0_scroll.1 = value & 0x01FF;
+    }
+
+    /// Read BG0VOFS (0x0400_0012).
+    pub fn read_bg0_vofs(&self) -> u16 {
+        self.bg0_scroll.1
     }
 
     /// True after a completed frame, until [`Self::clear_frame_ready`].

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -507,12 +507,17 @@ impl Ppu {
     }
 
     /// Mode 0 (initial increment): render BG0 as 4bpp text background
-    /// using charblock 0 + screenblock 0 (BG0CNT reset defaults).
+    /// using BG0CNT-selected charblock/screenblock and scroll/size state.
     fn render_mode0_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8]) {
         if !self.bg0_enabled() {
             self.render_backdrop_scanline(y, pram);
             return;
         }
+
+        assert!(
+            self.bg0cnt & (1 << 7) == 0,
+            "unimplemented GBA Mode 0 BG0 8bpp rendering requested via BG0CNT bit 7"
+        );
 
         let backdrop = self.backdrop_bgr555(pram);
         let bg_size = (self.bg0cnt >> 14) & 0x0003;
@@ -1078,6 +1083,26 @@ mod tests {
 
         // With V-flip set, source row 7 appears at output y=0.
         assert_eq!(&ppu.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "unimplemented GBA Mode 0 BG0 8bpp rendering")]
+    fn mode0_bg0_8bpp_panics_until_implemented() {
+        let mut ppu = Ppu::new();
+        let mut ic = make_ic();
+        let vram = make_vram();
+        let pram = make_pram();
+
+        // Mode 0 + BG0 enabled, and BG0CNT bit 7 (8bpp) set.
+        ppu.write_dispcnt(dispcnt::BG0_ENABLE);
+        ppu.write_bg0cnt(1 << 7);
+
+        ppu.step(
+            CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
     }
 
     #[test]

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -266,6 +266,11 @@ impl Ppu {
         self.dispcnt & dispcnt::BG2_ENABLE != 0
     }
 
+    /// Whether `BG0` is enabled in DISPCNT.
+    pub fn bg0_enabled(&self) -> bool {
+        self.dispcnt & dispcnt::BG0_ENABLE != 0
+    }
+
     /// Borrow the affine register file for BG2 (`bg`=0) or BG3 (`bg`=1).
     /// Used by the affine renderer (and tests) to read the latched
     /// parameters and reference points.
@@ -456,8 +461,67 @@ impl Ppu {
             return;
         }
         match self.mode() {
+            0 => self.render_mode0_scanline(y, vram, pram),
             3 => self.render_mode3_scanline(y, vram, pram),
             _ => self.render_backdrop_scanline(y, pram),
+        }
+    }
+
+    /// Mode 0 (initial increment): render BG0 as 4bpp text background
+    /// using charblock 0 + screenblock 0 (BG0CNT reset defaults).
+    fn render_mode0_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8]) {
+        if !self.bg0_enabled() {
+            self.render_backdrop_scanline(y, pram);
+            return;
+        }
+
+        let backdrop = self.backdrop_bgr555(pram);
+        let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
+        let screen_y = y as usize;
+
+        for x in 0..(SCREEN_WIDTH as usize) {
+            let screen_x = x;
+            let tile_x = screen_x >> 3;
+            let tile_y = screen_y >> 3;
+            let map_index = tile_y * 32 + tile_x;
+            let map_off = map_index * 2;
+
+            let entry = if map_off + 1 < vram.len() {
+                u16::from_le_bytes([vram[map_off], vram[map_off + 1]])
+            } else {
+                0
+            };
+
+            let tile_id = (entry & 0x03FF) as usize;
+            let palette_bank = ((entry >> 12) & 0x000F) as usize;
+            let pixel_x = screen_x & 7;
+            let pixel_y = screen_y & 7;
+            let tile_addr = tile_id * 32 + pixel_y * 4 + (pixel_x >> 1);
+
+            let palette_index = vram
+                .get(tile_addr)
+                .map(|byte| {
+                    if pixel_x & 1 == 0 {
+                        byte & 0x0F
+                    } else {
+                        byte >> 4
+                    }
+                })
+                .unwrap_or(0) as usize;
+
+            let bgr555 = if palette_index == 0 {
+                backdrop
+            } else {
+                let pram_index = (palette_bank * 16 + palette_index) * 2;
+                if pram_index + 1 < pram.len() {
+                    u16::from_le_bytes([pram[pram_index], pram[pram_index + 1]])
+                } else {
+                    backdrop
+                }
+            };
+
+            let dst = row_start + x * BYTES_PER_PIXEL;
+            color::write_pixel(&mut self.framebuffer, dst, bgr555);
         }
     }
 
@@ -485,11 +549,7 @@ impl Ppu {
     /// Backdrop fill — uses palette entry 0 from PRAM. Used for modes
     /// where rendering is not yet implemented in this increment.
     fn render_backdrop_scanline(&mut self, y: u32, pram: &[u8]) {
-        let backdrop = if pram.len() >= 2 {
-            u16::from_le_bytes([pram[0], pram[1]])
-        } else {
-            0
-        };
+        let backdrop = self.backdrop_bgr555(pram);
         let (r, g, b) = color::bgr555_to_rgb888(backdrop);
         let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
         for x in 0..(SCREEN_WIDTH as usize) {
@@ -497,6 +557,14 @@ impl Ppu {
             self.framebuffer[dst] = r;
             self.framebuffer[dst + 1] = g;
             self.framebuffer[dst + 2] = b;
+        }
+    }
+
+    fn backdrop_bgr555(&self, pram: &[u8]) -> u16 {
+        if pram.len() >= 2 {
+            u16::from_le_bytes([pram[0], pram[1]])
+        } else {
+            0
         }
     }
 }
@@ -848,6 +916,40 @@ mod tests {
             &pram,
         );
         assert_eq!(&ppu.framebuffer()[0..3], &[0, 0, 0xFF]);
+    }
+
+    #[test]
+    fn mode0_bg0_4bpp_renders_first_tile_pixel() {
+        // Arrange: Mode 0 with BG0 enabled. Tile 0 pixel (0,0) uses color
+        // index 1 from BG palette bank 0, which we set to pure red.
+        let mut ppu = Ppu::new();
+        let mut ic = make_ic();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        ppu.write_dispcnt(0 | dispcnt::BG0_ENABLE);
+
+        // BG palette entry 1 = BGR555 red (0x001F).
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Charblock 0, tile 1, row 0, first byte: pixel0=1, pixel1=1.
+        vram[32] = 0x11;
+
+        // Screenblock 0, map entry (0,0): tile index 1, palbank 0, no flip.
+        vram[0x0000] = 0x01;
+        vram[0x0001] = 0x00;
+
+        // Act: render one full frame.
+        ppu.step(
+            CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        // Assert: top-left output pixel should come from tile data, not backdrop.
+        assert_eq!(&ppu.framebuffer()[0..3], &[0xFF, 0, 0]);
     }
 
     #[test]

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -115,6 +115,8 @@ pub mod dispstat {
 pub const REG_DISPCNT: u32 = 0x0400_0000;
 pub const REG_DISPSTAT: u32 = 0x0400_0004;
 pub const REG_VCOUNT: u32 = 0x0400_0006;
+pub const REG_BG0HOFS: u32 = 0x0400_0010;
+pub const REG_BG0VOFS: u32 = 0x0400_0012;
 
 // Affine background register file (BG2 and BG3). All eight registers
 // per background are write-only; reads are handled by the bus's
@@ -187,6 +189,8 @@ pub struct Ppu {
     /// Index `0` is BG2, index `1` is BG3. Consumed by the (future)
     /// affine renderer; the registers are write-only on the bus side.
     bg_affine: [BgAffine; 2],
+    /// BG0 horizontal and vertical scroll offsets (low 9 bits are valid).
+    bg0_scroll: (u16, u16),
 }
 
 impl Default for Ppu {
@@ -210,6 +214,7 @@ impl Ppu {
             framebuffer: vec![0; FRAMEBUFFER_BYTES],
             frame_ready: false,
             bg_affine: [BgAffine::default(); 2],
+            bg0_scroll: (0, 0),
         };
         // VCOUNT == LYC == 0 at reset; reflect that in the match flag.
         // No IRQ is raised here — the controller hasn't been wired up
@@ -335,6 +340,16 @@ impl Ppu {
             _ => return false, // odd-aligned writes don't reach here via halfword bus
         }
         true
+    }
+
+    /// Write BG0HOFS (0x0400_0010). Only the low 9 bits are significant.
+    pub fn write_bg0_hofs(&mut self, value: u16) {
+        self.bg0_scroll.0 = value & 0x01FF;
+    }
+
+    /// Write BG0VOFS (0x0400_0012). Only the low 9 bits are significant.
+    pub fn write_bg0_vofs(&mut self, value: u16) {
+        self.bg0_scroll.1 = value & 0x01FF;
     }
 
     /// True after a completed frame, until [`Self::clear_frame_ready`].
@@ -477,10 +492,10 @@ impl Ppu {
 
         let backdrop = self.backdrop_bgr555(pram);
         let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
-        let screen_y = y as usize;
+        let screen_y = ((y as usize) + self.bg0_scroll.1 as usize) & 0xFF;
 
         for x in 0..(SCREEN_WIDTH as usize) {
-            let screen_x = x;
+            let screen_x = (x + self.bg0_scroll.0 as usize) & 0xFF;
             let tile_x = screen_x >> 3;
             let tile_y = screen_y >> 3;
             let map_index = tile_y * 32 + tile_x;

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -992,7 +992,7 @@ mod tests {
         let mut vram = make_vram();
         let mut pram = make_pram();
 
-        ppu.write_dispcnt(0 | dispcnt::BG0_ENABLE);
+        ppu.write_dispcnt(dispcnt::BG0_ENABLE);
 
         // BG palette entry 1 = BGR555 red (0x001F).
         pram[2] = 0x1F;
@@ -1024,7 +1024,7 @@ mod tests {
         let mut vram = make_vram();
         let mut pram = make_pram();
 
-        ppu.write_dispcnt(0 | dispcnt::BG0_ENABLE);
+        ppu.write_dispcnt(dispcnt::BG0_ENABLE);
 
         // BG palette entry 1 = pure red.
         pram[2] = 0x1F;
@@ -1056,7 +1056,7 @@ mod tests {
         let mut vram = make_vram();
         let mut pram = make_pram();
 
-        ppu.write_dispcnt(0 | dispcnt::BG0_ENABLE);
+        ppu.write_dispcnt(dispcnt::BG0_ENABLE);
 
         // BG palette entry 1 = pure red.
         pram[2] = 0x1F;

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -113,6 +113,7 @@ pub mod dispstat {
 
 /// I/O register addresses owned by the PPU.
 pub const REG_DISPCNT: u32 = 0x0400_0000;
+pub const REG_BG0CNT: u32 = 0x0400_0008;
 pub const REG_DISPSTAT: u32 = 0x0400_0004;
 pub const REG_VCOUNT: u32 = 0x0400_0006;
 pub const REG_BG0HOFS: u32 = 0x0400_0010;
@@ -174,6 +175,8 @@ pub struct Ppu {
     /// The low 3 bits (V-Blank/H-Blank/V-Count flags) are status owned
     /// by the PPU; software writes to them are ignored.
     dispstat: u16,
+    /// `BG0CNT` (0x0400_0008) — BG0 control.
+    bg0cnt: u16,
     /// Current scanline (`VCOUNT`, 0x0400_0006). Wraps at
     /// [`SCANLINES_PER_FRAME`].
     vcount: u16,
@@ -209,6 +212,7 @@ impl Ppu {
         let mut ppu = Self {
             dispcnt: 0,
             dispstat: 0,
+            bg0cnt: 0,
             vcount: 0,
             line_cycle: 0,
             framebuffer: vec![0; FRAMEBUFFER_BYTES],
@@ -239,6 +243,11 @@ impl Ppu {
         self.dispstat
     }
 
+    /// Read `BG0CNT`.
+    pub fn read_bg0cnt(&self) -> u16 {
+        self.bg0cnt
+    }
+
     /// Write `DISPSTAT`. Only the IRQ enables (bits 3..5) and V-Count
     /// setting (bits 8..15) are settable; the read-only status bits
     /// retain their PPU-owned values. Writing `DISPSTAT` may change LYC,
@@ -249,6 +258,11 @@ impl Ppu {
         let status = self.dispstat & dispstat::STATUS_MASK;
         self.dispstat = status | (value & dispstat::WRITE_MASK);
         self.update_vcount_match_flag(Some(ic));
+    }
+
+    /// Write `BG0CNT`.
+    pub fn write_bg0cnt(&mut self, value: u16) {
+        self.bg0cnt = value;
     }
 
     /// Read `VCOUNT`.
@@ -491,15 +505,31 @@ impl Ppu {
         }
 
         let backdrop = self.backdrop_bgr555(pram);
+        let bg_size = (self.bg0cnt >> 14) & 0x0003;
+        let (width_tiles, height_tiles) = match bg_size {
+            0 => (32usize, 32usize),
+            1 => (64usize, 32usize),
+            2 => (32usize, 64usize),
+            _ => (64usize, 64usize),
+        };
+        let width_mask = width_tiles * 8 - 1;
+        let height_mask = height_tiles * 8 - 1;
+        let screenblock_base = (((self.bg0cnt >> 8) & 0x001F) as usize) * 0x800;
+        let charblock_base = (((self.bg0cnt >> 2) & 0x0003) as usize) * 16 * 1024;
         let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
-        let screen_y = ((y as usize) + self.bg0_scroll.1 as usize) & 0xFF;
+        let screen_y = ((y as usize) + self.bg0_scroll.1 as usize) & height_mask;
 
         for x in 0..(SCREEN_WIDTH as usize) {
-            let screen_x = (x + self.bg0_scroll.0 as usize) & 0xFF;
+            let screen_x = (x + self.bg0_scroll.0 as usize) & width_mask;
             let tile_x = screen_x >> 3;
             let tile_y = screen_y >> 3;
-            let map_index = tile_y * 32 + tile_x;
-            let map_off = map_index * 2;
+            let screenblock_x = tile_x >> 5;
+            let screenblock_y = tile_y >> 5;
+            let screenblock = screenblock_y * (width_tiles >> 5) + screenblock_x;
+            let local_tile_x = tile_x & 31;
+            let local_tile_y = tile_y & 31;
+            let map_off =
+                screenblock_base + screenblock * 0x800 + (local_tile_y * 32 + local_tile_x) * 2;
 
             let entry = if map_off + 1 < vram.len() {
                 u16::from_le_bytes([vram[map_off], vram[map_off + 1]])
@@ -521,7 +551,7 @@ impl Ppu {
             } else {
                 screen_y & 7
             };
-            let tile_addr = tile_id * 32 + pixel_y * 4 + (pixel_x >> 1);
+            let tile_addr = charblock_base + tile_id * 32 + pixel_y * 4 + (pixel_x >> 1);
 
             let palette_index = vram
                 .get(tile_addr)

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -493,9 +493,19 @@ impl Ppu {
             };
 
             let tile_id = (entry & 0x03FF) as usize;
+            let hflip = (entry & (1 << 10)) != 0;
+            let vflip = (entry & (1 << 11)) != 0;
             let palette_bank = ((entry >> 12) & 0x000F) as usize;
-            let pixel_x = screen_x & 7;
-            let pixel_y = screen_y & 7;
+            let pixel_x = if hflip {
+                7 - (screen_x & 7)
+            } else {
+                screen_x & 7
+            };
+            let pixel_y = if vflip {
+                7 - (screen_y & 7)
+            } else {
+                screen_y & 7
+            };
             let tile_addr = tile_id * 32 + pixel_y * 4 + (pixel_x >> 1);
 
             let palette_index = vram
@@ -949,6 +959,69 @@ mod tests {
         );
 
         // Assert: top-left output pixel should come from tile data, not backdrop.
+        assert_eq!(&ppu.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
+    fn mode0_bg0_4bpp_hflip_mirrors_tile_pixels() {
+        let mut ppu = Ppu::new();
+        let mut ic = make_ic();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        ppu.write_dispcnt(0 | dispcnt::BG0_ENABLE);
+
+        // BG palette entry 1 = pure red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 1 row 0: pixel 7 uses color index 1, others are 0.
+        // Byte 3 contains pixels 6 (low nibble) and 7 (high nibble).
+        vram[32 + 3] = 0x10;
+
+        // Screenblock entry (0,0): tile 1 + horizontal flip (bit 10).
+        vram[0x0000] = 0x01;
+        vram[0x0001] = 0x04;
+
+        ppu.step(
+            CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        // With H-flip set, source pixel 7 appears at output x=0.
+        assert_eq!(&ppu.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    #[test]
+    fn mode0_bg0_4bpp_vflip_mirrors_tile_rows() {
+        let mut ppu = Ppu::new();
+        let mut ic = make_ic();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        ppu.write_dispcnt(0 | dispcnt::BG0_ENABLE);
+
+        // BG palette entry 1 = pure red.
+        pram[2] = 0x1F;
+        pram[3] = 0x00;
+
+        // Tile 1 row 7 (byte offset +28): first pixel uses color index 1.
+        vram[32 + 28] = 0x01;
+
+        // Screenblock entry (0,0): tile 1 + vertical flip (bit 11).
+        vram[0x0000] = 0x01;
+        vram[0x0001] = 0x08;
+
+        ppu.step(
+            CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+        );
+
+        // With V-flip set, source row 7 appears at output y=0.
         assert_eq!(&ppu.framebuffer()[0..3], &[0xFF, 0, 0]);
     }
 


### PR DESCRIPTION
## Summary
- implement initial GBA Mode 0 BG0 4bpp scanline rendering path
- allow GBA run_tick in modes 0 and 3 while keeping explicit panic for unsupported modes
- add BG0 tile flip handling (horizontal and vertical)
- add BG0 scroll support via BG0HOFS and BG0VOFS
- implement BG0CNT size-based map addressing for 32x32, 64x32, 32x64, and 64x64 layouts
- fix BG0 scroll write8 merge behavior so byte writes preserve previously written byte

## Tests Added
- mode0_bg0_4bpp_renders_first_tile_pixel
- mode0_bg0_4bpp_hflip_mirrors_tile_pixels
- mode0_bg0_4bpp_vflip_mirrors_tile_rows
- mode0_bg0_hofs_scroll_changes_leftmost_pixel
- mode0_bg0_vofs_scroll_changes_top_row_pixel
- mode0_bg0_64x32_uses_second_screenblock_for_x_over_255
- mode0_bg0_32x64_uses_lower_screenblock_for_y_over_255
- mode0_bg0_64x64_uses_bottom_right_screenblock_for_xy_over_255
- mode0_bg0_hofs_byte_writes_preserve_low_byte
- mode0_bg0_vofs_byte_writes_preserve_low_byte

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- ./scripts/test-dir.sh src/gba
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts/mappertool -s scripts/scraper -s scripts -t . -p "test_*.py"
- npm test

Relates to #2207.
