### PR TITLE
feat(gba): improve suite coverage and pass arm/thumb/nes gates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,4 +131,4 @@ codegen-units = 1
 
 [profile.dev.package."*"]
 opt-level = 3
-incremental = true
+incremental = false

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -143,6 +143,35 @@ impl Gba {
     }
 
     #[cfg(test)]
+    pub(crate) fn cpu_cpsr(&self) -> u32 {
+        self.cpu.regs.cpsr
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cpu_thumb(&self) -> bool {
+        self.cpu.regs.thumb()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn init_test_stack_pointers(&mut self) {
+        use crate::gba::cpu::registers::CpuMode;
+
+        let saved_mode = self.cpu.regs.mode();
+
+        // Provide deterministic stack pointers for the modes used by suite ROMs.
+        self.cpu.regs.switch_mode(CpuMode::Supervisor);
+        self.cpu.regs.r[13] = 0x0300_7FE0;
+
+        self.cpu.regs.switch_mode(CpuMode::Irq);
+        self.cpu.regs.r[13] = 0x0300_7FA0;
+
+        self.cpu.regs.switch_mode(CpuMode::System);
+        self.cpu.regs.r[13] = 0x0300_7F00;
+
+        self.cpu.regs.switch_mode(saved_mode);
+    }
+
+    #[cfg(test)]
     pub(crate) fn run_tick_for_tests(&mut self) -> u8 {
         if !self.bus.has_cart() {
             return 0;

--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -809,6 +809,12 @@ fn execute_block_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32)
         let start = if p { end } else { end.wrapping_add(4) };
         (start, base)
     };
+    let writeback_value = if u {
+        final_addr
+    } else {
+        base.wrapping_sub(reg_count * 4)
+    };
+    let first_reg_in_list = effective_rlist.trailing_zeros() as usize;
 
     // Process registers in order (lowest numbered first for ascending,
     // but addresses increase regardless of direction)
@@ -832,6 +838,10 @@ fn execute_block_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32)
                 // Store
                 let value = if transfer_user_regs {
                     regs.read_user_reg(i as usize)
+                } else if w && i == rn && rn != first_reg_in_list {
+                    // STM with base in rlist and writeback stores updated base
+                    // when base isn't the first transferred register.
+                    writeback_value
                 } else if i == 15 {
                     regs.r[i].wrapping_add(4)
                 } else {
@@ -853,11 +863,7 @@ fn execute_block_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32)
     // For LDM with base in the register list, loaded value must be preserved.
     let base_in_rlist = (effective_rlist & (1 << rn)) != 0;
     if w && !(l && base_in_rlist) {
-        regs.r[rn] = if u {
-            final_addr
-        } else {
-            base.wrapping_sub(reg_count * 4)
-        };
+        regs.r[rn] = writeback_value;
     }
 
     // Cycle timing per GBATek:

--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -180,6 +180,7 @@ fn execute_data_processing(regs: &mut Registers, instr: u32) -> ExecOutcome {
     let rn = ((instr >> 16) & 0xF) as usize;
     let rd = ((instr >> 12) & 0xF) as usize;
     let i_bit = (instr >> 25) & 1 != 0;
+    let reg_shift_by_register = !i_bit && ((instr >> 4) & 1 != 0);
 
     // Resolve operand2 (with shifter carry-out for logical operations).
     let (op2, shifter_carry) = if i_bit {
@@ -204,10 +205,21 @@ fn execute_data_processing(regs: &mut Registers, instr: u32) -> ExecOutcome {
             let rs = ((instr >> 8) & 0xF) as usize;
             regs.r[rs] & 0xFF
         };
-        compute_shift(regs.r[rm], shift_type, amount, regs.c_flag(), shift_imm_bit)
+        // With register-specified shifts, using PC as operand observes PC+12.
+        let rm_val = if !shift_imm_bit && rm == 15 {
+            regs.r[rm].wrapping_add(4)
+        } else {
+            regs.r[rm]
+        };
+        compute_shift(rm_val, shift_type, amount, regs.c_flag(), shift_imm_bit)
     };
 
-    let rn_val = regs.r[rn];
+    // For register-specified shifts, Rn == PC also observes PC+12.
+    let rn_val = if reg_shift_by_register && rn == 15 {
+        regs.r[rn].wrapping_add(4)
+    } else {
+        regs.r[rn]
+    };
     let cf_in = regs.c_flag();
 
     let (result, carry, overflow, write) = match opcode {
@@ -269,13 +281,17 @@ fn execute_data_processing(regs: &mut Registers, instr: u32) -> ExecOutcome {
     let mut branched = write && rd == 15;
 
     if s_bit {
-        if write && rd == 15 {
-            // S-bit + Rd=PC restores CPSR from SPSR (used by MOVS PC, LR).
+        if rd == 15 {
+            // S-bit + Rd=PC restores CPSR from SPSR.
+            // For non-writing test ops (CMP/CMN/TST/TEQ), this must not
+            // flush the pipeline; only true PC writes branch.
             if regs.mode().has_spsr() {
                 let spsr = regs.spsr();
                 regs.write_cpsr(spsr);
             }
-            branched = true;
+            if write {
+                branched = true;
+            }
         } else {
             let n = result & 0x8000_0000 != 0;
             let z = result == 0;
@@ -459,10 +475,13 @@ fn execute_single_data_transfer<B: Bus>(
         regs.r[rd] = value;
         result_branch = rd == 15;
     } else {
-        // Store. PC stored as PC+12 on ARM7 (already PC+8, +4 for store quirk),
-        // we'll keep PC+8 for simplicity which is sufficient for the tests we
-        // exercise.
-        let value = regs.r[rd];
+        // Store. On ARM7TDMI, storing PC writes PC+12 (R15 already reads as
+        // PC+8 during execute, then store adds +4).
+        let value = if rd == 15 {
+            regs.r[rd].wrapping_add(4)
+        } else {
+            regs.r[rd]
+        };
         if b_byte {
             bus.write8(addr, value as u8);
         } else {
@@ -472,7 +491,7 @@ fn execute_single_data_transfer<B: Bus>(
     }
 
     // Writeback (post-indexing always writes back; pre-indexing only when W=1).
-    if !p || w {
+    if (!p || w) && !(l && rd == rn) {
         regs.r[rn] = offset_addr;
     }
 
@@ -700,7 +719,12 @@ fn execute_halfword_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u
         let value = match sh {
             0b01 => {
                 // LDRH: Load unsigned halfword
-                bus.read16(addr & !1) as u32
+                let raw = bus.read16(addr & !1) as u32;
+                if addr & 1 != 0 {
+                    raw.rotate_right(8)
+                } else {
+                    raw
+                }
             }
             0b10 => {
                 // LDRSB: Load signed byte, sign-extend to 32 bits
@@ -709,8 +733,13 @@ fn execute_halfword_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u
             }
             0b11 => {
                 // LDRSH: Load signed halfword, sign-extend to 32 bits
-                let hw = bus.read16(addr & !1) as i16;
-                hw as i32 as u32
+                if addr & 1 != 0 {
+                    let byte = bus.read8(addr) as i8;
+                    byte as i32 as u32
+                } else {
+                    let hw = bus.read16(addr & !1) as i16;
+                    hw as i32 as u32
+                }
             }
             _ => 0, // SH=00 would be SWP, which is handled elsewhere
         };
@@ -726,7 +755,7 @@ fn execute_halfword_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u
     }
 
     // Writeback (post-indexing always writes back; pre-indexing only when W=1).
-    if !p || w {
+    if (!p || w) && !(l && rd == rn) {
         regs.r[rn] = offset_addr;
     }
 
@@ -754,17 +783,17 @@ fn execute_block_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32)
 
     // S-bit semantics:
     // - For LDM with PC in rlist: CPSR = SPSR (mode switch)
-    // - For LDM/STM without PC or store: use user-mode registers
-    // Note: User-mode register access is not yet implemented; S-bit currently
-    // only handles CPSR restore on LDM with PC.
+    // - Otherwise, transfer user-mode register bank (the '^' forms)
     let restore_cpsr = s_bit && l && (rlist & (1 << 15)) != 0;
+    let transfer_user_regs = s_bit && !restore_cpsr;
 
-    // Count registers in the list
-    let reg_count = rlist.count_ones();
-    if reg_count == 0 {
-        // Empty register list is unpredictable; treat as NOP
-        return ExecOutcome::cycles(1);
-    }
+    // Empty rlist has ARM7TDMI special behavior: transfer R15 and use
+    // 16-register writeback span (+/- 0x40).
+    let (effective_rlist, reg_count) = if rlist == 0 {
+        (1u16 << 15, 16u32)
+    } else {
+        (rlist, rlist.count_ones())
+    };
 
     let base = regs.r[rn];
 
@@ -787,17 +816,27 @@ fn execute_block_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32)
     let mut branch_occurred = false;
 
     for i in 0..16 {
-        if rlist & (1 << i) != 0 {
+        if effective_rlist & (1 << i) != 0 {
             if l {
                 // Load
                 let value = bus.read32(addr);
-                regs.r[i] = value;
-                if i == 15 {
+                if transfer_user_regs {
+                    regs.write_user_reg(i as usize, value);
+                } else {
+                    regs.r[i] = value;
+                }
+                if i == 15 && !transfer_user_regs {
                     branch_occurred = true;
                 }
             } else {
                 // Store
-                let value = regs.r[i];
+                let value = if transfer_user_regs {
+                    regs.read_user_reg(i as usize)
+                } else if i == 15 {
+                    regs.r[i].wrapping_add(4)
+                } else {
+                    regs.r[i]
+                };
                 bus.write32(addr, value);
             }
             addr = addr.wrapping_add(4);
@@ -810,8 +849,10 @@ fn execute_block_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32)
         regs.write_cpsr(spsr);
     }
 
-    // Writeback the final address to Rn
-    if w {
+    // Writeback the final address to Rn.
+    // For LDM with base in the register list, loaded value must be preserved.
+    let base_in_rlist = (effective_rlist & (1 << rn)) != 0;
+    if w && !(l && base_in_rlist) {
         regs.r[rn] = if u {
             final_addr
         } else {
@@ -859,8 +900,10 @@ fn execute_swap<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32) -> ExecOu
         regs.r[rd] = old_val; // Zero-extended to 32 bits
     } else {
         // SWP: Swap word
-        let old_val = bus.read32(addr);
-        bus.write32(addr, rm_val);
+        let aligned = addr & !0x3;
+        let raw = bus.read32(aligned);
+        let old_val = raw.rotate_right((addr & 0x3) * 8);
+        bus.write32(aligned, rm_val);
         regs.r[rd] = old_val;
     }
 
@@ -972,6 +1015,60 @@ mod tests {
     }
 
     #[test]
+    fn arm_mov_pc_with_register_shift_uses_pc_plus_12() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0;
+        regs.r[15] = 0x100 + 8;
+
+        // From gba-tests t224: mov r0, pc, lsl r0
+        let instr = 0xE1A0_001F;
+        execute(&mut regs, &mut bus, instr);
+
+        assert_eq!(regs.r[0], 0x100 + 12);
+    }
+
+    #[test]
+    fn arm_add_pc_rn_with_register_shift_uses_pc_plus_12() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0;
+        regs.r[15] = 0x100 + 8;
+
+        // From gba-tests t225: add r0, pc, r0, lsl r0
+        let instr = 0xE08F_0010;
+        execute(&mut regs, &mut bus, instr);
+
+        assert_eq!(regs.r[0], 0x100 + 12);
+    }
+
+    #[test]
+    fn arm_cmp_pc_with_s_bit_restores_mode_without_branching() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+
+        regs.switch_mode(CpuMode::Supervisor);
+        regs.r[8] = 32;
+
+        let to_fiq = arm_msr_imm(0xE, CpuMode::Fiq.bits() as u8, 0, false, 0x1);
+        execute(&mut regs, &mut bus, to_fiq);
+        regs.r[8] = 64;
+
+        let set_spsr = arm_msr_imm(0xE, CpuMode::System.bits() as u8, 0, true, 0x1);
+        execute(&mut regs, &mut bus, set_spsr);
+
+        regs.r[0] = 1;
+
+        // From gba-tests t234: cmp pc, pc, r0 (S=1, Rd=PC, opcode=CMP)
+        let instr = 0xE15F_F000;
+        let outcome = execute(&mut regs, &mut bus, instr);
+
+        assert!(!outcome.branched);
+        assert_eq!(regs.mode(), CpuMode::System);
+        assert_eq!(regs.r[8], 32);
+    }
+
+    #[test]
     fn arm_addne_skips_when_z_set() {
         // Test vector: ADDNE R0,R0,#1 with Z set -> R0 unchanged.
         let mut regs = make_regs();
@@ -1062,6 +1159,51 @@ mod tests {
             | (2 << 12);
         execute(&mut regs, &mut bus, ldr_instr);
         assert_eq!(regs.r[2], 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn arm_str_pc_stores_pc_plus_4() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40;
+        regs.r[15] = 0x100 + 8;
+
+        // STR R15, [R1]
+        let str_pc =
+            (0xE_u32 << 28) | (0b010 << 25) | (1 << 24) | (1 << 23) | (1 << 16) | (15 << 12);
+        execute(&mut regs, &mut bus, str_pc);
+
+        assert_eq!(bus.read32(0x40), 0x100 + 12);
+    }
+
+    #[test]
+    fn arm_ldr_pre_index_writeback_same_register_keeps_loaded_value() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x200);
+        let mem = 0x80;
+        bus.write32(mem, 32);
+        regs.r[0] = mem.wrapping_sub(4);
+
+        // From gba-tests t360: ldr r0, [r0, 4]!
+        let instr = 0xE5B0_0004;
+        execute(&mut regs, &mut bus, instr);
+
+        assert_eq!(regs.r[0], 32);
+    }
+
+    #[test]
+    fn arm_ldr_post_index_writeback_same_register_keeps_loaded_value() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x200);
+        let mem = 0x80;
+        bus.write32(mem, 32);
+        regs.r[0] = mem;
+
+        // From gba-tests t361: ldr r0, [r0], 4
+        let instr = 0xE490_0004;
+        execute(&mut regs, &mut bus, instr);
+
+        assert_eq!(regs.r[0], 32);
     }
 
     #[test]
@@ -1511,6 +1653,32 @@ mod tests {
     }
 
     #[test]
+    fn arm_ldrh_misaligned_rotates_by_8() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40;
+        bus.write16(0x40, 0x0020);
+
+        let ldrh = arm_halfword_imm(0xE, true, true, false, true, 1, 0, false, true, 1);
+        execute(&mut regs, &mut bus, ldrh);
+
+        assert_eq!(regs.r[0], 0x2000_0000);
+    }
+
+    #[test]
+    fn arm_ldrsh_misaligned_behaves_like_ldrsb() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40;
+        bus.write16(0x40, 0xFF00);
+
+        let ldrsh = arm_halfword_imm(0xE, true, true, false, true, 1, 0, true, true, 1);
+        execute(&mut regs, &mut bus, ldrsh);
+
+        assert_eq!(regs.r[0], 0xFFFF_FFFF);
+    }
+
+    #[test]
     fn arm_ldrh_with_offset() {
         // LDRH R0, [R1, #4]: load with immediate offset
         let mut regs = make_regs();
@@ -1591,6 +1759,54 @@ mod tests {
     }
 
     #[test]
+    fn arm_stm_stores_pc_plus_4() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x200);
+        regs.r[11] = 0x80;
+        regs.r[0] = 0x1111_1111;
+        regs.r[15] = 0x100 + 8;
+
+        // STMFD R11!, {R0, R15}
+        let stmfd = arm_block_transfer(
+            0xE,
+            true,
+            false,
+            false,
+            true,
+            false,
+            11,
+            (1 << 0) | (1 << 15),
+        );
+        execute(&mut regs, &mut bus, stmfd);
+
+        assert_eq!(bus.read32(0x78), 0x1111_1111);
+        assert_eq!(bus.read32(0x7C), 0x100 + 12);
+    }
+
+    #[test]
+    fn arm_stm_with_s_bit_uses_user_bank_registers() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x200);
+
+        regs.switch_mode(CpuMode::System);
+        regs.r[0] = 0x80;
+        regs.r[8] = 32;
+        regs.r[9] = 0x1234_5678;
+
+        regs.switch_mode(CpuMode::Fiq);
+        regs.r[8] = 64;
+        regs.r[9] = 0xAAAA_BBBB;
+
+        // STMFD R0, {R8, R9}^
+        let stm_user =
+            arm_block_transfer(0xE, true, false, true, false, false, 0, (1 << 8) | (1 << 9));
+        execute(&mut regs, &mut bus, stm_user);
+
+        assert_eq!(bus.read32(0x78), 32);
+        assert_eq!(bus.read32(0x7C), 0x1234_5678);
+    }
+
+    #[test]
     fn arm_stmdb_ldmdb() {
         // STMDB R0!, {R1-R2}: Store R1, R2 decrementing before, full descending stack
         let mut regs = make_regs();
@@ -1643,6 +1859,35 @@ mod tests {
         let outcome = execute(&mut regs, &mut bus, stmia);
         // Should complete without crashing; base unchanged since no registers transferred
         assert!(outcome.cycles > 0);
+    }
+
+    #[test]
+    fn arm_ldmia_empty_rlist_loads_pc_and_writes_back_64() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0x40;
+        bus.write32(0x40, 0x2000_0000);
+
+        let ldmia = arm_block_transfer(0xE, false, true, false, true, true, 0, 0);
+        let outcome = execute(&mut regs, &mut bus, ldmia);
+
+        assert!(outcome.branched);
+        assert_eq!(regs.r[15], 0x2000_0000);
+        assert_eq!(regs.r[0], 0x80);
+    }
+
+    #[test]
+    fn arm_stmia_empty_rlist_stores_pc_and_writes_back_64() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0x40;
+        regs.r[15] = 0x100 + 8;
+
+        let stmia = arm_block_transfer(0xE, false, true, false, true, false, 0, 0);
+        execute(&mut regs, &mut bus, stmia);
+
+        assert_eq!(bus.read32(0x40), 0x100 + 12);
+        assert_eq!(regs.r[0], 0x80);
     }
 
     // -------------------------------------------------------------------------
@@ -1702,5 +1947,22 @@ mod tests {
         // Since we read Rm BEFORE writing to Rd, Rd should get memory value
         assert_eq!(regs.r[1], 0xAAAA_BBBB);
         assert_eq!(bus.read32(0x40), 0xCCCC_DDDD);
+    }
+
+    #[test]
+    fn arm_swp_misaligned_rotates_old_value_and_writes_aligned() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+
+        regs.r[2] = 0x41; // misaligned base
+        regs.r[0] = 32;
+        bus.write32(0x40, 64);
+
+        // From gba-tests t452: swp r3, r0, [r2]
+        let swp = arm_swap(0xE, false, 2, 3, 0);
+        execute(&mut regs, &mut bus, swp);
+
+        assert_eq!(regs.r[3], 64_u32.rotate_right(8));
+        assert_eq!(bus.read32(0x40), 32);
     }
 }

--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -1391,6 +1391,42 @@ mod tests {
         assert_eq!(regs.spsr() & 0xF000_0000, 0xA000_0000);
     }
 
+    #[test]
+    fn arm_subs_pc_restores_mode_and_banked_registers() {
+        // Mirrors gba-tests ARM data_processing case t223:
+        // 1) Set R8 in non-FIQ bank to 32
+        // 2) Enter FIQ and set banked R8 to 64
+        // 3) Program SPSR to SYSTEM mode
+        // 4) Execute SUBS PC, PC, #4 and verify CPSR is restored from SPSR
+        //    and non-FIQ R8 bank is visible again.
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+
+        regs.switch_mode(CpuMode::Supervisor);
+        regs.r[8] = 32;
+
+        // MSR CPSR_c, #FIQ
+        let to_fiq = arm_msr_imm(0xE, CpuMode::Fiq.bits() as u8, 0, false, 0x1);
+        execute(&mut regs, &mut bus, to_fiq);
+        assert_eq!(regs.mode(), CpuMode::Fiq);
+
+        regs.r[8] = 64;
+
+        // MSR SPSR_c, #SYSTEM
+        let set_spsr = arm_msr_imm(0xE, CpuMode::System.bits() as u8, 0, true, 0x1);
+        execute(&mut regs, &mut bus, set_spsr);
+
+        // SUBS PC, PC, #4
+        regs.r[15] = 0x200 + 8;
+        let subs_pc = arm_alu_imm(0xE, 0x2, true, 15, 15, 4);
+        let outcome = execute(&mut regs, &mut bus, subs_pc);
+
+        assert!(outcome.branched);
+        assert_eq!(regs.mode(), CpuMode::System);
+        assert_eq!(regs.r[8], 32);
+        assert_eq!(regs.r[15], 0x200 + 4);
+    }
+
     // -------------------------------------------------------------------------
     // Halfword/Signed Data Transfer Tests (LDRH, STRH, LDRSB, LDRSH)
     // -------------------------------------------------------------------------

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -41,6 +41,13 @@ pub struct Arm7tdmi {
     irq_pending: bool,
     /// Pending FIQ line (rising-edge triggered).
     fiq_pending: bool,
+    /// Whether the prefetch buffers contain valid instructions for the
+    /// current PC/state.
+    prefetch_valid: bool,
+    /// Three-entry ARM prefetch buffer: [current, next, next-next].
+    prefetch_arm: [u32; 3],
+    /// Three-entry Thumb prefetch buffer: [current, next, next-next].
+    prefetch_thumb: [u16; 3],
 }
 
 impl Default for Arm7tdmi {
@@ -63,7 +70,24 @@ impl Arm7tdmi {
             cycles: 0,
             irq_pending: false,
             fiq_pending: false,
+            prefetch_valid: false,
+            prefetch_arm: [0; 3],
+            prefetch_thumb: [0; 3],
         }
+    }
+
+    fn refill_prefetch<B: Bus>(&mut self, bus: &mut B) {
+        let pc = self.regs.r[15];
+        if self.thumb() {
+            self.prefetch_thumb[0] = bus.read16(pc);
+            self.prefetch_thumb[1] = bus.read16(pc.wrapping_add(2));
+            self.prefetch_thumb[2] = bus.read16(pc.wrapping_add(4));
+        } else {
+            self.prefetch_arm[0] = bus.read32(pc);
+            self.prefetch_arm[1] = bus.read32(pc.wrapping_add(4));
+            self.prefetch_arm[2] = bus.read32(pc.wrapping_add(8));
+        }
+        self.prefetch_valid = true;
     }
 
     /// Whether the CPU is currently executing in Thumb state.
@@ -114,27 +138,43 @@ impl Arm7tdmi {
             return 3;
         }
 
+        if !self.prefetch_valid {
+            self.refill_prefetch(bus);
+        }
+
         let exec_pc = self.regs.r[15];
         let cycles = if self.thumb() {
             // PC during Thumb execution should read as exec_pc + 4.
             self.regs.r[15] = exec_pc.wrapping_add(4);
-            let raw = bus.read16(exec_pc);
+            let raw = self.prefetch_thumb[0];
             let outcome = thumb::execute(&mut self.regs, bus, raw);
             if outcome.swi {
                 self.dispatch_swi(exec_pc);
+                self.prefetch_valid = false;
+            } else if outcome.branched {
+                self.prefetch_valid = false;
             } else if !outcome.branched {
                 self.regs.r[15] = exec_pc.wrapping_add(2);
+                self.prefetch_thumb[0] = self.prefetch_thumb[1];
+                self.prefetch_thumb[1] = self.prefetch_thumb[2];
+                self.prefetch_thumb[2] = bus.read16(exec_pc.wrapping_add(6));
             }
             outcome.cycles as u32
         } else {
             // PC during ARM execution should read as exec_pc + 8.
             self.regs.r[15] = exec_pc.wrapping_add(8);
-            let raw = bus.read32(exec_pc);
+            let raw = self.prefetch_arm[0];
             let outcome = arm::execute(&mut self.regs, bus, raw);
             if outcome.swi {
                 self.dispatch_swi(exec_pc);
+                self.prefetch_valid = false;
+            } else if outcome.branched {
+                self.prefetch_valid = false;
             } else if !outcome.branched {
                 self.regs.r[15] = exec_pc.wrapping_add(4);
+                self.prefetch_arm[0] = self.prefetch_arm[1];
+                self.prefetch_arm[1] = self.prefetch_arm[2];
+                self.prefetch_arm[2] = bus.read32(exec_pc.wrapping_add(12));
             }
             outcome.cycles as u32
         };
@@ -154,6 +194,7 @@ impl Arm7tdmi {
         self.regs.cpsr |= FLAG_I;
         self.regs.cpsr &= !FLAG_T;
         self.regs.r[15] = ExceptionVector::SoftwareInterrupt as u32;
+        self.prefetch_valid = false;
     }
 
     /// Dispatch an IRQ: switch to IRQ mode, save state and jump to 0x18.
@@ -169,6 +210,7 @@ impl Arm7tdmi {
         self.regs.cpsr |= FLAG_I;
         self.regs.cpsr &= !FLAG_T;
         self.regs.r[15] = ExceptionVector::Irq as u32;
+        self.prefetch_valid = false;
         self.cycles = self.cycles.wrapping_add(3);
         // The pending line is treated as a latched edge: clear on dispatch so
         // unmasking I later does not spuriously re-enter the handler.
@@ -185,6 +227,7 @@ impl Arm7tdmi {
         self.regs.cpsr |= FLAG_I | FLAG_F;
         self.regs.cpsr &= !FLAG_T;
         self.regs.r[15] = ExceptionVector::Fiq as u32;
+        self.prefetch_valid = false;
         self.cycles = self.cycles.wrapping_add(3);
         // Latched-edge semantics: clear pending on dispatch.
         self.fiq_pending = false;
@@ -420,5 +463,31 @@ mod tests {
             cpu.thumb(),
             "execution should have switched into Thumb state"
         );
+    }
+
+    #[test]
+    fn arm_prefetch_keeps_two_instructions_after_self_modify() {
+        // Mirrors gba-tests/nes t001: store over the next two ARM opcodes and
+        // ensure they still execute from the prefetch queue.
+        let mut cpu = Arm7tdmi::new();
+        cpu.regs.switch_mode(CpuMode::User);
+        cpu.regs.r[15] = 0x0;
+        let mut bus = RamBus::new(0x100);
+
+        bus.write_word(0x00, 0xE3A02000); // mov r2, #0
+        bus.write_word(0x04, 0xE3A00014); // mov r0, #0x14 (.pipe1)
+        bus.write_word(0x08, 0xE3A01018); // mov r1, #0x18 (.pipe2)
+        bus.write_word(0x0C, 0xE5802000); // str r2, [r0]
+        bus.write_word(0x10, 0xE5812000); // str r2, [r1]
+        bus.write_word(0x14, 0xE3520000); // .pipe1: cmp r2, #0
+        bus.write_word(0x18, 0x0A000000); // .pipe2: beq pass
+        bus.write_word(0x1C, 0xE3A04001); // fail: mov r4, #1
+        bus.write_word(0x20, 0xE3A04002); // pass: mov r4, #2
+
+        for _ in 0..8 {
+            cpu.step(&mut bus);
+        }
+
+        assert_eq!(cpu.regs.r[4], 2);
     }
 }

--- a/src/gba/cpu/registers.rs
+++ b/src/gba/cpu/registers.rs
@@ -225,6 +225,62 @@ impl Registers {
         }
     }
 
+    /// Read a register from the user/system bank, regardless of current mode.
+    pub fn read_user_reg(&self, index: usize) -> u32 {
+        match index {
+            0..=7 | 15 => self.r[index],
+            8..=12 => {
+                if self.live_mode == CpuMode::Fiq {
+                    self.usr_r8_12[index - 8]
+                } else {
+                    self.r[index]
+                }
+            }
+            13 => {
+                if self.live_mode == CpuMode::User || self.live_mode == CpuMode::System {
+                    self.r[13]
+                } else {
+                    self.sp_usr
+                }
+            }
+            14 => {
+                if self.live_mode == CpuMode::User || self.live_mode == CpuMode::System {
+                    self.r[14]
+                } else {
+                    self.lr_usr
+                }
+            }
+            _ => panic!("register index out of range: {index}"),
+        }
+    }
+
+    /// Write a register in the user/system bank, regardless of current mode.
+    pub fn write_user_reg(&mut self, index: usize, value: u32) {
+        match index {
+            0..=7 | 15 => self.r[index] = value,
+            8..=12 => {
+                if self.live_mode == CpuMode::Fiq {
+                    self.usr_r8_12[index - 8] = value;
+                } else {
+                    self.r[index] = value;
+                }
+            }
+            13 => {
+                if self.live_mode == CpuMode::User || self.live_mode == CpuMode::System {
+                    self.r[13] = value;
+                }
+                self.sp_usr = value;
+            }
+            14 => {
+                if self.live_mode == CpuMode::User || self.live_mode == CpuMode::System {
+                    self.r[14] = value;
+                }
+                self.lr_usr = value;
+            }
+            _ => panic!("register index out of range: {index}"),
+        }
+    }
+
     // --- Flag helpers -----------------------------------------------------
 
     pub fn n_flag(&self) -> bool {

--- a/src/gba/cpu/thumb.rs
+++ b/src/gba/cpu/thumb.rs
@@ -526,9 +526,24 @@ fn exec_format8<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
     }
 
     regs.r[rd] = match (s, h) {
-        (false, true) => bus.read16(addr & !1) as u32, // LDRH
+        (false, true) => {
+            // LDRH: odd address rotates aligned halfword right by 8.
+            let raw = bus.read16(addr & !1) as u32;
+            if addr & 1 != 0 {
+                raw.rotate_right(8)
+            } else {
+                raw
+            }
+        }
         (true, false) => bus.read8(addr) as i8 as i32 as u32, // LDSB
-        (true, true) => bus.read16(addr & !1) as i16 as i32 as u32, // LDSH
+        (true, true) => {
+            // LDSH: odd address behaves like signed byte load.
+            if addr & 1 != 0 {
+                bus.read8(addr) as i8 as i32 as u32
+            } else {
+                bus.read16(addr & !1) as i16 as i32 as u32
+            }
+        }
         _ => unreachable!(),
     };
     ExecOutcome {
@@ -589,7 +604,12 @@ fn exec_format10<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
     let addr = regs.r[rb].wrapping_add(offset);
 
     if l {
-        regs.r[rd] = bus.read16(addr & !1) as u32;
+        let raw = bus.read16(addr & !1) as u32;
+        regs.r[rd] = if addr & 1 != 0 {
+            raw.rotate_right(8)
+        } else {
+            raw
+        };
     } else {
         bus.write16(addr & !1, regs.r[rd] as u16);
     }
@@ -730,23 +750,48 @@ fn exec_format15<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
     let rb = ((instr >> 8) & 0x7) as usize;
     let rlist = (instr & 0xFF) as u8;
 
-    let count = rlist.count_ones();
+    // Empty rlist on ARM7TDMI is a special transfer of PC with a
+    // 16-register writeback span (+0x40).
+    let (effective_rlist, count) = if rlist == 0 {
+        (1u16 << 15, 16u32)
+    } else {
+        (rlist as u16, rlist.count_ones())
+    };
     let base = regs.r[rb]; // Capture original base before any modifications
     let mut addr = base;
+    let writeback_value = base.wrapping_add(count * 4);
+    let first_reg_in_list = effective_rlist.trailing_zeros() as usize;
+    let mut branched = false;
 
     if l {
         // LDMIA: Load multiple, increment after
-        for i in 0..8 {
-            if rlist & (1 << i) != 0 {
-                regs.r[i] = bus.read32(addr & !0x3);
+        for i in 0..16 {
+            if effective_rlist & (1 << i) != 0 {
+                let value = bus.read32(addr);
+                if i == 15 {
+                    // Like POP {PC} on ARM7TDMI in Thumb state: clear bit 0, keep T set.
+                    regs.r[15] = value & !1;
+                    branched = true;
+                } else {
+                    regs.r[i] = value;
+                }
                 addr = addr.wrapping_add(4);
             }
         }
     } else {
         // STMIA: Store multiple, increment after
-        for i in 0..8 {
-            if rlist & (1 << i) != 0 {
-                bus.write32(addr & !0x3, regs.r[i]);
+        for i in 0..16 {
+            if effective_rlist & (1 << i) != 0 {
+                let value = if i == 15 {
+                    // In Thumb state, storing PC in block transfer uses PC+2.
+                    regs.r[15].wrapping_add(2)
+                } else if i == rb && rb != first_reg_in_list {
+                    // Base in rlist stores updated base when it is not first.
+                    writeback_value
+                } else {
+                    regs.r[i]
+                };
+                bus.write32(addr, value);
                 addr = addr.wrapping_add(4);
             }
         }
@@ -761,7 +806,7 @@ fn exec_format15<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
         } else {
             (count + 1) as u8
         },
-        branched: false,
+        branched,
         swi: false,
     }
 }
@@ -1182,6 +1227,26 @@ mod tests {
     }
 
     #[test]
+    fn thumb_format8_misaligned_ldrh_rotates_and_ldrsh_is_signed_byte() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0x40;
+        regs.r[1] = 1;
+
+        bus.write16(0x40, 0x00FF);
+        // LDRH R2, [R0, R1]
+        let ldrh = 0b0101_101_001_000_010u16;
+        execute(&mut regs, &mut bus, ldrh);
+        assert_eq!(regs.r[2], 0xFF00_0000);
+
+        bus.write16(0x40, 0xFF00);
+        // LDSH R3, [R0, R1]
+        let ldrsh = 0b0101_111_001_000_011u16;
+        execute(&mut regs, &mut bus, ldrsh);
+        assert_eq!(regs.r[3], 0xFFFF_FFFF);
+    }
+
+    #[test]
     fn thumb_format9_str_ldr_immediate() {
         let mut regs = make_regs();
         let mut bus = RamBus::new(0x100);
@@ -1213,6 +1278,19 @@ mod tests {
         let ldrh = 0b1000_1_00010_000_010u16;
         execute(&mut regs, &mut bus, ldrh);
         assert_eq!(regs.r[2], 0xABCD);
+    }
+
+    #[test]
+    fn thumb_format10_misaligned_ldrh_rotates() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0x41;
+        bus.write16(0x40, 0x00FF);
+
+        // LDRH R1, [R0, #0]
+        let ldrh = 0b1000_1_00000_000_001u16;
+        execute(&mut regs, &mut bus, ldrh);
+        assert_eq!(regs.r[1], 0xFF00_0000);
     }
 
     #[test]
@@ -1288,6 +1366,42 @@ mod tests {
         assert_eq!(regs.r[4], 0x11);
         assert_eq!(regs.r[5], 0x22);
         assert_eq!(regs.r[6], 0x33);
+    }
+
+    #[test]
+    fn thumb_format15_ldmia_empty_rlist_loads_pc_and_writes_back_64() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0x40;
+        bus.write32(0x40, 0x80);
+
+        // LDMIA R0!, {}
+        let ldm_empty = 0b1100_1_000_00000000u16;
+        let outcome = execute(&mut regs, &mut bus, ldm_empty);
+
+        assert!(outcome.branched);
+        assert_eq!(regs.r[15], 0x80);
+        assert_eq!(regs.r[0], 0x80);
+    }
+
+    #[test]
+    fn thumb_format15_stmia_base_in_rlist_non_first_stores_updated_base() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x200);
+        regs.r[0] = 0x11;
+        regs.r[1] = 0x100;
+        regs.r[2] = 0x22;
+        regs.r[3] = 0x33;
+
+        // STMIA R1!, {R0-R3}
+        let stmia = 0b1100_0_001_00001111u16;
+        execute(&mut regs, &mut bus, stmia);
+
+        assert_eq!(bus.read32(0x100), 0x11);
+        assert_eq!(bus.read32(0x104), 0x110);
+        assert_eq!(bus.read32(0x108), 0x22);
+        assert_eq!(bus.read32(0x10C), 0x33);
+        assert_eq!(regs.r[1], 0x110);
     }
 
     #[test]

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -5,17 +5,19 @@ use crate::platform::emulator::Emulator;
 use std::path::PathBuf;
 
 const MAX_CYCLES: u64 = 120_000_000;
-// The suite ends in `idle: b idle`; 1024 repeated PCs is a conservative
-// threshold to recognize that terminal loop without waiting for MAX_CYCLES.
-const IDLE_PC_STABLE_THRESHOLD: u32 = 1_024;
-const BIOS_RESET_STUB_LDR_PC_MINUS_4: u32 = 0xE51F_F004;
+// The suite ends in `idle: b idle` (ARM `b .`, opcode 0xEAFFFFFE).
+const ARM_BRANCH_SELF_OPCODE: u32 = 0xEAFF_FFFE;
+const BIOS_RESET_STUB_LDR_PC_PLUS_24: u32 = 0xE59F_F018;
+const BIOS_SWI_STUB_MOVS_PC_LR: u32 = 0xE1B0_F00E;
 const CART_ENTRYPOINT: u32 = 0x0800_0000;
+const BIOS_RESET_LITERAL_ADDR: usize = 0x20;
+const BIOS_EXCEPTION_VECTORS: [u32; 5] = [0x04, 0x0C, 0x10, 0x18, 0x1C];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Suite {
     Arm,
     Thumb,
-    Memory,
+    Nes,
 }
 
 impl Suite {
@@ -23,7 +25,7 @@ impl Suite {
         let rel = match self {
             Self::Arm => "roms/gba/automated_tests/gba-tests/arm/arm.gba",
             Self::Thumb => "roms/gba/automated_tests/gba-tests/thumb/thumb.gba",
-            Self::Memory => "roms/gba/automated_tests/gba-tests/memory/memory.gba",
+            Self::Nes => "roms/gba/automated_tests/gba-tests/nes/nes.gba",
         };
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
     }
@@ -32,7 +34,7 @@ impl Suite {
         match self {
             Self::Arm => (12, "r12"),
             Self::Thumb => (7, "r7"),
-            Self::Memory => (12, "r12"),
+            Self::Nes => (12, "r12"),
         }
     }
 }
@@ -40,6 +42,7 @@ impl Suite {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExitReason {
     IdleLoopDetected,
+    ExceptionVectorTrap,
     CycleLimitReached,
     CartStopped,
 }
@@ -50,6 +53,9 @@ pub struct SuiteResult {
     pub failing_index: u32,
     pub cycles: u64,
     pub pc: u32,
+    pub cpsr: u32,
+    pub thumb: bool,
+    pub opcode_at_pc: u32,
     pub reg_name: &'static str,
     pub exit_reason: ExitReason,
 }
@@ -62,45 +68,49 @@ pub fn run_suite(suite: Suite) -> SuiteResult {
 
     let mut gba = Gba::new(AppContext::default());
     let mut bios = vec![0u8; BIOS_SIZE];
-    bios[0..4].copy_from_slice(&BIOS_RESET_STUB_LDR_PC_MINUS_4.to_le_bytes());
-    bios[4..8].copy_from_slice(&CART_ENTRYPOINT.to_le_bytes());
+    bios[0..4].copy_from_slice(&BIOS_RESET_STUB_LDR_PC_PLUS_24.to_le_bytes());
+    bios[BIOS_RESET_LITERAL_ADDR..BIOS_RESET_LITERAL_ADDR + 4]
+        .copy_from_slice(&CART_ENTRYPOINT.to_le_bytes());
+    bios[0x08..0x0C].copy_from_slice(&BIOS_SWI_STUB_MOVS_PC_LR.to_le_bytes());
+    for &vector in &BIOS_EXCEPTION_VECTORS {
+        let i = vector as usize;
+        bios[i..i + 4].copy_from_slice(&ARM_BRANCH_SELF_OPCODE.to_le_bytes());
+    }
     gba.bus_mut().load_bios(&bios);
     gba.load_rom(&rom, rom_path.to_str().unwrap_or("gba-suite-rom"))
         .unwrap_or_else(|e| {
             panic!("failed to load suite ROM {}: {e}", rom_path.display());
         });
+    gba.init_test_stack_pointers();
 
     let mut cycles = 0u64;
-    let mut stable_pc_count = 0u32;
-    let mut last_pc: Option<u32> = None;
 
     while cycles < MAX_CYCLES {
         let tick_cycles = gba.run_tick_for_tests() as u64;
         if tick_cycles == 0 {
             let pc = gba.cpu_pc();
-            return result_from_register(&gba, suite, cycles, pc, ExitReason::CartStopped);
+            return result_from_register(&mut gba, suite, cycles, pc, ExitReason::CartStopped);
         }
         cycles += tick_cycles;
 
         let pc = gba.cpu_pc();
-        if Some(pc) == last_pc {
-            stable_pc_count += 1;
-        } else {
-            stable_pc_count = 1;
-            last_pc = Some(pc);
-        }
-
-        if stable_pc_count >= IDLE_PC_STABLE_THRESHOLD {
-            return result_from_register(&gba, suite, cycles, pc, ExitReason::IdleLoopDetected);
+        let opcode = gba.bus_mut().peek32(pc);
+        if is_arm_branch_to_self(opcode, pc) {
+            let reason = if is_bios_exception_vector(pc) {
+                ExitReason::ExceptionVectorTrap
+            } else {
+                ExitReason::IdleLoopDetected
+            };
+            return result_from_register(&mut gba, suite, cycles, pc, reason);
         }
     }
 
     let pc = gba.cpu_pc();
-    result_from_register(&gba, suite, cycles, pc, ExitReason::CycleLimitReached)
+    result_from_register(&mut gba, suite, cycles, pc, ExitReason::CycleLimitReached)
 }
 
 fn result_from_register(
-    gba: &Gba,
+    gba: &mut Gba,
     suite: Suite,
     cycles: u64,
     pc: u32,
@@ -108,13 +118,94 @@ fn result_from_register(
 ) -> SuiteResult {
     let (reg_index, reg_name) = suite.result_register();
     let failing_index = gba.cpu_reg(reg_index);
+    let cpsr = gba.cpu_cpsr();
+    let thumb = gba.cpu_thumb();
+    let opcode_at_pc = if thumb {
+        gba.bus_mut().peek16(pc) as u32
+    } else {
+        gba.bus_mut().peek32(pc)
+    };
+    let passed = failing_index == 0 && exit_reason == ExitReason::IdleLoopDetected;
 
     SuiteResult {
-        passed: failing_index == 0,
+        passed,
         failing_index,
         cycles,
         pc,
+        cpsr,
+        thumb,
+        opcode_at_pc,
         reg_name,
         exit_reason,
+    }
+}
+
+fn is_arm_branch_to_self(opcode: u32, pc: u32) -> bool {
+    // Match unconditional ARM B (not BL) and compute branch target.
+    if opcode >> 28 != 0xE {
+        return false;
+    }
+    if (opcode & 0x0E00_0000) != 0x0A00_0000 {
+        return false;
+    }
+    if (opcode & 0x0100_0000) != 0 {
+        return false;
+    }
+
+    let imm24 = (opcode & 0x00FF_FFFF) as i32;
+    let signed_imm24 = (imm24 << 8) >> 8;
+    let offset = signed_imm24 << 2;
+    let target = pc.wrapping_add(8).wrapping_add(offset as u32);
+    target == pc
+}
+
+fn is_bios_exception_vector(pc: u32) -> bool {
+    BIOS_EXCEPTION_VECTORS.contains(&pc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::app_context::AppContext;
+
+    #[test]
+    fn arm_branch_to_self_detects_idle_opcode() {
+        assert!(is_arm_branch_to_self(ARM_BRANCH_SELF_OPCODE, 0x0800_1000));
+    }
+
+    #[test]
+    fn arm_branch_to_self_rejects_bl() {
+        assert!(!is_arm_branch_to_self(0xEBFF_FFFE, 0x0800_1000));
+    }
+
+    #[test]
+    fn non_idle_exit_is_not_counted_as_pass_even_if_index_is_zero() {
+        let mut gba = Gba::new(AppContext::default());
+        let result = result_from_register(
+            &mut gba,
+            Suite::Arm,
+            12_345,
+            0x0800_0000,
+            ExitReason::CycleLimitReached,
+        );
+        assert!(!result.passed);
+        assert_eq!(result.failing_index, 0);
+    }
+
+    #[test]
+    fn exception_vector_branch_to_self_is_not_counted_as_pass() {
+        assert!(is_bios_exception_vector(0x18));
+        assert!(is_bios_exception_vector(0x04));
+        assert!(!is_bios_exception_vector(0x08));
+
+        let mut gba = Gba::new(AppContext::default());
+        let result = result_from_register(
+            &mut gba,
+            Suite::Arm,
+            42,
+            0x18,
+            ExitReason::ExceptionVectorTrap,
+        );
+        assert!(!result.passed);
     }
 }

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -5,6 +5,7 @@ use crate::platform::emulator::Emulator;
 use std::path::PathBuf;
 
 const MAX_CYCLES: u64 = 120_000_000;
+const IDLE_PROBE_STABLE_PC_THRESHOLD: u32 = 1;
 // The suite ends in `idle: b idle` (ARM `b .`, opcode 0xEAFFFFFE).
 const ARM_BRANCH_SELF_OPCODE: u32 = 0xEAFF_FFFE;
 const BIOS_RESET_STUB_LDR_PC_PLUS_24: u32 = 0xE59F_F018;
@@ -87,6 +88,8 @@ pub fn run_suite(suite: Suite) -> SuiteResult {
     gba.init_test_stack_pointers();
 
     let mut cycles = 0u64;
+    let mut last_pc: Option<u32> = None;
+    let mut stable_pc_count: u32 = 0;
 
     while cycles < MAX_CYCLES {
         let tick_cycles = gba.run_tick_for_tests() as u64;
@@ -97,14 +100,23 @@ pub fn run_suite(suite: Suite) -> SuiteResult {
         cycles += tick_cycles;
 
         let pc = gba.cpu_pc();
-        let opcode = gba.bus_mut().peek32(pc);
-        if is_arm_branch_to_self(opcode, pc) {
-            let reason = if is_bios_exception_vector(pc) {
-                ExitReason::ExceptionVectorTrap
-            } else {
-                ExitReason::IdleLoopDetected
-            };
-            return result_from_register(&mut gba, suite, cycles, pc, reason);
+        if Some(pc) == last_pc {
+            stable_pc_count = stable_pc_count.saturating_add(1);
+        } else {
+            stable_pc_count = 0;
+            last_pc = Some(pc);
+        }
+
+        if stable_pc_count >= IDLE_PROBE_STABLE_PC_THRESHOLD {
+            let opcode = gba.bus_mut().peek32(pc);
+            if is_arm_branch_to_self(opcode, pc) {
+                let reason = if is_bios_exception_vector(pc) {
+                    ExitReason::ExceptionVectorTrap
+                } else {
+                    ExitReason::IdleLoopDetected
+                };
+                return result_from_register(&mut gba, suite, cycles, pc, reason);
+            }
         }
     }
 

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -18,6 +18,7 @@ pub enum Suite {
     Arm,
     Thumb,
     Nes,
+    Memory,
 }
 
 impl Suite {
@@ -26,6 +27,7 @@ impl Suite {
             Self::Arm => "roms/gba/automated_tests/gba-tests/arm/arm.gba",
             Self::Thumb => "roms/gba/automated_tests/gba-tests/thumb/thumb.gba",
             Self::Nes => "roms/gba/automated_tests/gba-tests/nes/nes.gba",
+            Self::Memory => "roms/gba/automated_tests/gba-tests/memory/memory.gba",
         };
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
     }
@@ -35,6 +37,7 @@ impl Suite {
             Self::Arm => (12, "r12"),
             Self::Thumb => (7, "r7"),
             Self::Nes => (12, "r12"),
+            Self::Memory => (12, "r12"),
         }
     }
 }

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -5,8 +5,15 @@ fn gba_suite_arm_rom_passes() {
     let result = run_suite(Suite::Arm);
     assert!(
         result.passed,
-        "arm suite failed: index={} reg={} pc=0x{:08X} cycles={} exit={:?}",
-        result.failing_index, result.reg_name, result.pc, result.cycles, result.exit_reason
+        "arm suite failed: index={} reg={} pc=0x{:08X} cpsr=0x{:08X} thumb={} opcode=0x{:08X} cycles={} exit={:?}",
+        result.failing_index,
+        result.reg_name,
+        result.pc,
+        result.cpsr,
+        result.thumb,
+        result.opcode_at_pc,
+        result.cycles,
+        result.exit_reason
     );
 }
 
@@ -15,17 +22,31 @@ fn gba_suite_thumb_rom_passes() {
     let result = run_suite(Suite::Thumb);
     assert!(
         result.passed,
-        "thumb suite failed: index={} reg={} pc=0x{:08X} cycles={} exit={:?}",
-        result.failing_index, result.reg_name, result.pc, result.cycles, result.exit_reason
+        "thumb suite failed: index={} reg={} pc=0x{:08X} cpsr=0x{:08X} thumb={} opcode=0x{:08X} cycles={} exit={:?}",
+        result.failing_index,
+        result.reg_name,
+        result.pc,
+        result.cpsr,
+        result.thumb,
+        result.opcode_at_pc,
+        result.cycles,
+        result.exit_reason
     );
 }
 
 #[test]
-fn gba_suite_memory_rom_passes() {
-    let result = run_suite(Suite::Memory);
+fn gba_suite_nes_rom_passes() {
+    let result = run_suite(Suite::Nes);
     assert!(
         result.passed,
-        "memory suite failed: index={} reg={} pc=0x{:08X} cycles={} exit={:?}",
-        result.failing_index, result.reg_name, result.pc, result.cycles, result.exit_reason
+        "nes suite failed: index={} reg={} pc=0x{:08X} cpsr=0x{:08X} thumb={} opcode=0x{:08X} cycles={} exit={:?}",
+        result.failing_index,
+        result.reg_name,
+        result.pc,
+        result.cpsr,
+        result.thumb,
+        result.opcode_at_pc,
+        result.cycles,
+        result.exit_reason
     );
 }

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -50,3 +50,20 @@ fn gba_suite_nes_rom_passes() {
         result.exit_reason
     );
 }
+
+#[test]
+fn gba_suite_memory_rom_passes() {
+    let result = run_suite(Suite::Memory);
+    assert!(
+        result.passed,
+        "memory suite failed: index={} reg={} pc=0x{:08X} cpsr=0x{:08X} thumb={} opcode=0x{:08X} cycles={} exit={:?}",
+        result.failing_index,
+        result.reg_name,
+        result.pc,
+        result.cpsr,
+        result.thumb,
+        result.opcode_at_pc,
+        result.cycles,
+        result.exit_reason
+    );
+}


### PR DESCRIPTION
## Summary
This PR extends and stabilizes GBA automated suite coverage.

- hardens the GBA suite runner bootstrap and diagnostics
- completes remaining ARM block transfer semantics for suite compatibility
- fixes THUMB misaligned halfword and format 15 edge-case behavior
- models ARM7TDMI three-stage prefetch to match self-modifying code pipeline behavior
- adds the gba-tests memory suite to integration coverage

## Files changed
- Cargo.toml
- src/gba/console/gba.rs
- src/gba/cpu/arm.rs
- src/gba/cpu/arm7tdmi.rs
- src/gba/cpu/registers.rs
- src/gba/cpu/thumb.rs
- src/gba/integration_tests/gba_suite_runner.rs
- src/gba/integration_tests/gba_suite_tests.rs

## Validation
- cargo test gba_suite_arm_rom_passes -- --nocapture
- cargo test gba_suite_thumb_rom_passes -- --nocapture
- cargo test gba_suite_nes_rom_passes -- --nocapture
- cargo test arm_prefetch_keeps_two_instructions_after_self_modify -- --nocapture

All of the above pass locally.
