### PR TITLE
feat(gb/tests): integrate mealybug tearoom test suite (#2346)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "roms/gba/automated_tests/gba-tests"]
 	path = roms/gba/automated_tests/gba-tests
 	url = https://github.com/jsmolka/gba-tests.git
+[submodule "roms/gb/automated_tests/mealybug-tearoom-tests"]
+	path = roms/gb/automated_tests/mealybug-tearoom-tests
+	url = https://github.com/mattcurrie/mealybug-tearoom-tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +868,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "dirs-next"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +913,17 @@ checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.10.0",
  "objc2 0.6.4",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2452,6 +2483,7 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "winit",
+ "zip",
 ]
 
 [[package]]
@@ -5192,10 +5224,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ required-features = ["native"]
 hound = "3.5"
 serial_test = "3.2"
 tempfile = "3.24.0"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # Improve runtime performance in debug builds (helps reduce audio underruns) while
 # keeping debuggability. This is a common setup for emulator-style workloads.

--- a/src/gb/integration_tests/helpers.rs
+++ b/src/gb/integration_tests/helpers.rs
@@ -88,34 +88,43 @@ pub fn detect_mooneye_result_with_limit<B: GbBus>(
     gb: &mut Gb<B>,
     cycle_limit: u64,
 ) -> MooneyeResult {
+    if !step_until_breakpoint(gb, cycle_limit) {
+        return MooneyeResult::Timeout;
+    }
+    let r = &gb.cpu.regs;
+    if r.b == FIBO_B
+        && r.c == FIBO_C
+        && r.d == FIBO_D
+        && r.e == FIBO_E
+        && r.h == FIBO_H
+        && r.l == FIBO_L
+    {
+        MooneyeResult::Pass
+    } else {
+        MooneyeResult::Fail {
+            b: r.b,
+            c: r.c,
+            d: r.d,
+            e: r.e,
+            h: r.h,
+            l: r.l,
+        }
+    }
+}
+
+/// Step `gb` until the `LD B,B` (0x40) opcode is about to execute, or until
+/// `cycle_limit` M-cycles have elapsed.
+///
+/// Returns `true` if the breakpoint was reached, `false` on timeout.
+fn step_until_breakpoint<B: GbBus>(gb: &mut Gb<B>, cycle_limit: u64) -> bool {
     let start = gb.cycles();
     loop {
-        let opcode = gb.cpu.bus.read(gb.cpu.regs.pc);
-        if opcode == LD_B_B {
-            let r = &gb.cpu.regs;
-            if r.b == FIBO_B
-                && r.c == FIBO_C
-                && r.d == FIBO_D
-                && r.e == FIBO_E
-                && r.h == FIBO_H
-                && r.l == FIBO_L
-            {
-                return MooneyeResult::Pass;
-            }
-            return MooneyeResult::Fail {
-                b: r.b,
-                c: r.c,
-                d: r.d,
-                e: r.e,
-                h: r.h,
-                l: r.l,
-            };
+        if gb.cpu.bus.read(gb.cpu.regs.pc) == LD_B_B {
+            return true;
         }
-
         if gb.cycles().saturating_sub(start) >= cycle_limit {
-            return MooneyeResult::Timeout;
+            return false;
         }
-
         gb.step();
     }
 }
@@ -203,11 +212,11 @@ pub fn load_cgb_rom_from_bytes(bytes: &[u8], model: CgbModel) -> Gb<CgbBus> {
 // Breakpoint-based screen capture helper
 // ============================================================================
 
-/// Run `gb` until the mealybug `LD B,B` (0x40) software breakpoint fires and
-/// return the CRC-32 of the screen buffer at that moment.
+/// Run `gb` until the `LD B,B` (0x40) software breakpoint fires and return the
+/// CRC-32 of the screen buffer at that moment.
 ///
-/// Returns `Some(crc)` when the breakpoint is hit within `cycle_limit` M-cycles,
-/// or `None` on timeout.
+/// Panics if the breakpoint is not reached within `cycle_limit` M-cycles, so
+/// that a hanging ROM is always a test failure rather than a silent pass.
 ///
 /// When the `NESER_CAPTURE_SCREEN` environment variable is set, saves a PNG to
 /// `target/mealybug-captures/<capture_name>.png` for visual baseline comparison.
@@ -215,29 +224,21 @@ pub fn run_to_breakpoint_and_crc<B: GbBus>(
     gb: &mut Gb<B>,
     cycle_limit: u64,
     capture_name: &str,
-) -> Option<u32> {
-    let start = gb.cycles();
+) -> u32 {
+    assert!(
+        step_until_breakpoint(gb, cycle_limit),
+        "{capture_name}: LD B,B breakpoint not reached within {cycle_limit} M-cycles"
+    );
 
-    loop {
-        let opcode = gb.cpu.bus.read(gb.cpu.regs.pc);
-        if opcode == LD_B_B {
-            let crc = gb.cpu.bus.ppu().screen_buffer().crc32();
+    let crc = gb.cpu.bus.ppu().screen_buffer().crc32();
 
-            if std::env::var_os("NESER_CAPTURE_SCREEN").is_some() {
-                let dir = std::path::Path::new("target/mealybug-captures");
-                std::fs::create_dir_all(dir).expect("create mealybug-captures dir");
-                let path = dir.join(format!("{capture_name}.png"));
-                save_screen_png(gb, path.to_str().expect("valid path"));
-                println!("[mealybug] {capture_name}: CRC={crc:#010X}, PNG saved to {path:?}");
-            }
-
-            return Some(crc);
-        }
-
-        if gb.cycles().saturating_sub(start) >= cycle_limit {
-            return None;
-        }
-
-        gb.step();
+    if std::env::var_os("NESER_CAPTURE_SCREEN").is_some() {
+        let dir = std::path::Path::new("target/mealybug-captures");
+        std::fs::create_dir_all(dir).expect("create mealybug-captures dir");
+        let path = dir.join(format!("{capture_name}.png"));
+        save_screen_png(gb, path.to_str().expect("valid path"));
+        println!("[mealybug] {capture_name}: CRC={crc:#010X}, PNG saved to {path:?}");
     }
+
+    crc
 }

--- a/src/gb/integration_tests/helpers.rs
+++ b/src/gb/integration_tests/helpers.rs
@@ -180,3 +180,64 @@ pub fn save_screen_png<B: GbBus>(gb: &Gb<B>, path: &str) {
     drop(png_writer);
     bw.flush().expect("flush PNG writer");
 }
+
+// ============================================================================
+// In-memory ROM loading helpers (for zip-bundled test suites)
+// ============================================================================
+
+/// Load a DMG ROM from raw bytes and return a ready-to-step `Gb<DmgBus>`.
+pub fn load_gb_rom_from_bytes(bytes: &[u8], model: DmgModel) -> Gb<DmgBus> {
+    let cart = load_cartridge(bytes).expect("valid GB ROM bytes");
+    Gb::new(DmgBus::new(cart, model))
+}
+
+/// Load a CGB ROM from raw bytes and return a ready-to-step `Gb<CgbBus>`.
+pub fn load_cgb_rom_from_bytes(bytes: &[u8], model: CgbModel) -> Gb<CgbBus> {
+    let cart = load_cartridge(bytes).expect("valid CGB ROM bytes");
+    let mut gb = Gb::new(CgbBus::new(cart, model, true));
+    gb.cpu.reset_registers_cgb_for_model(model);
+    gb
+}
+
+// ============================================================================
+// Breakpoint-based screen capture helper
+// ============================================================================
+
+/// Run `gb` until the mealybug `LD B,B` (0x40) software breakpoint fires and
+/// return the CRC-32 of the screen buffer at that moment.
+///
+/// Returns `Some(crc)` when the breakpoint is hit within `cycle_limit` M-cycles,
+/// or `None` on timeout.
+///
+/// When the `NESER_CAPTURE_SCREEN` environment variable is set, saves a PNG to
+/// `target/mealybug-captures/<capture_name>.png` for visual baseline comparison.
+pub fn run_to_breakpoint_and_crc<B: GbBus>(
+    gb: &mut Gb<B>,
+    cycle_limit: u64,
+    capture_name: &str,
+) -> Option<u32> {
+    let start = gb.cycles();
+
+    loop {
+        let opcode = gb.cpu.bus.read(gb.cpu.regs.pc);
+        if opcode == LD_B_B {
+            let crc = gb.cpu.bus.ppu().screen_buffer().crc32();
+
+            if std::env::var_os("NESER_CAPTURE_SCREEN").is_some() {
+                let dir = std::path::Path::new("target/mealybug-captures");
+                std::fs::create_dir_all(dir).expect("create mealybug-captures dir");
+                let path = dir.join(format!("{capture_name}.png"));
+                save_screen_png(gb, path.to_str().expect("valid path"));
+                println!("[mealybug] {capture_name}: CRC={crc:#010X}, PNG saved to {path:?}");
+            }
+
+            return Some(crc);
+        }
+
+        if gb.cycles().saturating_sub(start) >= cycle_limit {
+            return None;
+        }
+
+        gb.step();
+    }
+}

--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -14,7 +14,8 @@
 //! `target/mealybug-captures/` alongside the CRC printed to stdout:
 //!
 //! ```bash
-//! NESER_CAPTURE_SCREEN=1 cargo test gb::integration_tests::mealybug -- --include-ignored
+//! NESER_CAPTURE_SCREEN=1 cargo test --no-default-features --lib \
+//!     gb::integration_tests::mealybug_tests -- --include-ignored --nocapture
 //! ```
 //!
 //! Compare each PNG to the reference image in the submodule:
@@ -27,6 +28,7 @@
 //! ```
 
 use std::io::Read;
+use std::sync::OnceLock;
 
 use super::helpers::{load_cgb_rom_from_bytes, load_gb_rom_from_bytes, run_to_breakpoint_and_crc};
 use crate::gb::model::{CgbModel, DmgModel};
@@ -35,11 +37,17 @@ const ZIP_PATH: &str = "roms/gb/automated_tests/mealybug-tearoom-tests/mealybug-
 
 const CYCLE_LIMIT: u64 = 10_000_000;
 
+/// Return the raw bytes of the mealybug ZIP archive, reading the file only once.
+fn zip_bytes() -> &'static [u8] {
+    static ZIP: OnceLock<Vec<u8>> = OnceLock::new();
+    ZIP.get_or_init(|| {
+        std::fs::read(ZIP_PATH).unwrap_or_else(|e| panic!("failed to read {ZIP_PATH}: {e}"))
+    })
+}
+
 /// Extract a ROM by filename from the mealybug zip archive and return its bytes.
 fn read_rom_from_zip(rom_name: &str) -> Vec<u8> {
-    let zip_data =
-        std::fs::read(ZIP_PATH).unwrap_or_else(|e| panic!("failed to read {ZIP_PATH}: {e}"));
-    let cursor = std::io::Cursor::new(zip_data);
+    let cursor = std::io::Cursor::new(zip_bytes());
     let mut archive =
         zip::ZipArchive::new(cursor).expect("mealybug zip should be a valid ZIP archive");
     let mut entry = archive
@@ -60,8 +68,7 @@ fn read_rom_from_zip(rom_name: &str) -> Vec<u8> {
 fn test_m2_win_en_toggle_dmg_b() {
     let bytes = read_rom_from_zip("m2_win_en_toggle.gb");
     let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
-    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_dmg_b")
-        .expect("m2_win_en_toggle should hit LD B,B breakpoint");
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_dmg_b");
     const EXPECTED_CRC: u32 = 0xCE29_5724;
     assert_eq!(
         crc, EXPECTED_CRC,

--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -1,0 +1,721 @@
+//! Integration tests for the [mealybug tearoom test suite](https://github.com/mattcurrie/mealybug-tearoom-tests).
+//!
+//! Each test runs a mealybug ROM until the `LD B,B` (0x40) software breakpoint fires, then
+//! compares the screen buffer CRC against a visually confirmed baseline.
+//!
+//! Tests are run per hardware model where reference images exist:
+//! - `dmg_b`  — DMG-B model (reference: `expected/DMG-blob/`)
+//! - `cgb_c`  — CGB-C model (reference: `expected/CPU CGB C/`)
+//! - `cgb_d`  — CGB-D model (reference: `expected/CPU CGB D/`)
+//!
+//! ## Baseline capture workflow
+//!
+//! Set `NESER_CAPTURE_SCREEN=1` before running to save PNGs to
+//! `target/mealybug-captures/` alongside the CRC printed to stdout:
+//!
+//! ```bash
+//! NESER_CAPTURE_SCREEN=1 cargo test gb::integration_tests::mealybug -- --include-ignored
+//! ```
+//!
+//! Compare each PNG to the reference image in the submodule:
+//!
+//! ```bash
+//! compare -metric AE \
+//!     target/mealybug-captures/m3_bgp_change_dmg_b.png \
+//!     roms/gb/automated_tests/mealybug-tearoom-tests/expected/DMG-blob/m3_bgp_change.png \
+//!     /dev/null
+//! ```
+
+use std::io::Read;
+
+use super::helpers::{load_cgb_rom_from_bytes, load_gb_rom_from_bytes, run_to_breakpoint_and_crc};
+use crate::gb::model::{CgbModel, DmgModel};
+
+const ZIP_PATH: &str = "roms/gb/automated_tests/mealybug-tearoom-tests/mealybug-tearoom-tests.zip";
+
+const CYCLE_LIMIT: u64 = 10_000_000;
+
+/// Extract a ROM by filename from the mealybug zip archive and return its bytes.
+fn read_rom_from_zip(rom_name: &str) -> Vec<u8> {
+    let zip_data =
+        std::fs::read(ZIP_PATH).unwrap_or_else(|e| panic!("failed to read {ZIP_PATH}: {e}"));
+    let cursor = std::io::Cursor::new(zip_data);
+    let mut archive =
+        zip::ZipArchive::new(cursor).expect("mealybug zip should be a valid ZIP archive");
+    let mut entry = archive
+        .by_name(rom_name)
+        .unwrap_or_else(|_| panic!("{rom_name} not found in mealybug zip"));
+    let mut bytes = Vec::new();
+    entry
+        .read_to_end(&mut bytes)
+        .expect("read ROM bytes from zip");
+    bytes
+}
+
+// ============================================================================
+// DMG-B tests (reference: expected/DMG-blob/)
+// ============================================================================
+
+#[test]
+fn test_m2_win_en_toggle_dmg_b() {
+    let bytes = read_rom_from_zip("m2_win_en_toggle.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_dmg_b")
+        .expect("m2_win_en_toggle should hit LD B,B breakpoint");
+    const EXPECTED_CRC: u32 = 0xCE29_5724;
+    assert_eq!(
+        crc, EXPECTED_CRC,
+        "m2_win_en_toggle DMG-B CRC mismatch: got {crc:#010X}, expected {EXPECTED_CRC:#010X}"
+    );
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2348"]
+fn test_m3_bgp_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_bgp_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_bgp_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2348"]
+fn test_m3_bgp_change_sprites_dmg_b() {
+    let bytes = read_rom_from_zip("m3_bgp_change_sprites.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_bgp_change_sprites_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2349"]
+fn test_m3_lcdc_bg_en_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_en_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_en_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2350"]
+fn test_m3_lcdc_bg_map_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_map_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_map_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2351"]
+fn test_m3_lcdc_obj_en_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_en_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_en_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2351"]
+fn test_m3_lcdc_obj_en_change_variant_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_en_change_variant.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc =
+        run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_en_change_variant_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2352"]
+fn test_m3_lcdc_obj_size_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_size_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_size_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2352"]
+fn test_m3_lcdc_obj_size_change_scx_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_size_change_scx.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_size_change_scx_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2353"]
+fn test_m3_lcdc_tile_sel_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_tile_sel_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_tile_sel_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2353"]
+fn test_m3_lcdc_tile_sel_win_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_tile_sel_win_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_tile_sel_win_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2354"]
+fn test_m3_lcdc_win_en_change_multiple_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_en_change_multiple.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc =
+        run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_en_change_multiple_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2354"]
+fn test_m3_lcdc_win_en_change_multiple_wx_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_en_change_multiple_wx.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(
+        &mut gb,
+        CYCLE_LIMIT,
+        "m3_lcdc_win_en_change_multiple_wx_dmg_b",
+    );
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2355"]
+fn test_m3_lcdc_win_map_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2356"]
+fn test_m3_obp0_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_obp0_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_obp0_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2357"]
+fn test_m3_scx_high_5_bits_dmg_b() {
+    let bytes = read_rom_from_zip("m3_scx_high_5_bits.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scx_high_5_bits_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2357"]
+fn test_m3_scx_low_3_bits_dmg_b() {
+    let bytes = read_rom_from_zip("m3_scx_low_3_bits.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scx_low_3_bits_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2358"]
+fn test_m3_scy_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_scy_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scy_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2359"]
+fn test_m3_window_timing_dmg_b() {
+    let bytes = read_rom_from_zip("m3_window_timing.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_window_timing_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2359"]
+fn test_m3_window_timing_wx_0_dmg_b() {
+    let bytes = read_rom_from_zip("m3_window_timing_wx_0.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_window_timing_wx_0_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_4_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_wx_4_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_4_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_4_change_sprites_dmg_b() {
+    let bytes = read_rom_from_zip("m3_wx_4_change_sprites.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_4_change_sprites_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_5_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_wx_5_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_5_change_dmg_b");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_6_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_wx_6_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_6_change_dmg_b");
+}
+
+// ============================================================================
+// CGB-C tests (reference: expected/CPU CGB C/)
+// ============================================================================
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2347"]
+fn test_m2_win_en_toggle_cgb_c() {
+    let bytes = read_rom_from_zip("m2_win_en_toggle.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2348"]
+fn test_m3_bgp_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_bgp_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_bgp_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2348"]
+fn test_m3_bgp_change_sprites_cgb_c() {
+    let bytes = read_rom_from_zip("m3_bgp_change_sprites.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_bgp_change_sprites_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2349"]
+fn test_m3_lcdc_bg_en_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_en_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_en_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2349"]
+fn test_m3_lcdc_bg_en_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_en_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_en_change2_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2350"]
+fn test_m3_lcdc_bg_map_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_map_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_map_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2350"]
+fn test_m3_lcdc_bg_map_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_map_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_map_change2_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2351"]
+fn test_m3_lcdc_obj_en_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_en_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_en_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2351"]
+fn test_m3_lcdc_obj_en_change_variant_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_en_change_variant.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc =
+        run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_en_change_variant_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2352"]
+fn test_m3_lcdc_obj_size_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_size_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_size_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2352"]
+fn test_m3_lcdc_obj_size_change_scx_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_size_change_scx.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_size_change_scx_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2353"]
+fn test_m3_lcdc_tile_sel_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_tile_sel_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_tile_sel_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2353"]
+fn test_m3_lcdc_tile_sel_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_tile_sel_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_tile_sel_change2_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2353"]
+fn test_m3_lcdc_tile_sel_win_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_tile_sel_win_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_tile_sel_win_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2353"]
+fn test_m3_lcdc_tile_sel_win_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_tile_sel_win_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc =
+        run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_tile_sel_win_change2_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2354"]
+fn test_m3_lcdc_win_en_change_multiple_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_en_change_multiple.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc =
+        run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_en_change_multiple_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2354"]
+fn test_m3_lcdc_win_en_change_multiple_wx_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_en_change_multiple_wx.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(
+        &mut gb,
+        CYCLE_LIMIT,
+        "m3_lcdc_win_en_change_multiple_wx_cgb_c",
+    );
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2355"]
+fn test_m3_lcdc_win_map_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2355"]
+fn test_m3_lcdc_win_map_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change2_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2356"]
+fn test_m3_obp0_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_obp0_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_obp0_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2357"]
+fn test_m3_scx_high_5_bits_cgb_c() {
+    let bytes = read_rom_from_zip("m3_scx_high_5_bits.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scx_high_5_bits_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2357"]
+fn test_m3_scx_high_5_bits_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_scx_high_5_bits_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scx_high_5_bits_change2_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2357"]
+fn test_m3_scx_low_3_bits_cgb_c() {
+    let bytes = read_rom_from_zip("m3_scx_low_3_bits.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scx_low_3_bits_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2358"]
+fn test_m3_scy_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_scy_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scy_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2358"]
+fn test_m3_scy_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_scy_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scy_change2_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2359"]
+fn test_m3_window_timing_cgb_c() {
+    let bytes = read_rom_from_zip("m3_window_timing.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_window_timing_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2359"]
+fn test_m3_window_timing_wx_0_cgb_c() {
+    let bytes = read_rom_from_zip("m3_window_timing_wx_0.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_window_timing_wx_0_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_4_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_wx_4_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_4_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_4_change_sprites_cgb_c() {
+    let bytes = read_rom_from_zip("m3_wx_4_change_sprites.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_4_change_sprites_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_5_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_wx_5_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_5_change_cgb_c");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_6_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_wx_6_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_6_change_cgb_c");
+}
+
+// ============================================================================
+// CGB-D tests (reference: expected/CPU CGB D/)
+// ============================================================================
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2347"]
+fn test_m2_win_en_toggle_cgb_d() {
+    let bytes = read_rom_from_zip("m2_win_en_toggle.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2348"]
+fn test_m3_bgp_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_bgp_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_bgp_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2348"]
+fn test_m3_bgp_change_sprites_cgb_d() {
+    let bytes = read_rom_from_zip("m3_bgp_change_sprites.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_bgp_change_sprites_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2349"]
+fn test_m3_lcdc_bg_en_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_en_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_en_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2350"]
+fn test_m3_lcdc_bg_map_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_map_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_map_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2351"]
+fn test_m3_lcdc_obj_en_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_en_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_en_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2351"]
+fn test_m3_lcdc_obj_en_change_variant_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_en_change_variant.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc =
+        run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_en_change_variant_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2352"]
+fn test_m3_lcdc_obj_size_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_size_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_size_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2352"]
+fn test_m3_lcdc_obj_size_change_scx_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_obj_size_change_scx.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_obj_size_change_scx_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2353"]
+fn test_m3_lcdc_tile_sel_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_tile_sel_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_tile_sel_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2353"]
+fn test_m3_lcdc_tile_sel_win_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_tile_sel_win_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_tile_sel_win_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2354"]
+fn test_m3_lcdc_win_en_change_multiple_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_en_change_multiple.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc =
+        run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_en_change_multiple_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2354"]
+fn test_m3_lcdc_win_en_change_multiple_wx_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_en_change_multiple_wx.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(
+        &mut gb,
+        CYCLE_LIMIT,
+        "m3_lcdc_win_en_change_multiple_wx_cgb_d",
+    );
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2355"]
+fn test_m3_lcdc_win_map_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2356"]
+fn test_m3_obp0_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_obp0_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_obp0_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2357"]
+fn test_m3_scx_high_5_bits_cgb_d() {
+    let bytes = read_rom_from_zip("m3_scx_high_5_bits.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scx_high_5_bits_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2357"]
+fn test_m3_scx_low_3_bits_cgb_d() {
+    let bytes = read_rom_from_zip("m3_scx_low_3_bits.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scx_low_3_bits_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2358"]
+fn test_m3_scy_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_scy_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_scy_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2359"]
+fn test_m3_window_timing_cgb_d() {
+    let bytes = read_rom_from_zip("m3_window_timing.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_window_timing_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2359"]
+fn test_m3_window_timing_wx_0_cgb_d() {
+    let bytes = read_rom_from_zip("m3_window_timing_wx_0.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_window_timing_wx_0_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_4_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_wx_4_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_4_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_4_change_sprites_cgb_d() {
+    let bytes = read_rom_from_zip("m3_wx_4_change_sprites.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_4_change_sprites_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_5_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_wx_5_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_5_change_cgb_d");
+}
+
+#[test]
+#[ignore = "mealybug: PPU timing not yet accurate — tracked in #2360"]
+fn test_m3_wx_6_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_wx_6_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let _crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_wx_6_change_cgb_d");
+}

--- a/src/gb/integration_tests/mod.rs
+++ b/src/gb/integration_tests/mod.rs
@@ -2,6 +2,7 @@ pub mod acid_tests;
 pub mod blargg_tests;
 pub mod boot_tests;
 pub mod helpers;
+pub mod mealybug_tests;
 pub mod mooneye_tests;
 pub mod samesuite_apu_tests;
 pub mod samesuite_dma_tests;


### PR DESCRIPTION
Closes #2346

## Summary

Integrates the [mealybug tearoom test suite](https://github.com/mattcurrie/mealybug-tearoom-tests) as automated GB integration tests. Runs 79 tests (one per ROM × hardware model), with 1 already passing and 78 marked `#[ignore]` pending PPU timing improvements.

## Changes

- **Git submodule**: `roms/gb/automated_tests/mealybug-tearoom-tests/`
- **Cargo.toml**: `zip` added as dev-dependency for in-memory ROM extraction
- **helpers.rs**: New `load_gb_rom_from_bytes`, `load_cgb_rom_from_bytes`, and `run_to_breakpoint_and_crc` (with `NESER_CAPTURE_SCREEN` support)
- **mealybug_tests.rs**: 79 tests across 3 hardware models (DmgB, CgbC, CgbD), triggered by `LD B,B` breakpoint
- **mod.rs**: Registers new module

## Test results

```
test result: ok. 1 passed; 0 failed; 78 ignored
```

| Status | Test | CRC |
|--------|------|-----|
| ✅ PASSES | test_m2_win_en_toggle_dmg_b | 0xCE295724 |
| 🔇 78 tests ignored | PPU timing not yet accurate | tracked in #2347–#2360 |

## Baseline capture

To capture screenshots for visual comparison:
```bash
NESER_CAPTURE_SCREEN=1 cargo test --no-default-features --lib gb::integration_tests::mealybug -- --include-ignored --nocapture
```
PNGs are saved to `target/mealybug-captures/`.

## Sub-issues filed

#2347, #2348, #2349, #2350, #2351, #2352, #2353, #2354, #2355, #2356, #2357, #2358, #2359, #2360