### PR TITLE
fix(gb): apply CGB compat palette to all DMG games, not just Nintendo (#2347)

### DIFF
--- a/src/gb/compat_palettes.rs
+++ b/src/gb/compat_palettes.rs
@@ -286,13 +286,10 @@ pub fn is_nintendo_licensee(header: &[u8]) -> bool {
 /// Gets the palette combination index for a cartridge header.
 ///
 /// Returns the index into `PALETTE_COMBINATIONS` (0-54).
-/// Non-Nintendo games return 5 (the "Up button" default palette).
+/// All DMG games (including non-Nintendo) use the title checksum lookup,
+/// matching the real CGB boot ROM behaviour. Unknown checksums fall back to
+/// combination 0 (the "Default" / "Right+A" palette).
 pub fn get_palette_id(header: &[u8]) -> u8 {
-    // Non-Nintendo games get the default palette (combination 5)
-    if !is_nintendo_licensee(header) {
-        return 5; // Palette combination 5 = Up button
-    }
-
     let checksum = compute_title_checksum(header);
 
     // Find the checksum in the table
@@ -313,7 +310,7 @@ pub fn get_palette_id(header: &[u8]) -> u8 {
         // Mask off the $80 flag (logo tilemap indicator)
         PALETTE_PER_CHECKSUM[final_index] & 0x7F
     } else {
-        5 // Default fallback
+        0 // Default fallback (combination 0 = "Right+A")
     }
 }
 
@@ -503,11 +500,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_palette_id_non_nintendo() {
+    fn test_get_palette_id_non_nintendo_uses_checksum_lookup() {
+        // Non-Nintendo games must go through the title checksum lookup, not return a
+        // hardcoded default. An all-zero title gives checksum 0x00, which matches
+        // TITLE_CHECKSUMS[0] ("Default") → PALETTE_PER_CHECKSUM[0] = 0.
         let title: [u8; 16] = [0u8; 16];
-        let header = make_header(&title, 0x00);
-        // Non-Nintendo games get palette combination 5 (grayscale)
-        assert_eq!(get_palette_id(&header), 5);
+        let header = make_header(&title, 0x00); // old_licensee=0x00 → non-Nintendo
+        assert_eq!(get_palette_id(&header), 0);
     }
 
     #[test]
@@ -520,14 +519,16 @@ mod tests {
     }
 
     #[test]
-    fn test_get_palette_colors_default() {
+    fn test_get_palette_colors_non_nintendo_all_zero_title() {
+        // An all-zero title (checksum 0x00) for any DMG game should yield palette
+        // combination 0: OBJ0=PALETTES[4], OBJ1=PALETTES[4], BG=PALETTES[29].
+        // This is the real CGB boot ROM "Default" mapping — not a grayscale fallback.
         let title: [u8; 16] = [0u8; 16];
         let header = make_header(&title, 0x00);
         let palette = get_palette_colors(&header);
-        // Non-Nintendo → palette 5 → combination [0, 0, 0] → all palette 0
-        assert_eq!(palette.bg0, PALETTES[0]);
-        assert_eq!(palette.obj0, PALETTES[0]);
-        assert_eq!(palette.obj1, PALETTES[0]);
+        assert_eq!(palette.bg0, PALETTES[29]);
+        assert_eq!(palette.obj0, PALETTES[4]);
+        assert_eq!(palette.obj1, PALETTES[4]);
     }
 
     #[test]

--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -120,26 +120,82 @@ fn test_m2_win_en_toggle_dmg_b() {
 }
 
 mealybug_ignored_dmg_b!(test_m3_bgp_change_dmg_b, "m3_bgp_change", "2348");
-mealybug_ignored_dmg_b!(test_m3_bgp_change_sprites_dmg_b, "m3_bgp_change_sprites", "2348");
-mealybug_ignored_dmg_b!(test_m3_lcdc_bg_en_change_dmg_b, "m3_lcdc_bg_en_change", "2349");
-mealybug_ignored_dmg_b!(test_m3_lcdc_bg_map_change_dmg_b, "m3_lcdc_bg_map_change", "2350");
-mealybug_ignored_dmg_b!(test_m3_lcdc_obj_en_change_dmg_b, "m3_lcdc_obj_en_change", "2351");
-mealybug_ignored_dmg_b!(test_m3_lcdc_obj_en_change_variant_dmg_b, "m3_lcdc_obj_en_change_variant", "2351");
-mealybug_ignored_dmg_b!(test_m3_lcdc_obj_size_change_dmg_b, "m3_lcdc_obj_size_change", "2352");
-mealybug_ignored_dmg_b!(test_m3_lcdc_obj_size_change_scx_dmg_b, "m3_lcdc_obj_size_change_scx", "2352");
-mealybug_ignored_dmg_b!(test_m3_lcdc_tile_sel_change_dmg_b, "m3_lcdc_tile_sel_change", "2353");
-mealybug_ignored_dmg_b!(test_m3_lcdc_tile_sel_win_change_dmg_b, "m3_lcdc_tile_sel_win_change", "2353");
-mealybug_ignored_dmg_b!(test_m3_lcdc_win_en_change_multiple_dmg_b, "m3_lcdc_win_en_change_multiple", "2354");
-mealybug_ignored_dmg_b!(test_m3_lcdc_win_en_change_multiple_wx_dmg_b, "m3_lcdc_win_en_change_multiple_wx", "2354");
-mealybug_ignored_dmg_b!(test_m3_lcdc_win_map_change_dmg_b, "m3_lcdc_win_map_change", "2355");
+mealybug_ignored_dmg_b!(
+    test_m3_bgp_change_sprites_dmg_b,
+    "m3_bgp_change_sprites",
+    "2348"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_bg_en_change_dmg_b,
+    "m3_lcdc_bg_en_change",
+    "2349"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_bg_map_change_dmg_b,
+    "m3_lcdc_bg_map_change",
+    "2350"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_obj_en_change_dmg_b,
+    "m3_lcdc_obj_en_change",
+    "2351"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_obj_en_change_variant_dmg_b,
+    "m3_lcdc_obj_en_change_variant",
+    "2351"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_obj_size_change_dmg_b,
+    "m3_lcdc_obj_size_change",
+    "2352"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_obj_size_change_scx_dmg_b,
+    "m3_lcdc_obj_size_change_scx",
+    "2352"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_tile_sel_change_dmg_b,
+    "m3_lcdc_tile_sel_change",
+    "2353"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_tile_sel_win_change_dmg_b,
+    "m3_lcdc_tile_sel_win_change",
+    "2353"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_win_en_change_multiple_dmg_b,
+    "m3_lcdc_win_en_change_multiple",
+    "2354"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_win_en_change_multiple_wx_dmg_b,
+    "m3_lcdc_win_en_change_multiple_wx",
+    "2354"
+);
+mealybug_ignored_dmg_b!(
+    test_m3_lcdc_win_map_change_dmg_b,
+    "m3_lcdc_win_map_change",
+    "2355"
+);
 mealybug_ignored_dmg_b!(test_m3_obp0_change_dmg_b, "m3_obp0_change", "2356");
 mealybug_ignored_dmg_b!(test_m3_scx_high_5_bits_dmg_b, "m3_scx_high_5_bits", "2357");
 mealybug_ignored_dmg_b!(test_m3_scx_low_3_bits_dmg_b, "m3_scx_low_3_bits", "2357");
 mealybug_ignored_dmg_b!(test_m3_scy_change_dmg_b, "m3_scy_change", "2358");
 mealybug_ignored_dmg_b!(test_m3_window_timing_dmg_b, "m3_window_timing", "2359");
-mealybug_ignored_dmg_b!(test_m3_window_timing_wx_0_dmg_b, "m3_window_timing_wx_0", "2359");
+mealybug_ignored_dmg_b!(
+    test_m3_window_timing_wx_0_dmg_b,
+    "m3_window_timing_wx_0",
+    "2359"
+);
 mealybug_ignored_dmg_b!(test_m3_wx_4_change_dmg_b, "m3_wx_4_change", "2360");
-mealybug_ignored_dmg_b!(test_m3_wx_4_change_sprites_dmg_b, "m3_wx_4_change_sprites", "2360");
+mealybug_ignored_dmg_b!(
+    test_m3_wx_4_change_sprites_dmg_b,
+    "m3_wx_4_change_sprites",
+    "2360"
+);
 mealybug_ignored_dmg_b!(test_m3_wx_5_change_dmg_b, "m3_wx_5_change", "2360");
 mealybug_ignored_dmg_b!(test_m3_wx_6_change_dmg_b, "m3_wx_6_change", "2360");
 
@@ -147,35 +203,125 @@ mealybug_ignored_dmg_b!(test_m3_wx_6_change_dmg_b, "m3_wx_6_change", "2360");
 // CGB-C tests (reference: expected/CPU CGB C/)
 // ============================================================================
 
-mealybug_ignored_cgb_c!(test_m2_win_en_toggle_cgb_c, "m2_win_en_toggle", "2347");
+#[test]
+fn test_m2_win_en_toggle_cgb_c() {
+    let bytes = read_rom_from_zip("m2_win_en_toggle.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_cgb_c");
+    const EXPECTED_CRC: u32 = 0x5BB7_9D8A;
+    assert_eq!(
+        crc, EXPECTED_CRC,
+        "m2_win_en_toggle CGB-C CRC mismatch: got {crc:#010X}, expected {EXPECTED_CRC:#010X}"
+    );
+}
 mealybug_ignored_cgb_c!(test_m3_bgp_change_cgb_c, "m3_bgp_change", "2348");
-mealybug_ignored_cgb_c!(test_m3_bgp_change_sprites_cgb_c, "m3_bgp_change_sprites", "2348");
-mealybug_ignored_cgb_c!(test_m3_lcdc_bg_en_change_cgb_c, "m3_lcdc_bg_en_change", "2349");
-mealybug_ignored_cgb_c!(test_m3_lcdc_bg_en_change2_cgb_c, "m3_lcdc_bg_en_change2", "2349");
-mealybug_ignored_cgb_c!(test_m3_lcdc_bg_map_change_cgb_c, "m3_lcdc_bg_map_change", "2350");
-mealybug_ignored_cgb_c!(test_m3_lcdc_bg_map_change2_cgb_c, "m3_lcdc_bg_map_change2", "2350");
-mealybug_ignored_cgb_c!(test_m3_lcdc_obj_en_change_cgb_c, "m3_lcdc_obj_en_change", "2351");
-mealybug_ignored_cgb_c!(test_m3_lcdc_obj_en_change_variant_cgb_c, "m3_lcdc_obj_en_change_variant", "2351");
-mealybug_ignored_cgb_c!(test_m3_lcdc_obj_size_change_cgb_c, "m3_lcdc_obj_size_change", "2352");
-mealybug_ignored_cgb_c!(test_m3_lcdc_obj_size_change_scx_cgb_c, "m3_lcdc_obj_size_change_scx", "2352");
-mealybug_ignored_cgb_c!(test_m3_lcdc_tile_sel_change_cgb_c, "m3_lcdc_tile_sel_change", "2353");
-mealybug_ignored_cgb_c!(test_m3_lcdc_tile_sel_change2_cgb_c, "m3_lcdc_tile_sel_change2", "2353");
-mealybug_ignored_cgb_c!(test_m3_lcdc_tile_sel_win_change_cgb_c, "m3_lcdc_tile_sel_win_change", "2353");
-mealybug_ignored_cgb_c!(test_m3_lcdc_tile_sel_win_change2_cgb_c, "m3_lcdc_tile_sel_win_change2", "2353");
-mealybug_ignored_cgb_c!(test_m3_lcdc_win_en_change_multiple_cgb_c, "m3_lcdc_win_en_change_multiple", "2354");
-mealybug_ignored_cgb_c!(test_m3_lcdc_win_en_change_multiple_wx_cgb_c, "m3_lcdc_win_en_change_multiple_wx", "2354");
-mealybug_ignored_cgb_c!(test_m3_lcdc_win_map_change_cgb_c, "m3_lcdc_win_map_change", "2355");
-mealybug_ignored_cgb_c!(test_m3_lcdc_win_map_change2_cgb_c, "m3_lcdc_win_map_change2", "2355");
+mealybug_ignored_cgb_c!(
+    test_m3_bgp_change_sprites_cgb_c,
+    "m3_bgp_change_sprites",
+    "2348"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_bg_en_change_cgb_c,
+    "m3_lcdc_bg_en_change",
+    "2349"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_bg_en_change2_cgb_c,
+    "m3_lcdc_bg_en_change2",
+    "2349"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_bg_map_change_cgb_c,
+    "m3_lcdc_bg_map_change",
+    "2350"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_bg_map_change2_cgb_c,
+    "m3_lcdc_bg_map_change2",
+    "2350"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_obj_en_change_cgb_c,
+    "m3_lcdc_obj_en_change",
+    "2351"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_obj_en_change_variant_cgb_c,
+    "m3_lcdc_obj_en_change_variant",
+    "2351"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_obj_size_change_cgb_c,
+    "m3_lcdc_obj_size_change",
+    "2352"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_obj_size_change_scx_cgb_c,
+    "m3_lcdc_obj_size_change_scx",
+    "2352"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_tile_sel_change_cgb_c,
+    "m3_lcdc_tile_sel_change",
+    "2353"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_tile_sel_change2_cgb_c,
+    "m3_lcdc_tile_sel_change2",
+    "2353"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_tile_sel_win_change_cgb_c,
+    "m3_lcdc_tile_sel_win_change",
+    "2353"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_tile_sel_win_change2_cgb_c,
+    "m3_lcdc_tile_sel_win_change2",
+    "2353"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_win_en_change_multiple_cgb_c,
+    "m3_lcdc_win_en_change_multiple",
+    "2354"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_win_en_change_multiple_wx_cgb_c,
+    "m3_lcdc_win_en_change_multiple_wx",
+    "2354"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_win_map_change_cgb_c,
+    "m3_lcdc_win_map_change",
+    "2355"
+);
+mealybug_ignored_cgb_c!(
+    test_m3_lcdc_win_map_change2_cgb_c,
+    "m3_lcdc_win_map_change2",
+    "2355"
+);
 mealybug_ignored_cgb_c!(test_m3_obp0_change_cgb_c, "m3_obp0_change", "2356");
 mealybug_ignored_cgb_c!(test_m3_scx_high_5_bits_cgb_c, "m3_scx_high_5_bits", "2357");
-mealybug_ignored_cgb_c!(test_m3_scx_high_5_bits_change2_cgb_c, "m3_scx_high_5_bits_change2", "2357");
+mealybug_ignored_cgb_c!(
+    test_m3_scx_high_5_bits_change2_cgb_c,
+    "m3_scx_high_5_bits_change2",
+    "2357"
+);
 mealybug_ignored_cgb_c!(test_m3_scx_low_3_bits_cgb_c, "m3_scx_low_3_bits", "2357");
 mealybug_ignored_cgb_c!(test_m3_scy_change_cgb_c, "m3_scy_change", "2358");
 mealybug_ignored_cgb_c!(test_m3_scy_change2_cgb_c, "m3_scy_change2", "2358");
 mealybug_ignored_cgb_c!(test_m3_window_timing_cgb_c, "m3_window_timing", "2359");
-mealybug_ignored_cgb_c!(test_m3_window_timing_wx_0_cgb_c, "m3_window_timing_wx_0", "2359");
+mealybug_ignored_cgb_c!(
+    test_m3_window_timing_wx_0_cgb_c,
+    "m3_window_timing_wx_0",
+    "2359"
+);
 mealybug_ignored_cgb_c!(test_m3_wx_4_change_cgb_c, "m3_wx_4_change", "2360");
-mealybug_ignored_cgb_c!(test_m3_wx_4_change_sprites_cgb_c, "m3_wx_4_change_sprites", "2360");
+mealybug_ignored_cgb_c!(
+    test_m3_wx_4_change_sprites_cgb_c,
+    "m3_wx_4_change_sprites",
+    "2360"
+);
 mealybug_ignored_cgb_c!(test_m3_wx_5_change_cgb_c, "m3_wx_5_change", "2360");
 mealybug_ignored_cgb_c!(test_m3_wx_6_change_cgb_c, "m3_wx_6_change", "2360");
 
@@ -183,27 +329,93 @@ mealybug_ignored_cgb_c!(test_m3_wx_6_change_cgb_c, "m3_wx_6_change", "2360");
 // CGB-D tests (reference: expected/CPU CGB D/)
 // ============================================================================
 
-mealybug_ignored_cgb_d!(test_m2_win_en_toggle_cgb_d, "m2_win_en_toggle", "2347");
+#[test]
+fn test_m2_win_en_toggle_cgb_d() {
+    let bytes = read_rom_from_zip("m2_win_en_toggle.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_cgb_d");
+    const EXPECTED_CRC: u32 = 0x5BB7_9D8A;
+    assert_eq!(
+        crc, EXPECTED_CRC,
+        "m2_win_en_toggle CGB-D CRC mismatch: got {crc:#010X}, expected {EXPECTED_CRC:#010X}"
+    );
+}
 mealybug_ignored_cgb_d!(test_m3_bgp_change_cgb_d, "m3_bgp_change", "2348");
-mealybug_ignored_cgb_d!(test_m3_bgp_change_sprites_cgb_d, "m3_bgp_change_sprites", "2348");
-mealybug_ignored_cgb_d!(test_m3_lcdc_bg_en_change_cgb_d, "m3_lcdc_bg_en_change", "2349");
-mealybug_ignored_cgb_d!(test_m3_lcdc_bg_map_change_cgb_d, "m3_lcdc_bg_map_change", "2350");
-mealybug_ignored_cgb_d!(test_m3_lcdc_obj_en_change_cgb_d, "m3_lcdc_obj_en_change", "2351");
-mealybug_ignored_cgb_d!(test_m3_lcdc_obj_en_change_variant_cgb_d, "m3_lcdc_obj_en_change_variant", "2351");
-mealybug_ignored_cgb_d!(test_m3_lcdc_obj_size_change_cgb_d, "m3_lcdc_obj_size_change", "2352");
-mealybug_ignored_cgb_d!(test_m3_lcdc_obj_size_change_scx_cgb_d, "m3_lcdc_obj_size_change_scx", "2352");
-mealybug_ignored_cgb_d!(test_m3_lcdc_tile_sel_change_cgb_d, "m3_lcdc_tile_sel_change", "2353");
-mealybug_ignored_cgb_d!(test_m3_lcdc_tile_sel_win_change_cgb_d, "m3_lcdc_tile_sel_win_change", "2353");
-mealybug_ignored_cgb_d!(test_m3_lcdc_win_en_change_multiple_cgb_d, "m3_lcdc_win_en_change_multiple", "2354");
-mealybug_ignored_cgb_d!(test_m3_lcdc_win_en_change_multiple_wx_cgb_d, "m3_lcdc_win_en_change_multiple_wx", "2354");
-mealybug_ignored_cgb_d!(test_m3_lcdc_win_map_change_cgb_d, "m3_lcdc_win_map_change", "2355");
+mealybug_ignored_cgb_d!(
+    test_m3_bgp_change_sprites_cgb_d,
+    "m3_bgp_change_sprites",
+    "2348"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_bg_en_change_cgb_d,
+    "m3_lcdc_bg_en_change",
+    "2349"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_bg_map_change_cgb_d,
+    "m3_lcdc_bg_map_change",
+    "2350"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_obj_en_change_cgb_d,
+    "m3_lcdc_obj_en_change",
+    "2351"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_obj_en_change_variant_cgb_d,
+    "m3_lcdc_obj_en_change_variant",
+    "2351"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_obj_size_change_cgb_d,
+    "m3_lcdc_obj_size_change",
+    "2352"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_obj_size_change_scx_cgb_d,
+    "m3_lcdc_obj_size_change_scx",
+    "2352"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_tile_sel_change_cgb_d,
+    "m3_lcdc_tile_sel_change",
+    "2353"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_tile_sel_win_change_cgb_d,
+    "m3_lcdc_tile_sel_win_change",
+    "2353"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_win_en_change_multiple_cgb_d,
+    "m3_lcdc_win_en_change_multiple",
+    "2354"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_win_en_change_multiple_wx_cgb_d,
+    "m3_lcdc_win_en_change_multiple_wx",
+    "2354"
+);
+mealybug_ignored_cgb_d!(
+    test_m3_lcdc_win_map_change_cgb_d,
+    "m3_lcdc_win_map_change",
+    "2355"
+);
 mealybug_ignored_cgb_d!(test_m3_obp0_change_cgb_d, "m3_obp0_change", "2356");
 mealybug_ignored_cgb_d!(test_m3_scx_high_5_bits_cgb_d, "m3_scx_high_5_bits", "2357");
 mealybug_ignored_cgb_d!(test_m3_scx_low_3_bits_cgb_d, "m3_scx_low_3_bits", "2357");
 mealybug_ignored_cgb_d!(test_m3_scy_change_cgb_d, "m3_scy_change", "2358");
 mealybug_ignored_cgb_d!(test_m3_window_timing_cgb_d, "m3_window_timing", "2359");
-mealybug_ignored_cgb_d!(test_m3_window_timing_wx_0_cgb_d, "m3_window_timing_wx_0", "2359");
+mealybug_ignored_cgb_d!(
+    test_m3_window_timing_wx_0_cgb_d,
+    "m3_window_timing_wx_0",
+    "2359"
+);
 mealybug_ignored_cgb_d!(test_m3_wx_4_change_cgb_d, "m3_wx_4_change", "2360");
-mealybug_ignored_cgb_d!(test_m3_wx_4_change_sprites_cgb_d, "m3_wx_4_change_sprites", "2360");
+mealybug_ignored_cgb_d!(
+    test_m3_wx_4_change_sprites_cgb_d,
+    "m3_wx_4_change_sprites",
+    "2360"
+);
 mealybug_ignored_cgb_d!(test_m3_wx_5_change_cgb_d, "m3_wx_5_change", "2360");
 mealybug_ignored_cgb_d!(test_m3_wx_6_change_cgb_d, "m3_wx_6_change", "2360");


### PR DESCRIPTION
## Summary

Fixes the mealybug `m2_win_en_toggle` test for CGB-C and CGB-D models by correcting the CGB DMG-compat palette initialisation.

## Root Cause

The `m2_win_en_toggle.gb` ROM is a DMG-only game (CGB flag = 0x00, all title bytes = 0x00). When run in CGB compat mode with `skip_boot_rom=true`, our emulator calls `get_palette_id()` to select a colorisation palette.

`get_palette_id()` had an early-return that bypassed the checksum lookup for non-Nintendo games, returning palette combination 5 (hardcoded). This produced:

- Our output: BG palette 0 → colour 1 = RGB555(31,21,12) = **orange** ❌
- Reference (real CGB hardware): palette combination 0 → BG palette 29 → colour 1 = RGB555(15,31,6) = **green** ✅

The real CGB boot ROM applies the title-checksum-based palette to **all** DMG games regardless of licensee. An all-zero title gives checksum `0x00`, which matches the "Default" entry → palette combination 0.

## Fix

Remove the `is_nintendo_licensee()` early-return from `get_palette_id()`. All DMG games now go through the checksum lookup, matching real CGB boot ROM behaviour. The doc comment is updated to reflect this.

`is_nintendo_licensee()` is retained — it is still tested and may be useful for other purposes.

## Tests

- ✅ `test_m2_win_en_toggle_cgb_c` — enabled with expected CRC `0x5BB7_9D8A`
- ✅ `test_m2_win_en_toggle_cgb_d` — enabled with expected CRC `0x5BB7_9D8A`
- ✅ `test_m2_win_en_toggle_dmg_b` — unchanged, still passes
- ✅ 32 `compat_palettes` unit tests pass (2 updated to encode correct behaviour)

## Impact on Other Mealybug Tests

The palette fix does **not** resolve any other mealybug tests. All remaining mismatches are genuine PPU timing issues tracked separately in #2348–#2360.

## Note on Base Branch

This PR branches from the sibling PR #2363 (mealybug test macro refactor) to avoid merge conflicts on `mealybug_tests.rs`. It should be merged **after** #2363 merges to main, at which point GitHub will auto-update the base to `main`.

## Pre-merge Checks

- ✅ `cargo clippy --all-targets --all-features -- -D warnings`
- ✅ `cargo fmt`
- ✅ `./scripts/test-dir.sh src/gb --skip-integration` (1204 passed)
- ✅ `cargo test --no-default-features --lib` (9680 passed)
- ⚠️ `wasm-pack test --headless --chrome` — ChromeDriver SIGKILL (pre-existing env issue, also fails on parent branch without these changes)
- ✅ Python tests (328 passed)
- ✅ `npm test` (298 passed)

Closes #2347
