### PR TITLE
feat(gba): require external BIOS for ROM loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,14 @@ Options:
   --display <N>         Select display index for fullscreen (default: 0)
   --nes-filter <name>   Specify NES shader filter (crt|ntsc|smooth|pal|none)
   --gb-filter <name>    Specify Game Boy shader filter (dmg|none)
+  --gba-bios-path <path>
+                         Path to external GBA BIOS file (required for GBA ROMs)
   --config <path>       Specify config file path (overrides default locations)
   --window-height <N>   Window height in pixels, windowed mode only (e.g., 720)
 ```
+
+For GBA ROMs, provide a 16384-byte BIOS file via `--gba-bios-path` or config key
+`gba-bios-path`. If unset, NESER also checks `~/.neser/gba_bios.bin`.
 
 ## Controller Mapping
 

--- a/neser.conf.example
+++ b/neser.conf.example
@@ -30,6 +30,7 @@
 #
 # NES-specific settings are prefixed with nes- (e.g., nes-hardware, nes-pulse1).
 # Game Boy-specific settings are prefixed with gb- (e.g., gb-hardware, gb-dmg-variant).
+# GBA-specific settings are prefixed with gba- (e.g., gba-hardware, gba-bios-path).
 # Generic platform settings have no prefix (e.g., audio, ram_init_mode).
 #
 # CLI boolean flags:
@@ -288,3 +289,17 @@ nes-vertical_overscan=8
 # Default: false (skip boot animation for faster startup)
 # Valid values: true, false
 #gb-boot-animation=false
+
+# -----------------------------------------------------------------------------
+# Game Boy Advance Settings
+# -----------------------------------------------------------------------------
+# GBA hardware model.
+# Valid values: agb, sp, micro
+# Default: agb
+#gba-hardware=agb
+
+# Path to an external GBA BIOS image.
+# This file is required to run GBA ROMs.
+# File must be exactly 16384 bytes.
+# If omitted, NESER also tries: ~/.neser/gba_bios.bin
+#gba-bios-path=/absolute/path/to/gba_bios.bin

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -112,6 +112,8 @@ pub struct GbaBus {
     /// BIOS reads from outside the BIOS region return open-bus instead of
     /// the BIOS contents.
     bios_locked: bool,
+    /// Whether a full BIOS image has been loaded into the bus.
+    bios_image_loaded: bool,
 }
 
 impl Default for GbaBus {
@@ -152,6 +154,7 @@ impl GbaBus {
             keypad: Keypad::new(),
             last_bus_value: 0,
             bios_locked: false,
+            bios_image_loaded: false,
         }
     }
 
@@ -161,6 +164,12 @@ impl GbaBus {
         let n = data.len().min(BIOS_SIZE);
         self.bios[..n].copy_from_slice(&data[..n]);
         self.bios_locked = false;
+        self.bios_image_loaded = n == BIOS_SIZE;
+    }
+
+    /// Whether a full BIOS image is currently loaded.
+    pub fn has_bios_image(&self) -> bool {
+        self.bios_image_loaded
     }
 
     /// Lock BIOS access. After this is called, reads of the BIOS region

--- a/src/gba/console/config.rs
+++ b/src/gba/console/config.rs
@@ -19,6 +19,11 @@ pub(crate) const GBA_CLI_FLAGS: &[CliFlag] = &[
         help: Some("GBA hardware model: agb, sp, micro (default: agb)"),
         has_value: true,
     },
+    CliFlag {
+        flag: "--gba-bios-path",
+        help: Some("Path to external GBA BIOS image (exactly 16384 bytes)"),
+        has_value: true,
+    },
 ];
 
 /// Valid values for the `gba-hardware` option (used in error messages).
@@ -43,11 +48,14 @@ pub enum GbaModel {
 impl GbaModel {
     /// Parse a hardware model string (case-insensitive).
     pub fn parse(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "agb" => Some(Self::Agb),
-            "sp" => Some(Self::Sp),
-            "micro" => Some(Self::Micro),
-            _ => None,
+        if s.eq_ignore_ascii_case("agb") {
+            Some(Self::Agb)
+        } else if s.eq_ignore_ascii_case("sp") {
+            Some(Self::Sp)
+        } else if s.eq_ignore_ascii_case("micro") {
+            Some(Self::Micro)
+        } else {
+            None
         }
     }
 
@@ -66,9 +74,20 @@ impl GbaModel {
 pub struct GbaConfig {
     /// Emulated GBA hardware model.
     pub hardware: GbaModel,
+    /// Optional path to an external GBA BIOS image.
+    pub bios_path: Option<String>,
 }
 
 impl GbaConfig {
+    fn set_bios_path_from_input(&mut self, value: &str) {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            self.bios_path = None;
+        } else {
+            self.bios_path = Some(trimmed.to_string());
+        }
+    }
+
     /// Parse GBA-specific CLI arguments and apply them to this config.
     pub(crate) fn apply_args(&mut self, args: &[String]) -> Result<(), String> {
         if let Some(hardware) =
@@ -79,6 +98,10 @@ impl GbaConfig {
                     "Invalid --gba-hardware value: '{hardware}'. Valid options are: {VALID_HARDWARE_MODELS}",
                 )
             })?;
+        }
+
+        if let Some(path) = crate::platform::config::parse_cli_string_arg(args, "--gba-bios-path") {
+            self.set_bios_path_from_input(&path);
         }
 
         Ok(())
@@ -95,6 +118,9 @@ impl GbaConfig {
                         "Invalid gba-hardware value: '{value}'. Valid options are: {VALID_HARDWARE_MODELS}",
                     )
                 })?;
+            }
+            "gba-bios-path" => {
+                self.set_bios_path_from_input(value);
             }
             _ => {
                 return Err(format!("Unknown GBA config key: {key}"));
@@ -233,5 +259,23 @@ mod tests {
         let result = config.apply_config_value("unknown-key", "value");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Unknown GBA config key"));
+    }
+
+    #[test]
+    fn test_gba_cli_flags_include_gba_bios_path() {
+        assert!(
+            GBA_CLI_FLAGS.iter().any(|f| f.flag == "--gba-bios-path"),
+            "GBA CLI flags should include --gba-bios-path"
+        );
+    }
+
+    #[test]
+    fn test_config_file_parse_gba_bios_path_supported() {
+        let mut config = GbaConfig::default();
+        let result = config.apply_config_value("gba-bios-path", "/tmp/gba_bios.bin");
+        assert!(
+            result.is_ok(),
+            "gba-bios-path should be accepted as a valid GBA config key"
+        );
     }
 }

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -18,6 +18,8 @@ use crate::gba::debugging::{disasm_arm, disasm_thumb};
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
 use crate::platform::debugging::cpu_trace_level;
 use crate::platform::emulator::{Emulator, SystemType};
+use std::fs;
+use std::path::PathBuf;
 use std::time::Duration;
 
 /// GBA display width in pixels.
@@ -31,6 +33,40 @@ const FRAME_DURATION_NANOS: u64 = 16_743_000;
 /// Shader presets allowed for GBA.
 const ALLOWED_SHADERS: &[&str] = &["none", "gba-lcd"];
 
+fn default_gba_bios_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".neser").join("gba_bios.bin"))
+}
+
+fn bios_size() -> usize {
+    crate::gba::bus::memory::BIOS_SIZE
+}
+
+fn load_bios_image(path: &PathBuf) -> Result<Vec<u8>, String> {
+    let metadata = fs::metadata(path).map_err(|_| "GBA BIOS file could not be read".to_string())?;
+
+    if !metadata.is_file() {
+        return Err("GBA BIOS path must point to a regular file".to_string());
+    }
+
+    if metadata.len() != bios_size() as u64 {
+        return Err(format!(
+            "GBA BIOS has invalid size: expected {} bytes",
+            bios_size()
+        ));
+    }
+
+    let bytes = fs::read(path).map_err(|_| "GBA BIOS file could not be read".to_string())?;
+    if bytes.len() != bios_size() {
+        return Err(format!(
+            "GBA BIOS has invalid size: expected {} bytes",
+            bios_size()
+        ));
+    }
+
+    Ok(bytes)
+}
+
 /// Game Boy Advance emulator wrapper.
 ///
 /// This struct wraps the GBA emulation core and provides the [`Emulator`] trait
@@ -42,6 +78,8 @@ pub struct Gba {
     /// System bus owning all peripheral state including APU, keypad and
     /// interrupt controller.
     bus: GbaBus,
+    bios_loaded: bool,
+    bios_load_error: Option<String>,
 }
 
 impl Gba {
@@ -52,10 +90,39 @@ impl Gba {
 
     /// Create a new GBA emulator instance.
     pub fn new(app_context: impl IntoSharedAppContext) -> Self {
+        let app_context = app_context.into_shared();
+        let mut bus = GbaBus::new();
+
+        let configured_bios_path = {
+            let cfg = app_context.borrow();
+            cfg.config().gba.bios_path.clone()
+        };
+
+        let bios_path = configured_bios_path
+            .map(PathBuf::from)
+            .or_else(default_gba_bios_path);
+
+        let (bios_loaded, bios_load_error) = if let Some(path) = bios_path {
+            match load_bios_image(&path) {
+                Ok(bytes) => {
+                    bus.load_bios(&bytes);
+                    (true, None)
+                }
+                Err(err) => (false, Some(err)),
+            }
+        } else {
+            (
+                false,
+                Some("GBA BIOS is required but no BIOS path is available".to_string()),
+            )
+        };
+
         Self {
-            app_context: app_context.into_shared(),
+            app_context,
             cpu: Arm7tdmi::new(),
-            bus: GbaBus::new(),
+            bus,
+            bios_loaded,
+            bios_load_error,
         }
     }
 
@@ -119,10 +186,16 @@ impl Emulator for Gba {
     }
 
     fn load_rom(&mut self, bytes: &[u8], _name: &str) -> Result<(), String> {
+        if !self.bios_loaded {
+            return Err(self
+                .bios_load_error
+                .clone()
+                .unwrap_or_else(|| "GBA BIOS is required but was not loaded".to_string()));
+        }
+
         let cart = load_cartridge(bytes).map_err(|e| format!("{e:?}"))?;
         self.bus.load_rom(cart.rom());
-        // With no BIOS loaded yet, start from cart space for incremental bring-up.
-        self.cpu.regs.r[15] = 0x0800_0000;
+        self.cpu.regs.r[15] = 0x0000_0000;
         Ok(())
     }
 
@@ -222,7 +295,7 @@ impl Emulator for Gba {
         // from cart space when a ROM is present (or BIOS reset vector with no cart).
         self.cpu = Arm7tdmi::new();
         if self.bus.has_cart() {
-            self.cpu.regs.r[15] = 0x0800_0000;
+            self.cpu.regs.r[15] = 0x0000_0000;
         }
         self.bus.ppu.clear_frame_ready();
     }
@@ -251,8 +324,17 @@ mod tests {
     use crate::gba::ppu;
     use crate::platform::app_context::AppContext;
 
-    fn make_gba() -> Gba {
+    fn make_gba_without_bios() -> Gba {
         Gba::new(AppContext::default())
+    }
+
+    fn make_gba() -> Gba {
+        let mut gba = make_gba_without_bios();
+        let bios = vec![0u8; crate::gba::bus::memory::BIOS_SIZE];
+        gba.bus.load_bios(&bios);
+        gba.bios_loaded = true;
+        gba.bios_load_error = None;
+        gba
     }
 
     fn make_minimal_valid_gba_rom() -> Vec<u8> {
@@ -306,6 +388,20 @@ mod tests {
     }
 
     #[test]
+    fn test_load_rom_fails_when_bios_is_missing() {
+        let mut gba = make_gba_without_bios();
+        let rom = make_minimal_valid_gba_rom();
+
+        let result = gba.load_rom(&rom, "test.gba");
+        assert!(result.is_err(), "GBA ROM loading should require BIOS");
+        let err = result.unwrap_err();
+        assert!(
+            err.to_lowercase().contains("bios"),
+            "error should mention BIOS, got: {err}"
+        );
+    }
+
+    #[test]
     fn test_run_tick_advances_to_frame_ready_and_clear_acknowledges() {
         let mut gba = make_gba();
         let rom = make_minimal_valid_gba_rom();
@@ -349,14 +445,14 @@ mod tests {
 
         let _ = gba.run_tick();
         let _ = gba.run_tick();
-        assert_ne!(gba.cpu.regs.r[15], 0x0800_0000);
+        assert_ne!(gba.cpu.regs.r[15], 0x0000_0000);
 
         gba.reset(true);
-        assert_eq!(gba.cpu.regs.r[15], 0x0800_0000);
+        assert_eq!(gba.cpu.regs.r[15], 0x0000_0000);
 
         let _ = gba.run_tick();
         gba.reset(false);
-        assert_eq!(gba.cpu.regs.r[15], 0x0800_0000);
+        assert_eq!(gba.cpu.regs.r[15], 0x0000_0000);
     }
 
     #[test]
@@ -382,7 +478,7 @@ mod tests {
             "trace line should be available when ROM is loaded"
         );
         let line = line.unwrap_or_default();
-        assert!(line.contains("PC=08000000"));
+        assert!(line.contains("PC=00000000"));
         assert!(line.contains("RAW="));
         #[cfg(not(target_arch = "wasm32"))]
         assert!(line.contains("ASM="));

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -78,7 +78,6 @@ pub struct Gba {
     /// System bus owning all peripheral state including APU, keypad and
     /// interrupt controller.
     bus: GbaBus,
-    bios_loaded: bool,
     bios_load_error: Option<String>,
 }
 
@@ -102,26 +101,22 @@ impl Gba {
             .map(PathBuf::from)
             .or_else(default_gba_bios_path);
 
-        let (bios_loaded, bios_load_error) = if let Some(path) = bios_path {
+        let bios_load_error = if let Some(path) = bios_path {
             match load_bios_image(&path) {
                 Ok(bytes) => {
                     bus.load_bios(&bytes);
-                    (true, None)
+                    None
                 }
-                Err(err) => (false, Some(err)),
+                Err(err) => Some(err),
             }
         } else {
-            (
-                false,
-                Some("GBA BIOS is required but no BIOS path is available".to_string()),
-            )
+            Some("GBA BIOS is required but no BIOS path is available".to_string())
         };
 
         Self {
             app_context,
             cpu: Arm7tdmi::new(),
             bus,
-            bios_loaded,
             bios_load_error,
         }
     }
@@ -186,7 +181,7 @@ impl Emulator for Gba {
     }
 
     fn load_rom(&mut self, bytes: &[u8], _name: &str) -> Result<(), String> {
-        if !self.bios_loaded {
+        if !self.bus.has_bios_image() {
             return Err(self
                 .bios_load_error
                 .clone()
@@ -323,16 +318,18 @@ mod tests {
     use crate::gba::cpu::bus::Bus;
     use crate::gba::ppu;
     use crate::platform::app_context::AppContext;
+    use crate::platform::config::Config;
 
     fn make_gba_without_bios() -> Gba {
-        Gba::new(AppContext::default())
+        let mut config = Config::default();
+        config.gba.bios_path = Some("/__neser_missing_gba_bios.bin".to_string());
+        Gba::new(AppContext::new_with_config(config))
     }
 
     fn make_gba() -> Gba {
         let mut gba = make_gba_without_bios();
         let bios = vec![0u8; crate::gba::bus::memory::BIOS_SIZE];
         gba.bus.load_bios(&bios);
-        gba.bios_loaded = true;
         gba.bios_load_error = None;
         gba
     }

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -1090,6 +1090,9 @@ impl Config {
             "gba-hardware" => {
                 self.gba.apply_config_value("gba-hardware", value)?;
             }
+            "gba-bios-path" => {
+                self.gba.apply_config_value("gba-bios-path", value)?;
+            }
             _ => {} // Unknown keys are silently ignored (may have been handled by sub-configs)
         }
         Ok(())
@@ -4913,6 +4916,15 @@ nes-filter=invalid-shader
         let result = config.apply_config_value("gb-hardware", "dmg-a");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid gb-hardware value"));
+    }
+
+    #[test]
+    fn test_config_file_gba_bios_path_sets_gba_config() {
+        let mut config = Config::with_defaults();
+        config
+            .apply_config_value("gba-bios-path", "/tmp/gba_bios.bin")
+            .unwrap();
+        assert_eq!(config.gba.bios_path.as_deref(), Some("/tmp/gba_bios.bin"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require an external BIOS before GBA ROM loading
- add GBA config/CLI plumbing for BIOS path:
  - `gba-bios-path` config key
  - `--gba-bios-path` CLI flag
- support fallback BIOS path lookup at `~/.neser/gba_bios.bin`
- validate BIOS file is a regular file and exactly 16384 bytes
- surface descriptive BIOS load errors at GBA ROM load time
- route `gba-bios-path` through top-level config delegation
- update docs in `neser.conf.example` and `README.md`
- add tests for new config keys/flags and strict BIOS-required load behavior

## Behavior changes
- GBA ROM loading now fails when BIOS is missing or invalid.
- With a valid BIOS loaded, GBA ROM execution starts at reset vector `0x00000000`.

## Validation
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/gba src/nes/console --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts/mappertool -s scripts/scraper -s scripts -t . -p "test_*.py"`
- `npm test`
