### PR TITLE
feat(gba): trigger undefined instruction exception for ARMv5TE opcodes

### DIFF
--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -41,6 +41,8 @@ pub struct ExecOutcome {
     pub branched: bool,
     /// `true` if the instruction triggered a software interrupt (SWI).
     pub swi: bool,
+    /// `true` if the instruction is undefined (triggers undefined exception).
+    pub undefined: bool,
 }
 
 impl ExecOutcome {
@@ -49,6 +51,7 @@ impl ExecOutcome {
             cycles: c,
             branched: false,
             swi: false,
+            undefined: false,
         }
     }
     fn branch(c: u8) -> Self {
@@ -56,6 +59,7 @@ impl ExecOutcome {
             cycles: c,
             branched: true,
             swi: false,
+            undefined: false,
         }
     }
     fn swi(c: u8) -> Self {
@@ -63,6 +67,15 @@ impl ExecOutcome {
             cycles: c,
             branched: true,
             swi: true,
+            undefined: false,
+        }
+    }
+    pub(super) fn undefined() -> Self {
+        Self {
+            cycles: 1,
+            branched: true,
+            undefined: true,
+            swi: false,
         }
     }
 }
@@ -115,6 +128,13 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32) -> ExecOut
             // bits[7:4] = 1011 (STRH/LDRH), 1101 (LDRSB), 1111 (LDRSH)
             if (instr & 0x0E00_0090) == 0x0000_0090 && (instr & 0x60) != 0 {
                 return execute_halfword_transfer(regs, bus, instr);
+            }
+            // ARMv4T undefined-instruction guard: opcodes 0x8–0xB (TST/TEQ/CMP/CMN)
+            // with S=0 encode MRS/MSR/BX/SWP (already handled above). Anything
+            // else in this space is undefined on ARMv4T (CLZ, QADD/QSUB, DSP
+            // multiplies, BLX register, BKPT in ARMv5TE).
+            if (instr & 0x0190_0000) == 0x0100_0000 {
+                return ExecOutcome::undefined();
             }
             // Data-processing immediate / register
             execute_data_processing(regs, instr)
@@ -755,16 +775,18 @@ fn execute_halfword_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u
         regs.r[rd] = value;
         result_branch = rd == 15;
     } else {
-        // Store: only STRH (SH=01) is valid for stores
-        if sh == 0b01 {
-            let value = regs.r[rd] as u16;
-            let store_addr = if is_cart_sram_region(addr) {
-                addr
-            } else {
-                addr & !1
-            };
-            bus.write16(store_addr, value);
+        // Store: only STRH (SH=01) is valid in ARMv4T.
+        // SH=10 (LDRD) and SH=11 (STRD) are ARMv5TE-exclusive and undefined.
+        if sh != 0b01 {
+            return ExecOutcome::undefined();
         }
+        let value = regs.r[rd] as u16;
+        let store_addr = if is_cart_sram_region(addr) {
+            addr
+        } else {
+            addr & !1
+        };
+        bus.write16(store_addr, value);
         result_branch = false;
     }
 
@@ -1984,5 +2006,223 @@ mod tests {
 
         assert_eq!(regs.r[3], 64_u32.rotate_right(8));
         assert_eq!(bus.read32(0x40), 32);
+    }
+
+    // -----------------------------------------------------------------------
+    // ARMv5TE undefined instruction tests
+    // -----------------------------------------------------------------------
+
+    /// Encode CLZ: cond 0001 0110 1111 Rd 1111 0001 Rm
+    fn arm_clz(cond: u8, rd: u8, rm: u8) -> u32 {
+        ((cond as u32) << 28)
+            | (0b0001_0110 << 20)
+            | (0xF << 16)
+            | ((rd as u32 & 0xF) << 12)
+            | (0xF << 8)
+            | (0b0001 << 4)
+            | (rm as u32 & 0xF)
+    }
+
+    /// Encode QADD: cond 0001 0000 Rn Rd 0000 0101 Rm
+    fn arm_qadd(cond: u8, rn: u8, rd: u8, rm: u8) -> u32 {
+        ((cond as u32) << 28)
+            | (0b0001_0000 << 20)
+            | ((rn as u32 & 0xF) << 16)
+            | ((rd as u32 & 0xF) << 12)
+            | (0b0000_0101 << 4)
+            | (rm as u32 & 0xF)
+    }
+
+    /// Encode BLX register (ARMv5TE): cond 0001 0010 1111 1111 1111 0011 Rm
+    fn arm_blx_reg(cond: u8, rm: u8) -> u32 {
+        ((cond as u32) << 28) | (0x012F_FF30) | (rm as u32 & 0xF)
+    }
+
+    /// Encode LDRD: cond 000P U I W 0 Rn Rd offset_hi 1101 offset_lo
+    /// Simplified: immediate offset=0, pre-indexed, up, no writeback.
+    fn arm_ldrd(cond: u8, rn: u8, rd: u8) -> u32 {
+        ((cond as u32) << 28)
+            | (1 << 24)       // P=1 (pre)
+            | (1 << 23)       // U=1 (up)
+            | (1 << 22)       // I=1 (immediate offset)
+            // bit[21]=0 (W=0), bit[20]=0 (L=0 for LDRD encoding)
+            | ((rn as u32 & 0xF) << 16)
+            | ((rd as u32 & 0xF) << 12)
+            | (0b1101 << 4) // SH=10, bits[7:4]=1101
+    }
+
+    /// Encode STRD: cond 000P U I W 0 Rn Rd offset_hi 1111 offset_lo
+    fn arm_strd(cond: u8, rn: u8, rd: u8) -> u32 {
+        ((cond as u32) << 28)
+            | (1 << 24)       // P=1 (pre)
+            | (1 << 23)       // U=1 (up)
+            | (1 << 22)       // I=1 (immediate offset)
+            | ((rn as u32 & 0xF) << 16)
+            | ((rd as u32 & 0xF) << 12)
+            | (0b1111 << 4) // SH=11, bits[7:4]=1111
+    }
+
+    /// Encode SMLABB: cond 0001 0000 Rd Rn Rs 1000 Rm
+    fn arm_smlabb(cond: u8, rd: u8, rn: u8, rs: u8, rm: u8) -> u32 {
+        ((cond as u32) << 28)
+            | (0b0001_0000 << 20)
+            | ((rd as u32 & 0xF) << 16)
+            | ((rn as u32 & 0xF) << 12)
+            | ((rs as u32 & 0xF) << 8)
+            | (0b1000 << 4)
+            | (rm as u32 & 0xF)
+    }
+
+    /// Encode BKPT: cond 0001 0010 imm12 0111 imm4
+    fn arm_bkpt(cond: u8) -> u32 {
+        ((cond as u32) << 28) | (0b0001_0010 << 20) | (0b0111 << 4)
+    }
+
+    #[test]
+    fn arm_clz_triggers_undefined() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_clz(0xE, 0, 1); // CLZ R0, R1
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "CLZ should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_qadd_triggers_undefined() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_qadd(0xE, 1, 0, 2); // QADD R0, R2, R1
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "QADD should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_blx_register_triggers_undefined() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_blx_reg(0xE, 0); // BLX R0
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "BLX (register) should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_ldrd_triggers_undefined() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40; // base address
+        let instr = arm_ldrd(0xE, 1, 0); // LDRD R0, [R1]
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "LDRD should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_strd_triggers_undefined() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40;
+        let instr = arm_strd(0xE, 1, 0); // STRD R0, [R1]
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "STRD should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_smlabb_triggers_undefined() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_smlabb(0xE, 0, 1, 2, 3); // SMLABB R0, R3, R2, R1
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "SMLABB should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_bkpt_triggers_undefined() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_bkpt(0xE); // BKPT
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "BKPT should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_valid_mrs_still_works() {
+        // MRS R0, CPSR: cond 0001 0000 1111 Rd 0000 0000 0000
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr: u32 = 0xE10F_0000; // MRS R0, CPSR
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            !outcome.undefined,
+            "MRS should NOT trigger undefined, got: {outcome:?}"
+        );
+        assert_eq!(regs.r[0], regs.cpsr);
+    }
+
+    #[test]
+    fn arm_valid_bx_still_works() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0x100;
+        let instr: u32 = 0xE12F_FF10; // BX R0
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            !outcome.undefined,
+            "BX should NOT trigger undefined, got: {outcome:?}"
+        );
+        assert_eq!(regs.r[15], 0x100);
+    }
+
+    #[test]
+    fn arm_valid_swp_still_works() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40;
+        regs.r[2] = 42;
+        bus.write32(0x40, 99);
+        let instr = arm_swap(0xE, false, 1, 0, 2); // SWP R0, R2, [R1]
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            !outcome.undefined,
+            "SWP should NOT trigger undefined, got: {outcome:?}"
+        );
+        assert_eq!(regs.r[0], 99);
+        assert_eq!(bus.read32(0x40), 42);
+    }
+
+    #[test]
+    fn arm_valid_strh_still_works() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0x1234;
+        regs.r[1] = 0x40;
+        // STRH R0, [R1]: cond 000 1 1 1 0 0 Rn Rd 0000 1011 0000
+        // P=1, U=1, I=1, W=0, L=0, SH=01
+        let instr: u32 = 0xE1C1_00B0; // STRH R0, [R1]
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            !outcome.undefined,
+            "STRH should NOT trigger undefined, got: {outcome:?}"
+        );
+        assert_eq!(bus.read16(0x40), 0x1234);
     }
 }

--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -72,7 +72,7 @@ impl ExecOutcome {
     }
     pub(super) fn undefined() -> Self {
         Self {
-            cycles: 1,
+            cycles: 3,
             branched: true,
             undefined: true,
             swi: false,

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -150,10 +150,8 @@ impl Arm7tdmi {
             let outcome = thumb::execute(&mut self.regs, bus, raw);
             if outcome.undefined {
                 self.dispatch_undefined(exec_pc);
-                self.prefetch_valid = false;
             } else if outcome.swi {
                 self.dispatch_swi(exec_pc);
-                self.prefetch_valid = false;
             } else if outcome.branched {
                 self.prefetch_valid = false;
             } else if !outcome.branched {
@@ -170,10 +168,8 @@ impl Arm7tdmi {
             let outcome = arm::execute(&mut self.regs, bus, raw);
             if outcome.undefined {
                 self.dispatch_undefined(exec_pc);
-                self.prefetch_valid = false;
             } else if outcome.swi {
                 self.dispatch_swi(exec_pc);
-                self.prefetch_valid = false;
             } else if outcome.branched {
                 self.prefetch_valid = false;
             } else if !outcome.branched {

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -148,7 +148,10 @@ impl Arm7tdmi {
             self.regs.r[15] = exec_pc.wrapping_add(4);
             let raw = self.prefetch_thumb[0];
             let outcome = thumb::execute(&mut self.regs, bus, raw);
-            if outcome.swi {
+            if outcome.undefined {
+                self.dispatch_undefined(exec_pc);
+                self.prefetch_valid = false;
+            } else if outcome.swi {
                 self.dispatch_swi(exec_pc);
                 self.prefetch_valid = false;
             } else if outcome.branched {
@@ -165,7 +168,10 @@ impl Arm7tdmi {
             self.regs.r[15] = exec_pc.wrapping_add(8);
             let raw = self.prefetch_arm[0];
             let outcome = arm::execute(&mut self.regs, bus, raw);
-            if outcome.swi {
+            if outcome.undefined {
+                self.dispatch_undefined(exec_pc);
+                self.prefetch_valid = false;
+            } else if outcome.swi {
                 self.dispatch_swi(exec_pc);
                 self.prefetch_valid = false;
             } else if outcome.branched {
@@ -194,6 +200,20 @@ impl Arm7tdmi {
         self.regs.cpsr |= FLAG_I;
         self.regs.cpsr &= !FLAG_T;
         self.regs.r[15] = ExceptionVector::SoftwareInterrupt as u32;
+        self.prefetch_valid = false;
+    }
+
+    /// Dispatch an undefined instruction exception: switch to Undefined mode,
+    /// save state and jump to the undefined vector (0x04).
+    fn dispatch_undefined(&mut self, instr_pc: u32) {
+        let return_addr = instr_pc.wrapping_add(self.instr_size());
+        let cpsr = self.regs.cpsr;
+        self.regs.switch_mode(CpuMode::Undefined);
+        self.regs.set_spsr(cpsr);
+        self.regs.r[14] = return_addr;
+        self.regs.cpsr |= FLAG_I;
+        self.regs.cpsr &= !FLAG_T;
+        self.regs.r[15] = ExceptionVector::Undefined as u32;
         self.prefetch_valid = false;
     }
 
@@ -489,5 +509,83 @@ mod tests {
         }
 
         assert_eq!(cpu.regs.r[4], 2);
+    }
+
+    #[test]
+    fn undefined_instruction_dispatch_arm() {
+        // Test that executing a CLZ instruction (ARMv5TE) causes the CPU to
+        // enter Undefined mode with correct state.
+        let mut cpu = Arm7tdmi::new();
+        cpu.regs.switch_mode(CpuMode::User);
+        cpu.regs.cpsr &= !FLAG_I; // unmask IRQ
+        cpu.regs.r[15] = 0x100;
+        let cpsr_before = cpu.regs.cpsr;
+
+        let mut bus = RamBus::new(0x200);
+        // CLZ R0, R1: cond(0xE) 0001 0110 1111 0000 1111 0001 0001
+        let clz: u32 = 0xE16F_0F11;
+        write_arm_word(&mut bus, 0x100, clz);
+
+        cpu.step(&mut bus);
+
+        assert_eq!(
+            cpu.regs.mode(),
+            CpuMode::Undefined,
+            "CPU should be in Undefined mode"
+        );
+        assert_eq!(cpu.regs.spsr(), cpsr_before, "SPSR_und should be old CPSR");
+        assert_eq!(
+            cpu.regs.r[14],
+            0x100 + 4,
+            "LR_und should be address after undefined instr"
+        );
+        assert!(
+            cpu.regs.i_flag(),
+            "IRQ must be masked after undefined dispatch"
+        );
+        assert_eq!(
+            cpu.regs.r[15],
+            ExceptionVector::Undefined as u32,
+            "PC should be at undefined vector (0x04)"
+        );
+    }
+
+    #[test]
+    fn undefined_instruction_dispatch_thumb() {
+        // Test that executing Thumb BLX (ARMv5TE) causes the CPU to enter
+        // Undefined mode with correct state.
+        let mut cpu = Arm7tdmi::new();
+        cpu.regs.switch_mode(CpuMode::User);
+        cpu.regs.set_thumb(true);
+        cpu.regs.cpsr &= !FLAG_I;
+        cpu.regs.r[15] = 0x100;
+        let cpsr_before = cpu.regs.cpsr;
+
+        let mut bus = RamBus::new(0x200);
+        // Thumb BLX: 11101_00000000000 = 0xE800
+        let blx_thumb: u16 = 0xE800;
+        bus.write16(0x100, blx_thumb);
+        bus.write16(0x102, 0); // padding for prefetch
+        bus.write16(0x104, 0);
+
+        cpu.step(&mut bus);
+
+        assert_eq!(
+            cpu.regs.mode(),
+            CpuMode::Undefined,
+            "CPU should be in Undefined mode"
+        );
+        assert_eq!(cpu.regs.spsr(), cpsr_before, "SPSR_und should be old CPSR");
+        assert_eq!(
+            cpu.regs.r[14],
+            0x100 + 2,
+            "LR_und should be address after undefined Thumb instr"
+        );
+        assert!(
+            cpu.regs.i_flag(),
+            "IRQ must be masked after undefined dispatch"
+        );
+        assert!(!cpu.regs.thumb(), "T bit should be clear (ARM state)");
+        assert_eq!(cpu.regs.r[15], ExceptionVector::Undefined as u32);
     }
 }

--- a/src/gba/cpu/thumb.rs
+++ b/src/gba/cpu/thumb.rs
@@ -83,6 +83,7 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOut
                     cycles: 1,
                     branched: false,
                     swi: false,
+                    undefined: false,
                 }
             }
         }
@@ -102,11 +103,15 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOut
             } else if instr & 0xF600 == 0xB400 {
                 // Format 14: PUSH/POP
                 exec_format14(regs, bus, instr)
+            } else if instr & 0xFF00 == 0xBE00 {
+                // BKPT (ARMv5TE): undefined on ARMv4T.
+                ExecOutcome::undefined()
             } else {
                 ExecOutcome {
                     cycles: 1,
                     branched: false,
                     swi: false,
+                    undefined: false,
                 }
             }
         }
@@ -116,12 +121,15 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOut
         0b11010 | 0b11011 => exec_format16(regs, instr),
         // Format 18 (uncond branch): 11100
         0b11100 => exec_format18(regs, instr),
+        // BLX (ARMv5TE Thumb): 11101_xxxxxxxxxxx — undefined on ARMv4T.
+        0b11101 => ExecOutcome::undefined(),
         // Format 19: 1111x — Long branch with link
         0b11110 | 0b11111 => exec_format19(regs, instr),
         _ => ExecOutcome {
             cycles: 1,
             branched: false,
             swi: false,
+            undefined: false,
         },
     }
 }
@@ -176,6 +184,7 @@ fn exec_format1(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 1,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -207,6 +216,7 @@ fn exec_format2(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 1,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -248,6 +258,7 @@ fn exec_format3(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 1,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -393,6 +404,7 @@ fn exec_format4(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 1,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -418,6 +430,7 @@ fn exec_format5(regs: &mut Registers, instr: u16) -> ExecOutcome {
                     cycles: 3,
                     branched: true,
                     swi: false,
+                    undefined: false,
                 };
             }
         }
@@ -435,6 +448,7 @@ fn exec_format5(regs: &mut Registers, instr: u16) -> ExecOutcome {
                     cycles: 3,
                     branched: true,
                     swi: false,
+                    undefined: false,
                 };
             }
         }
@@ -451,6 +465,7 @@ fn exec_format5(regs: &mut Registers, instr: u16) -> ExecOutcome {
                 cycles: 3,
                 branched: true,
                 swi: false,
+                undefined: false,
             };
         }
         _ => unreachable!(),
@@ -459,6 +474,7 @@ fn exec_format5(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 1,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -477,6 +493,7 @@ fn exec_format6<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         cycles: 3,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -515,6 +532,7 @@ fn exec_format7<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         cycles: if l { 3 } else { 2 },
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -542,6 +560,7 @@ fn exec_format8<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
             cycles: 2,
             branched: false,
             swi: false,
+            undefined: false,
         };
     }
 
@@ -570,6 +589,7 @@ fn exec_format8<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         cycles: 3,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -608,6 +628,7 @@ fn exec_format9<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         cycles: if l { 3 } else { 2 },
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -637,6 +658,7 @@ fn exec_format10<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
         cycles: if l { 3 } else { 2 },
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -663,6 +685,7 @@ fn exec_format11<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
         cycles: if l { 3 } else { 2 },
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -685,6 +708,7 @@ fn exec_format12(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 1,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -705,6 +729,7 @@ fn exec_format13(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 1,
         branched: false,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -758,6 +783,7 @@ fn exec_format14<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
         cycles: 3,
         branched,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -828,6 +854,7 @@ fn exec_format15<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
         },
         branched,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -843,6 +870,7 @@ fn exec_format16(regs: &mut Registers, instr: u16) -> ExecOutcome {
             cycles: 3,
             branched: true,
             swi: true,
+            undefined: false,
         };
     }
     if !condition_met(regs.cpsr, cond) {
@@ -850,6 +878,7 @@ fn exec_format16(regs: &mut Registers, instr: u16) -> ExecOutcome {
             cycles: 1,
             branched: false,
             swi: false,
+            undefined: false,
         };
     }
     let offset = ((instr & 0xFF) as i8) as i32 * 2;
@@ -858,6 +887,7 @@ fn exec_format16(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 3,
         branched: true,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -874,6 +904,7 @@ fn exec_format18(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 3,
         branched: true,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -899,6 +930,7 @@ fn exec_format19(regs: &mut Registers, instr: u16) -> ExecOutcome {
             cycles: 1,
             branched: false,
             swi: false,
+            undefined: false,
         };
     }
 
@@ -911,6 +943,7 @@ fn exec_format19(regs: &mut Registers, instr: u16) -> ExecOutcome {
         cycles: 4,
         branched: true,
         swi: false,
+        undefined: false,
     }
 }
 
@@ -1456,5 +1489,49 @@ mod tests {
         // LR = (PC - 2) | 1 = 0x1000 | 1 (next instruction address with Thumb bit)
         assert_eq!(regs.r[14] & !1, 0x1000);
         assert!(outcome.branched);
+    }
+
+    // -----------------------------------------------------------------------
+    // ARMv5TE undefined instruction tests (Thumb)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn thumb_blx_triggers_undefined() {
+        // BLX (Thumb, v5TE): 11101_xxxxxxxxxxx (top5 = 0b11101)
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr: u16 = 0b11101_00000000000; // BLX offset=0
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "Thumb BLX should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn thumb_bkpt_triggers_undefined() {
+        // BKPT (Thumb, v5TE): 1011_1110_xxxxxxxx = 0xBExx
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr: u16 = 0xBE00; // BKPT #0
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            outcome.undefined,
+            "Thumb BKPT should trigger undefined on ARMv4T, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn thumb_valid_unconditional_branch_still_works() {
+        // Format 18: 11100_xxxxxxxxxxx (top5 = 0b11100) - should NOT be undefined
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[15] = 0x100;
+        let instr: u16 = 0b11100_00000000100; // B #8 (offset=4, <<1 = 8)
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(
+            !outcome.undefined,
+            "Unconditional B should NOT trigger undefined, got: {outcome:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements undefined instruction exception handling for ARMv5TE-exclusive opcodes on the GBA's ARM7TDMI (ARMv4T) processor.

## Problem

The GBA CPU emulator was silently accepting ARMv5TE instructions that the real ARM7TDMI would trap as undefined:
- CLZ, QADD/QSUB, DSP multiplies, BLX register, BKPT fell through to data processing as NOPs
- LDRD/STRD partially executed via the halfword transfer handler
- Thumb BLX and BKPT fell to default NOP handlers

## Solution

- Extended `ExecOutcome` with an `undefined` field to signal the exception
- Added `dispatch_undefined` to `Arm7tdmi` (mirrors `dispatch_swi`: saves CPSR, switches to Undefined mode, sets LR, disables IRQ, clears T, jumps to vector 0x04)
- ARM decode guard: `(instr & 0x0190_0000) == 0x0100_0000` catches misc-space after valid ARMv4T checks (MRS/MSR/BX/SWP)
- Halfword transfer guard: rejects LDRD/STRD (SH != 01 in store path)
- Thumb guards: BLX (top5=0b11101) and BKPT (0xBExx)

## Testing

- 19 new unit tests (11 undefined triggers + 5 valid-instruction regressions + 3 Thumb)
- All 122 GBA CPU tests pass
- Full test suite: 9799 pass (9 pre-existing GB mealybug failures unrelated to this change)
- Clippy clean, fmt clean
- armwrestler integration test CRCs unchanged

## Pre-existing failures (not introduced by this PR)

- 9 GB mealybug tests (PPU timing, same on main)
- wasm-pack ChromeDriver infrastructure (HTTP 404, same on main)

Closes #2374
