### PR TITLE
Integrate ArmWrestler ROM test suite for GBA ARM7TDMI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "roms/gba/automated_tests/FuzzARM"]
 	path = roms/gba/automated_tests/FuzzARM
 	url = https://github.com/DenSinH/FuzzARM.git
+[submodule "roms/gba/automated_tests/armwrestler"]
+	path = roms/gba/automated_tests/armwrestler
+	url = https://github.com/destoer/armwrestler-gba-fixed.git

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -27,3 +27,11 @@ fuzzarm_any=0x9A78A7EB
 fuzzthumb_data_processing=0x9A78A7EB
 fuzzthumb_any=0x9A78A7EB
 fuzzarm_mixed=0x9A78A7EB
+
+# ArmWrestler (https://github.com/destoer/armwrestler-gba-fixed)
+# Each page corresponds to one test screen (Test0 through Test4).
+armwrestler_page0=0xAA081A57
+armwrestler_page1=0x7725D68D
+armwrestler_page2=0xF9C38336
+armwrestler_page3=0x76CED72B
+armwrestler_page4=0x6795E0F8

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -29,9 +29,13 @@ fuzzthumb_any=0x9A78A7EB
 fuzzarm_mixed=0x9A78A7EB
 
 # ArmWrestler (https://github.com/destoer/armwrestler-gba-fixed)
-# Each page corresponds to one test screen (Test0 through Test4).
+# Pages 0–4: ARM tests (ALU, Barrel-Shift, Multiply, LDR/STR, LDM/STM)
+# Pages 5–7: THUMB tests (ALU, LDR/STR, LDM/STM)
 armwrestler_page0=0xAA081A57
 armwrestler_page1=0x7725D68D
 armwrestler_page2=0xF9C38336
 armwrestler_page3=0x76CED72B
 armwrestler_page4=0x6795E0F8
+armwrestler_page5=0xE215C2B0
+armwrestler_page6=0xA52234A7
+armwrestler_page7=0x562A5C65

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -37,11 +37,12 @@ pub enum Suite {
     FuzzThumbDataProcessing,
     FuzzThumbAny,
     FuzzArmMixed,
+    ArmWrestler,
 }
 
 impl Suite {
-    fn rom_path(self) -> PathBuf {
-        let rel = match self {
+    fn rom_path_str(self) -> &'static str {
+        match self {
             Self::Arm => "roms/gba/automated_tests/gba-tests/arm/arm.gba",
             Self::Thumb => "roms/gba/automated_tests/gba-tests/thumb/thumb.gba",
             Self::Nes => "roms/gba/automated_tests/gba-tests/nes/nes.gba",
@@ -62,8 +63,12 @@ impl Suite {
             }
             Self::FuzzThumbAny => "roms/gba/automated_tests/FuzzARM/THUMB_Any.gba",
             Self::FuzzArmMixed => "roms/gba/automated_tests/FuzzARM/FuzzARM.gba",
-        };
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel)
+            Self::ArmWrestler => "roms/gba/automated_tests/armwrestler/armwrestler-gba-fixed.gba",
+        }
+    }
+
+    fn rom_path(self) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(self.rom_path_str())
     }
 
     fn result_register(self) -> Option<(usize, &'static str)> {
@@ -83,7 +88,8 @@ impl Suite {
             | Self::FuzzArmAny
             | Self::FuzzThumbDataProcessing
             | Self::FuzzThumbAny
-            | Self::FuzzArmMixed => None,
+            | Self::FuzzArmMixed
+            | Self::ArmWrestler => None,
         }
     }
 
@@ -105,6 +111,7 @@ impl Suite {
             Self::FuzzThumbDataProcessing => "fuzzthumb_data_processing",
             Self::FuzzThumbAny => "fuzzthumb_any",
             Self::FuzzArmMixed => "fuzzarm_mixed",
+            Self::ArmWrestler => "armwrestler",
         }
     }
 
@@ -408,6 +415,182 @@ fn is_bios_exception_vector(pc: u32) -> bool {
     BIOS_EXCEPTION_VECTORS.contains(&pc)
 }
 
+// --- ArmWrestler-specific runner ---
+//
+// The armwrestler ROM presents a menu and requires button input to navigate
+// through test pages. This runner injects START presses at frame boundaries
+// to advance through all 5 ARM test pages (Test0–Test4), capturing the
+// framebuffer CRC after each test renders.
+//
+// Menu structure: 3 ARM groups (ALU, LDR/STR, LDM/STM) accessible via menu
+// items. From the first menu item, pressing START enters Test0. Subsequent
+// START presses advance: Test0→Test1→Test2→Test3→Test4→menu.
+
+/// Number of ARM test pages in armwrestler (Test0 through Test4).
+pub const ARMWRESTLER_ARM_TEST_COUNT: usize = 5;
+
+/// Button bitmask for Start (NES-convention bit 3).
+const BTN_START: u8 = 0x08;
+
+/// Result of running the armwrestler ROM through all ARM test pages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArmWrestlerResult {
+    /// CRC32 of the framebuffer after each test page renders.
+    pub page_crcs: Vec<u32>,
+    /// Total cycles consumed.
+    pub cycles: u64,
+}
+
+/// Run armwrestler-gba-fixed.gba, navigating through all ARM test pages.
+///
+/// Returns one CRC per test page (5 total for the ARM tests).
+pub fn run_armwrestler() -> ArmWrestlerResult {
+    let rom_path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(Suite::ArmWrestler.rom_path_str());
+
+    let rom = std::fs::read(&rom_path).unwrap_or_else(|e| {
+        panic!("failed to read armwrestler ROM {}: {e}", rom_path.display());
+    });
+
+    let mut gba = Gba::new(AppContext::default());
+    let mut bios = vec![0u8; BIOS_SIZE];
+    bios[0..4].copy_from_slice(&BIOS_RESET_STUB_LDR_PC_PLUS_24.to_le_bytes());
+    bios[BIOS_RESET_LITERAL_ADDR..BIOS_RESET_LITERAL_ADDR + 4]
+        .copy_from_slice(&CART_ENTRYPOINT.to_le_bytes());
+    bios[0x08..0x0C].copy_from_slice(&BIOS_SWI_STUB_MOVS_PC_LR.to_le_bytes());
+    for &vector in &BIOS_EXCEPTION_VECTORS {
+        let i = vector as usize;
+        bios[i..i + 4].copy_from_slice(&ARM_BRANCH_SELF_OPCODE.to_le_bytes());
+    }
+    gba.bus_mut().load_bios(&bios);
+    gba.load_rom(&rom, rom_path.to_str().unwrap_or("armwrestler"))
+        .unwrap_or_else(|e| {
+            panic!("failed to load armwrestler ROM {}: {e}", rom_path.display());
+        });
+    gba.init_test_stack_pointers();
+
+    // Run frame-by-frame, injecting button presses to navigate tests.
+    //
+    // Schedule (frame = VBlank count):
+    //   Frame 2: press START (selects first menu item → enters Test0)
+    //   Frame 4: capture Test0 CRC, press START (advance to Test1)
+    //   Frame 6: capture Test1 CRC, press START (advance to Test2)
+    //   Frame 8: capture Test2 CRC, press START (advance to Test3)
+    //   Frame 10: capture Test3 CRC, press START (advance to Test4)
+    //   Frame 12: capture Test4 CRC → done
+    //
+    // Button held for exactly 1 frame, released the next. This gives the
+    // ROM's edge-detection (XOR with previous state) a clean transition.
+
+    let mut frame_count: u32 = 0;
+    let mut cycles: u64 = 0;
+    let mut page_crcs: Vec<u32> = Vec::new();
+    let mut button_state: u8 = 0;
+    let max_frames: u32 = 30;
+
+    // Advance to first VBlank (frame 0 is the initial partial frame)
+    run_until_frame_ready(&mut gba, &mut cycles);
+    gba.clear_ready_to_render();
+    frame_count += 1;
+
+    while frame_count < max_frames && page_crcs.len() < ARMWRESTLER_ARM_TEST_COUNT {
+        // Apply button state for this frame
+        gba.set_joypad_button_states(0, button_state);
+
+        // Run to next VBlank
+        run_until_frame_ready(&mut gba, &mut cycles);
+        gba.clear_ready_to_render();
+        frame_count += 1;
+
+        // Frame-based schedule:
+        // - Press START on frames 2, 4, 6, 8, 10 (odd-indexed in the sequence)
+        // - Capture CRC on frames 4, 6, 8, 10, 12 (after test has rendered)
+        // - Release START on frames 3, 5, 7, 9, 11
+        match frame_count {
+            2 => {
+                // Press START to enter Test0 from menu
+                button_state = BTN_START;
+            }
+            3 => {
+                // Release START (edge detection needs release before next press)
+                button_state = 0;
+            }
+            4 => {
+                // Test0 is now rendered; capture CRC and press START for next
+                page_crcs.push(gba.screen_crc32());
+                maybe_write_armwrestler_png(&gba, 0, *page_crcs.last().unwrap());
+                button_state = BTN_START;
+            }
+            5 => {
+                button_state = 0;
+            }
+            6 => {
+                page_crcs.push(gba.screen_crc32());
+                maybe_write_armwrestler_png(&gba, 1, *page_crcs.last().unwrap());
+                button_state = BTN_START;
+            }
+            7 => {
+                button_state = 0;
+            }
+            8 => {
+                page_crcs.push(gba.screen_crc32());
+                maybe_write_armwrestler_png(&gba, 2, *page_crcs.last().unwrap());
+                button_state = BTN_START;
+            }
+            9 => {
+                button_state = 0;
+            }
+            10 => {
+                page_crcs.push(gba.screen_crc32());
+                maybe_write_armwrestler_png(&gba, 3, *page_crcs.last().unwrap());
+                button_state = BTN_START;
+            }
+            11 => {
+                button_state = 0;
+            }
+            12 => {
+                page_crcs.push(gba.screen_crc32());
+                maybe_write_armwrestler_png(&gba, 4, *page_crcs.last().unwrap());
+                button_state = 0;
+            }
+            _ => {}
+        }
+    }
+
+    ArmWrestlerResult { page_crcs, cycles }
+}
+
+fn run_until_frame_ready(gba: &mut Gba, cycles: &mut u64) {
+    let max_cycle_budget = GBA_CYCLES_PER_FRAME * 2;
+    let mut spent: u64 = 0;
+    while spent < max_cycle_budget {
+        let tick = gba.run_tick_for_tests() as u64;
+        if tick == 0 {
+            return;
+        }
+        *cycles += tick;
+        spent += tick;
+        if gba.is_ready_to_render() {
+            return;
+        }
+    }
+}
+
+fn maybe_write_armwrestler_png(gba: &Gba, page_index: usize, crc: u32) {
+    if std::env::var_os("NESER_CAPTURE_SCREEN").is_none() {
+        return;
+    }
+
+    let file_name = format!("armwrestler_page{page_index}_crc_{crc:08X}.png");
+    let path = PathBuf::from("target/gba_suite_checkpoints").join(file_name);
+    let rgb = gba.screen_snapshot();
+    crate::platform::png_utils::write_rgb_png(&path, &rgb, Gba::SCREEN_WIDTH, Gba::SCREEN_HEIGHT);
+    println!(
+        "[armwrestler-capture] saved {} (page={page_index}, crc=0x{crc:08X})",
+        path.display()
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -504,5 +687,6 @@ mod tests {
         );
         assert_eq!(Suite::FuzzThumbAny.capture_stem(), "fuzzthumb_any");
         assert_eq!(Suite::FuzzArmMixed.capture_stem(), "fuzzarm_mixed");
+        assert_eq!(Suite::ArmWrestler.capture_stem(), "armwrestler");
     }
 }

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -418,32 +418,41 @@ fn is_bios_exception_vector(pc: u32) -> bool {
 // --- ArmWrestler-specific runner ---
 //
 // The armwrestler ROM presents a menu and requires button input to navigate
-// through test pages. This runner injects START presses at frame boundaries
-// to advance through all 5 ARM test pages (Test0–Test4), capturing the
-// framebuffer CRC after each test renders.
+// through test pages. This runner injects button presses at frame boundaries
+// to advance through all test pages, capturing the framebuffer CRC after each.
 //
-// Menu structure: 3 ARM groups (ALU, LDR/STR, LDM/STM) accessible via menu
-// items. From the first menu item, pressing START enters Test0. Subsequent
-// START presses advance: Test0→Test1→Test2→Test3→Test4→menu.
+// Menu structure (6 groups):
+//   Item 0: ARM ALU      → Test0, START chains: Test0→Test1→Test2→Test3→Test4→menu
+//   Item 1: ARM LDR/STR  → Test2 (subset of above chain)
+//   Item 2: ARM LDM/STM  → Test4 (subset of above chain)
+//   Item 3: THUMB ALU    → _test0, START chains: _test0→_test1→_test2→menu
+//   Item 4: THUMB LDR/STR→ _test1 (subset of above chain)
+//   Item 5: THUMB LDM/STM→ _test2 (subset of above chain)
+//
+// We enter via ARM ALU (item 0) to cover all 5 ARM pages, return to menu,
+// navigate DOWN×3 to THUMB ALU (item 3), then cover all 3 THUMB pages.
 
-/// Number of ARM test pages in armwrestler (Test0 through Test4).
-pub const ARMWRESTLER_ARM_TEST_COUNT: usize = 5;
+/// Total test pages: 5 ARM (Test0–Test4) + 3 THUMB (_test0–_test2).
+pub const ARMWRESTLER_TEST_PAGE_COUNT: usize = 8;
 
 /// Button bitmask for Start (NES-convention bit 3).
 const BTN_START: u8 = 0x08;
+/// Button bitmask for Down (NES-convention bit 5).
+const BTN_DOWN: u8 = 0x20;
 
-/// Result of running the armwrestler ROM through all ARM test pages.
+/// Result of running the armwrestler ROM through all test pages.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArmWrestlerResult {
     /// CRC32 of the framebuffer after each test page renders.
+    /// Indices 0–4: ARM pages, indices 5–7: THUMB pages.
     pub page_crcs: Vec<u32>,
     /// Total cycles consumed.
     pub cycles: u64,
 }
 
-/// Run armwrestler-gba-fixed.gba, navigating through all ARM test pages.
+/// Run armwrestler-gba-fixed.gba, navigating through all ARM and THUMB test pages.
 ///
-/// Returns one CRC per test page (5 total for the ARM tests).
+/// Returns one CRC per test page (8 total: 5 ARM + 3 THUMB).
 pub fn run_armwrestler() -> ArmWrestlerResult {
     let rom_path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(Suite::ArmWrestler.rom_path_str());
@@ -471,29 +480,41 @@ pub fn run_armwrestler() -> ArmWrestlerResult {
 
     // Run frame-by-frame, injecting button presses to navigate tests.
     //
-    // Schedule (frame = VBlank count):
-    //   Frame 2: press START (selects first menu item → enters Test0)
-    //   Frame 4: capture Test0 CRC, press START (advance to Test1)
-    //   Frame 6: capture Test1 CRC, press START (advance to Test2)
-    //   Frame 8: capture Test2 CRC, press START (advance to Test3)
-    //   Frame 10: capture Test3 CRC, press START (advance to Test4)
-    //   Frame 12: capture Test4 CRC → done
+    // Button held for exactly 1 frame, released the next. The ROM's
+    // edge-detection (XOR with previous state) requires a clean release
+    // between successive presses.
     //
-    // Button held for exactly 1 frame, released the next. This gives the
-    // ROM's edge-detection (XOR with previous state) a clean transition.
+    // Frame schedule:
+    //   ARM tests (enter from menu item 0, chain Test0–Test4):
+    //     Frame 2: START (menu → Test0)
+    //     Frame 4: capture[0], START (→ Test1)
+    //     Frame 6: capture[1], START (→ Test2)
+    //     Frame 8: capture[2], START (→ Test3)
+    //     Frame 10: capture[3], START (→ Test4)
+    //     Frame 12: capture[4], START (→ menu, TESTNUM wraps)
+    //   Navigate to THUMB ALU (menu item 3 via DOWN×3):
+    //     Frame 14: DOWN (CURSEL 0→1)
+    //     Frame 16: DOWN (CURSEL 1→2)
+    //     Frame 18: DOWN (CURSEL 2→3)
+    //   THUMB tests (enter from menu item 3, chain _test0–_test2):
+    //     Frame 20: START (menu → _tmbmain → _test0 init)
+    //     Frame 22-23: wait (THUMB entry does extra VSync before rendering)
+    //     Frame 24: capture[5], START (→ _test1)
+    //     Frame 26: capture[6], START (→ _test2)
+    //     Frame 28: capture[7] → done
 
     let mut frame_count: u32 = 0;
     let mut cycles: u64 = 0;
     let mut page_crcs: Vec<u32> = Vec::new();
     let mut button_state: u8 = 0;
-    let max_frames: u32 = 30;
+    let max_frames: u32 = 35;
 
     // Advance to first VBlank (frame 0 is the initial partial frame)
     run_until_frame_ready(&mut gba, &mut cycles);
     gba.clear_ready_to_render();
     frame_count += 1;
 
-    while frame_count < max_frames && page_crcs.len() < ARMWRESTLER_ARM_TEST_COUNT {
+    while frame_count < max_frames && page_crcs.len() < ARMWRESTLER_TEST_PAGE_COUNT {
         // Apply button state for this frame
         gba.set_joypad_button_states(0, button_state);
 
@@ -502,55 +523,67 @@ pub fn run_armwrestler() -> ArmWrestlerResult {
         gba.clear_ready_to_render();
         frame_count += 1;
 
-        // Frame-based schedule:
-        // - Press START on frames 2, 4, 6, 8, 10 (odd-indexed in the sequence)
-        // - Capture CRC on frames 4, 6, 8, 10, 12 (after test has rendered)
-        // - Release START on frames 3, 5, 7, 9, 11
         match frame_count {
-            2 => {
-                // Press START to enter Test0 from menu
-                button_state = BTN_START;
-            }
-            3 => {
-                // Release START (edge detection needs release before next press)
-                button_state = 0;
-            }
+            // --- ARM test chain (pages 0–4) ---
+            2 => button_state = BTN_START,
+            3 => button_state = 0,
             4 => {
-                // Test0 is now rendered; capture CRC and press START for next
                 page_crcs.push(gba.screen_crc32());
                 maybe_write_armwrestler_png(&gba, 0, *page_crcs.last().unwrap());
                 button_state = BTN_START;
             }
-            5 => {
-                button_state = 0;
-            }
+            5 => button_state = 0,
             6 => {
                 page_crcs.push(gba.screen_crc32());
                 maybe_write_armwrestler_png(&gba, 1, *page_crcs.last().unwrap());
                 button_state = BTN_START;
             }
-            7 => {
-                button_state = 0;
-            }
+            7 => button_state = 0,
             8 => {
                 page_crcs.push(gba.screen_crc32());
                 maybe_write_armwrestler_png(&gba, 2, *page_crcs.last().unwrap());
                 button_state = BTN_START;
             }
-            9 => {
-                button_state = 0;
-            }
+            9 => button_state = 0,
             10 => {
                 page_crcs.push(gba.screen_crc32());
                 maybe_write_armwrestler_png(&gba, 3, *page_crcs.last().unwrap());
                 button_state = BTN_START;
             }
-            11 => {
-                button_state = 0;
-            }
+            11 => button_state = 0,
             12 => {
                 page_crcs.push(gba.screen_crc32());
                 maybe_write_armwrestler_png(&gba, 4, *page_crcs.last().unwrap());
+                // Press START to return from Test4 to menu
+                button_state = BTN_START;
+            }
+            13 => button_state = 0,
+            // --- Navigate menu DOWN×3 to THUMB ALU (item 3) ---
+            14 => button_state = BTN_DOWN,
+            15 => button_state = 0,
+            16 => button_state = BTN_DOWN,
+            17 => button_state = 0,
+            18 => button_state = BTN_DOWN,
+            19 => button_state = 0,
+            // --- Enter THUMB tests ---
+            20 => button_state = BTN_START,
+            21 => button_state = 0,
+            // Frames 22-23: THUMB entry does an extra VSync before rendering _test0
+            24 => {
+                page_crcs.push(gba.screen_crc32());
+                maybe_write_armwrestler_png(&gba, 5, *page_crcs.last().unwrap());
+                button_state = BTN_START;
+            }
+            25 => button_state = 0,
+            26 => {
+                page_crcs.push(gba.screen_crc32());
+                maybe_write_armwrestler_png(&gba, 6, *page_crcs.last().unwrap());
+                button_state = BTN_START;
+            }
+            27 => button_state = 0,
+            28 => {
+                page_crcs.push(gba.screen_crc32());
+                maybe_write_armwrestler_png(&gba, 7, *page_crcs.last().unwrap());
                 button_state = 0;
             }
             _ => {}

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -510,7 +510,10 @@ pub fn run_armwrestler() -> ArmWrestlerResult {
     let max_frames: u32 = 35;
 
     // Advance to first VBlank (frame 0 is the initial partial frame)
-    run_until_frame_ready(&mut gba, &mut cycles);
+    assert!(
+        run_until_frame_ready(&mut gba, &mut cycles),
+        "armwrestler: CPU halted or timed out before first frame"
+    );
     gba.clear_ready_to_render();
     frame_count += 1;
 
@@ -519,7 +522,10 @@ pub fn run_armwrestler() -> ArmWrestlerResult {
         gba.set_joypad_button_states(0, button_state);
 
         // Run to next VBlank
-        run_until_frame_ready(&mut gba, &mut cycles);
+        assert!(
+            run_until_frame_ready(&mut gba, &mut cycles),
+            "armwrestler: CPU halted or timed out at frame {frame_count}"
+        );
         gba.clear_ready_to_render();
         frame_count += 1;
 
@@ -593,20 +599,25 @@ pub fn run_armwrestler() -> ArmWrestlerResult {
     ArmWrestlerResult { page_crcs, cycles }
 }
 
-fn run_until_frame_ready(gba: &mut Gba, cycles: &mut u64) {
+/// Advance emulation until the next VBlank (frame-ready edge).
+///
+/// Returns `true` if a fresh frame was produced, `false` if the CPU halted
+/// (`tick == 0`) or the cycle budget was exhausted without a frame-ready edge.
+fn run_until_frame_ready(gba: &mut Gba, cycles: &mut u64) -> bool {
     let max_cycle_budget = GBA_CYCLES_PER_FRAME * 2;
     let mut spent: u64 = 0;
     while spent < max_cycle_budget {
         let tick = gba.run_tick_for_tests() as u64;
         if tick == 0 {
-            return;
+            return false;
         }
         *cycles += tick;
         spent += tick;
         if gba.is_ready_to_render() {
-            return;
+            return true;
         }
     }
+    false
 }
 
 fn maybe_write_armwrestler_png(gba: &Gba, page_index: usize, crc: u32) {

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -1,4 +1,4 @@
-use super::gba_suite_runner::{ARMWRESTLER_ARM_TEST_COUNT, Suite, run_armwrestler, run_suite};
+use super::gba_suite_runner::{ARMWRESTLER_TEST_PAGE_COUNT, Suite, run_armwrestler, run_suite};
 use std::collections::HashMap;
 
 const APPROVALS_FILE: &str = "src/gba/integration_tests/gba_suite_crc_approvals.txt";
@@ -182,9 +182,9 @@ fn gba_suite_armwrestler_passes() {
     let result = run_armwrestler();
     assert_eq!(
         result.page_crcs.len(),
-        ARMWRESTLER_ARM_TEST_COUNT,
+        ARMWRESTLER_TEST_PAGE_COUNT,
         "expected {} test page CRCs but got {}",
-        ARMWRESTLER_ARM_TEST_COUNT,
+        ARMWRESTLER_TEST_PAGE_COUNT,
         result.page_crcs.len()
     );
     for (i, &crc) in result.page_crcs.iter().enumerate() {
@@ -229,4 +229,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("armwrestler_page2"), Some(&0xF9C3_8336));
     assert_eq!(approvals.get("armwrestler_page3"), Some(&0x76CE_D72B));
     assert_eq!(approvals.get("armwrestler_page4"), Some(&0x6795_E0F8));
+    assert_eq!(approvals.get("armwrestler_page5"), Some(&0xE215_C2B0));
+    assert_eq!(approvals.get("armwrestler_page6"), Some(&0xA522_34A7));
+    assert_eq!(approvals.get("armwrestler_page7"), Some(&0x562A_5C65));
 }

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -1,4 +1,4 @@
-use super::gba_suite_runner::{Suite, run_suite};
+use super::gba_suite_runner::{ARMWRESTLER_ARM_TEST_COUNT, Suite, run_armwrestler, run_suite};
 use std::collections::HashMap;
 
 const APPROVALS_FILE: &str = "src/gba/integration_tests/gba_suite_crc_approvals.txt";
@@ -177,6 +177,32 @@ fn gba_fuzzarm_mixed_passes() {
 }
 
 #[test]
+fn gba_suite_armwrestler_passes() {
+    let approvals = load_approved_crcs();
+    let result = run_armwrestler();
+    assert_eq!(
+        result.page_crcs.len(),
+        ARMWRESTLER_ARM_TEST_COUNT,
+        "expected {} test page CRCs but got {}",
+        ARMWRESTLER_ARM_TEST_COUNT,
+        result.page_crcs.len()
+    );
+    for (i, &crc) in result.page_crcs.iter().enumerate() {
+        let key = format!("armwrestler_page{i}");
+        let expected = approvals.get(&key).unwrap_or_else(|| {
+            panic!(
+                "missing approved CRC for '{}' in {}. Run with NESER_CAPTURE_SCREEN=1 and add {}=0x{:08X}",
+                key, APPROVALS_FILE, key, crc
+            )
+        });
+        assert_eq!(
+            crc, *expected,
+            "armwrestler page {i} CRC mismatch: expected=0x{expected:08X} actual=0x{crc:08X}"
+        );
+    }
+}
+
+#[test]
 fn approvals_manifest_parses() {
     let approvals = load_approved_crcs();
     assert_eq!(approvals.get("arm"), Some(&0x12FD_AE0B));
@@ -198,4 +224,9 @@ fn approvals_manifest_parses() {
     );
     assert_eq!(approvals.get("fuzzthumb_any"), Some(&0x9A78_A7EB));
     assert_eq!(approvals.get("fuzzarm_mixed"), Some(&0x9A78_A7EB));
+    assert_eq!(approvals.get("armwrestler_page0"), Some(&0xAA08_1A57));
+    assert_eq!(approvals.get("armwrestler_page1"), Some(&0x7725_D68D));
+    assert_eq!(approvals.get("armwrestler_page2"), Some(&0xF9C3_8336));
+    assert_eq!(approvals.get("armwrestler_page3"), Some(&0x76CE_D72B));
+    assert_eq!(approvals.get("armwrestler_page4"), Some(&0x6795_E0F8));
 }


### PR DESCRIPTION
## Summary

Adds the [armwrestler-gba-fixed](https://github.com/destoer/armwrestler-gba-fixed) ROM as a git submodule and integrates it into the GBA integration test suite. This validates ARM7TDMI instruction correctness across 8 test pages (5 ARM + 3 THUMB) covering:

**ARM tests (pages 0-4):**
- Page 0: ALU Tests Part 1 (ADC, ADD, AND, BIC, CMN, CMP, EOR, MOV, MVN, ORR, RSB, RSC, SBC, MLA, MUL, MULL, SMULL)
- Page 1: ALU Pt 2 / Misc (UMLAL, SMLAL, SWP, SWPB, MRS, MSR)
- Page 2: Load Tests Part 1 (LDR variants with various addressing modes)
- Page 3: Load Tests Part 2 (LDRH, LDRB, LDRSB with various addressing modes)
- Page 4: LDM/STM Tests (LDMIB, LDMDB, LDMIBS, LDMIAS, LDMDBA, STMIA, STMDA)

**THUMB tests (pages 5-7):**
- Page 5: ALU TEST (ADD, ADR, BIC, CMP, LSL, LSR, MUL, MUN, MOV, SUB, ROR)
- Page 6: LDR/STR TEST 1 (LDR, LDRB, LDRH, LDRH R, LDRSH, LDRSB)
- Page 7: LDM/STM TEST (LDMIA, STMIA)

All instruction tests show OK on every page.

## Implementation notes

The armwrestler ROM uses a menu-driven interface (not auto-run as initially assumed in the issue). A specialized runner (run_armwrestler) injects button presses at frame boundaries to:
1. Navigate through all 5 ARM test pages (START from menu item 0, chain via START)
2. Return to menu, press DOWN x3 to reach THUMB ALU (item 3)
3. Navigate through all 3 THUMB test pages (chain via START)

Framebuffer CRC32 is captured after each page renders. The THUMB entry path requires a 2-frame extra delay due to an additional VSync during initialization.

## Changes

- Added git submodule: roms/gba/automated_tests/armwrestler/
- Added Suite::ArmWrestler variant and run_armwrestler() specialized runner
- Added gba_suite_armwrestler_passes test (verifies 8 page CRCs)
- Updated gba_suite_crc_approvals.txt with approved CRC values
- Updated approvals_manifest_parses test

## Validation

All GBA integration tests pass (477 tests). No regressions in existing tests.

Closes #2369