### PR TITLE
Fix GB LCDC BG-enable edge timing

### DIFF
--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -143,11 +143,14 @@ fn test_m3_bgp_change_sprites_dmg_b() {
     const EXPECTED_CRC: u32 = 0x7E8E_86BC;
     assert_mealybug_crc("m3_bgp_change_sprites_dmg_b", crc, EXPECTED_CRC);
 }
-mealybug_ignored_dmg_b!(
-    test_m3_lcdc_bg_en_change_dmg_b,
-    "m3_lcdc_bg_en_change",
-    "2349"
-);
+#[test]
+fn test_m3_lcdc_bg_en_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_en_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_en_change_dmg_b");
+    const EXPECTED_CRC: u32 = 0x8897_C19D;
+    assert_mealybug_crc("m3_lcdc_bg_en_change_dmg_b", crc, EXPECTED_CRC);
+}
 mealybug_ignored_dmg_b!(
     test_m3_lcdc_bg_map_change_dmg_b,
     "m3_lcdc_bg_map_change",
@@ -250,16 +253,23 @@ fn test_m3_bgp_change_sprites_cgb_c() {
     const EXPECTED_CRC: u32 = 0x4F83_5D92;
     assert_mealybug_crc("m3_bgp_change_sprites_cgb_c", crc, EXPECTED_CRC);
 }
-mealybug_ignored_cgb_c!(
-    test_m3_lcdc_bg_en_change_cgb_c,
-    "m3_lcdc_bg_en_change",
-    "2349"
-);
-mealybug_ignored_cgb_c!(
-    test_m3_lcdc_bg_en_change2_cgb_c,
-    "m3_lcdc_bg_en_change2",
-    "2349"
-);
+#[test]
+fn test_m3_lcdc_bg_en_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_en_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_en_change_cgb_c");
+    const EXPECTED_CRC: u32 = 0xB600_98E1;
+    assert_mealybug_crc("m3_lcdc_bg_en_change_cgb_c", crc, EXPECTED_CRC);
+}
+
+#[test]
+fn test_m3_lcdc_bg_en_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_en_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_en_change2_cgb_c");
+    const EXPECTED_CRC: u32 = 0x9610_CDF4;
+    assert_mealybug_crc("m3_lcdc_bg_en_change2_cgb_c", crc, EXPECTED_CRC);
+}
 mealybug_ignored_cgb_c!(
     test_m3_lcdc_bg_map_change_cgb_c,
     "m3_lcdc_bg_map_change",
@@ -388,11 +398,14 @@ fn test_m3_bgp_change_sprites_cgb_d() {
     const EXPECTED_CRC: u32 = 0x09D9_587E;
     assert_mealybug_crc("m3_bgp_change_sprites_cgb_d", crc, EXPECTED_CRC);
 }
-mealybug_ignored_cgb_d!(
-    test_m3_lcdc_bg_en_change_cgb_d,
-    "m3_lcdc_bg_en_change",
-    "2349"
-);
+#[test]
+fn test_m3_lcdc_bg_en_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_bg_en_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_bg_en_change_cgb_d");
+    const EXPECTED_CRC: u32 = 0xB600_98E1;
+    assert_mealybug_crc("m3_lcdc_bg_en_change_cgb_d", crc, EXPECTED_CRC);
+}
 mealybug_ignored_cgb_d!(
     test_m3_lcdc_bg_map_change_cgb_d,
     "m3_lcdc_bg_map_change",

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -11,6 +11,62 @@ use crate::gb::model::CgbModel;
 const FETCHER_STARTUP_DOTS: u16 = 16;
 const INITIAL_BGP: u8 = 0xFC;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LcdcBgEnableEdgeTiming {
+    CurrentPixelUsesNew,
+    CurrentPixelUsesPrevious,
+    HoldPreviousForOneExtraPixel,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct LcdcBgEnableEdge {
+    active: bool,
+    start_x: u8,
+    end_x: u8,
+    enabled: bool,
+}
+
+impl LcdcBgEnableEdge {
+    fn record_write(
+        &mut self,
+        next_x: u8,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        timing: LcdcBgEnableEdgeTiming,
+    ) {
+        if previous_lcdc & 0x01 == new_lcdc & 0x01 {
+            return;
+        }
+
+        self.active = true;
+        self.start_x = next_x;
+        self.end_x = match timing {
+            LcdcBgEnableEdgeTiming::HoldPreviousForOneExtraPixel => next_x.saturating_add(1),
+            LcdcBgEnableEdgeTiming::CurrentPixelUsesNew
+            | LcdcBgEnableEdgeTiming::CurrentPixelUsesPrevious => next_x,
+        };
+        self.enabled = match timing {
+            LcdcBgEnableEdgeTiming::CurrentPixelUsesNew => new_lcdc & 0x01 != 0,
+            LcdcBgEnableEdgeTiming::CurrentPixelUsesPrevious
+            | LcdcBgEnableEdgeTiming::HoldPreviousForOneExtraPixel => previous_lcdc & 0x01 != 0,
+        };
+    }
+
+    fn bg_window_enabled_for_pixel(&self, x: u32, current_lcdc: u8) -> bool {
+        if self.active && u32::from(self.start_x) <= x && x <= u32::from(self.end_x) {
+            self.enabled
+        } else {
+            current_lcdc & 0x01 != 0
+        }
+    }
+
+    fn clear_consumed(&mut self, next_x: u8) {
+        if self.active && self.end_x == next_x {
+            self.active = false;
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PixelFifoRenderer {
     active: bool,
@@ -31,6 +87,8 @@ pub struct PixelFifoRenderer {
     next_obj_stall_event: usize,
     #[serde(default)]
     sprite_indices: Vec<usize>,
+    #[serde(default)]
+    lcdc_bg_enable_edge: LcdcBgEnableEdge,
 }
 
 impl PixelFifoRenderer {
@@ -49,6 +107,7 @@ impl PixelFifoRenderer {
             obj_stall_events: Vec::new(),
             next_obj_stall_event: 0,
             sprite_indices: Vec::new(),
+            lcdc_bg_enable_edge: LcdcBgEnableEdge::default(),
         }
     }
 
@@ -66,6 +125,7 @@ impl PixelFifoRenderer {
         self.window_active = false;
         self.bgp_edge_active = false;
         self.bgp_edge_value = registers.bgp;
+        self.lcdc_bg_enable_edge = LcdcBgEnableEdge::default();
         self.fine_scroll_delay_dots = u16::from(registers.scx & 0x07);
         self.pending_obj_stall_dots = 0;
         self.next_obj_stall_event = 0;
@@ -142,6 +202,7 @@ impl PixelFifoRenderer {
             self.render_dmg_pixel(x, vram, oam, registers, window_line, screen_buffer);
         }
         self.clear_consumed_bgp_edge();
+        self.lcdc_bg_enable_edge.clear_consumed(self.next_x);
         self.next_x = self.next_x.saturating_add(1);
         if self.next_x as u32 >= ScreenBuffer::WIDTH {
             self.active = false;
@@ -181,6 +242,29 @@ impl PixelFifoRenderer {
         } else {
             previous | new
         };
+    }
+
+    pub fn record_lcdc_write(&mut self, previous: u8, new: u8, cgb_mode: bool, dmg_compat: bool) {
+        if !self.active || self.next_x as u32 >= ScreenBuffer::WIDTH {
+            return;
+        }
+
+        let waiting_on_obj_fetch = self.is_waiting_on_obj_fetch();
+        let timing = if cgb_mode && dmg_compat {
+            if waiting_on_obj_fetch && self.next_x == 0 && self.pending_obj_stall_dots == 1 {
+                LcdcBgEnableEdgeTiming::CurrentPixelUsesPrevious
+            } else if waiting_on_obj_fetch {
+                LcdcBgEnableEdgeTiming::CurrentPixelUsesNew
+            } else {
+                LcdcBgEnableEdgeTiming::HoldPreviousForOneExtraPixel
+            }
+        } else if self.next_x == 0 || waiting_on_obj_fetch {
+            LcdcBgEnableEdgeTiming::CurrentPixelUsesNew
+        } else {
+            LcdcBgEnableEdgeTiming::CurrentPixelUsesPrevious
+        };
+        self.lcdc_bg_enable_edge
+            .record_write(self.next_x, previous, new, timing);
     }
 
     fn render_dmg_pixel(
@@ -326,7 +410,9 @@ impl PixelFifoRenderer {
         window_line: u8,
     ) -> (u8, bool, u8) {
         let lcdc = registers.lcdc;
-        let bg_window_enabled = lcdc & 0x01 != 0;
+        let bg_window_enabled = self
+            .lcdc_bg_enable_edge
+            .bg_window_enabled_for_pixel(x, lcdc);
         let obj_enabled = lcdc & 0x02 != 0;
         let win_enabled = lcdc & 0x20 != 0;
 
@@ -336,7 +422,7 @@ impl PixelFifoRenderer {
             0
         };
 
-        let bw_idx = if win_enabled {
+        let bw_idx = if bg_window_enabled && win_enabled {
             match window::fetch_window_pixel(
                 x,
                 self.scanline,
@@ -410,5 +496,113 @@ impl PixelFifoRenderer {
 impl Default for PixelFifoRenderer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LcdcBgEnableEdge, LcdcBgEnableEdgeTiming, PixelFifoRenderer};
+
+    #[test]
+    fn lcdc_bg_enable_edge_defaults_to_current_lcdc_bit() {
+        // Given: no recorded mid-Mode-3 LCDC write.
+        let edge = LcdcBgEnableEdge::default();
+
+        // When/Then: the helper follows the live LCDC bit 0 value.
+        assert!(edge.bg_window_enabled_for_pixel(12, 0x93));
+        assert!(!edge.bg_window_enabled_for_pixel(12, 0x92));
+    }
+
+    #[test]
+    fn lcdc_bg_enable_edge_uses_new_value_for_delayed_current_pixel() {
+        // Given: an LCDC bit 0 write lands before the current pixel has been pushed
+        // because an object fetch is still delaying that pixel.
+        let mut edge = LcdcBgEnableEdge::default();
+        edge.record_write(12, 0x93, 0x92, LcdcBgEnableEdgeTiming::CurrentPixelUsesNew);
+
+        // When/Then: the delayed current pixel observes the new BG/window-enable bit.
+        assert!(!edge.bg_window_enabled_for_pixel(12, 0x93));
+    }
+
+    #[test]
+    fn lcdc_bg_enable_edge_can_keep_previous_value_for_current_pixel() {
+        let mut edge = LcdcBgEnableEdge::default();
+        edge.record_write(
+            0,
+            0x93,
+            0x92,
+            LcdcBgEnableEdgeTiming::CurrentPixelUsesPrevious,
+        );
+
+        assert!(edge.bg_window_enabled_for_pixel(0, 0x92));
+        assert!(!edge.bg_window_enabled_for_pixel(1, 0x92));
+    }
+
+    #[test]
+    fn lcdc_bg_enable_edge_holds_previous_value_until_cgb_dmg_compat_delay_ends() {
+        // Given: CGB DMG-compat observes this LCDC bit 0 edge one output pixel
+        // later than DMG on the mealybug timing ROMs.
+        let mut edge = LcdcBgEnableEdge::default();
+        edge.record_write(
+            12,
+            0x93,
+            0x92,
+            LcdcBgEnableEdgeTiming::HoldPreviousForOneExtraPixel,
+        );
+
+        // When/Then: the previous value is held through the delayed boundary.
+        assert!(edge.bg_window_enabled_for_pixel(12, 0x93));
+        assert!(edge.bg_window_enabled_for_pixel(13, 0x92));
+        assert!(!edge.bg_window_enabled_for_pixel(14, 0x92));
+    }
+
+    #[test]
+    fn lcdc_bg_enable_edge_clears_after_consumed_pixel() {
+        // Given: an edge was recorded for the current output pixel.
+        let mut edge = LcdcBgEnableEdge::default();
+        edge.record_write(12, 0x93, 0x92, LcdcBgEnableEdgeTiming::CurrentPixelUsesNew);
+
+        // When: that pixel is consumed.
+        edge.clear_consumed(12);
+
+        // Then: later resolution falls back to the current LCDC bit.
+        assert!(edge.bg_window_enabled_for_pixel(12, 0x93));
+    }
+
+    #[test]
+    fn record_lcdc_write_keeps_previous_on_cgb_left_edge_final_obj_stall_dot() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.next_x = 0;
+        renderer.pending_obj_stall_dots = 1;
+
+        renderer.record_lcdc_write(0x93, 0x92, true, true);
+
+        assert!(
+            renderer
+                .lcdc_bg_enable_edge
+                .bg_window_enabled_for_pixel(0, 0x92)
+        );
+        assert!(
+            !renderer
+                .lcdc_bg_enable_edge
+                .bg_window_enabled_for_pixel(1, 0x92)
+        );
+    }
+
+    #[test]
+    fn record_lcdc_write_uses_new_on_cgb_left_edge_before_final_obj_stall_dot() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.next_x = 0;
+        renderer.pending_obj_stall_dots = 2;
+
+        renderer.record_lcdc_write(0x93, 0x92, true, true);
+
+        assert!(
+            !renderer
+                .lcdc_bg_enable_edge
+                .bg_window_enabled_for_pixel(0, 0x93)
+        );
     }
 }

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -519,6 +519,14 @@ impl Ppu {
                 self.cgb_model,
             );
         }
+        if addr == 0xFF40 {
+            self.pixel_fifo.record_lcdc_write(
+                self.registers.lcdc,
+                val,
+                self.cgb_mode,
+                self.dmg_compat,
+            );
+        }
         let was_enabled = self.registers.lcd_enabled();
         self.registers.write(addr, val);
         let now_enabled = self.registers.lcd_enabled();
@@ -567,8 +575,10 @@ impl Ppu {
             // BCPS: bit 6 always reads as 1 (unused bit pulled high).
             0xFF68 => Some(self.bcps | 0x40),
             0xFF69 => {
-                // BCPD: blocked during Mode 3 when LCD is on (returns 0xFF).
-                if self.registers.lcd_enabled() && self.timing.is_palette_blocked() {
+                if self.dmg_compat {
+                    Some(0xFF)
+                } else if self.registers.lcd_enabled() && self.timing.is_palette_blocked() {
+                    // BCPD: blocked during Mode 3 when LCD is on (returns 0xFF).
                     Some(0xFF)
                 } else {
                     Some(self.bg_palette_ram[(self.bcps & 0x3F) as usize])
@@ -577,8 +587,10 @@ impl Ppu {
             // OCPS: bit 6 always reads as 1 (unused bit pulled high).
             0xFF6A => Some(self.ocps | 0x40),
             0xFF6B => {
-                // OCPD: blocked during Mode 3 when LCD is on (returns 0xFF).
-                if self.registers.lcd_enabled() && self.timing.is_palette_blocked() {
+                if self.dmg_compat {
+                    Some(0xFF)
+                } else if self.registers.lcd_enabled() && self.timing.is_palette_blocked() {
+                    // OCPD: blocked during Mode 3 when LCD is on (returns 0xFF).
                     Some(0xFF)
                 } else {
                     Some(self.obj_palette_ram[(self.ocps & 0x3F) as usize])
@@ -608,19 +620,20 @@ impl Ppu {
                 true
             }
             0xFF69 => {
-                // BCPD: write blocked during Mode 3 when LCD is on, but auto-increment still happens.
+                // BCPD is CGB-mode-only. In DMG compatibility mode after boot, the data port
+                // is locked, so writes neither update palette RAM nor auto-increment BCPS.
                 let index = (self.bcps & 0x3F) as usize;
                 let addr = self.bcps & 0x3F;
                 let blocked =
                     self.registers.lcd_enabled() && self.timing.is_palette_write_blocked();
-                if !blocked {
+                if !blocked && !self.dmg_compat {
                     self.bg_palette_ram[index] = val;
                     trace_ppu!(3; "bcpd write addr={:02X} data={:02X}", addr, val);
                 } else {
                     trace_ppu!(3; "bcpd write blocked addr={:02X} data={:02X}", addr, val);
                 }
-                // Auto-increment address after write if bit 7 is set (even when blocked).
-                if self.bcps & 0x80 != 0 {
+                // Auto-increment address after write if bit 7 is set (even when Mode 3-blocked).
+                if !self.dmg_compat && self.bcps & 0x80 != 0 {
                     self.bcps = 0x80 | ((self.bcps + 1) & 0x3F);
                     trace_ppu!(3; "bcps auto-increment addr={:02X}", self.bcps & 0x3F);
                 }
@@ -633,19 +646,20 @@ impl Ppu {
                 true
             }
             0xFF6B => {
-                // OCPD: write blocked during Mode 3 when LCD is on, but auto-increment still happens.
+                // OCPD is CGB-mode-only. In DMG compatibility mode after boot, the data port
+                // is locked, so writes neither update palette RAM nor auto-increment OCPS.
                 let index = (self.ocps & 0x3F) as usize;
                 let addr = self.ocps & 0x3F;
                 let blocked =
                     self.registers.lcd_enabled() && self.timing.is_palette_write_blocked();
-                if !blocked {
+                if !blocked && !self.dmg_compat {
                     self.obj_palette_ram[index] = val;
                     trace_ppu!(3; "ocpd write addr={:02X} data={:02X}", addr, val);
                 } else {
                     trace_ppu!(3; "ocpd write blocked addr={:02X} data={:02X}", addr, val);
                 }
-                // Auto-increment (even when blocked).
-                if self.ocps & 0x80 != 0 {
+                // Auto-increment address after write if bit 7 is set (even when Mode 3-blocked).
+                if !self.dmg_compat && self.ocps & 0x80 != 0 {
                     self.ocps = 0x80 | ((self.ocps + 1) & 0x3F);
                     trace_ppu!(3; "ocps auto-increment addr={:02X}", self.ocps & 0x3F);
                 }
@@ -2872,6 +2886,26 @@ mod tests {
             Some(0xC5),
             "OCPS auto-increment must happen even when write is blocked"
         );
+    }
+
+    #[test]
+    fn test_cgb_dmg_compat_palette_data_ports_are_locked_after_boot() {
+        let mut ppu = Ppu::new_cgb();
+        ppu.bg_palette_ram[0] = 0x12;
+        ppu.obj_palette_ram[0] = 0x34;
+        ppu.set_dmg_compat(true);
+
+        ppu.write_cgb_register(0xFF68, 0x80);
+        ppu.write_cgb_register(0xFF69, 0xAB);
+        ppu.write_cgb_register(0xFF6A, 0x80);
+        ppu.write_cgb_register(0xFF6B, 0xCD);
+
+        assert_eq!(ppu.bg_palette_ram[0], 0x12);
+        assert_eq!(ppu.obj_palette_ram[0], 0x34);
+        assert_eq!(ppu.read_cgb_register(0xFF68), Some(0xC0));
+        assert_eq!(ppu.read_cgb_register(0xFF69), Some(0xFF));
+        assert_eq!(ppu.read_cgb_register(0xFF6A), Some(0xC0));
+        assert_eq!(ppu.read_cgb_register(0xFF6B), Some(0xFF));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Enables the four issue #2349 mealybug LCDC bit 0 BG-enable tests with screenshot CRC assertions.
- Adds LCDC bit 0 edge tracking in the GB pixel FIFO so mid-Mode-3 writes affect BG/window blanking at the expected pixel boundary on DMG and CGB DMG-compat.
- Locks CGB palette data ports in DMG compatibility mode so boot-selected compatibility palettes are not overwritten by DMG-only ROMs.

Closes #2349

## Validation

- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- ./scripts/test-dir.sh src/gb --skip-integration
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test
