### PR TITLE
feat(gba): integrate gba-suite ARM/Thumb ROM tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       nes: ${{ steps.filter.outputs.nes }}
       gb: ${{ steps.filter.outputs.gb }}
       gba: ${{ steps.filter.outputs.gba }}
+      gba_test_assets: ${{ steps.filter.outputs.gba_test_assets }}
       platform: ${{ steps.filter.outputs.platform }}
       root_rust: ${{ steps.filter.outputs.root_rust }}
 
@@ -65,6 +66,9 @@ jobs:
               - 'src/gb/**'
             gba:
               - 'src/gba/**'
+            gba_test_assets:
+              - 'roms/gba/automated_tests/gba-tests'
+              - 'roms/gba/automated_tests/gba-tests/**'
             platform:
               - 'src/platform/**'
             root_rust:
@@ -115,30 +119,35 @@ jobs:
           CHANGED_NES: ${{ needs.changes.outputs.nes }}
           CHANGED_GB: ${{ needs.changes.outputs.gb }}
           CHANGED_GBA: ${{ needs.changes.outputs.gba }}
+          CHANGED_GBA_TEST_ASSETS: ${{ needs.changes.outputs.gba_test_assets }}
           CHANGED_PLATFORM: ${{ needs.changes.outputs.platform }}
           CHANGED_ROOT: ${{ needs.changes.outputs.root_rust }}
         run: |
           # If platform or root files changed, run all tests (cross-cutting deps)
           if [[ "$CHANGED_PLATFORM" == "true" || "$CHANGED_ROOT" == "true" ]]; then
             echo "filter=" >> "$GITHUB_OUTPUT"
-            echo "run_integration=true" >> "$GITHUB_OUTPUT"
+            echo "run_nes_integration=true" >> "$GITHUB_OUTPUT"
+            echo "run_gba_integration=true" >> "$GITHUB_OUTPUT"
             echo "Running all tests (platform or root change detected)"
           else
             FILTER=""
-            RUN_INTEGRATION=false
+            RUN_NES_INTEGRATION=false
+            RUN_GBA_INTEGRATION=false
             if [[ "$CHANGED_NES" == "true" ]]; then
               FILTER="${FILTER} nes::"
-              RUN_INTEGRATION=true
+              RUN_NES_INTEGRATION=true
             fi
             if [[ "$CHANGED_GB" == "true" ]]; then
               FILTER="${FILTER} gb::"
             fi
-            if [[ "$CHANGED_GBA" == "true" ]]; then
+            if [[ "$CHANGED_GBA" == "true" || "$CHANGED_GBA_TEST_ASSETS" == "true" ]]; then
               FILTER="${FILTER} gba::"
+              RUN_GBA_INTEGRATION=true
             fi
             echo "filter=${FILTER}" >> "$GITHUB_OUTPUT"
-            echo "run_integration=${RUN_INTEGRATION}" >> "$GITHUB_OUTPUT"
-            echo "Test filter: '${FILTER}', integration: ${RUN_INTEGRATION}"
+            echo "run_nes_integration=${RUN_NES_INTEGRATION}" >> "$GITHUB_OUTPUT"
+            echo "run_gba_integration=${RUN_GBA_INTEGRATION}" >> "$GITHUB_OUTPUT"
+            echo "Test filter: '${FILTER}', nes_integration: ${RUN_NES_INTEGRATION}, gba_integration: ${RUN_GBA_INTEGRATION}"
           fi
 
       - name: Run unit tests
@@ -146,15 +155,19 @@ jobs:
           FILTER="${{ steps.test-filter.outputs.filter }}"
           if [[ -z "$FILTER" ]]; then
             echo "Running all unit tests (no filter)"
-            cargo test --lib --examples --all-features -- --skip 'nes::integration_tests'
+            cargo test --lib --examples --all-features -- --skip 'nes::integration_tests' --skip 'gba::integration_tests'
           else
             echo "Running filtered unit tests: $FILTER"
-            cargo test --lib --examples --all-features -- $FILTER --skip 'nes::integration_tests'
+            cargo test --lib --examples --all-features -- $FILTER --skip 'nes::integration_tests' --skip 'gba::integration_tests'
           fi
 
-      - name: Run integration tests
-        if: steps.test-filter.outputs.run_integration == 'true'
+      - name: Run NES integration tests
+        if: steps.test-filter.outputs.run_nes_integration == 'true'
         run: cargo test --lib --all-features -- 'nes::integration_tests::'
+
+      - name: Run GBA integration tests
+        if: steps.test-filter.outputs.run_gba_integration == 'true'
+        run: cargo test --lib --all-features -- 'gba::integration_tests::'
 
   rust-lint-pr:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -121,6 +121,27 @@ Options:
 For GBA ROMs, provide a 16384-byte BIOS file via `--gba-bios-path` or config key
 `gba-bios-path`. If unset, NESER also checks `~/.neser/gba_bios.bin`.
 
+### GBA Automated CPU Suite Tests
+
+The repository includes the jsmolka `gba-tests` suite as a submodule at
+`roms/gba/automated_tests/gba-tests`.
+
+Run the ARM/Thumb GBA suite integration tests with:
+
+```bash
+cargo test --no-default-features --lib gba::integration_tests::gba_suite_tests::
+```
+
+These tests execute:
+
+- `roms/gba/automated_tests/gba-tests/arm/arm.gba`
+- `roms/gba/automated_tests/gba-tests/thumb/thumb.gba`
+
+Pass/fail is read from suite-native registers at completion:
+
+- ARM uses `R12`
+- Thumb uses `R7`
+
 ## Controller Mapping
 
 NESER supports two controller ports (port 1 and port 2), each of which can be configured with different controller types.

--- a/architecture.md
+++ b/architecture.md
@@ -242,8 +242,11 @@ All Game Boy Advance hardware lives under `src/gba/`. The module currently provi
 
 | Directory/File | Description |
 | ---------------- | ------------- |
-| `src/gba/mod.rs` | Game Boy Advance module root. Re-exports `Gba` (platform-facing wrapper), the `cpu`, `input` and `ppu` sub-modules, `GbaBus`, `Ppu`, `Keypad`, and `GbaCartridge` / `SaveType` / `load_cartridge`. |
-| `src/gba/console/gba.rs` | `Gba` — platform-facing GBA wrapper implementing the `Emulator` trait. Currently a stub; will own the ARM7TDMI core, bus, PPU, etc. as subsequent phases land. |
+| `src/gba/mod.rs` | Game Boy Advance module root. Re-exports `Gba` (platform-facing wrapper), the `cpu`, `input` and `ppu` sub-modules, `GbaBus`, `Ppu`, `Keypad`, and `GbaCartridge` / `SaveType` / `load_cartridge`. Includes `#[cfg(test)]` GBA integration test modules under `src/gba/integration_tests/`. |
+| `src/gba/console/gba.rs` | `Gba` — platform-facing GBA wrapper implementing the `Emulator` trait. Owns ARM7TDMI + bus, executes per-instruction ticks, handles IRQ line dispatch, frame-ready signaling, and ROM loading guarded by BIOS presence. |
+| `src/gba/integration_tests/mod.rs` | GBA integration test module root. Includes gba-suite runner and test definitions. |
+| `src/gba/integration_tests/gba_suite_runner.rs` | Headless harness for jsmolka `gba-tests` ARM/Thumb ROMs. Loads ROM assets from `roms/gba/automated_tests/gba-tests`, injects a synthetic BIOS for CI-safe execution, runs until idle-loop detection/timeout, and reports pass/fail from suite registers (ARM `R12`, Thumb `R7`). |
+| `src/gba/integration_tests/gba_suite_tests.rs` | Two ROM-level integration tests (`arm.gba`, `thumb.gba`) with failure diagnostics (index/register/PC/cycles/exit reason). |
 | `src/gba/cpu/mod.rs` | Module root for the ARM7TDMI core. Re-exports `Arm7tdmi`, `Bus`, `RamBus`, `Registers`, `CpuMode`, etc. |
 | `src/gba/cpu/registers.rs` | `Registers` — ARM7TDMI register file with R0–R15, CPSR, and per-mode banked SPSR/SP/LR (and FIQ-banked R8–R12). Includes `CpuMode` (USR/FIQ/IRQ/SVC/ABT/UND/SYS) and `condition_met` for the 16 ARM condition codes. |
 | `src/gba/cpu/bus.rs` | `Bus` trait used by the CPU for byte/halfword/word reads and writes, plus a flat little-endian `RamBus` implementation used by tests and boot stubs. |
@@ -386,6 +389,7 @@ Shader presets using the Slang shading language, loaded via librashader:
 | Directory | Description |
 | --------- | ------------- |
 | `roms/automated_tests/` | **70+ test ROM suites** used by the integration test harness. Includes Blargg's CPU/PPU/APU tests, DMA timing tests, mapper-specific tests (MMC3, MMC5, FME-7, VRC6), sprite tests, and more. |
+| `roms/gba/automated_tests/gba-tests/` | Git submodule snapshot of jsmolka `gba-tests` (ARM/Thumb GBA CPU validation ROMs) used by `src/gba/integration_tests/gba_suite_tests.rs`. |
 | `roms/automated_tests/mapper_verification/` | Custom mapper verification ROMs built from assembly source with per-mapper test definitions. |
 | `roms/manual_tests/` | ROMs for manual visual/audio verification (e.g., volume tests). |
 | `roms/games/` | Game ROMs (not checked into version control). Subdirectories organized by mapper number for autorun regression tests. |
@@ -405,7 +409,7 @@ Shader presets using the Slang shading language, loaded via librashader:
 
 | Workflow | Description |
 | ---------- | ------------- |
-| `ci.yml` | Main CI pipeline. Runs on push to `main` and PRs. Jobs: Rust tests (`cargo test --lib --all-features`), Clippy lint, `cargo fmt` check, WASM build + test (`wasm-pack test`), web JS unit tests (`npm test`), web Playwright integration tests, and Python script tests. Uses path-based change detection to skip unchanged jobs. |
+| `ci.yml` | Main CI pipeline. Runs on push to `main` and PRs. Jobs: Rust tests (`cargo test --lib --all-features`), Clippy lint, `cargo fmt` check, WASM build + test (`wasm-pack test`), web JS unit tests (`npm test`), web Playwright integration tests, and Python script tests. Uses path-based change detection to skip unchanged jobs, and runs NES/GBA integration suites selectively (GBA integration also triggers on `roms/gba/automated_tests/gba-tests` asset changes). |
 | `release.yml` | Release pipeline triggered by version tags (`v*.*.*`). Runs full CI, then cross-compiles release binaries for Linux (x86_64), macOS (x86_64 + aarch64), and Windows (x86_64). Windows builds bundle SDL2.dll and SDL2_ttf.dll. Publishes to GitHub Releases with a git-cliff changelog. |
 
 #### Agentic Workflows (Copilot-powered)

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -131,6 +131,34 @@ impl Gba {
         &mut self.bus
     }
 
+    #[cfg(test)]
+    pub(crate) fn cpu_pc(&self) -> u32 {
+        self.cpu.regs.r[15]
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cpu_reg(&self, index: usize) -> u32 {
+        assert!(index < 16, "cpu register index out of range: {index}");
+        self.cpu.regs.r[index]
+    }
+
+    #[cfg(test)]
+    pub(crate) fn run_tick_for_tests(&mut self) -> u8 {
+        if !self.bus.has_cart() {
+            return 0;
+        }
+
+        if self.bus.ic.irq_line() {
+            self.cpu.raise_irq();
+        } else {
+            self.cpu.clear_irq();
+        }
+
+        let cycles = self.cpu.step(&mut self.bus);
+        self.bus.step(cycles);
+        cycles as u8
+    }
+
     fn current_instruction_trace_line(&mut self) -> Option<String> {
         if !self.bus.has_cart() {
             return None;

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -8,6 +8,8 @@ const MAX_CYCLES: u64 = 120_000_000;
 // The suite ends in `idle: b idle`; 1024 repeated PCs is a conservative
 // threshold to recognize that terminal loop without waiting for MAX_CYCLES.
 const IDLE_PC_STABLE_THRESHOLD: u32 = 1_024;
+const BIOS_RESET_STUB_LDR_PC_MINUS_4: u32 = 0xE51F_F004;
+const CART_ENTRYPOINT: u32 = 0x0800_0000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Suite {
@@ -57,6 +59,9 @@ pub fn run_suite(suite: Suite) -> SuiteResult {
 
     let mut gba = Gba::new(AppContext::default());
     let bios = vec![0u8; BIOS_SIZE];
+    let mut bios = bios;
+    bios[0..4].copy_from_slice(&BIOS_RESET_STUB_LDR_PC_MINUS_4.to_le_bytes());
+    bios[4..8].copy_from_slice(&CART_ENTRYPOINT.to_le_bytes());
     gba.bus_mut().load_bios(&bios);
     gba.load_rom(&rom, rom_path.to_str().unwrap_or("gba-suite-rom"))
         .unwrap_or_else(|e| {

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -1,0 +1,113 @@
+use crate::gba::Gba;
+use crate::gba::bus::memory::BIOS_SIZE;
+use crate::platform::app_context::AppContext;
+use crate::platform::emulator::Emulator;
+use std::path::PathBuf;
+
+const MAX_CYCLES: u64 = 120_000_000;
+// The suite ends in `idle: b idle`; 1024 repeated PCs is a conservative
+// threshold to recognize that terminal loop without waiting for MAX_CYCLES.
+const IDLE_PC_STABLE_THRESHOLD: u32 = 1_024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Suite {
+    Arm,
+    Thumb,
+}
+
+impl Suite {
+    fn rom_path(self) -> PathBuf {
+        let rel = match self {
+            Self::Arm => "roms/gba/automated_tests/gba-tests/arm/arm.gba",
+            Self::Thumb => "roms/gba/automated_tests/gba-tests/thumb/thumb.gba",
+        };
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+    }
+
+    fn result_register(self) -> (usize, &'static str) {
+        match self {
+            Self::Arm => (12, "r12"),
+            Self::Thumb => (7, "r7"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitReason {
+    IdleLoopDetected,
+    CycleLimitReached,
+    CartStopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SuiteResult {
+    pub passed: bool,
+    pub failing_index: u32,
+    pub cycles: u64,
+    pub pc: u32,
+    pub reg_name: &'static str,
+    pub exit_reason: ExitReason,
+}
+
+pub fn run_suite(suite: Suite) -> SuiteResult {
+    let rom_path = suite.rom_path();
+    let rom = std::fs::read(&rom_path).unwrap_or_else(|e| {
+        panic!("failed to read suite ROM {}: {e}", rom_path.display());
+    });
+
+    let mut gba = Gba::new(AppContext::default());
+    let bios = vec![0u8; BIOS_SIZE];
+    gba.bus_mut().load_bios(&bios);
+    gba.load_rom(&rom, rom_path.to_str().unwrap_or("gba-suite-rom"))
+        .unwrap_or_else(|e| {
+            panic!("failed to load suite ROM {}: {e}", rom_path.display());
+        });
+
+    let mut cycles = 0u64;
+    let mut stable_pc_count = 0u32;
+    let mut last_pc: Option<u32> = None;
+
+    while cycles < MAX_CYCLES {
+        let tick_cycles = gba.run_tick_for_tests() as u64;
+        if tick_cycles == 0 {
+            let pc = gba.cpu_pc();
+            return result_from_register(&gba, suite, cycles, pc, ExitReason::CartStopped);
+        }
+        cycles += tick_cycles;
+
+        let pc = gba.cpu_pc();
+        if Some(pc) == last_pc {
+            stable_pc_count += 1;
+        } else {
+            stable_pc_count = 1;
+            last_pc = Some(pc);
+        }
+
+        if stable_pc_count >= IDLE_PC_STABLE_THRESHOLD {
+            return result_from_register(&gba, suite, cycles, pc, ExitReason::IdleLoopDetected);
+        }
+    }
+
+    let pc = gba.cpu_pc();
+    result_from_register(&gba, suite, cycles, pc, ExitReason::CycleLimitReached)
+}
+
+fn result_from_register(
+    gba: &Gba,
+    suite: Suite,
+    cycles: u64,
+    pc: u32,
+    exit_reason: ExitReason,
+) -> SuiteResult {
+    let (reg_index, reg_name) = suite.result_register();
+    let failing_index = gba.cpu_reg(reg_index);
+
+    SuiteResult {
+        passed: failing_index == 0,
+        failing_index,
+        cycles,
+        pc,
+        reg_name,
+        exit_reason,
+    }
+}

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -1,0 +1,21 @@
+use super::gba_suite_runner::{Suite, run_suite};
+
+#[test]
+fn gba_suite_arm_rom_passes() {
+    let result = run_suite(Suite::Arm);
+    assert!(
+        result.passed,
+        "arm suite failed: index={} reg={} pc=0x{:08X} cycles={} exit={:?}",
+        result.failing_index, result.reg_name, result.pc, result.cycles, result.exit_reason
+    );
+}
+
+#[test]
+fn gba_suite_thumb_rom_passes() {
+    let result = run_suite(Suite::Thumb);
+    assert!(
+        result.passed,
+        "thumb suite failed: index={} reg={} pc=0x{:08X} cycles={} exit={:?}",
+        result.failing_index, result.reg_name, result.pc, result.cycles, result.exit_reason
+    );
+}

--- a/src/gba/integration_tests/mod.rs
+++ b/src/gba/integration_tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod gba_suite_runner;
+pub mod gba_suite_tests;

--- a/src/gba/mod.rs
+++ b/src/gba/mod.rs
@@ -12,6 +12,8 @@ pub mod cpu;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod debugging;
 pub mod input;
+#[cfg(test)]
+pub mod integration_tests;
 pub mod ppu;
 
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary
- add GBA integration test module wiring under `src/gba/integration_tests`
- add gba-suite ROM runner for `arm.gba` and `thumb.gba` from the `roms/gba/automated_tests/gba-tests` submodule
- assert suite-native result registers (`R12` for ARM, `R7` for Thumb) with detailed failure diagnostics
- add test-only GBA stepping helper to bypass unsupported PPU mode assertions during CPU-suite execution
- update CI path filters and test jobs to run GBA integration tests when GBA code or GBA test assets change
- update README and architecture docs for the new GBA suite workflow

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt`
- `./scripts/test-dir.sh src/gba`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts/mappertool -s scripts/scraper -s scripts -t . -p "test_*.py"`
- `npm test`

## Issue
- Closes #2304
