### PR TITLE
GBA: Fix mgba-emu/suite sub-suite failures (#2381)

### DIFF
--- a/src/gba/bus/dma.rs
+++ b/src/gba/bus/dma.rs
@@ -227,17 +227,23 @@ impl DmaController {
     }
 
     /// Read register at `addr` (within `0x0400_00B0..0x0400_00DF`).
-    /// Writes-only registers (SAD, DAD, CNT_L) read as `0` per GBATek.
+    ///
+    /// Per GBATek, SAD and DAD are write-only and return open-bus (None).
+    /// CNT_L is write-only but reads as zero. CNT_HI is readable with a
+    /// mask: bits 0-4 always zero, bit 11 only on channel 3 (Game Pak DRQ).
     pub fn try_read16(&self, addr: u32) -> Option<u16> {
         let (chan, off) = decode_addr(addr)?;
         match off {
-            // SAD is write-only.
-            0 | 2 => Some(0),
-            // DAD is write-only.
-            4 | 6 => Some(0),
-            // CNT_L is write-only.
+            // SAD is write-only → open-bus.
+            0 | 2 => None,
+            // DAD is write-only → open-bus.
+            4 | 6 => None,
+            // CNT_L is write-only but reads as zero.
             8 => Some(0),
-            10 => Some(self.channels[chan].cnt_h),
+            10 => {
+                let mask = if chan == 3 { 0xFFE0 } else { 0xF7E0 };
+                Some(self.channels[chan].cnt_h & mask)
+            }
             _ => None,
         }
     }
@@ -1131,7 +1137,7 @@ mod tests {
     }
 
     #[test]
-    fn write_only_registers_read_zero() {
+    fn write_only_sad_dad_return_none_cnt_l_returns_zero() {
         let mut d = DmaController::new();
         write_dma_setup(
             &mut d,
@@ -1141,13 +1147,33 @@ mod tests {
             0x1234,
             cnt_h(false, false, 0, true, false, 0, 0),
         );
-        // SAD/DAD/CNT_L are write-only; reads return 0.
-        assert_eq!(d.try_read16(0x0400_00B0), Some(0));
-        assert_eq!(d.try_read16(0x0400_00B2), Some(0));
-        assert_eq!(d.try_read16(0x0400_00B4), Some(0));
-        assert_eq!(d.try_read16(0x0400_00B6), Some(0));
-        assert_eq!(d.try_read16(0x0400_00B8), Some(0));
+        // SAD/DAD are write-only → return None (open-bus on real hardware).
+        assert_eq!(d.try_read16(0x0400_00B0), None, "DMA0 SAD_LO");
+        assert_eq!(d.try_read16(0x0400_00B2), None, "DMA0 SAD_HI");
+        assert_eq!(d.try_read16(0x0400_00B4), None, "DMA0 DAD_LO");
+        assert_eq!(d.try_read16(0x0400_00B6), None, "DMA0 DAD_HI");
+        // CNT_L is write-only but reads as zero (not open-bus).
+        assert_eq!(d.try_read16(0x0400_00B8), Some(0), "DMA0 CNT_LO");
         // CNT_H reads back.
         assert!(d.try_read16(0x0400_00BA).unwrap() & 0x8000 == 0);
+    }
+
+    /// DMA CNT_HI has a read mask: bits 0-4 are not readable (always 0),
+    /// and bit 11 (Game Pak DRQ) is only available on channel 3.
+    /// CH0-2: mask 0xF7E0, CH3: mask 0xFFE0.
+    #[test]
+    fn dma_cnt_hi_applies_read_mask() {
+        let mut d = DmaController::new();
+        // Write 0xFFFF to all four channels' CNT_HI.
+        for ch in 0..4u32 {
+            let addr = 0x0400_00BA + ch * 12;
+            d.write16(addr, 0xFFFF);
+        }
+        // CH0-2: bits 0-4 and bit 11 masked out → 0xF7E0.
+        assert_eq!(d.try_read16(0x0400_00BA), Some(0xF7E0), "DMA0 CNT_HI");
+        assert_eq!(d.try_read16(0x0400_00C6), Some(0xF7E0), "DMA1 CNT_HI");
+        assert_eq!(d.try_read16(0x0400_00D2), Some(0xF7E0), "DMA2 CNT_HI");
+        // CH3: only bits 0-4 masked → 0xFFE0.
+        assert_eq!(d.try_read16(0x0400_00DE), Some(0xFFE0), "DMA3 CNT_HI");
     }
 }

--- a/src/gba/bus/io.rs
+++ b/src/gba/bus/io.rs
@@ -41,7 +41,6 @@ pub const REG_TM0CNT_H: u32 = 0x0400_0102;
 
 /// Address of `REG_DISPCNT` (PPU display control).
 pub const REG_DISPCNT: u32 = 0x0400_0000;
-const REG_BG0_SCROLL_END: u32 = ppu::REG_BG0VOFS + 1;
 
 /// I/O register backing store.
 ///
@@ -83,9 +82,9 @@ impl IoRegisters {
 
     /// Try to read a halfword from the I/O register space.
     ///
-    /// Returns `None` for addresses outside the 1 KB I/O window so the bus
-    /// can supply the correct open-bus value instead of treating the read
-    /// as a handled register access returning zero.
+    /// Returns `None` for write-only registers and addresses outside the
+    /// 1 KB I/O window so the bus can supply the correct open-bus value.
+    /// Readable registers with unused bits apply read masks per GBATek.
     pub fn try_read16(
         &self,
         addr: u32,
@@ -99,7 +98,7 @@ impl IoRegisters {
             REG_IE => Some(ic.ie),
             REG_IF => Some(ic.if_flags),
             REG_IME => Some(ic.read_ime()),
-            // PPU display registers.
+            // PPU display registers (readable).
             ppu::REG_DISPCNT => Some(ppu.read_dispcnt()),
             ppu::REG_BG0CNT => Some(ppu.read_bg_cnt(0)),
             ppu::REG_BG1CNT => Some(ppu.read_bg_cnt(1)),
@@ -107,6 +106,21 @@ impl IoRegisters {
             ppu::REG_BG3CNT => Some(ppu.read_bg_cnt(3)),
             ppu::REG_DISPSTAT => Some(ppu.read_dispstat()),
             ppu::REG_VCOUNT => Some(ppu.read_vcount()),
+            // PPU write-only registers → open-bus.
+            0x0400_0010..=0x0400_001E => None, // BG scroll offsets
+            0x0400_0020..=0x0400_003E => None, // BG affine params
+            0x0400_0040..=0x0400_0046 => None, // Window H/V coords
+            0x0400_004C => None,               // MOSAIC
+            0x0400_0054 => None,               // BLDY
+            // PPU readable registers with masks.
+            0x0400_0048 => self.read_backing(addr, 0x3F3F), // WININ
+            0x0400_004A => self.read_backing(addr, 0x3F3F), // WINOUT
+            0x0400_0050 => self.read_backing(addr, 0x3FFF), // BLDCNT
+            0x0400_0052 => self.read_backing(addr, 0x1F1F), // BLDALPHA
+            // Invalid addresses in PPU/blend range → open-bus.
+            0x0400_004E | 0x0400_0056..=0x0400_005E => None,
+            // Invalid addresses after sound FIFO (not in APU intercept range).
+            0x0400_00A8..=0x0400_00AF => None,
             // Keypad.
             REG_KEYINPUT => Some(keypad.read_keyinput()),
             REG_KEYCNT => Some(keypad.read_keycnt()),
@@ -120,10 +134,21 @@ impl IoRegisters {
             0x0400_010A => Some(timers.read_cnt_h(2)),
             0x0400_010C => Some(timers.read_cnt_l(3)),
             0x0400_010E => Some(timers.read_cnt_h(3)),
-            // DMA: 0x0400_00B0..=0x0400_00DF — write-only regs read 0.
+            // DMA registers.
             0x0400_00B0..=0x0400_00DF => dma.try_read16(addr),
+            // Invalid addresses post-DMA → open-bus.
+            0x0400_00E0..=0x0400_00FF => None,
+            // Invalid system-area addresses → read as zero (not open-bus).
+            0x0400_0136 | 0x0400_0142 | 0x0400_015A | 0x0400_0206 | 0x0400_020A | 0x0400_0302 => {
+                Some(0)
+            }
             _ => Self::idx(addr).map(|i| u16::from_le_bytes([self.bytes[i], self.bytes[i + 1]])),
         }
+    }
+
+    /// Read a halfword from the backing store with a mask applied.
+    fn read_backing(&self, addr: u32, mask: u16) -> Option<u16> {
+        Self::idx(addr).map(|i| u16::from_le_bytes([self.bytes[i], self.bytes[i + 1]]) & mask)
     }
 
     /// Try to read a word from the I/O register space (two halfwords).
@@ -334,25 +359,27 @@ impl IoRegisters {
             ppu.write_affine(aligned, merged);
             return;
         }
-        // BG0 scroll registers are write-only as well. Merge byte writes
-        // against live PPU state instead of io.read16() (which returns
-        // backing-store/open-bus for these addresses).
-        if (ppu::REG_BG0HOFS..=REG_BG0_SCROLL_END).contains(&addr) {
+        // BG scroll registers (0x10..0x1E) are write-only. Merge byte
+        // writes against the PPU's live scroll state instead of io.read16()
+        // (which returns open-bus zero for these addresses).
+        if (ppu::REG_BG0HOFS..=ppu::REG_BG3VOFS + 1).contains(&addr) {
             let aligned = addr & !1;
-            let current = match aligned {
-                ppu::REG_BG0HOFS => ppu.read_bg0_hofs(),
-                ppu::REG_BG0VOFS => ppu.read_bg0_vofs(),
-                _ => unreachable!("unexpected BG0 scroll register address: {aligned:#010X}"),
+            let bg = ((aligned - ppu::REG_BG0HOFS) / 4) as usize;
+            let is_vofs = (aligned - ppu::REG_BG0HOFS) % 4 == 2;
+            let current = if is_vofs {
+                ppu.read_bg_vofs(bg)
+            } else {
+                ppu.read_bg_hofs(bg)
             };
             let merged = if addr & 1 == 0 {
                 (current & 0xFF00) | value as u16
             } else {
                 (current & 0x00FF) | ((value as u16) << 8)
             };
-            match aligned {
-                ppu::REG_BG0HOFS => ppu.write_bg0_hofs(merged),
-                ppu::REG_BG0VOFS => ppu.write_bg0_vofs(merged),
-                _ => unreachable!("unexpected BG0 scroll register address: {aligned:#010X}"),
+            if is_vofs {
+                ppu.write_bg_vofs(bg, merged);
+            } else {
+                ppu.write_bg_hofs(bg, merged);
             }
             return;
         }
@@ -379,10 +406,10 @@ mod tests {
         let mut d = DmaController::new();
         let mut p = Ppu::new();
         let mut k = Keypad::new();
-        // 0x40 is REG_SOUNDCNT_H; not specially handled here — should just
+        // WAITCNT (0x204) is not specially handled — should just
         // round-trip through the backing store.
-        io.write16(0x0400_0040, 0xBEEF, &mut ic, &mut t, &mut d, &mut p, &mut k);
-        assert_eq!(io.read16(0x0400_0040, &ic, &t, &d, &p, &k), 0xBEEF);
+        io.write16(0x0400_0204, 0xBEEF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(io.read16(0x0400_0204, &ic, &t, &d, &p, &k), 0xBEEF);
     }
 
     #[test]
@@ -1010,5 +1037,155 @@ mod tests {
         );
 
         assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    // ---------------------------------------------------------------
+    // I/O read-back tests (per GBATek I/O map & mgba-emu/suite io-read)
+    // ---------------------------------------------------------------
+
+    /// Write-only PPU registers (BG scroll offsets, affine params, window
+    /// coords, MOSAIC, BLDY) must return `None` from `try_read16` so the
+    /// bus can substitute the open-bus value.
+    #[test]
+    fn write_only_ppu_registers_return_none() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let write_only_addrs: &[(u32, &str)] = &[
+            // BG scroll offsets (0x10..0x1E)
+            (0x0400_0010, "BG0HOFS"),
+            (0x0400_0012, "BG0VOFS"),
+            (0x0400_0014, "BG1HOFS"),
+            (0x0400_0016, "BG1VOFS"),
+            (0x0400_0018, "BG2HOFS"),
+            (0x0400_001A, "BG2VOFS"),
+            (0x0400_001C, "BG3HOFS"),
+            (0x0400_001E, "BG3VOFS"),
+            // BG affine params (0x20..0x3E)
+            (ppu::REG_BG2PA, "BG2PA"),
+            (ppu::REG_BG2PB, "BG2PB"),
+            (ppu::REG_BG2X_L, "BG2X_LO"),
+            (ppu::REG_BG2Y_H, "BG2Y_HI"),
+            (ppu::REG_BG3PA, "BG3PA"),
+            (ppu::REG_BG3Y_L, "BG3Y_LO"),
+            // Window coordinates (0x40..0x46)
+            (0x0400_0040, "WIN0H"),
+            (0x0400_0042, "WIN1H"),
+            (0x0400_0044, "WIN0V"),
+            (0x0400_0046, "WIN1V"),
+            // MOSAIC
+            (0x0400_004C, "MOSAIC"),
+            // BLDY (write-only)
+            (0x0400_0054, "BLDY"),
+        ];
+
+        for &(addr, name) in write_only_addrs {
+            io.write16(addr, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+            assert_eq!(
+                io.try_read16(addr, &ic, &t, &d, &p, &k),
+                None,
+                "{name} at {addr:#010X} should return None (write-only)"
+            );
+        }
+    }
+
+    /// Readable PPU registers with masks: WININ, WINOUT, BLDCNT, BLDALPHA.
+    /// After writing 0xFFFF, reads must return the value with unused bits
+    /// masked out.
+    #[test]
+    fn readable_ppu_registers_apply_read_masks() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let masked_regs: &[(u32, u16, &str)] = &[
+            (0x0400_0048, 0x3F3F, "WININ"),
+            (0x0400_004A, 0x3F3F, "WINOUT"),
+            (0x0400_0050, 0x3FFF, "BLDCNT"),
+            (0x0400_0052, 0x1F1F, "BLDALPHA"),
+        ];
+
+        for &(addr, expected, name) in masked_regs {
+            io.write16(addr, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+            assert_eq!(
+                io.try_read16(addr, &ic, &t, &d, &p, &k),
+                Some(expected),
+                "{name} at {addr:#010X} should read back {expected:#06X}"
+            );
+        }
+    }
+
+    /// Invalid addresses in the PPU range (0x4E, 0x56-0x5E) and post-DMA
+    /// range (0xA8-0xAE, 0xE0-0xFE) must return `None` (open-bus).
+    #[test]
+    fn invalid_io_addresses_return_none() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let invalid_addrs: &[(u32, &str)] = &[
+            (0x0400_004E, "INVALID (4E)"),
+            (0x0400_0056, "INVALID (56)"),
+            (0x0400_0058, "INVALID (58)"),
+            (0x0400_005A, "INVALID (5A)"),
+            (0x0400_005C, "INVALID (5C)"),
+            (0x0400_005E, "INVALID (5E)"),
+            (0x0400_00A8, "INVALID (A8)"),
+            (0x0400_00AA, "INVALID (AA)"),
+            (0x0400_00AC, "INVALID (AC)"),
+            (0x0400_00AE, "INVALID (AE)"),
+            (0x0400_00E0, "INVALID (E0)"),
+            (0x0400_00F0, "INVALID (F0)"),
+            (0x0400_00FE, "INVALID (FE)"),
+        ];
+
+        for &(addr, name) in invalid_addrs {
+            io.write16(addr, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+            assert_eq!(
+                io.try_read16(addr, &ic, &t, &d, &p, &k),
+                None,
+                "{name} at {addr:#010X} should return None (open-bus)"
+            );
+        }
+    }
+
+    /// Invalid system-area addresses (0x136, 0x142, 0x15A, 0x206, 0x20A,
+    /// 0x302) read as zero on real hardware — not open-bus.
+    #[test]
+    fn invalid_system_addresses_return_zero() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        let system_addrs: &[(u32, &str)] = &[
+            (0x0400_0136, "INVALID (136)"),
+            (0x0400_0142, "INVALID (142)"),
+            (0x0400_015A, "INVALID (15A)"),
+            (0x0400_0206, "INVALID (206)"),
+            (0x0400_020A, "INVALID (20A)"),
+            (0x0400_0302, "INVALID (302)"),
+        ];
+
+        for &(addr, name) in system_addrs {
+            io.write16(addr, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+            assert_eq!(
+                io.try_read16(addr, &ic, &t, &d, &p, &k),
+                Some(0),
+                "{name} at {addr:#010X} should return Some(0)"
+            );
+        }
     }
 }

--- a/src/gba/bus/io.rs
+++ b/src/gba/bus/io.rs
@@ -80,6 +80,53 @@ impl IoRegisters {
         (off + 1 < IO_SIZE).then_some(off)
     }
 
+    /// Read a raw halfword from the backing store (no masking).
+    fn backing_u16(&self, addr: u32) -> u16 {
+        Self::idx(addr)
+            .map(|i| u16::from_le_bytes([self.bytes[i], self.bytes[i + 1]]))
+            .unwrap_or(0)
+    }
+
+    /// Returns `true` when the current SIO mode is UART (RCNT bit 15 = 0
+    /// AND SIOCNT bits 12-13 = 11).
+    fn is_uart_mode(&self) -> bool {
+        self.backing_u16(0x0400_0134) & 0x8000 == 0
+            && (self.backing_u16(0x0400_0128) >> 12) & 3 == 3
+    }
+
+    /// Returns `true` when the current SIO mode is Normal 32-bit
+    /// (RCNT bit 15 = 0 AND SIOCNT bits 12-13 = 01).
+    fn is_normal32_mode(&self) -> bool {
+        self.backing_u16(0x0400_0134) & 0x8000 == 0
+            && (self.backing_u16(0x0400_0128) >> 12) & 3 == 1
+    }
+
+    /// Compute the RCNT read mask based on the current SIO mode.
+    ///
+    /// All modes clear bits 9-13. Pin-state bits 0-3 vary:
+    /// - Normal 8/32: bits 1,3 forced low (SD, SO idle low).
+    /// - JOY Bus: bits 0,1 forced low (SC, SD idle low).
+    /// - Multi / UART / GPIO: all pin bits pass through.
+    fn rcnt_read_mask(&self) -> u16 {
+        let rcnt = self.backing_u16(0x0400_0134);
+        let base_mask: u16 = 0xC1FF; // bits 14-15 + bits 0-8; clears 9-13
+        let pin_mask: u16 = if rcnt & 0x8000 != 0 {
+            // GPIO (bit 14=0) or JOY Bus (bit 14=1).
+            if rcnt & 0x4000 != 0 {
+                !0x0003 // JOY Bus: clear bits 0-1
+            } else {
+                0xFFFF // GPIO: all pins pass through
+            }
+        } else {
+            let siocnt = self.backing_u16(0x0400_0128);
+            match (siocnt >> 12) & 3 {
+                0 | 1 => !0x000A, // Normal 8/32: clear bits 1,3
+                _ => 0xFFFF,      // Multi / UART: all pins pass through
+            }
+        };
+        base_mask & pin_mask
+    }
+
     /// Try to read a halfword from the I/O register space.
     ///
     /// Returns `None` for write-only registers and addresses outside the
@@ -138,10 +185,43 @@ impl IoRegisters {
             0x0400_00B0..=0x0400_00DF => dma.try_read16(addr),
             // Invalid addresses post-DMA → open-bus.
             0x0400_00E0..=0x0400_00FF => None,
+            // --- SIO / JOY Bus registers ---
+            // SIODATA32_L/H (SIOMULTI0/1): R/W in Normal-32 mode, 0 otherwise.
+            0x0400_0120 | 0x0400_0122 => {
+                if self.is_normal32_mode() {
+                    self.read_backing(addr, 0xFFFF)
+                } else {
+                    Some(0)
+                }
+            }
+            // SIOMULTI2/3: receive-only buffers, always 0 (disconnected).
+            0x0400_0124 | 0x0400_0126 => Some(0),
+            // SIOCNT: mode-dependent read mask.
+            0x0400_0128 => {
+                let mask = if self.is_uart_mode() { 0x7FAF } else { 0x7F8F };
+                self.read_backing(addr, mask)
+            }
+            // SIOMLT_SEND / SIODATA8: backing in most modes, 0 in UART.
+            0x0400_012A => {
+                if self.is_uart_mode() {
+                    Some(0)
+                } else {
+                    self.read_backing(addr, 0xFFFF)
+                }
+            }
+            // RCNT: mode-dependent read mask (bits 9-13 always clear,
+            // pin bits 0-3 vary by mode).
+            0x0400_0134 => self.read_backing(addr, self.rcnt_read_mask()),
             // Invalid system-area addresses → read as zero (not open-bus).
             0x0400_0136 | 0x0400_0142 | 0x0400_015A | 0x0400_0206 | 0x0400_020A | 0x0400_0302 => {
                 Some(0)
             }
+            // JOYCNT: R/W with mask 0x0047.
+            0x0400_0140 => self.read_backing(addr, 0x0047),
+            // JOY_RECV / JOY_TRANS: always 0 (disconnected, no JOY Bus peer).
+            0x0400_0150..=0x0400_0156 => Some(0),
+            // JOYSTAT: always 0 (disconnected).
+            0x0400_0158 => Some(0),
             _ => Self::idx(addr).map(|i| u16::from_le_bytes([self.bytes[i], self.bytes[i + 1]])),
         }
     }
@@ -286,6 +366,16 @@ impl IoRegisters {
             0x0400_010E => timers.write_cnt_h(3, value),
             0x0400_00B0..=0x0400_00DF => {
                 dma.write16(addr, value);
+            }
+            // JOYCNT: bits 0-2 are write-1-to-clear flags, bit 6 is R/W.
+            0x0400_0140 => {
+                if let Some(i) = Self::idx(addr) {
+                    let cur = u16::from_le_bytes([self.bytes[i], self.bytes[i + 1]]);
+                    let new_val = (cur & !(value & 0x07)) | (value & 0x40);
+                    let b = new_val.to_le_bytes();
+                    self.bytes[i] = b[0];
+                    self.bytes[i + 1] = b[1];
+                }
             }
             _ => {
                 if let Some(i) = Self::idx(addr) {
@@ -1185,6 +1275,216 @@ mod tests {
                 io.try_read16(addr, &ic, &t, &d, &p, &k),
                 Some(0),
                 "{name} at {addr:#010X} should return Some(0)"
+            );
+        }
+    }
+
+    /// Helper to set SIO mode via RCNT + SIOCNT writes.
+    #[allow(clippy::too_many_arguments)]
+    fn set_sio_mode(
+        io: &mut IoRegisters,
+        ic: &mut InterruptController,
+        t: &mut Timers,
+        d: &mut DmaController,
+        p: &mut Ppu,
+        k: &mut Keypad,
+        siocnt: u16,
+        rcnt: u16,
+    ) {
+        io.write16(0x0400_0134, rcnt, ic, t, d, p, k);
+        io.write16(0x0400_0128, siocnt, ic, t, d, p, k);
+    }
+
+    /// SIOMULTI2 (0x124) and SIOMULTI3 (0x126) are receive-only buffers
+    /// for multi-player mode. They always read as 0 when disconnected,
+    /// regardless of what was written to them.
+    #[test]
+    fn siomulti2_3_always_read_zero() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        for addr in [0x0400_0124, 0x0400_0126] {
+            io.write16(addr, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+            assert_eq!(
+                io.try_read16(addr, &ic, &t, &d, &p, &k),
+                Some(0),
+                "SIOMULTI at {addr:#010X} should always read 0"
+            );
+        }
+    }
+
+    /// SIODATA32_L/H (0x120/0x122) are R/W only in Normal 32-bit mode.
+    /// In all other modes, they behave as receive buffers returning 0.
+    #[test]
+    fn siodata32_mode_dependent_read() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        // Normal 32-bit mode: SIODATA32 is R/W.
+        set_sio_mode(&mut io, &mut ic, &mut t, &mut d, &mut p, &mut k, 0x1000, 0);
+        io.write16(0x0400_0120, 0xBEEF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_0120, &ic, &t, &d, &p, &k),
+            Some(0xBEEF),
+            "SIODATA32_L in N32 mode should read back written value"
+        );
+
+        // Multi-player mode: reads as 0.
+        set_sio_mode(&mut io, &mut ic, &mut t, &mut d, &mut p, &mut k, 0x2000, 0);
+        io.write16(0x0400_0120, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_0120, &ic, &t, &d, &p, &k),
+            Some(0),
+            "SIODATA32_L in Multi mode should read 0"
+        );
+    }
+
+    /// SIOCNT (0x128) read mask: non-UART modes mask = 0x7F8F,
+    /// UART mode mask = 0x7FAF.
+    #[test]
+    fn siocnt_read_mask_mode_dependent() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        // Multi-player mode: write 0xEFFF, expect 0x6F8F.
+        set_sio_mode(&mut io, &mut ic, &mut t, &mut d, &mut p, &mut k, 0x2000, 0);
+        io.write16(0x0400_0128, 0xEFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_0128, &ic, &t, &d, &p, &k),
+            Some(0x6F8F),
+            "SIOCNT in Multi mode should apply mask 0x7F8F"
+        );
+
+        // UART mode: write 0xFFFF, expect 0x7FAF.
+        set_sio_mode(&mut io, &mut ic, &mut t, &mut d, &mut p, &mut k, 0x3000, 0);
+        io.write16(0x0400_0128, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_0128, &ic, &t, &d, &p, &k),
+            Some(0x7FAF),
+            "SIOCNT in UART mode should apply mask 0x7FAF"
+        );
+    }
+
+    /// SIOMLT_SEND / SIODATA8 (0x12A) reads back the written value in
+    /// most modes, but returns 0 in UART mode.
+    #[test]
+    fn siomlt_send_uart_reads_zero() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        // Multi mode: read back written value.
+        set_sio_mode(&mut io, &mut ic, &mut t, &mut d, &mut p, &mut k, 0x2000, 0);
+        io.write16(0x0400_012A, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_012A, &ic, &t, &d, &p, &k),
+            Some(0xFFFF),
+            "SIOMLT_SEND in Multi mode should read back written value"
+        );
+
+        // UART mode: reads as 0.
+        set_sio_mode(&mut io, &mut ic, &mut t, &mut d, &mut p, &mut k, 0x3000, 0);
+        io.write16(0x0400_012A, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_012A, &ic, &t, &d, &p, &k),
+            Some(0),
+            "SIODATA8 in UART mode should read 0"
+        );
+    }
+
+    /// RCNT (0x134) read mask varies by SIO mode. All modes clear bits
+    /// 9-13. Pin state bits 0-3 differ: Normal modes force bits 1,3 = 0;
+    /// JOY Bus forces bits 0,1 = 0.
+    #[test]
+    fn rcnt_mode_dependent_read_mask() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        // Multi-player: write 0x3FFF, expect 0x01FF.
+        set_sio_mode(&mut io, &mut ic, &mut t, &mut d, &mut p, &mut k, 0x2000, 0);
+        io.write16(0x0400_0134, 0x3FFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_0134, &ic, &t, &d, &p, &k),
+            Some(0x01FF),
+            "RCNT in Multi mode"
+        );
+
+        // Normal 8-bit: write 0x3FFF, expect 0x01F5.
+        set_sio_mode(&mut io, &mut ic, &mut t, &mut d, &mut p, &mut k, 0x0000, 0);
+        io.write16(0x0400_0134, 0x3FFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_0134, &ic, &t, &d, &p, &k),
+            Some(0x01F5),
+            "RCNT in Normal 8-bit mode"
+        );
+
+        // JOY Bus: write 0xFFFF, expect 0xC1FC.
+        io.write16(0x0400_0134, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        // RCNT=0xFFFF has bits 15-14 = 11 → JOY Bus mode.
+        assert_eq!(
+            io.try_read16(0x0400_0134, &ic, &t, &d, &p, &k),
+            Some(0xC1FC),
+            "RCNT in JOY Bus mode"
+        );
+    }
+
+    /// JOYCNT (0x140) is R/W with mask 0x0047. Bits 0-2 are
+    /// write-1-to-clear flags, bit 6 is a normal R/W bit.
+    /// Writing 0xFFFF to a zeroed JOYCNT results in 0x0040
+    /// (bits 0-2 cleared by W1C, bit 6 set).
+    #[test]
+    fn joycnt_read_mask_and_w1c() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        io.write16(0x0400_0140, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+        assert_eq!(
+            io.try_read16(0x0400_0140, &ic, &t, &d, &p, &k),
+            Some(0x0040),
+            "JOYCNT after writing 0xFFFF should be 0x0040"
+        );
+    }
+
+    /// JOY_RECV (0x150-0x152) and JOY_TRANS (0x154-0x156) always read
+    /// as 0 when disconnected.
+    #[test]
+    fn joy_recv_trans_always_read_zero() {
+        let mut io = IoRegisters::new();
+        let mut ic = InterruptController::new();
+        let mut t = Timers::new();
+        let mut d = DmaController::new();
+        let mut p = Ppu::new();
+        let mut k = Keypad::new();
+
+        for addr in [0x0400_0150, 0x0400_0152, 0x0400_0154, 0x0400_0156] {
+            io.write16(addr, 0xFFFF, &mut ic, &mut t, &mut d, &mut p, &mut k);
+            assert_eq!(
+                io.try_read16(addr, &ic, &t, &d, &p, &k),
+                Some(0),
+                "JOY register at {addr:#010X} should read 0"
             );
         }
     }

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -111,6 +111,10 @@ pub struct GbaBus {
     pub keypad: Keypad,
     /// Last value driven on the bus (used to model open-bus reads).
     last_bus_value: u32,
+    /// DMA internal data latch — separate from the CPU's open-bus register.
+    /// Updated only by DMA reads; DMA writes to restricted regions return
+    /// this value instead of the CPU's `last_bus_value`.
+    dma_latch: u32,
     /// Whether the BIOS is locked. After the boot ROM finishes executing,
     /// BIOS reads from outside the BIOS region return open-bus instead of
     /// the BIOS contents.
@@ -158,6 +162,7 @@ impl GbaBus {
             apu: Apu::new(),
             keypad: Keypad::new(),
             last_bus_value: 0,
+            dma_latch: 0,
             bios_locked: false,
             bios_image_loaded: false,
         }
@@ -335,6 +340,7 @@ impl GbaBus {
             sram: self.sram.clone(),
             bios_locked: self.bios_locked,
             last_bus_value: self.last_bus_value,
+            dma_latch: self.dma_latch,
         }
     }
 
@@ -372,6 +378,7 @@ impl GbaBus {
         }
         self.bios_locked = state.bios_locked;
         self.last_bus_value = state.last_bus_value;
+        self.dma_latch = state.dma_latch;
         Ok(())
     }
 
@@ -804,16 +811,32 @@ impl Bus for GbaBus {
 /// CPU stores.
 impl dma::DmaBus for GbaBus {
     fn dma_read16(&mut self, addr: u32) -> u16 {
-        <Self as Bus>::read16(self, addr)
+        // Swap in the DMA latch so open-bus reads return the DMA's own
+        // latched value rather than the CPU's last_bus_value.
+        let saved = self.last_bus_value;
+        self.last_bus_value = self.dma_latch;
+        let val = <Self as Bus>::read16(self, addr);
+        self.dma_latch = self.last_bus_value;
+        self.last_bus_value = saved;
+        val
     }
     fn dma_write16(&mut self, addr: u32, value: u16) {
+        let saved = self.last_bus_value;
         <Self as Bus>::write16(self, addr, value);
+        self.last_bus_value = saved;
     }
     fn dma_read32(&mut self, addr: u32) -> u32 {
-        <Self as Bus>::read32(self, addr)
+        let saved = self.last_bus_value;
+        self.last_bus_value = self.dma_latch;
+        let val = <Self as Bus>::read32(self, addr);
+        self.dma_latch = self.last_bus_value;
+        self.last_bus_value = saved;
+        val
     }
     fn dma_write32(&mut self, addr: u32, value: u32) {
+        let saved = self.last_bus_value;
         <Self as Bus>::write32(self, addr, value);
+        self.last_bus_value = saved;
     }
     fn dma_raise_irq(&mut self, sources: u16) {
         self.ic.raise(sources);
@@ -1267,5 +1290,97 @@ mod tests {
         bus.write16(0x0600_FFE0, 0xBB66);
         bus.write8(0x0600_FFE0, 0xD8);
         assert_eq!(bus.read16(0x0600_FFE0), 0xD8D8);
+    }
+
+    #[test]
+    fn dma_read32_uses_dma_latch_not_cpu_bus_value() {
+        // The DMA controller has its own internal data latch, separate from
+        // the CPU's open-bus value. When DMA reads from a restricted region
+        // (e.g. locked BIOS), it returns the DMA latch — not the CPU's
+        // last_bus_value.
+        use crate::gba::bus::dma::DmaBus;
+        let mut bus = GbaBus::new();
+        bus.lock_bios();
+
+        // Write known data to IWRAM.
+        bus.write32(0x0300_0000, 0xCAFE_BABE);
+
+        // DMA reads IWRAM → primes the DMA latch.
+        let val = bus.dma_read32(0x0300_0000);
+        assert_eq!(val, 0xCAFE_BABE);
+
+        // CPU reads from EWRAM → changes last_bus_value but NOT DMA latch.
+        bus.write32(0x0200_0000, 0xDEAD_BEEF);
+        let _ = bus.read32(0x0200_0000);
+
+        // DMA reads locked BIOS → should get DMA latch (0xCAFE_BABE),
+        // not the CPU's last_bus_value (0xDEAD_BEEF).
+        let bios_val = bus.dma_read32(0x0000_0000);
+        assert_eq!(bios_val, 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn dma_read16_uses_dma_latch_halfword() {
+        // 16-bit DMA reads should update only half the DMA latch, matching
+        // the halfword alignment within the 32-bit latch register.
+        use crate::gba::bus::dma::DmaBus;
+        let mut bus = GbaBus::new();
+        bus.lock_bios();
+
+        // Prime DMA latch via two 16-bit reads from IWRAM.
+        bus.write32(0x0300_0000, 0xAAAA_BBBB);
+        let _ = bus.dma_read16(0x0300_0000); // low half → 0xBBBB
+        let _ = bus.dma_read16(0x0300_0002); // high half → 0xAAAA
+        // DMA latch is now 0xAAAA_BBBB.
+
+        // CPU activity changes last_bus_value.
+        bus.write32(0x0200_0000, 0x1111_2222);
+        let _ = bus.read32(0x0200_0000);
+
+        // DMA reads locked BIOS at aligned addr → returns DMA latch low half.
+        let bios_lo = bus.dma_read16(0x0000_0000);
+        assert_eq!(bios_lo, 0xBBBB);
+    }
+
+    #[test]
+    fn dma_read_does_not_corrupt_cpu_last_bus_value() {
+        // DMA reads must not change the CPU's open-bus value.
+        use crate::gba::bus::dma::DmaBus;
+        let mut bus = GbaBus::new();
+
+        // Pre-populate IWRAM before setting the CPU sentinel.
+        bus.write32(0x0300_0000, 0xBEEF_CAFE);
+
+        // Set CPU's last_bus_value to a known sentinel.
+        bus.write32(0x0200_0000, 0x5555_6666);
+        let _ = bus.read32(0x0200_0000);
+
+        // DMA reads from IWRAM — must not disturb CPU bus value.
+        let _ = bus.dma_read32(0x0300_0000);
+
+        // CPU's open-bus should still return the sentinel, not the DMA value.
+        // Read from a region that returns open-bus (locked BIOS).
+        bus.lock_bios();
+        let cpu_open = bus.read32(0x0000_0000);
+        assert_eq!(cpu_open, 0x5555_6666);
+    }
+
+    #[test]
+    fn dma_write_does_not_corrupt_cpu_last_bus_value() {
+        // DMA writes must not change the CPU's open-bus value.
+        use crate::gba::bus::dma::DmaBus;
+        let mut bus = GbaBus::new();
+
+        // Set CPU's last_bus_value to a known sentinel.
+        bus.write32(0x0200_0000, 0xAAAA_BBBB);
+        let _ = bus.read32(0x0200_0000);
+
+        // DMA writes to EWRAM — must not disturb CPU bus value.
+        bus.dma_write32(0x0200_1000, 0xDEAD_BEEF);
+
+        // CPU's open-bus should still return the sentinel.
+        bus.lock_bios();
+        let cpu_open = bus.read32(0x0000_0000);
+        assert_eq!(cpu_open, 0xAAAA_BBBB);
     }
 }

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -448,16 +448,11 @@ impl GbaBus {
     }
 
     /// Map the cartridge ROM with mirroring across the three wait-state
-    /// regions. The ROM is intentionally mirrored within its 32 MB window
-    /// (the cart bus repeats the inserted image), so this only returns
-    /// `None` when no cartridge is inserted at all — in which case callers
-    /// substitute the GBATek "no-cart" open-bus pattern.
+    /// regions. Returns `None` when no cartridge is inserted or when the
+    /// offset falls beyond the ROM image — callers substitute the GBATek
+    /// "no-cart" open-bus pattern (addr >> 1).
     fn rom_byte(&self, offset: usize) -> Option<u8> {
-        if self.rom.is_empty() {
-            return None;
-        }
-        // ROM is mirrored within its 32 MB window.
-        Some(self.rom[offset % self.rom.len()])
+        self.rom.get(offset).copied()
     }
 
     /// Read a 16-bit little-endian halfword from cart ROM, respecting
@@ -781,11 +776,17 @@ impl Bus for GbaBus {
                 self.pram[off + 1] = value;
             }
             0x6 => {
-                // Byte writes to VRAM duplicate; ignored for OBJ region in
-                // bitmap modes — modelling the simple case here.
-                let off = vram_offset(addr) & !1;
-                self.vram[off] = value;
-                self.vram[off + 1] = value;
+                // Byte writes to BG VRAM duplicate the byte to a halfword.
+                // Byte writes to OBJ VRAM (offset >= 0x10000) are ignored.
+                // TODO: In bitmap modes 3/5, the BG/OBJ boundary is 0x14000
+                // rather than 0x10000. This threshold is correct for tile modes
+                // (0-2) and mode 4, but needs DISPCNT check for full accuracy.
+                let off = vram_offset(addr);
+                if off < 0x10000 {
+                    let aligned = off & !1;
+                    self.vram[aligned] = value;
+                    self.vram[aligned + 1] = value;
+                }
             }
             0x7 => { /* OAM ignores byte writes */ }
             0x8..=0xD => {}
@@ -1202,5 +1203,69 @@ mod tests {
         let mut bus = GbaBus::new();
         bus.write16(crate::gba::input::REG_KEYINPUT, 0x0000);
         assert_eq!(bus.read16(crate::gba::input::REG_KEYINPUT), 0x03FF);
+    }
+
+    // ---------------------------------------------------------------
+    // ROM out-of-bounds reads return addr>>1 pattern (open bus)
+    // Per GBATek: when reading beyond ROM size, the cartridge bus
+    // returns the halfword address / 2 (i.e., addr >> 1).
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn rom_oob_read16_returns_addr_shr1() {
+        let mut bus = GbaBus::new();
+        // Load a small 256-byte ROM.
+        bus.load_rom(&[0u8; 256]);
+        // Address 0x0924_68AC is well beyond 256 bytes.
+        let v = bus.read16(0x0924_68AC);
+        // Expected: (0x092468AC >> 1) & 0xFFFF = 0x3456
+        assert_eq!(v, 0x3456);
+    }
+
+    #[test]
+    fn rom_oob_read32_returns_addr_shr1_pattern() {
+        let mut bus = GbaBus::new();
+        bus.load_rom(&[0u8; 256]);
+        let v = bus.read32(0x0924_68AC);
+        // Low halfword: (0x092468AC >> 1) & 0xFFFF = 0x3456
+        // High halfword: (0x092468AE >> 1) & 0xFFFF = 0x3457
+        assert_eq!(v, 0x3457_3456);
+    }
+
+    #[test]
+    fn rom_oob_read8_returns_addr_shr1_byte() {
+        let mut bus = GbaBus::new();
+        bus.load_rom(&[0u8; 256]);
+        // 0x092468AC >> 1 = 0x049234D6 → halfword 0x3456
+        // byte 0 (even) = 0x56, byte 1 (odd) = 0x34
+        assert_eq!(bus.read8(0x0924_68AC), 0x56);
+        assert_eq!(bus.read8(0x0924_68AD), 0x34);
+    }
+
+    // ---------------------------------------------------------------
+    // VRAM OBJ region byte writes must be ignored
+    // Per GBATek: byte writes to OBJ tile VRAM (offset >= 0x10000
+    // in modes 0-2, >= 0x14000 in modes 3-5) are ignored.
+    // The mgba suite tests non-bitmap mode (modes 0-2).
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn vram_obj_byte_write_is_ignored() {
+        let mut bus = GbaBus::new();
+        // Write initial data to OBJ VRAM (0x06010000+).
+        bus.write16(0x0601_0000, 0xBB66);
+        // Byte write to OBJ VRAM should be ignored.
+        bus.write8(0x0601_0000, 0xD8);
+        // Original data should be unchanged.
+        assert_eq!(bus.read16(0x0601_0000), 0xBB66);
+    }
+
+    #[test]
+    fn vram_bg_byte_write_still_duplicates() {
+        let mut bus = GbaBus::new();
+        // BG VRAM (< 0x06010000) byte writes should still duplicate.
+        bus.write16(0x0600_FFE0, 0xBB66);
+        bus.write8(0x0600_FFE0, 0xD8);
+        assert_eq!(bus.read16(0x0600_FFE0), 0xD8D8);
     }
 }

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -1056,9 +1056,9 @@ mod tests {
         // REG_DISPCNT (0x04000000)
         bus.write16(0x0400_0000, 0x1234);
         assert_eq!(bus.read16(0x0400_0000), 0x1234);
-        // A random unimplemented register stretching the dispatch.
-        bus.write16(0x0400_0050, 0xBEEF);
-        assert_eq!(bus.read16(0x0400_0050), 0xBEEF);
+        // WAITCNT (0x04000204) — unimplemented, round-trips via backing store.
+        bus.write16(0x0400_0204, 0xBEEF);
+        assert_eq!(bus.read16(0x0400_0204), 0xBEEF);
     }
 
     #[test]

--- a/src/gba/console/save_state.rs
+++ b/src/gba/console/save_state.rs
@@ -50,6 +50,9 @@ pub struct BusMemoryState {
     pub bios_locked: bool,
     /// Last value driven on the bus (used to model open-bus reads).
     pub last_bus_value: u32,
+    /// DMA internal data latch (separate from CPU open-bus).
+    #[serde(default)]
+    pub dma_latch: u32,
 }
 
 /// Complete Game Boy Advance emulator state snapshot.

--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -549,24 +549,24 @@ fn execute_multiply(regs: &mut Registers, instr: u32) -> ExecOutcome {
     let rs_val = regs.r[rs];
 
     let product = rm_val.wrapping_mul(rs_val);
-    let result = if acc {
-        product.wrapping_add(regs.r[rn])
-    } else {
-        product
-    };
+    let accum_val = if acc { regs.r[rn] } else { 0 };
+    let result = product.wrapping_add(accum_val);
 
     regs.r[rd] = result;
+
+    let (cycles, full) = multiply_cycles_and_full(rs_val, true);
 
     if s_bit {
         let n = result & 0x8000_0000 != 0;
         let z = result == 0;
-        // C and V flags are UNPREDICTABLE after MUL/MLA per ARM spec; preserve them.
-        regs.set_nzcv(n, z, regs.c_flag(), regs.v_flag());
+        let c = if full {
+            multiply_carry_simple(rs_val)
+        } else {
+            multiply_carry_lo(rm_val, rs_val, accum_val)
+        };
+        regs.set_nzcv(n, z, c, regs.v_flag());
     }
 
-    // Cycle count: 1S + mI where mI depends on Rs magnitude (early termination).
-    // Uses cycle-accurate timing based on Rs byte positions containing all 0s or all 1s.
-    let cycles = multiply_cycles(rs_val);
     ExecOutcome::cycles(cycles)
 }
 
@@ -592,8 +592,14 @@ fn execute_long_multiply(regs: &mut Registers, instr: u32) -> ExecOutcome {
         rm_val as u64 * rs_val as u64
     };
 
+    let (accum_lo, accum_hi) = if acc {
+        (regs.r[rd_lo], regs.r[rd_hi])
+    } else {
+        (0, 0)
+    };
+
     let result = if acc {
-        let existing = ((regs.r[rd_hi] as u64) << 32) | (regs.r[rd_lo] as u64);
+        let existing = ((accum_hi as u64) << 32) | (accum_lo as u64);
         product.wrapping_add(existing)
     } else {
         product
@@ -602,36 +608,168 @@ fn execute_long_multiply(regs: &mut Registers, instr: u32) -> ExecOutcome {
     regs.r[rd_lo] = result as u32;
     regs.r[rd_hi] = (result >> 32) as u32;
 
+    let (cycles, full) = long_multiply_cycles(rs_val, signed);
+
     if s_bit {
         let n = (result >> 63) & 1 != 0;
         let z = result == 0;
-        // C and V flags are UNPREDICTABLE; preserve them.
-        regs.set_nzcv(n, z, regs.c_flag(), regs.v_flag());
+        let c = if full {
+            multiply_carry_hi(rm_val, rs_val, accum_hi, signed)
+        } else {
+            multiply_carry_lo(rm_val, rs_val, accum_lo)
+        };
+        regs.set_nzcv(n, z, c, regs.v_flag());
     }
 
-    // Long multiply takes slightly more cycles than short multiply.
-    let cycles = long_multiply_cycles(rs_val);
     ExecOutcome::cycles(cycles)
 }
 
 /// Compute multiply internal cycles based on Rs magnitude (early termination).
 /// Per GBATek, cycles = 1S + mI where mI = 1..4 depending on Rs[31:8].
-fn multiply_cycles(rs: u32) -> u8 {
-    // Check how many leading bytes are all 0s or all 1s (sign extension).
-    if rs & 0xFFFF_FF00 == 0 || rs & 0xFFFF_FF00 == 0xFFFF_FF00 {
-        2 // 1S + 1I
-    } else if rs & 0xFFFF_0000 == 0 || rs & 0xFFFF_0000 == 0xFFFF_0000 {
-        3 // 1S + 2I
-    } else if rs & 0xFF00_0000 == 0 || rs & 0xFF00_0000 == 0xFF00_0000 {
-        4 // 1S + 3I
+/// Also returns whether the multiplier used all 4 cycles (no early termination),
+/// which determines how the C flag is computed.
+pub(crate) fn multiply_cycles_and_full(rs: u32, signed: bool) -> (u8, bool) {
+    if signed {
+        if rs & 0xFFFF_FF00 == 0 || rs & 0xFFFF_FF00 == 0xFFFF_FF00 {
+            (2, false)
+        } else if rs & 0xFFFF_0000 == 0 || rs & 0xFFFF_0000 == 0xFFFF_0000 {
+            (3, false)
+        } else if rs & 0xFF00_0000 == 0 || rs & 0xFF00_0000 == 0xFF00_0000 {
+            (4, false)
+        } else {
+            (5, true) // full 4 internal cycles, no early termination
+        }
+    } else if rs & 0xFFFF_FF00 == 0 {
+        (2, false)
+    } else if rs & 0xFFFF_0000 == 0 {
+        (3, false)
+    } else if rs & 0xFF00_0000 == 0 {
+        (4, false)
     } else {
-        5 // 1S + 4I
+        (5, true)
     }
 }
 
 /// Long multiply cycles: similar to multiply but +1 for 64-bit result.
-fn long_multiply_cycles(rs: u32) -> u8 {
-    multiply_cycles(rs) + 1
+fn long_multiply_cycles(rs: u32, signed: bool) -> (u8, bool) {
+    let (cycles, full) = multiply_cycles_and_full(rs, signed);
+    (cycles + 1, full)
+}
+
+// ---------------------------------------------------------------------------
+// ARM7TDMI Booth multiplier carry flag computation
+// ---------------------------------------------------------------------------
+//
+// The ARM spec says the C flag after multiply is "unpredictable", but real
+// ARM7TDMI hardware produces deterministic values from the internal Booth
+// carry-save adder. The C flag is the carry-out from the final Booth
+// iteration, which depends on the operand values and whether the multiplier
+// terminated early.
+//
+// Algorithm based on analysis of ARM7TDMI Booth multiplier internals.
+// Reference: zaydlang & calc84maniac's research, verified against
+// NanoBoyAdvance (GPL-3.0) and mgba-emu/suite hardware test data.
+
+/// C flag for regular MUL/MLA when the Booth multiplier ran all 4 cycles.
+/// The carry comes from the final injected Booth carry bit; the last addend
+/// is negative only when the upper 2 bits of the multiplier are 0b10.
+pub(crate) fn multiply_carry_simple(multiplier: u32) -> bool {
+    (multiplier >> 30) == 2
+}
+
+/// C flag from the low partial result, used when the Booth multiplier
+/// terminated early (for both MUL and long multiply).
+///
+/// Simulates the carry-save adder processing Rs in Booth-encoded pairs,
+/// tracking the carry bit through the iterations.
+pub(crate) fn multiply_carry_lo(multiplicand: u32, multiplier: u32, accum: u32) -> bool {
+    // Set low bit to cause negation to invert upper bits.
+    // This bit can't propagate to the carry output.
+    let multiplicand = multiplicand | 1;
+
+    // First Booth iteration: factor is sign-extension of bit 0
+    let booth: i32 = ((multiplier as i32) << 31) >> 31;
+    let carry = multiplicand.wrapping_mul(booth as u32);
+    let sum = carry.wrapping_add(accum);
+
+    let mut current_booth = booth;
+    let mut current_carry = carry;
+    let mut current_sum = sum;
+    let mut current_accum = accum;
+
+    let mut shift: i32 = 29;
+    loop {
+        // Process 8 multiplier bits using 4 Booth iterations
+        for _ in 0..4 {
+            let next_booth: i32 = ((multiplier as i32) << shift) >> shift;
+            let factor = next_booth.wrapping_sub(current_booth);
+            current_booth = next_booth;
+            let addend = multiplicand.wrapping_mul(factor as u32);
+            current_accum ^= current_carry ^ addend;
+            current_sum = current_sum.wrapping_add(addend);
+            current_carry = current_sum.wrapping_sub(current_accum);
+            shift -= 2;
+        }
+        if current_booth == multiplier as i32 {
+            break;
+        }
+    }
+
+    (current_carry >> 31) != 0
+}
+
+/// C flag from the high partial result for long multiply when all 4 Booth
+/// cycles were used. Handles both signed and unsigned variants.
+///
+/// Only the last 3 Booth iterations matter for the bit-63 carry. The inputs
+/// are scaled down so that the upper bits of the 64-bit addends fit in 32 bits.
+fn multiply_carry_hi(multiplicand: u32, multiplier: u32, accum_hi: u32, signed: bool) -> bool {
+    // Scale inputs: only last 3 Booth iterations (6 bits of multiplier) matter.
+    let (md, mp) = if signed {
+        (
+            (multiplicand as i32 >> 6) as u32,
+            (multiplier as i32 >> 26) as u32,
+        )
+    } else {
+        (multiplicand >> 6, multiplier >> 26)
+    };
+    let md = md | 1; // Set low bit for negation handling
+
+    // Pre-populate magic bit 61 for carry
+    let carry = (!accum_hi) & 0x2000_0000;
+    // Pre-populate magic bits 63-60 for accum (with carry magic pre-added)
+    let accum = accum_hi.wrapping_sub(0x0800_0000);
+
+    // Get Booth factors for last 3 iterations
+    let booth0: i32 = ((mp as i32) << 27) >> 27;
+    let booth1: i32 = ((mp as i32) << 29) >> 29;
+    let booth2: i32 = ((mp as i32) << 31) >> 31;
+    let factor0 = (mp as i32).wrapping_sub(booth0) as u32;
+    let factor1 = booth0.wrapping_sub(booth1) as u32;
+    let factor2 = booth1.wrapping_sub(booth2) as u32;
+
+    // Get scaled value of 3rd-last Booth addend
+    let addend2 = md.wrapping_mul(factor2);
+    // Finalize bits 61-60 of accum magic using its sign
+    let accum = accum.wrapping_sub(addend2 & 0x1000_0000);
+
+    // Get scaled value of 2nd-last Booth addend
+    let addend1 = md.wrapping_mul(factor1);
+    // Finalize bits 63-62 of accum magic using its sign
+    let accum = accum.wrapping_sub(addend1 & 0x4000_0000);
+
+    // Get carry from carry-save add in bit 61 and propagate to bit 62
+    let sum = accum.wrapping_add(addend1 & 0x2000_0000);
+    // Subtract carry magic to get actual accum magic
+    let accum = accum.wrapping_sub(carry);
+
+    // Get scaled value of last Booth addend
+    let addend0 = md.wrapping_mul(factor0);
+    // Add to bit 62 and propagate carry
+    let sum = sum.wrapping_add(addend0 & 0x4000_0000);
+
+    // Cancel out accum magic bit 63 to get carry bit 63
+    ((sum ^ accum) >> 31) != 0
 }
 
 // ---------------------------------------------------------------------------
@@ -1460,6 +1598,115 @@ mod tests {
         execute(&mut regs, &mut bus, instr);
         assert!(regs.n_flag());
         assert!(!regs.z_flag());
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiply C flag (ARM7TDMI Booth carry) Tests
+    // -------------------------------------------------------------------------
+    // The ARM spec says C/V are "unpredictable" after multiply, but real
+    // ARM7TDMI hardware produces deterministic C values from the internal
+    // Booth multiplier carry-save adder. These tests verify that behavior
+    // using known input/output pairs from mgba-emu/suite's multiply-long.c.
+    //
+    // Test format: flags are cleared to 0 before each multiply (matching
+    // mgba suite's `msr cpsr_f, #0`), then we check the C flag after.
+
+    /// Helper: execute SMULLS with cleared flags, return (result_lo, result_hi, c_flag).
+    fn smulls_with_cleared_flags(rm: u32, rs: u32) -> (u32, u32, bool) {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = rm;
+        regs.r[1] = rs;
+        // Clear all flags to 0
+        regs.set_nzcv(false, false, false, false);
+        // SMULLS R2, R3, R0, R1
+        let instr = arm_long_mul(0xE, true, false, true, 3, 2, 1, 0);
+        execute(&mut regs, &mut bus, instr);
+        (regs.r[2], regs.r[3], regs.c_flag())
+    }
+
+    /// Helper: execute UMULLS with cleared flags, return (result_lo, result_hi, c_flag).
+    fn umulls_with_cleared_flags(rm: u32, rs: u32) -> (u32, u32, bool) {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = rm;
+        regs.r[1] = rs;
+        regs.set_nzcv(false, false, false, false);
+        // UMULLS R2, R3, R0, R1
+        let instr = arm_long_mul(0xE, false, false, true, 3, 2, 1, 0);
+        execute(&mut regs, &mut bus, instr);
+        (regs.r[2], regs.r[3], regs.c_flag())
+    }
+
+    #[test]
+    fn smulls_c_flag_zero_times_0x80000000() {
+        // SMULLS: 0 * 0x80000000 → result=0, expected C=1
+        // (mgba suite test case #25)
+        let (lo, hi, c) = smulls_with_cleared_flags(0x0000_0000, 0x8000_0000);
+        assert_eq!(lo, 0);
+        assert_eq!(hi, 0);
+        assert!(c, "SMULLS 0 * 0x80000000: C should be 1");
+    }
+
+    #[test]
+    fn smulls_c_flag_neg1_times_0x7fffffff() {
+        // SMULLS: -1 * 0x7FFFFFFF → result=0xFFFFFFFF_80000001, expected C=1
+        // (mgba suite test case #21)
+        let (lo, hi, c) = smulls_with_cleared_flags(0xFFFF_FFFF, 0x7FFF_FFFF);
+        assert_eq!(lo, 0x8000_0001);
+        assert_eq!(hi, 0xFFFF_FFFF);
+        assert!(c, "SMULLS -1 * 0x7FFFFFFF: C should be 1");
+    }
+
+    #[test]
+    fn smulls_c_flag_1_times_1_no_carry() {
+        // SMULLS: 1 * 1 → result=1, expected C=0
+        // (mgba suite test case #7)
+        let (lo, hi, c) = smulls_with_cleared_flags(0x0000_0001, 0x0000_0001);
+        assert_eq!(lo, 1);
+        assert_eq!(hi, 0);
+        assert!(!c, "SMULLS 1 * 1: C should be 0");
+    }
+
+    #[test]
+    fn umulls_c_flag_neg1_times_neg1() {
+        // UMULLS: 0xFFFFFFFF * 0xFFFFFFFF → 0xFFFFFFFE_00000001, expected C=1
+        // (mgba suite test case #15)
+        let (lo, hi, c) = umulls_with_cleared_flags(0xFFFF_FFFF, 0xFFFF_FFFF);
+        assert_eq!(lo, 0x0000_0001);
+        assert_eq!(hi, 0xFFFF_FFFE);
+        assert!(c, "UMULLS 0xFFFFFFFF * 0xFFFFFFFF: C should be 1");
+    }
+
+    #[test]
+    fn umulls_c_flag_0x80000000_times_0x80000000() {
+        // UMULLS: 0x80000000 * 0x80000000 → 0x40000000_00000000, expected C=1
+        // (mgba suite test case #29)
+        let (lo, hi, c) = umulls_with_cleared_flags(0x8000_0000, 0x8000_0000);
+        assert_eq!(lo, 0x0000_0000);
+        assert_eq!(hi, 0x4000_0000);
+        assert!(c, "UMULLS 0x80000000 * 0x80000000: C should be 1");
+    }
+
+    #[test]
+    fn umulls_c_flag_1_times_1_no_carry() {
+        // UMULLS: 1 * 1 → result=1, expected C=0
+        let (lo, hi, c) = umulls_with_cleared_flags(0x0000_0001, 0x0000_0001);
+        assert_eq!(lo, 1);
+        assert_eq!(hi, 0);
+        assert!(!c, "UMULLS 1 * 1: C should be 0");
+    }
+
+    #[test]
+    fn umulls_c_flag_asymmetric_operand_order() {
+        // UMULLS: operand order matters for C flag on ARM7TDMI
+        // 0x7FFFFFFF * 0x80000000: C=0 (rm=0x7F, rs=0x80)
+        let (_, _, c1) = umulls_with_cleared_flags(0x7FFF_FFFF, 0x8000_0000);
+        assert!(!c1, "UMULLS 0x7FFFFFFF * 0x80000000: C should be 0");
+
+        // 0x80000000 * 0x7FFFFFFF: C=1 (rm=0x80, rs=0x7F)
+        let (_, _, c2) = umulls_with_cleared_flags(0x8000_0000, 0x7FFF_FFFF);
+        assert!(c2, "UMULLS 0x80000000 * 0x7FFFFFFF: C should be 1");
     }
 
     // -------------------------------------------------------------------------

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -366,6 +366,17 @@ impl Arm7tdmi {
                 self.halted = true;
                 true
             }
+            0x0B => {
+                // CpuSet: memory copy/fill using 16-bit or 32-bit units.
+                self.hle_cpu_set(bus);
+                true
+            }
+            0x0C => {
+                // CpuFastSet: memory copy/fill using 32-bit units, count
+                // rounded up to a multiple of 8.
+                self.hle_cpu_fast_set(bus);
+                true
+            }
             _ => {
                 #[cfg(test)]
                 {
@@ -375,6 +386,77 @@ impl Arm7tdmi {
                 }
                 false
             }
+        }
+    }
+
+    /// HLE implementation of SWI 0x0B — CpuSet.
+    ///
+    /// r0 = source address, r1 = destination address,
+    /// r2 = count + flags (bit 26: 0=16-bit, 1=32-bit; bit 24: 0=copy, 1=fill).
+    fn hle_cpu_set<B: Bus>(&mut self, bus: &mut B) {
+        let src = self.regs.r[0];
+        let dst = self.regs.r[1];
+        let ctrl = self.regs.r[2];
+        let count = ctrl & 0x001F_FFFF;
+        let word_mode = ctrl & (1 << 26) != 0;
+        let fill_mode = ctrl & (1 << 24) != 0;
+
+        if word_mode {
+            let src_aligned = src & !3;
+            let dst_aligned = dst & !3;
+            let fill_val = if fill_mode {
+                bus.read32(src_aligned)
+            } else {
+                0
+            };
+            for i in 0..count {
+                let val = if fill_mode {
+                    fill_val
+                } else {
+                    bus.read32(src_aligned.wrapping_add(i * 4))
+                };
+                bus.write32(dst_aligned.wrapping_add(i * 4), val);
+            }
+        } else {
+            let src_aligned = src & !1;
+            let dst_aligned = dst & !1;
+            let fill_val = if fill_mode {
+                bus.read16(src_aligned)
+            } else {
+                0
+            };
+            for i in 0..count {
+                let val = if fill_mode {
+                    fill_val
+                } else {
+                    bus.read16(src_aligned.wrapping_add(i * 2))
+                };
+                bus.write16(dst_aligned.wrapping_add(i * 2), val);
+            }
+        }
+    }
+
+    /// HLE implementation of SWI 0x0C — CpuFastSet.
+    ///
+    /// r0 = source address, r1 = destination address,
+    /// r2 = count + flags (bit 24: 0=copy, 1=fill).
+    /// Always 32-bit transfers; count is rounded up to a multiple of 8.
+    fn hle_cpu_fast_set<B: Bus>(&mut self, bus: &mut B) {
+        let src = self.regs.r[0] & !3;
+        let dst = self.regs.r[1] & !3;
+        let ctrl = self.regs.r[2];
+        let raw_count = ctrl & 0x001F_FFFF;
+        let count = (raw_count + 7) & !7; // round up to multiple of 8
+        let fill_mode = ctrl & (1 << 24) != 0;
+
+        let fill_val = if fill_mode { bus.read32(src) } else { 0 };
+        for i in 0..count {
+            let val = if fill_mode {
+                fill_val
+            } else {
+                bus.read32(src.wrapping_add(i * 4))
+            };
+            bus.write32(dst.wrapping_add(i * 4), val);
         }
     }
 }
@@ -712,5 +794,134 @@ mod tests {
         );
         assert!(!cpu.regs.thumb(), "T bit should be clear (ARM state)");
         assert_eq!(cpu.regs.r[15], ExceptionVector::Undefined as u32);
+    }
+
+    // ---------------------------------------------------------------
+    // CpuSet (SWI 0x0B) and CpuFastSet (SWI 0x0C) HLE tests
+    // ---------------------------------------------------------------
+
+    /// Helper: create a CPU + bus for HLE SWI tests.
+    /// Returns CPU at PC=0 in ARM mode with hle_swi=true and a 4KB RamBus.
+    fn hle_setup() -> (Arm7tdmi, RamBus) {
+        let mut cpu = Arm7tdmi::new();
+        cpu.hle_swi = true;
+        cpu.regs.switch_mode(CpuMode::User);
+        cpu.regs.r[15] = 0x0;
+        let bus = RamBus::new(0x1000);
+        (cpu, bus)
+    }
+
+    #[test]
+    fn hle_cpu_set_copies_halfwords() {
+        // CpuSet(src=0x100, dst=0x200, count=4 | size=16bit | copy mode)
+        // Should copy 4 halfwords (8 bytes) from 0x100 to 0x200.
+        let (mut cpu, mut bus) = hle_setup();
+
+        // Write source data at 0x100.
+        bus.write16(0x100, 0xCAFE);
+        bus.write16(0x102, 0xBABE);
+        bus.write16(0x104, 0xDEAD);
+        bus.write16(0x106, 0xBEEF);
+
+        // SWI 0x0B (CpuSet): ARM encoding 0xEF0B0000
+        write_arm_word(&mut bus, 0x0, 0xEF0B_0000);
+
+        cpu.regs.r[0] = 0x100; // source
+        cpu.regs.r[1] = 0x200; // destination
+        cpu.regs.r[2] = 4; // count=4, bit24=0 (16-bit), bit25=0 (copy)
+        cpu.step(&mut bus);
+
+        assert_eq!(bus.read16(0x200), 0xCAFE);
+        assert_eq!(bus.read16(0x202), 0xBABE);
+        assert_eq!(bus.read16(0x204), 0xDEAD);
+        assert_eq!(bus.read16(0x206), 0xBEEF);
+    }
+
+    #[test]
+    fn hle_cpu_set_copies_words() {
+        // CpuSet with bit26=1 (32-bit copy)
+        let (mut cpu, mut bus) = hle_setup();
+
+        bus.write32(0x100, 0xDEAD_BEEF);
+        bus.write32(0x104, 0xCAFE_BABE);
+
+        write_arm_word(&mut bus, 0x0, 0xEF0B_0000);
+
+        cpu.regs.r[0] = 0x100;
+        cpu.regs.r[1] = 0x200;
+        cpu.regs.r[2] = 2 | (1 << 26); // count=2, bit26=1 (32-bit), copy
+        cpu.step(&mut bus);
+
+        assert_eq!(bus.read32(0x200), 0xDEAD_BEEF);
+        assert_eq!(bus.read32(0x204), 0xCAFE_BABE);
+    }
+
+    #[test]
+    fn hle_cpu_set_fill_mode_replicates_first_value() {
+        // CpuSet with bit24=1 (fill), bit26=1 (32-bit): copies first source value repeatedly.
+        let (mut cpu, mut bus) = hle_setup();
+
+        bus.write32(0x100, 0xA5A5_A5A5);
+
+        write_arm_word(&mut bus, 0x0, 0xEF0B_0000);
+
+        cpu.regs.r[0] = 0x100;
+        cpu.regs.r[1] = 0x200;
+        // count=4, bit26=1 (32-bit), bit24=1 (fill)
+        cpu.regs.r[2] = 4 | (1 << 26) | (1 << 24);
+        cpu.step(&mut bus);
+
+        assert_eq!(bus.read32(0x200), 0xA5A5_A5A5);
+        assert_eq!(bus.read32(0x204), 0xA5A5_A5A5);
+        assert_eq!(bus.read32(0x208), 0xA5A5_A5A5);
+        assert_eq!(bus.read32(0x20C), 0xA5A5_A5A5);
+    }
+
+    #[test]
+    fn hle_cpu_fast_set_copies_words() {
+        // CpuFastSet (SWI 0x0C): always 32-bit, count rounded to multiple of 8.
+        let (mut cpu, mut bus) = hle_setup();
+
+        for i in 0u32..8 {
+            bus.write32(0x100 + i * 4, 0x1000_0000 + i);
+        }
+
+        write_arm_word(&mut bus, 0x0, 0xEF0C_0000);
+
+        cpu.regs.r[0] = 0x100;
+        cpu.regs.r[1] = 0x200;
+        cpu.regs.r[2] = 8; // count=8, bit24=0 (copy)
+        cpu.step(&mut bus);
+
+        for i in 0u32..8 {
+            assert_eq!(
+                bus.read32(0x200 + i * 4),
+                0x1000_0000 + i,
+                "CpuFastSet word {i} mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn hle_cpu_fast_set_fill_mode() {
+        // CpuFastSet fill: replicate first source word, count rounded to 8.
+        let (mut cpu, mut bus) = hle_setup();
+
+        bus.write32(0x100, 0xBEEF_CAFE);
+
+        write_arm_word(&mut bus, 0x0, 0xEF0C_0000);
+
+        cpu.regs.r[0] = 0x100;
+        cpu.regs.r[1] = 0x200;
+        cpu.regs.r[2] = 3 | (1 << 24); // count=3, fill. Rounds up to 8.
+        cpu.step(&mut bus);
+
+        for i in 0u32..8 {
+            assert_eq!(
+                bus.read32(0x200 + i * 4),
+                0xBEEF_CAFE,
+                "CpuFastSet fill word {i} mismatch"
+            );
+        }
     }
 }

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -328,10 +328,9 @@ impl Arm7tdmi {
     /// SWI was handled (caller should skip normal BIOS dispatch).
     ///
     /// Reads the SWI number from the prefetched instruction. Currently
-    /// handles:
-    /// - **0x02 (Halt)**: halt CPU until any enabled interrupt.
-    /// - **0x05 (VBlankIntrWait)**: set IME=1, clear VBlank in IntrCheck
-    ///   at 0x03007FF8, halt CPU.
+    /// handles Halt (0x02), VBlankIntrWait (0x05), Div (0x06), DivArm
+    /// (0x07), Sqrt (0x08), ArcTan (0x09), ArcTan2 (0x0A), CpuSet
+    /// (0x0B), and CpuFastSet (0x0C).
     fn try_hle_swi<B: Bus>(&mut self, bus: &mut B) -> bool {
         if !self.hle_swi {
             return false;

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -377,6 +377,31 @@ impl Arm7tdmi {
                 self.hle_cpu_fast_set(bus);
                 true
             }
+            0x06 => {
+                // Div: signed integer division.
+                self.hle_div();
+                true
+            }
+            0x07 => {
+                // DivArm: same as Div but with swapped arguments.
+                self.hle_div_arm();
+                true
+            }
+            0x08 => {
+                // Sqrt: integer square root.
+                self.hle_sqrt();
+                true
+            }
+            0x09 => {
+                // ArcTan: fixed-point arctangent.
+                self.hle_arctan();
+                true
+            }
+            0x0A => {
+                // ArcTan2: fixed-point atan2.
+                self.hle_arctan2();
+                true
+            }
             _ => {
                 #[cfg(test)]
                 {
@@ -458,6 +483,132 @@ impl Arm7tdmi {
             };
             bus.write32(dst.wrapping_add(i * 4), val);
         }
+    }
+
+    /// HLE implementation of SWI 0x06 — Div.
+    ///
+    /// r0 = numerator, r1 = denominator →
+    /// r0 = quotient, r1 = remainder, r3 = abs(quotient).
+    fn hle_div(&mut self) {
+        let num = self.regs.r[0] as i32;
+        let denom = self.regs.r[1] as i32;
+
+        if denom == 0 {
+            // GBA BIOS div-by-zero behavior: return sign(num) as quotient.
+            self.regs.r[0] = if num < 0 { (-1i32) as u32 } else { 1 };
+            self.regs.r[1] = num as u32;
+            self.regs.r[3] = 1;
+        } else if denom == -1 && num == i32::MIN {
+            // Overflow: INT_MIN / -1 can't be represented.
+            self.regs.r[0] = i32::MIN as u32;
+            self.regs.r[1] = 0;
+            self.regs.r[3] = i32::MIN as u32;
+        } else {
+            let quot = num / denom;
+            let rem = num % denom;
+            self.regs.r[0] = quot as u32;
+            self.regs.r[1] = rem as u32;
+            self.regs.r[3] = quot.unsigned_abs();
+        }
+    }
+
+    /// HLE implementation of SWI 0x07 — DivArm.
+    ///
+    /// Same as Div but r0 = denominator, r1 = numerator (swapped).
+    fn hle_div_arm(&mut self) {
+        self.regs.r.swap(0, 1);
+        self.hle_div();
+    }
+
+    /// HLE implementation of SWI 0x08 — Sqrt.
+    ///
+    /// r0 = unsigned 32-bit value → r0 = integer square root.
+    fn hle_sqrt(&mut self) {
+        let x = self.regs.r[0];
+        self.regs.r[0] = (x as f64).sqrt() as u32;
+    }
+
+    /// HLE implementation of SWI 0x09 — ArcTan.
+    ///
+    /// r0 = tan (signed fixed-point 1.14) → r0 = angle, r1 = intermediate a,
+    /// r3 = accumulated coefficient b.
+    ///
+    /// Uses the same Taylor-series coefficients as the real GBA BIOS.
+    fn hle_arctan(&mut self) {
+        let i = self.regs.r[0] as i32;
+        let a = (i.wrapping_mul(i) >> 14).wrapping_neg();
+        let mut b = ((0xA9_i32).wrapping_mul(a) >> 14).wrapping_add(0x390);
+        b = (b.wrapping_mul(a) >> 14).wrapping_add(0x91C);
+        b = (b.wrapping_mul(a) >> 14).wrapping_add(0xFB6);
+        b = (b.wrapping_mul(a) >> 14).wrapping_add(0x16AA);
+        b = (b.wrapping_mul(a) >> 14).wrapping_add(0x2081);
+        b = (b.wrapping_mul(a) >> 14).wrapping_add(0x3651);
+        b = (b.wrapping_mul(a) >> 14).wrapping_add(0xA2F9);
+        self.regs.r[0] = (i.wrapping_mul(b) >> 16) as u32;
+        self.regs.r[1] = a as u32;
+        self.regs.r[3] = b as u32;
+    }
+
+    /// HLE implementation of SWI 0x0A — ArcTan2.
+    ///
+    /// r0 = x, r1 = y → r0 = angle in [0, 0xFFFF] (full circle).
+    /// Sets r3 = 0x170 to match the real BIOS's register clobber.
+    fn hle_arctan2(&mut self) {
+        let x = self.regs.r[0] as i32;
+        let y = self.regs.r[1] as i32;
+
+        if y == 0 {
+            self.regs.r[0] = if x >= 0 { 0 } else { 0x8000 };
+            self.regs.r[3] = 0x170;
+            return;
+        }
+        if x == 0 {
+            self.regs.r[0] = if y >= 0 { 0x4000 } else { 0xC000 };
+            self.regs.r[3] = 0x170;
+            return;
+        }
+
+        if y >= 0 {
+            if x >= 0 {
+                if x >= y {
+                    self.regs.r[0] = ((y as i64) << 14).wrapping_div(x as i64) as i32 as u32;
+                    self.hle_arctan();
+                } else {
+                    self.regs.r[0] = ((x as i64) << 14).wrapping_div(y as i64) as i32 as u32;
+                    self.hle_arctan();
+                    self.regs.r[0] = 0x4000_u32.wrapping_sub(self.regs.r[0]);
+                }
+            } else if (-x) >= y {
+                self.regs.r[0] = ((y as i64) << 14).wrapping_div(x as i64) as i32 as u32;
+                self.hle_arctan();
+                self.regs.r[0] = self.regs.r[0].wrapping_add(0x8000);
+            } else {
+                self.regs.r[0] = ((x as i64) << 14).wrapping_div(y as i64) as i32 as u32;
+                self.hle_arctan();
+                self.regs.r[0] = 0x4000_u32.wrapping_sub(self.regs.r[0]);
+            }
+        } else if x <= 0 {
+            if (-x) > (-y) {
+                self.regs.r[0] = ((y as i64) << 14).wrapping_div(x as i64) as i32 as u32;
+                self.hle_arctan();
+                self.regs.r[0] = self.regs.r[0].wrapping_add(0x8000);
+            } else {
+                self.regs.r[0] = ((x as i64) << 14).wrapping_div(y as i64) as i32 as u32;
+                self.hle_arctan();
+                self.regs.r[0] = 0xC000_u32.wrapping_sub(self.regs.r[0]);
+            }
+        } else if x >= (-y) {
+            self.regs.r[0] = ((y as i64) << 14).wrapping_div(x as i64) as i32 as u32;
+            self.hle_arctan();
+            self.regs.r[0] = self.regs.r[0].wrapping_add(0x10000);
+        } else {
+            self.regs.r[0] = ((x as i64) << 14).wrapping_div(y as i64) as i32 as u32;
+            self.hle_arctan();
+            self.regs.r[0] = 0xC000_u32.wrapping_sub(self.regs.r[0]);
+        }
+
+        self.regs.r[0] &= 0xFFFF;
+        self.regs.r[3] = 0x170;
     }
 }
 
@@ -923,5 +1074,113 @@ mod tests {
                 "CpuFastSet fill word {i} mismatch"
             );
         }
+    }
+
+    // ── BIOS Math HLE tests ──────────────────────────────────────────
+
+    /// Helper: execute an ARM SWI instruction with input registers and return
+    /// the CPU state. SWI number is embedded in the instruction encoding.
+    fn run_hle_swi(swi_num: u8, r0: u32, r1: u32) -> Arm7tdmi {
+        let (mut cpu, mut bus) = hle_setup();
+        // ARM SWI encoding: 0xEF000000 | (swi_num << 16)
+        let instr = 0xEF00_0000 | ((swi_num as u32) << 16);
+        write_arm_word(&mut bus, 0x0, instr);
+        cpu.regs.r[0] = r0;
+        cpu.regs.r[1] = r1;
+        cpu.regs.r[3] = 0; // clear r3 to detect if it's set
+        cpu.step(&mut bus);
+        cpu
+    }
+
+    #[test]
+    fn hle_div_basic() {
+        // Div(7, 3) → r0=2, r1=1, r3=2
+        let cpu = run_hle_swi(0x06, 7, 3);
+        assert_eq!(cpu.regs.r[0], 2, "quotient");
+        assert_eq!(cpu.regs.r[1], 1, "remainder");
+        assert_eq!(cpu.regs.r[3], 2, "abs(quotient)");
+    }
+
+    #[test]
+    fn hle_div_negative_numerator() {
+        // Div(-7, 3) → r0=-2 (0xFFFFFFFE), r1=-1 (0xFFFFFFFF), r3=2
+        let cpu = run_hle_swi(0x06, (-7i32) as u32, 3);
+        assert_eq!(cpu.regs.r[0] as i32, -2, "quotient");
+        assert_eq!(cpu.regs.r[1] as i32, -1, "remainder");
+        assert_eq!(cpu.regs.r[3], 2, "abs(quotient)");
+    }
+
+    #[test]
+    fn hle_div_by_zero() {
+        // Div(1, 0) → r0=1, r1=1, r3=1 (per GBA BIOS behavior)
+        let cpu = run_hle_swi(0x06, 1, 0);
+        assert_eq!(cpu.regs.r[0], 1, "quotient for div-by-zero");
+        assert_eq!(cpu.regs.r[1], 1, "remainder for div-by-zero");
+        assert_eq!(cpu.regs.r[3], 1, "abs for div-by-zero");
+    }
+
+    #[test]
+    fn hle_div_zero_by_zero() {
+        // Div(0, 0) → r0=1, r1=0, r3=1
+        let cpu = run_hle_swi(0x06, 0, 0);
+        assert_eq!(cpu.regs.r[0], 1, "quotient 0/0");
+        assert_eq!(cpu.regs.r[1], 0, "remainder 0/0");
+        assert_eq!(cpu.regs.r[3], 1, "abs 0/0");
+    }
+
+    #[test]
+    fn hle_div_int_min_by_neg_one() {
+        // Div(INT_MIN, -1) → r0=INT_MIN, r1=0, r3=INT_MIN (overflow)
+        let cpu = run_hle_swi(0x06, 0x8000_0000, 0xFFFF_FFFF);
+        assert_eq!(cpu.regs.r[0], 0x8000_0000, "quotient INT_MIN/-1");
+        assert_eq!(cpu.regs.r[1], 0, "remainder INT_MIN/-1");
+        assert_eq!(cpu.regs.r[3], 0x8000_0000, "abs INT_MIN/-1 (overflow)");
+    }
+
+    #[test]
+    fn hle_arctan_zero() {
+        // ArcTan(0) → r0=0, r1=0, r3=0xA2F9
+        // (from mgba-emu/suite: i=0, a=0, b=0xA2F9, result=0)
+        let cpu = run_hle_swi(0x09, 0, 0);
+        assert_eq!(cpu.regs.r[0], 0, "ArcTan(0) result");
+        assert_eq!(cpu.regs.r[1] as i32, 0, "ArcTan(0) intermediate a");
+        assert_eq!(cpu.regs.r[3], 0xA2F9, "ArcTan(0) coefficient b");
+    }
+
+    #[test]
+    fn hle_arctan_quarter() {
+        // ArcTan(0x4000) → r0=0x2000, r1=0xFFFFC000, r3=0x8000
+        // (from mgba-emu/suite expected values)
+        let cpu = run_hle_swi(0x09, 0x4000, 0);
+        assert_eq!(cpu.regs.r[0], 0x2000, "ArcTan(0x4000) result");
+        assert_eq!(cpu.regs.r[1], 0xFFFFC000, "ArcTan(0x4000) intermediate a");
+        assert_eq!(cpu.regs.r[3], 0x8000, "ArcTan(0x4000) coefficient b");
+    }
+
+    #[test]
+    fn hle_arctan2_zero_zero() {
+        // ArcTan2(0, 0) → r0=0, r1=0, r3=0x170
+        let cpu = run_hle_swi(0x0A, 0, 0);
+        assert_eq!(cpu.regs.r[0], 0, "ArcTan2(0,0) angle");
+        assert_eq!(cpu.regs.r[1], 0, "ArcTan2(0,0) r1");
+        assert_eq!(cpu.regs.r[3], 0x170, "ArcTan2(0,0) r3 clobber");
+    }
+
+    #[test]
+    fn hle_arctan2_equal_positive() {
+        // ArcTan2(0x4000, 0x4000) → r0=0x2000, r1=0xFFFFC000, r3=0x170
+        let cpu = run_hle_swi(0x0A, 0x4000, 0x4000);
+        assert_eq!(cpu.regs.r[0], 0x2000, "ArcTan2(0x4000,0x4000) angle");
+        assert_eq!(cpu.regs.r[1], 0xFFFFC000, "ArcTan2(0x4000,0x4000) r1");
+        assert_eq!(cpu.regs.r[3], 0x170, "ArcTan2(0x4000,0x4000) r3");
+    }
+
+    #[test]
+    fn hle_arctan2_negative_x_zero_y() {
+        // ArcTan2(0xFFFF0000, 0) → r0=0x8000, r1=0, r3=0x170
+        let cpu = run_hle_swi(0x0A, 0xFFFF0000, 0);
+        assert_eq!(cpu.regs.r[0], 0x8000, "ArcTan2(neg,0) angle");
+        assert_eq!(cpu.regs.r[1], 0, "ArcTan2(neg,0) r1");
+        assert_eq!(cpu.regs.r[3], 0x170, "ArcTan2(neg,0) r3");
     }
 }

--- a/src/gba/cpu/thumb.rs
+++ b/src/gba/cpu/thumb.rs
@@ -388,9 +388,15 @@ fn exec_format4(regs: &mut Registers, instr: u16) -> ExecOutcome {
         0xC => (a | b, regs.c_flag(), regs.v_flag(), true), // ORR
         0xD => {
             // MUL: Rd = Rd * Rs
+            // C flag is computed by the ARM7TDMI Booth multiplier
             let result = a.wrapping_mul(b);
-            // C and V flags are destroyed (set to meaningless values) per ARM spec
-            (result, regs.c_flag(), regs.v_flag(), true)
+            let (_, full) = super::arm::multiply_cycles_and_full(b, true);
+            let c = if full {
+                super::arm::multiply_carry_simple(b)
+            } else {
+                super::arm::multiply_carry_lo(a, b, 0)
+            };
+            (result, c, regs.v_flag(), true)
         }
         0xE => (a & !b, regs.c_flag(), regs.v_flag(), true), // BIC
         0xF => (!b, regs.c_flag(), regs.v_flag(), true),     // MVN

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -43,12 +43,12 @@ armwrestler_page7=0x562A5C65
 # mgba-emu/suite (https://github.com/mgba-emu/suite)
 # 14 sub-suites exercising memory, I/O, timing, shifter, carry, multiply,
 # BIOS math, DMA, SIO, misc edge cases, and video.
-# Scores (passing/total): Memory 1379/1552, I/O read 31/130, Timing 249/2020,
+# Scores (passing/total): Memory 1379/1552, I/O read 83/130, Timing 249/2020,
 # Timers 257/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
-# Multiply long 72/72, BIOS math 615/615, DMA 895/1256, SIO read 7/90,
+# Multiply long 72/72, BIOS math 615/615, DMA 891/1256, SIO read 25/90,
 # SIO timing 0/4, Misc. edge 4/12, Video (sub-menu only).
 mgba_memory=0x22984983
-mgba_io_read=0xB73C0C86
+mgba_io_read=0x5A3CD2D5
 mgba_timing=0x697DA0C7
 mgba_timers=0xBC59F692
 mgba_timer_irq=0xD1FFFC47
@@ -56,8 +56,8 @@ mgba_shifter=0x8B4A12AA
 mgba_carry=0xFD9E45E6
 mgba_multiply_long=0x699655AB
 mgba_bios_math=0x3C1B28DE
-mgba_dma=0x0D8D9433
-mgba_sio_read=0x5BE0B36B
+mgba_dma=0x076FC108
+mgba_sio_read=0x94A5E99A
 mgba_sio_timing=0xD95ACB03
 mgba_misc_edge=0xFF974835
 mgba_video=0xAB7EC249

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -43,11 +43,11 @@ armwrestler_page7=0x562A5C65
 # mgba-emu/suite (https://github.com/mgba-emu/suite)
 # 14 sub-suites exercising memory, I/O, timing, shifter, carry, multiply,
 # BIOS math, DMA, SIO, misc edge cases, and video.
-# Scores (passing/total): Memory 1075/1552, I/O read 31/130, Timing 249/2020,
+# Scores (passing/total): Memory 1331/1552, I/O read 31/130, Timing 249/2020,
 # Timers 257/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
-# Multiply long 72/72, BIOS math 287/615, DMA 891/1256, SIO read 7/90,
+# Multiply long 72/72, BIOS math 287/615, DMA 895/1256, SIO read 7/90,
 # SIO timing 0/4, Misc. edge 4/12, Video (sub-menu only).
-mgba_memory=0xFF66E63B
+mgba_memory=0x9338115D
 mgba_io_read=0xB73C0C86
 mgba_timing=0x697DA0C7
 mgba_timers=0xBC59F692
@@ -56,7 +56,7 @@ mgba_shifter=0x8B4A12AA
 mgba_carry=0xFD9E45E6
 mgba_multiply_long=0x699655AB
 mgba_bios_math=0xE1DC7B2D
-mgba_dma=0x076FC108
+mgba_dma=0x0D8D9433
 mgba_sio_read=0x5BE0B36B
 mgba_sio_timing=0xD95ACB03
 mgba_misc_edge=0xFF974835

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -45,7 +45,7 @@ armwrestler_page7=0x562A5C65
 # BIOS math, DMA, SIO, misc edge cases, and video.
 # Scores (passing/total): Memory 1379/1552, I/O read 31/130, Timing 249/2020,
 # Timers 257/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
-# Multiply long 72/72, BIOS math 287/615, DMA 895/1256, SIO read 7/90,
+# Multiply long 72/72, BIOS math 615/615, DMA 895/1256, SIO read 7/90,
 # SIO timing 0/4, Misc. edge 4/12, Video (sub-menu only).
 mgba_memory=0x22984983
 mgba_io_read=0xB73C0C86
@@ -55,7 +55,7 @@ mgba_timer_irq=0xD1FFFC47
 mgba_shifter=0x8B4A12AA
 mgba_carry=0xFD9E45E6
 mgba_multiply_long=0x699655AB
-mgba_bios_math=0xE1DC7B2D
+mgba_bios_math=0x3C1B28DE
 mgba_dma=0x0D8D9433
 mgba_sio_read=0x5BE0B36B
 mgba_sio_timing=0xD95ACB03

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -43,11 +43,11 @@ armwrestler_page7=0x562A5C65
 # mgba-emu/suite (https://github.com/mgba-emu/suite)
 # 14 sub-suites exercising memory, I/O, timing, shifter, carry, multiply,
 # BIOS math, DMA, SIO, misc edge cases, and video.
-# Scores (passing/total): Memory 1331/1552, I/O read 31/130, Timing 249/2020,
+# Scores (passing/total): Memory 1379/1552, I/O read 31/130, Timing 249/2020,
 # Timers 257/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
 # Multiply long 72/72, BIOS math 287/615, DMA 895/1256, SIO read 7/90,
 # SIO timing 0/4, Misc. edge 4/12, Video (sub-menu only).
-mgba_memory=0x9338115D
+mgba_memory=0x22984983
 mgba_io_read=0xB73C0C86
 mgba_timing=0x697DA0C7
 mgba_timers=0xBC59F692

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -45,7 +45,7 @@ armwrestler_page7=0x562A5C65
 # BIOS math, DMA, SIO, misc edge cases, and video.
 # Scores (passing/total): Memory 1379/1552, I/O read 83/130, Timing 249/2020,
 # Timers 257/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
-# Multiply long 72/72, BIOS math 615/615, DMA 891/1256, SIO read 25/90,
+# Multiply long 72/72, BIOS math 615/615, DMA 891/1256, SIO read 90/90,
 # SIO timing 0/4, Misc. edge 4/12, Video (sub-menu only).
 mgba_memory=0x22984983
 mgba_io_read=0x5A3CD2D5
@@ -57,7 +57,7 @@ mgba_carry=0xFD9E45E6
 mgba_multiply_long=0x699655AB
 mgba_bios_math=0x3C1B28DE
 mgba_dma=0x076FC108
-mgba_sio_read=0x94A5E99A
+mgba_sio_read=0xF5D98687
 mgba_sio_timing=0xD95ACB03
 mgba_misc_edge=0xFF974835
 mgba_video=0xAB7EC249

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -43,18 +43,18 @@ armwrestler_page7=0x562A5C65
 # mgba-emu/suite (https://github.com/mgba-emu/suite)
 # 14 sub-suites exercising memory, I/O, timing, shifter, carry, multiply,
 # BIOS math, DMA, SIO, misc edge cases, and video.
-# Scores (passing/total): Memory 1075/1552, I/O read 31/130, Timing 224/2020,
+# Scores (passing/total): Memory 1075/1552, I/O read 31/130, Timing 249/2020,
 # Timers 257/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
-# Multiply long 52/72, BIOS math 287/615, DMA 891/1256, SIO read 7/90,
+# Multiply long 72/72, BIOS math 287/615, DMA 891/1256, SIO read 7/90,
 # SIO timing 0/4, Misc. edge 4/12, Video (sub-menu only).
 mgba_memory=0xFF66E63B
 mgba_io_read=0xB73C0C86
-mgba_timing=0x17B5F199
+mgba_timing=0x697DA0C7
 mgba_timers=0xBC59F692
 mgba_timer_irq=0xD1FFFC47
 mgba_shifter=0x8B4A12AA
 mgba_carry=0xFD9E45E6
-mgba_multiply_long=0x66B4CAEA
+mgba_multiply_long=0x699655AB
 mgba_bios_math=0xE1DC7B2D
 mgba_dma=0x076FC108
 mgba_sio_read=0x5BE0B36B

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -267,7 +267,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("armwrestler_page7"), Some(&0x562A_5C65));
 
     // mgba-emu/suite keys
-    assert_eq!(approvals.get("mgba_memory"), Some(&0x9338_115D));
+    assert_eq!(approvals.get("mgba_memory"), Some(&0x2298_4983));
     assert_eq!(approvals.get("mgba_io_read"), Some(&0xB73C_0C86));
     assert_eq!(approvals.get("mgba_timing"), Some(&0x697D_A0C7));
     assert_eq!(approvals.get("mgba_timers"), Some(&0xBC59_F692));

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -269,12 +269,12 @@ fn approvals_manifest_parses() {
     // mgba-emu/suite keys
     assert_eq!(approvals.get("mgba_memory"), Some(&0xFF66_E63B));
     assert_eq!(approvals.get("mgba_io_read"), Some(&0xB73C_0C86));
-    assert_eq!(approvals.get("mgba_timing"), Some(&0x17B5_F199));
+    assert_eq!(approvals.get("mgba_timing"), Some(&0x697D_A0C7));
     assert_eq!(approvals.get("mgba_timers"), Some(&0xBC59_F692));
     assert_eq!(approvals.get("mgba_timer_irq"), Some(&0xD1FF_FC47));
     assert_eq!(approvals.get("mgba_shifter"), Some(&0x8B4A_12AA));
     assert_eq!(approvals.get("mgba_carry"), Some(&0xFD9E_45E6));
-    assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x66B4_CAEA));
+    assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
     assert_eq!(approvals.get("mgba_bios_math"), Some(&0xE1DC_7B2D));
     assert_eq!(approvals.get("mgba_dma"), Some(&0x076F_C108));
     assert_eq!(approvals.get("mgba_sio_read"), Some(&0x5BE0_B36B));

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -275,7 +275,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("mgba_shifter"), Some(&0x8B4A_12AA));
     assert_eq!(approvals.get("mgba_carry"), Some(&0xFD9E_45E6));
     assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
-    assert_eq!(approvals.get("mgba_bios_math"), Some(&0xE1DC_7B2D));
+    assert_eq!(approvals.get("mgba_bios_math"), Some(&0x3C1B_28DE));
     assert_eq!(approvals.get("mgba_dma"), Some(&0x0D8D_9433));
     assert_eq!(approvals.get("mgba_sio_read"), Some(&0x5BE0_B36B));
     assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -277,7 +277,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
     assert_eq!(approvals.get("mgba_bios_math"), Some(&0x3C1B_28DE));
     assert_eq!(approvals.get("mgba_dma"), Some(&0x076F_C108));
-    assert_eq!(approvals.get("mgba_sio_read"), Some(&0x94A5_E99A));
+    assert_eq!(approvals.get("mgba_sio_read"), Some(&0xF5D9_8687));
     assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));
     assert_eq!(approvals.get("mgba_misc_edge"), Some(&0xFF97_4835));
     assert_eq!(approvals.get("mgba_video"), Some(&0xAB7E_C249));

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -267,7 +267,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("armwrestler_page7"), Some(&0x562A_5C65));
 
     // mgba-emu/suite keys
-    assert_eq!(approvals.get("mgba_memory"), Some(&0xFF66_E63B));
+    assert_eq!(approvals.get("mgba_memory"), Some(&0x9338_115D));
     assert_eq!(approvals.get("mgba_io_read"), Some(&0xB73C_0C86));
     assert_eq!(approvals.get("mgba_timing"), Some(&0x697D_A0C7));
     assert_eq!(approvals.get("mgba_timers"), Some(&0xBC59_F692));
@@ -276,7 +276,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("mgba_carry"), Some(&0xFD9E_45E6));
     assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
     assert_eq!(approvals.get("mgba_bios_math"), Some(&0xE1DC_7B2D));
-    assert_eq!(approvals.get("mgba_dma"), Some(&0x076F_C108));
+    assert_eq!(approvals.get("mgba_dma"), Some(&0x0D8D_9433));
     assert_eq!(approvals.get("mgba_sio_read"), Some(&0x5BE0_B36B));
     assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));
     assert_eq!(approvals.get("mgba_misc_edge"), Some(&0xFF97_4835));

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -268,7 +268,7 @@ fn approvals_manifest_parses() {
 
     // mgba-emu/suite keys
     assert_eq!(approvals.get("mgba_memory"), Some(&0x2298_4983));
-    assert_eq!(approvals.get("mgba_io_read"), Some(&0xB73C_0C86));
+    assert_eq!(approvals.get("mgba_io_read"), Some(&0x5A3C_D2D5));
     assert_eq!(approvals.get("mgba_timing"), Some(&0x697D_A0C7));
     assert_eq!(approvals.get("mgba_timers"), Some(&0xBC59_F692));
     assert_eq!(approvals.get("mgba_timer_irq"), Some(&0xD1FF_FC47));
@@ -276,8 +276,8 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("mgba_carry"), Some(&0xFD9E_45E6));
     assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
     assert_eq!(approvals.get("mgba_bios_math"), Some(&0x3C1B_28DE));
-    assert_eq!(approvals.get("mgba_dma"), Some(&0x0D8D_9433));
-    assert_eq!(approvals.get("mgba_sio_read"), Some(&0x5BE0_B36B));
+    assert_eq!(approvals.get("mgba_dma"), Some(&0x076F_C108));
+    assert_eq!(approvals.get("mgba_sio_read"), Some(&0x94A5_E99A));
     assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));
     assert_eq!(approvals.get("mgba_misc_edge"), Some(&0xFF97_4835));
     assert_eq!(approvals.get("mgba_video"), Some(&0xAB7E_C249));

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -280,8 +280,11 @@ impl Ppu {
     }
 
     /// Read `BGnCNT` for background layer `n` (0–3).
+    ///
+    /// Per GBATek, bit 13 is not used for BG0/BG1 and reads as zero.
     pub fn read_bg_cnt(&self, n: usize) -> u16 {
-        self.bg_cnt[n]
+        let mask = if n <= 1 { 0xDFFF } else { 0xFFFF };
+        self.bg_cnt[n] & mask
     }
 
     /// Write `BGnCNT` for background layer `n` (0–3).
@@ -411,9 +414,19 @@ impl Ppu {
         self.bg_scroll[n].0 = value & 0x01FF;
     }
 
+    /// Read `BGnHOFS` for background layer `n` (0–3).
+    pub fn read_bg_hofs(&self, n: usize) -> u16 {
+        self.bg_scroll[n].0
+    }
+
     /// Write `BGnVOFS` for background layer `n` (0–3).
     pub fn write_bg_vofs(&mut self, n: usize, value: u16) {
         self.bg_scroll[n].1 = value & 0x01FF;
+    }
+
+    /// Read `BGnVOFS` for background layer `n` (0–3).
+    pub fn read_bg_vofs(&self, n: usize) -> u16 {
+        self.bg_scroll[n].1
     }
 
     /// True after a completed frame, until [`Self::clear_frame_ready`].
@@ -1617,5 +1630,23 @@ mod tests {
 
         // Equal priority: BG0 (lower number) wins → red.
         assert_eq!(&ppu.framebuffer()[0..3], &[0xFF, 0, 0]);
+    }
+
+    /// Per GBATek, BGnCNT bit 13 is not used (zero) for BG0 and BG1.
+    /// Reads of BG0CNT/BG1CNT must mask bit 13 out; BG2/BG3 are unmasked.
+    #[test]
+    fn bg0_bg1_cnt_mask_bit_13_on_read() {
+        let mut ppu = Ppu::new();
+        // Write all bits set.
+        ppu.write_bg_cnt(0, 0xFFFF);
+        ppu.write_bg_cnt(1, 0xFFFF);
+        ppu.write_bg_cnt(2, 0xFFFF);
+        ppu.write_bg_cnt(3, 0xFFFF);
+        // BG0 and BG1: bit 13 must be masked out → 0xDFFF.
+        assert_eq!(ppu.read_bg_cnt(0), 0xDFFF, "BG0CNT should mask bit 13");
+        assert_eq!(ppu.read_bg_cnt(1), 0xDFFF, "BG1CNT should mask bit 13");
+        // BG2 and BG3: all bits readable.
+        assert_eq!(ppu.read_bg_cnt(2), 0xFFFF, "BG2CNT should be unmasked");
+        assert_eq!(ppu.read_bg_cnt(3), 0xFFFF, "BG3CNT should be unmasked");
     }
 }


### PR DESCRIPTION
## Summary

Fix multiple mgba-emu/suite sub-suites through iterative TDD, achieving 6 perfect scores out of 13 scored sub-suites (up from 2).

Closes #2381

## Changes by Sub-Suite

### Multiply Long: 52/72 -> 72/72 (PERFECT)
- Implemented ARM7TDMI Booth carry algorithm for SMULLS/UMULLS/MUL/MLA C flag
- Files: src/gba/cpu/arm.rs

### Memory: 1075/1552 -> 1379/1552 (+304)
- Fixed CpuSet/CpuFastSet HLE (fill mode, half-word alignment)
- ROM out-of-bounds reads return open bus
- VRAM OBJ region byte writes ignored per spec
- Files: src/gba/cpu/arm7tdmi.rs, src/gba/bus/mod.rs, src/gba/bus/memory.rs

### DMA: 891/1256 (latch isolation, +48 cross-cutting to Memory)
- Added dma_latch field for proper DMA value isolation
- Files: src/gba/bus/dma.rs, src/gba/bus/mod.rs

### BIOS Math: 287/615 -> 615/615 (PERFECT)
- Implemented Div, DivArm, Sqrt, ArcTan, ArcTan2 HLE methods
- Files: src/gba/cpu/arm7tdmi.rs, src/gba/cpu/bios_math.rs (new)

### I/O Read: 31/130 -> 83/130 (+52)
- Reworked io.rs try_read16 with explicit write-only/masked/invalid dispatch
- Fixed PPU BG0/BG1 BGCNT bit 13 mask, DMA SAD/DAD -> None, CNT_HI read masks
- Extended write8 BG scroll byte-merge to all BG0-3
- Files: src/gba/bus/io.rs, src/gba/bus/dma.rs, src/gba/ppu/mod.rs

### SIO Read: 25/90 -> 90/90 (PERFECT)
- Implemented full SIO register read behavior (SIODATA32, SIOMULTI, SIOCNT, RCNT, JOYCNT, JOY Bus)
- Mode-dependent masking and write-1-to-clear for JOYCNT
- Files: src/gba/bus/io.rs

## Results Summary

| Suite | Before | After | Delta |
|-------|--------|-------|-------|
| Multiply long | 52/72 | **72/72** | +20 |
| Memory | 1075/1552 | **1379/1552** | +304 |
| BIOS math | 287/615 | **615/615** | +328 |
| I/O read | 31/130 | **83/130** | +52 |
| SIO read | 25/90 | **90/90** | +65 |
| DMA | 891/1256 | 891/1256 | latch fix |
| Timing | 224/2020 | 249/2020 | +25 cross-cutting |

**Total tests improved: ~794 additional passing tests**

## Blocked Sub-Suites (follow-up issues created)

- #2385 - Cycle-accurate timing (Timers 257/936, Timer IRQ 0/90, Timing 249/2020, Misc Edge 4/12)
- #2386 - SIO transfer logic (SIO timing 0/4)
- #2387 - Video visual correctness investigation

## Testing

- All pre-merge checks pass (clippy, fmt, cargo test, python, npm)
- 17 pre-existing GB mealybug test failures (unrelated)
- WASM ChromeDriver 404 (pre-existing on main)
- Integration test CRCs updated for all improved sub-suites
