### PR TITLE
feat(gba): add selectable handheld shader filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Options:
   --display <N>         Select display index for fullscreen (default: 0)
   --nes-filter <name>   Specify NES shader filter (crt|ntsc|smooth|pal|none)
   --gb-filter <name>    Specify Game Boy shader filter (dmg|none)
+  --gba-filter <name>   Specify Game Boy Advance shader filter (none|gba-lcd|agb001|nso-gba-color|sp101-color|gba-lcd-grid)
   --gba-bios-path <path>
                          Path to external GBA BIOS file (required for GBA ROMs)
   --config <path>       Specify config file path (overrides default locations)

--- a/neser.conf.example
+++ b/neser.conf.example
@@ -99,9 +99,20 @@ display=0
 # Shader/filter preset (Game Boy).
 # Valid values:
 #   - dmg    : DMG dot-matrix green-tint LCD simulation
-#   - none    : No filter, raw pixels
+#   - none   : No filter, raw pixels
 # Leave empty or comment out for no shader.
 #gb-filter=dmg
+
+# Shader/filter preset (Game Boy Advance).
+# Valid values:
+#   - none          : No filter, raw pixels
+#   - gba-lcd       : Default GBA LCD shader
+#   - agb001        : AGB-001 handheld preset
+#   - nso-gba-color : Nintendo Switch Online GBA color preset
+#   - sp101-color   : GBA SP-101 color preset
+#   - gba-lcd-grid  : GBA LCD grid + border preset
+# Leave empty or comment out for no shader.
+#gba-filter=gba-lcd
 
 # -----------------------------------------------------------------------------
 # Input Settings

--- a/shaders/README.md
+++ b/shaders/README.md
@@ -25,7 +25,8 @@ git clone --recurse-submodules https://github.com/rmstdope/neser
 
 ## Usage
 
-Use the `--nes-filter` flag for NES or `--gb-filter` for Game Boy:
+Use the `--nes-filter` flag for NES, `--gb-filter` for Game Boy, or
+`--gba-filter` for Game Boy Advance:
 
 ```bash
 neser rom.nes --nes-filter crt     # CRT simulation
@@ -33,6 +34,11 @@ neser rom.nes --nes-filter ntsc    # NTSC composite
 neser rom.nes --nes-filter smooth  # Smooth upscaling
 neser rom.nes --nes-filter none    # No filter
 neser rom.gb  --gb-filter dmg  # DMG dot-matrix LCD
+neser rom.gba --gba-filter gba-lcd        # GBA LCD shader
+neser rom.gba --gba-filter agb001         # AGB-001 style handheld look
+neser rom.gba --gba-filter nso-gba-color  # NSO color mod preset
+neser rom.gba --gba-filter sp101-color    # SP-101 color mod preset
+neser rom.gba --gba-filter gba-lcd-grid   # GBA LCD grid with border
 ```
 
 Or set in config file:
@@ -41,7 +47,9 @@ Or set in config file:
 nes-filter=crt
 ```
 
-You can also cycle through shaders at runtime with F6.
+You can also cycle through shaders at runtime with F4.
+For GBA, cycling follows this order: none, gba-lcd, agb001,
+nso-gba-color, sp101-color, gba-lcd-grid.
 
 ## Why a submodule?
 

--- a/src/frontends/native/shader_manager.rs
+++ b/src/frontends/native/shader_manager.rs
@@ -99,12 +99,10 @@ impl ShaderManager {
 
     fn discover_presets_filtered(allowed_names: &[&str]) -> Vec<PathBuf> {
         // Like discover_presets but restricted to names allowed for the active emulator.
-        let mut presets: Vec<PathBuf> = Self::presets_for_names(allowed_names, SHADER_PRESETS)
+        Self::presets_for_names(allowed_names, SHADER_PRESETS)
             .into_iter()
             .filter(|p| p.exists())
-            .collect();
-        presets.sort();
-        presets
+            .collect()
     }
 
     /// Returns the paths from `all_presets` whose short names appear in `allowed_names`.
@@ -272,6 +270,7 @@ impl Drop for ShaderManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gba::console::config::GBA_FILTER_NAMES;
 
     impl ShaderManager {
         fn with_presets(presets: Vec<PathBuf>) -> Self {
@@ -290,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_cycle_starts_after_initially_loaded_preset() {
-        // Sorted alphabetical order matches discover_presets: stock(0) crt(1) xbrz(2) ntsc(3)
+        // Presets are cycled in the same order they are discovered.
         let presets = vec![
             PathBuf::from("shaders/stock.slangp"),
             PathBuf::from("vendor/slang-shaders/crt/crt-lottes.slangp"),
@@ -316,7 +315,7 @@ mod tests {
     fn test_initial_cycle_without_loaded_shader_starts_after_stock() {
         // When no shader is configured at startup, cycling should behave as if
         // the current position is "stock" (the passthrough preset), so the first
-        // F4 press goes to crt (the preset after stock in sorted order).
+        // F4 press goes to crt (the preset after stock in discovery order).
         let presets = vec![
             PathBuf::from("shaders/stock.slangp"), // 0
             PathBuf::from("vendor/slang-shaders/crt/crt-lottes.slangp"), // 1
@@ -378,6 +377,25 @@ mod tests {
                 .iter()
                 .any(|p| p.to_str().unwrap_or("").contains("gameboy")),
             "NES must not include dmg"
+        );
+    }
+
+    #[test]
+    fn test_discover_presets_filtered_keeps_explicit_gba_cycle_order() {
+        let discovered = ShaderManager::discover_presets_filtered(GBA_FILTER_NAMES);
+
+        let expected = vec![
+            PathBuf::from("shaders/stock.slangp"),
+            PathBuf::from("shaders/gba-lcd.slangp"),
+            PathBuf::from("vendor/slang-shaders/handheld/agb001.slangp"),
+            PathBuf::from("vendor/slang-shaders/handheld/color-mod/NSO-gba-color.slangp"),
+            PathBuf::from("vendor/slang-shaders/handheld/color-mod/SP101-color.slangp"),
+            PathBuf::from("vendor/slang-shaders/handheld/console-border/gba-lcd-grid-v2.slangp"),
+        ];
+
+        assert_eq!(
+            discovered, expected,
+            "GBA shader discovery order should match user-visible F4 cycle order"
         );
     }
 }

--- a/src/frontends/native/shader_manager.rs
+++ b/src/frontends/native/shader_manager.rs
@@ -113,10 +113,14 @@ impl ShaderManager {
         allowed_names: &[&str],
         all_presets: &[(&str, &str)],
     ) -> Vec<PathBuf> {
-        all_presets
+        allowed_names
             .iter()
-            .filter(|(name, _)| allowed_names.contains(name))
-            .map(|(_, path)| PathBuf::from(path))
+            .filter_map(|allowed| {
+                all_presets
+                    .iter()
+                    .find(|(name, _)| name == allowed)
+                    .map(|(_, path)| PathBuf::from(path))
+            })
             .collect()
     }
 
@@ -381,9 +385,26 @@ mod tests {
     }
 
     #[test]
-    fn test_discover_presets_filtered_keeps_explicit_gba_cycle_order() {
-        let discovered = ShaderManager::discover_presets_filtered(GBA_FILTER_NAMES);
+    fn test_presets_for_names_preserves_allowed_names_order() {
+        let all: &[(&str, &str)] = &[
+            (
+                "gba-lcd-grid",
+                "vendor/slang-shaders/handheld/console-border/gba-lcd-grid-v2.slangp",
+            ),
+            (
+                "sp101-color",
+                "vendor/slang-shaders/handheld/color-mod/SP101-color.slangp",
+            ),
+            ("none", "shaders/stock.slangp"),
+            (
+                "nso-gba-color",
+                "vendor/slang-shaders/handheld/color-mod/NSO-gba-color.slangp",
+            ),
+            ("gba-lcd", "shaders/gba-lcd.slangp"),
+            ("agb001", "vendor/slang-shaders/handheld/agb001.slangp"),
+        ];
 
+        let discovered = ShaderManager::presets_for_names(GBA_FILTER_NAMES, all);
         let expected = vec![
             PathBuf::from("shaders/stock.slangp"),
             PathBuf::from("shaders/gba-lcd.slangp"),
@@ -393,9 +414,6 @@ mod tests {
             PathBuf::from("vendor/slang-shaders/handheld/console-border/gba-lcd-grid-v2.slangp"),
         ];
 
-        assert_eq!(
-            discovered, expected,
-            "GBA shader discovery order should match user-visible F4 cycle order"
-        );
+        assert_eq!(discovered, expected);
     }
 }

--- a/src/gba/console/config.rs
+++ b/src/gba/console/config.rs
@@ -5,13 +5,27 @@
 
 use crate::platform::config::CliFlag;
 
+/// Ordered list of GBA shader filter short names accepted by CLI/config and
+/// used for runtime shader cycling.
+pub(crate) const GBA_FILTER_NAMES: &[&str] = &[
+    "none",
+    "gba-lcd",
+    "agb001",
+    "nso-gba-color",
+    "sp101-color",
+    "gba-lcd-grid",
+];
+
+const GBA_FILTER_HELP: &str =
+    "GBA shader filter: none, gba-lcd, agb001, nso-gba-color, sp101-color, gba-lcd-grid";
+
 /// GBA-specific CLI flags, defined here so that the GBA module owns its flag
 /// declarations and parsing logic. These are chained into the global flag list
 /// by the platform config parser for validation and help-text generation.
 pub(crate) const GBA_CLI_FLAGS: &[CliFlag] = &[
     CliFlag {
         flag: "--gba-filter",
-        help: Some("GBA shader filter: gba-lcd or none"),
+        help: Some(GBA_FILTER_HELP),
         has_value: true,
     },
     CliFlag {

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -12,6 +12,7 @@
 
 use crate::gba::GbaBus;
 use crate::gba::cartridge::load_cartridge;
+use crate::gba::console::config::GBA_FILTER_NAMES;
 use crate::gba::cpu::Arm7tdmi;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::gba::debugging::{disasm_arm, disasm_thumb};
@@ -30,9 +31,6 @@ const SCREEN_HEIGHT: u32 = 160;
 /// GBA frame duration (~59.7275 Hz refresh rate).
 /// CPU clock: 16.78 MHz, 280896 cycles per frame → 16.743 ms per frame.
 const FRAME_DURATION_NANOS: u64 = 16_743_000;
-/// Shader presets allowed for GBA.
-const ALLOWED_SHADERS: &[&str] = &["none", "gba-lcd"];
-
 fn default_gba_bios_path() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     Some(PathBuf::from(home).join(".neser").join("gba_bios.bin"))
@@ -226,7 +224,7 @@ impl Emulator for Gba {
     }
 
     fn allowed_shaders(&self) -> &'static [&'static str] {
-        ALLOWED_SHADERS
+        GBA_FILTER_NAMES
     }
 
     fn load_rom(&mut self, bytes: &[u8], _name: &str) -> Result<(), String> {

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -6,6 +6,7 @@
 //! 2. Config file (neser.conf)
 //! 3. Default values
 
+use crate::gba::console::config::GBA_FILTER_NAMES;
 use crate::nes::console::TimingMode;
 use crate::nes::input::ControllerType;
 use crate::platform::config::CliFlag;
@@ -856,10 +857,8 @@ impl Config {
         }
 
         if let Some(filter_name) = Self::parse_named_arg(args, "--gba-filter") {
-            self.frontend.shader_path = Some(Self::map_filter_name_for(
-                &filter_name,
-                &["none", "gba-lcd"],
-            )?);
+            self.frontend.shader_path =
+                Some(Self::map_filter_name_for(&filter_name, GBA_FILTER_NAMES)?);
         }
 
         // ROM path from positional argument
@@ -1096,7 +1095,7 @@ impl Config {
             "gba-filter" => {
                 if !value.is_empty() {
                     self.frontend.shader_path =
-                        Some(Self::map_filter_name_for(value, &["none", "gba-lcd"])?);
+                        Some(Self::map_filter_name_for(value, GBA_FILTER_NAMES)?);
                 }
             }
             "nes-controller_port1" => {
@@ -5299,5 +5298,135 @@ nes-filter=invalid-shader
         let mut config = Config::default();
         config.apply_config_value("gb-filter", "").unwrap();
         assert_eq!(config.frontend.shader_path, None);
+    }
+
+    // --gba-filter CLI flag tests
+
+    #[test]
+    fn test_config_cmdline_gba_filter_agb001_sets_shader_path() {
+        let args = vec![
+            "neser".to_string(),
+            "--gba-filter".to_string(),
+            "agb001".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/agb001.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_cmdline_gba_filter_nso_gba_color_sets_shader_path() {
+        let args = vec![
+            "neser".to_string(),
+            "--gba-filter".to_string(),
+            "nso-gba-color".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/color-mod/NSO-gba-color.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_cmdline_gba_filter_sp101_color_sets_shader_path() {
+        let args = vec![
+            "neser".to_string(),
+            "--gba-filter".to_string(),
+            "sp101-color".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/color-mod/SP101-color.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_cmdline_gba_filter_gba_lcd_grid_sets_shader_path() {
+        let args = vec![
+            "neser".to_string(),
+            "--gba-filter".to_string(),
+            "gba-lcd-grid".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/console-border/gba-lcd-grid-v2.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_cmdline_gba_filter_rejects_bogus_shader_with_valid_options() {
+        let args = vec![
+            "neser".to_string(),
+            "--gba-filter".to_string(),
+            "bogus".to_string(),
+        ];
+        let result = config_new(args);
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("bogus"));
+        assert!(msg.contains("none, gba-lcd, agb001, nso-gba-color, sp101-color, gba-lcd-grid"));
+    }
+
+    // gba-filter= config file key tests
+
+    #[test]
+    fn test_config_file_gba_filter_agb001_sets_shader_path() {
+        let mut config = Config::default();
+        config.apply_config_value("gba-filter", "agb001").unwrap();
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/agb001.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_file_gba_filter_nso_gba_color_sets_shader_path() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("gba-filter", "nso-gba-color")
+            .unwrap();
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/color-mod/NSO-gba-color.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_file_gba_filter_sp101_color_sets_shader_path() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("gba-filter", "sp101-color")
+            .unwrap();
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/color-mod/SP101-color.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_file_gba_filter_gba_lcd_grid_sets_shader_path() {
+        let mut config = Config::default();
+        config
+            .apply_config_value("gba-filter", "gba-lcd-grid")
+            .unwrap();
+        assert_eq!(
+            config.frontend.shader_path,
+            Some("vendor/slang-shaders/handheld/console-border/gba-lcd-grid-v2.slangp".to_string())
+        );
+    }
+
+    #[test]
+    fn test_config_file_gba_filter_rejects_bogus_shader_with_valid_options() {
+        let mut config = Config::default();
+        let result = config.apply_config_value("gba-filter", "bogus");
+        assert!(result.is_err());
+        let msg = result.unwrap_err();
+        assert!(msg.contains("bogus"));
+        assert!(msg.contains("none, gba-lcd, agb001, nso-gba-color, sp101-color, gba-lcd-grid"));
     }
 }

--- a/src/platform/shaders.rs
+++ b/src/platform/shaders.rs
@@ -23,4 +23,64 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
     ("dmg", "vendor/slang-shaders/handheld/gameboy.slangp"),
     // GBA LCD placeholder - has its own preset path so it remains distinct from `none`
     ("gba-lcd", "shaders/gba-lcd.slangp"),
+    ("agb001", "vendor/slang-shaders/handheld/agb001.slangp"),
+    (
+        "nso-gba-color",
+        "vendor/slang-shaders/handheld/color-mod/NSO-gba-color.slangp",
+    ),
+    (
+        "sp101-color",
+        "vendor/slang-shaders/handheld/color-mod/SP101-color.slangp",
+    ),
+    (
+        "gba-lcd-grid",
+        "vendor/slang-shaders/handheld/console-border/gba-lcd-grid-v2.slangp",
+    ),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::SHADER_PRESETS;
+
+    fn assert_preset_path(name: &str, expected_path: &str) {
+        let found = SHADER_PRESETS
+            .iter()
+            .find(|(preset_name, _)| *preset_name == name)
+            .map(|(_, path)| *path);
+
+        assert_eq!(
+            found,
+            Some(expected_path),
+            "Preset '{name}' should resolve to '{expected_path}'"
+        );
+    }
+
+    #[test]
+    fn test_gba_preset_agb001_maps_to_expected_path() {
+        assert_preset_path("agb001", "vendor/slang-shaders/handheld/agb001.slangp");
+    }
+
+    #[test]
+    fn test_gba_preset_nso_gba_color_maps_to_expected_path() {
+        assert_preset_path(
+            "nso-gba-color",
+            "vendor/slang-shaders/handheld/color-mod/NSO-gba-color.slangp",
+        );
+    }
+
+    #[test]
+    fn test_gba_preset_sp101_color_maps_to_expected_path() {
+        assert_preset_path(
+            "sp101-color",
+            "vendor/slang-shaders/handheld/color-mod/SP101-color.slangp",
+        );
+    }
+
+    #[test]
+    fn test_gba_preset_gba_lcd_grid_maps_to_expected_path() {
+        assert_preset_path(
+            "gba-lcd-grid",
+            "vendor/slang-shaders/handheld/console-border/gba-lcd-grid-v2.slangp",
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add four new GBA handheld shader presets to the global preset table
- centralize the ordered GBA filter allow-list and reuse it for CLI help, CLI/config validation, and runtime shader filtering
- enforce deterministic GBA shader cycling order (none -> gba-lcd -> agb001 -> nso-gba-color -> sp101-color -> gba-lcd-grid)
- document new GBA filter options in user-facing docs

## Changes
- updated GBA presets in src/platform/shaders.rs
- added preset mapping tests in src/platform/shaders.rs
- added shared GBA filter name constant in src/gba/console/config.rs
- wired shared list into src/gba/console/gba.rs and src/nes/console/config.rs
- added GBA CLI/config acceptance + invalid-value tests in src/nes/console/config.rs
- updated ShaderManager discovery order behavior and added explicit GBA order test in src/frontends/native/shader_manager.rs
- updated docs in README.md, shaders/README.md, and neser.conf.example

## Validation
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/test-dir.sh src/platform src/gba src/frontends src/nes (interrupted once, then re-run during final verification flow)
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts/mappertool -s scripts/scraper -s scripts -t . -p "test_*.py"
- npm test

## Issue
Closes #2318
