### PR TITLE
feat(gba): refactor ExecOutcome to S/N/I cycle model

### DIFF
--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -383,7 +383,7 @@ impl GbaBus {
     }
 
     /// Return non-sequential access cycle count for `addr` and access width.
-    pub fn n_cycles(&self, addr: u32, width: WidthClass) -> u32 {
+    pub fn n_cycles_width(&self, addr: u32, width: WidthClass) -> u32 {
         let i = width.idx();
         match (addr >> 24) & 0xF {
             0x0 => wait_states::BIOS[i],
@@ -400,12 +400,12 @@ impl GbaBus {
     }
 
     /// Return sequential access cycle count for `addr` and access width.
-    pub fn s_cycles(&self, addr: u32, width: WidthClass) -> u32 {
+    pub fn s_cycles_width(&self, addr: u32, width: WidthClass) -> u32 {
         let i = width.idx();
         match (addr >> 24) & 0xF {
             0x2 => wait_states::EWRAM_S[i],
             0x8..=0xD => wait_states::ROM_S[i],
-            _ => self.n_cycles(addr, width),
+            _ => self.n_cycles_width(addr, width),
         }
     }
 
@@ -804,6 +804,14 @@ impl Bus for GbaBus {
             self.run_pending_dma();
         }
     }
+
+    fn n_cycles(&self, addr: u32) -> u32 {
+        self.n_cycles_width(addr, WidthClass::HalfwordOrByte)
+    }
+
+    fn s_cycles(&self, addr: u32) -> u32 {
+        self.s_cycles_width(addr, WidthClass::HalfwordOrByte)
+    }
 }
 
 /// DMA transfers use the bus' standard read/write paths so that DMA
@@ -983,13 +991,25 @@ mod tests {
     }
 
     #[test]
-    fn n_and_s_cycles_match_gbatek_defaults() {
+    fn n_and_s_cycles_width_match_gbatek_defaults() {
         let bus = GbaBus::new();
-        assert_eq!(bus.n_cycles(0x0300_0000, WidthClass::HalfwordOrByte), 1);
-        assert_eq!(bus.n_cycles(0x0200_0000, WidthClass::HalfwordOrByte), 3);
-        assert_eq!(bus.n_cycles(0x0200_0000, WidthClass::Word), 6);
-        assert_eq!(bus.n_cycles(0x0800_0000, WidthClass::HalfwordOrByte), 5);
-        assert_eq!(bus.s_cycles(0x0800_0000, WidthClass::HalfwordOrByte), 3);
+        assert_eq!(
+            bus.n_cycles_width(0x0300_0000, WidthClass::HalfwordOrByte),
+            1
+        );
+        assert_eq!(
+            bus.n_cycles_width(0x0200_0000, WidthClass::HalfwordOrByte),
+            3
+        );
+        assert_eq!(bus.n_cycles_width(0x0200_0000, WidthClass::Word), 6);
+        assert_eq!(
+            bus.n_cycles_width(0x0800_0000, WidthClass::HalfwordOrByte),
+            5
+        );
+        assert_eq!(
+            bus.s_cycles_width(0x0800_0000, WidthClass::HalfwordOrByte),
+            3
+        );
     }
 
     #[test]

--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -657,7 +657,8 @@ fn execute_long_multiply(regs: &mut Registers, instr: u32) -> ExecOutcome {
         regs.set_nzcv(n, z, c, regs.v_flag());
     }
 
-    // Long multiply: UMULL/SMULL = 1S + mI; UMLAL/SMLAL = 1S + (m+1)I
+    // GBATek: UMULL/SMULL = 1S+(m+1)I, UMLAL/SMLAL = 1S+(m+2)I
+    // long_multiply_cycles returns m+2, so: non-acc = (m+2)-1 = m+1, acc = m+2
     let internal = if acc { cycles } else { cycles - 1 };
     ExecOutcome::sni(1, 0, internal)
 }
@@ -2606,8 +2607,8 @@ mod tests {
         let mut bus = RamBus::new(0x100);
         regs.r[0] = 5; // Rm
         regs.r[1] = 1; // Rs (small → early termination, m=1)
-        // MUL R2, R0, R1: cond 0000 00 0 0 Rd Rs 1001 Rm
-        let instr = 0xE000_2190; // MUL R2, R0, R1
+        // MUL R0, R0, R1: cond=E, bits[27:22]=000000, A=0, S=0, Rd=0, Rn=0, Rs=1, 1001, Rm=0
+        let instr = 0xE000_2190; // MUL R0, R0, R1
         let outcome = execute(&mut regs, &mut bus, instr);
         assert_eq!(outcome.seq, 1, "MUL should have 1S");
         assert!(outcome.internal >= 1, "MUL should have at least 1I");

--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -657,7 +657,9 @@ fn execute_long_multiply(regs: &mut Registers, instr: u32) -> ExecOutcome {
         regs.set_nzcv(n, z, c, regs.v_flag());
     }
 
-    ExecOutcome::sni(1, 0, cycles - 1) // Long multiply: 1S + mI
+    // Long multiply: UMULL/SMULL = 1S + mI; UMLAL/SMLAL = 1S + (m+1)I
+    let internal = if acc { cycles } else { cycles - 1 };
+    ExecOutcome::sni(1, 0, internal)
 }
 
 /// Compute multiply internal cycles based on Rs magnitude (early termination).
@@ -2610,6 +2612,28 @@ mod tests {
         assert_eq!(outcome.seq, 1, "MUL should have 1S");
         assert!(outcome.internal >= 1, "MUL should have at least 1I");
         assert_eq!(outcome.nonseq, 0, "MUL should have 0N");
+    }
+
+    /// UMLAL/SMLAL (accumulate) gets +1I vs UMULL/SMULL per GBATek.
+    #[test]
+    fn arm_long_mul_accumulate_has_extra_internal() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 5; // Rm
+        regs.r[1] = 1; // Rs (small → early termination)
+        regs.r[2] = 0;
+        regs.r[3] = 0;
+        // UMULL R2, R3, R0, R1 (no accumulate)
+        let umull = arm_long_mul(0xE, false, false, false, 3, 2, 1, 0);
+        let outcome_umull = execute(&mut regs, &mut bus, umull);
+        // UMLAL R2, R3, R0, R1 (accumulate)
+        let umlal = arm_long_mul(0xE, false, true, false, 3, 2, 1, 0);
+        let outcome_umlal = execute(&mut regs, &mut bus, umlal);
+        assert_eq!(
+            outcome_umlal.internal,
+            outcome_umull.internal + 1,
+            "UMLAL should have +1I vs UMULL"
+        );
     }
 
     /// ARM condition-false (skipped): 1S per GBATek.

--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -35,8 +35,12 @@ use super::registers::{FLAG_C, FLAG_N, FLAG_V, FLAG_Z};
 /// Outcome of executing one ARM instruction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExecOutcome {
-    /// Number of cycles consumed.
-    pub cycles: u8,
+    /// Number of sequential (S) memory access cycles.
+    pub seq: u8,
+    /// Number of non-sequential (N) memory access cycles.
+    pub nonseq: u8,
+    /// Number of internal (I) CPU-only cycles.
+    pub internal: u8,
     /// `true` if PC was modified by the instruction (pipeline must refill).
     pub branched: bool,
     /// `true` if the instruction triggered a software interrupt (SWI).
@@ -46,37 +50,63 @@ pub struct ExecOutcome {
 }
 
 impl ExecOutcome {
-    fn cycles(c: u8) -> Self {
+    /// Non-branching instruction with explicit S/N/I cycle counts.
+    fn sni(seq: u8, nonseq: u8, internal: u8) -> Self {
         Self {
-            cycles: c,
+            seq,
+            nonseq,
+            internal,
             branched: false,
             swi: false,
             undefined: false,
         }
     }
-    fn branch(c: u8) -> Self {
+    /// Branching instruction with explicit S/N/I cycle counts.
+    fn branch_sni(seq: u8, nonseq: u8, internal: u8) -> Self {
         Self {
-            cycles: c,
+            seq,
+            nonseq,
+            internal,
             branched: true,
             swi: false,
             undefined: false,
         }
     }
-    fn swi(c: u8) -> Self {
+    /// SWI instruction with explicit S/N/I cycle counts.
+    fn swi_sni(seq: u8, nonseq: u8, internal: u8) -> Self {
         Self {
-            cycles: c,
+            seq,
+            nonseq,
+            internal,
             branched: true,
             swi: true,
             undefined: false,
         }
     }
     pub(super) fn undefined() -> Self {
+        // Undefined exception: 2S + 1N (pipeline flush + vector fetch)
         Self {
-            cycles: 3,
+            seq: 2,
+            nonseq: 1,
+            internal: 0,
             branched: true,
             undefined: true,
             swi: false,
         }
+    }
+
+    /// Resolve S/N/I cycle counts to a concrete total using bus timing.
+    ///
+    /// `s_cost` is the sequential access cost and `n_cost` is the
+    /// non-sequential access cost. Internal cycles always cost 1.
+    pub fn resolve_cycles(&self, s_cost: u32, n_cost: u32) -> u32 {
+        (self.seq as u32) * s_cost + (self.nonseq as u32) * n_cost + (self.internal as u32)
+    }
+
+    /// Total flat cycles (seq + nonseq + internal) — convenience for
+    /// unit-test buses where all access costs are 1.
+    pub fn total_flat_cycles(&self) -> u8 {
+        self.seq + self.nonseq + self.internal
     }
 }
 
@@ -84,7 +114,7 @@ impl ExecOutcome {
 pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32) -> ExecOutcome {
     let cond = (instr >> 28) as u8;
     if !condition_met(regs.cpsr, cond) {
-        return ExecOutcome::cycles(1);
+        return ExecOutcome::sni(1, 0, 0); // 1S: condition failed
     }
 
     // Decode the major instruction class. The encoding hierarchy mostly
@@ -151,11 +181,11 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32) -> ExecOut
         0b111 => {
             // SWI is encoded as 1111_xxxx_xxxx_xxxx_xxxx_xxxx_xxxx
             if (instr >> 24) & 0xF == 0xF {
-                return ExecOutcome::swi(3);
+                return ExecOutcome::swi_sni(2, 1, 0); // 2S + 1N
             }
-            ExecOutcome::cycles(1)
+            ExecOutcome::sni(1, 0, 0) // 1S: coprocessor (treated as NOP)
         }
-        _ => ExecOutcome::cycles(1),
+        _ => ExecOutcome::sni(1, 0, 0), // 1S: unrecognized
     }
 }
 
@@ -178,7 +208,7 @@ fn execute_branch(regs: &mut Registers, instr: u32) -> ExecOutcome {
     }
 
     regs.r[15] = regs.r[15].wrapping_add(offset as u32);
-    ExecOutcome::branch(3)
+    ExecOutcome::branch_sni(2, 1, 0) // 2S + 1N
 }
 
 fn execute_bx(regs: &mut Registers, instr: u32) -> ExecOutcome {
@@ -191,7 +221,7 @@ fn execute_bx(regs: &mut Registers, instr: u32) -> ExecOutcome {
         regs.cpsr &= !FLAG_T;
         regs.r[15] = target & !0x3;
     }
-    ExecOutcome::branch(3)
+    ExecOutcome::branch_sni(2, 1, 0) // 2S + 1N
 }
 
 // ---------------------------------------------------------------------------
@@ -324,9 +354,15 @@ fn execute_data_processing(regs: &mut Registers, instr: u32) -> ExecOutcome {
     }
 
     if branched {
-        ExecOutcome::branch(2)
+        if reg_shift_by_register {
+            ExecOutcome::branch_sni(2, 1, 1) // 2S + 1N + 1I: PC written + reg shift
+        } else {
+            ExecOutcome::branch_sni(2, 1, 0) // 2S + 1N: PC written
+        }
+    } else if reg_shift_by_register {
+        ExecOutcome::sni(1, 0, 1) // 1S + 1I: register-specified shift
     } else {
-        ExecOutcome::cycles(1)
+        ExecOutcome::sni(1, 0, 0) // 1S
     }
 }
 
@@ -525,11 +561,11 @@ fn execute_single_data_transfer<B: Bus>(
     }
 
     if result_branch {
-        ExecOutcome::branch(3)
+        ExecOutcome::branch_sni(2, 2, 1) // LDR PC: 2S + 2N + 1I
     } else if l {
-        ExecOutcome::cycles(3)
+        ExecOutcome::sni(1, 1, 1) // LDR: 1S + 1N + 1I
     } else {
-        ExecOutcome::cycles(2)
+        ExecOutcome::sni(0, 2, 0) // STR: 2N
     }
 }
 
@@ -567,7 +603,7 @@ fn execute_multiply(regs: &mut Registers, instr: u32) -> ExecOutcome {
         regs.set_nzcv(n, z, c, regs.v_flag());
     }
 
-    ExecOutcome::cycles(cycles)
+    ExecOutcome::sni(1, 0, cycles - 1) // MUL/MLA: 1S + mI
 }
 
 // ---------------------------------------------------------------------------
@@ -621,7 +657,7 @@ fn execute_long_multiply(regs: &mut Registers, instr: u32) -> ExecOutcome {
         regs.set_nzcv(n, z, c, regs.v_flag());
     }
 
-    ExecOutcome::cycles(cycles)
+    ExecOutcome::sni(1, 0, cycles - 1) // Long multiply: 1S + mI
 }
 
 /// Compute multiply internal cycles based on Rs magnitude (early termination).
@@ -784,7 +820,7 @@ fn execute_mrs(regs: &mut Registers, instr: u32) -> ExecOutcome {
     let value = if spsr { regs.spsr() } else { regs.cpsr };
     regs.r[rd] = value;
 
-    ExecOutcome::cycles(1)
+    ExecOutcome::sni(1, 0, 0) // MRS: 1S
 }
 
 /// MSR (register): Move register to PSR with field mask.
@@ -795,7 +831,7 @@ fn execute_msr_reg(regs: &mut Registers, instr: u32) -> ExecOutcome {
     let value = regs.r[rm];
 
     apply_msr(regs, value, mask, spsr);
-    ExecOutcome::cycles(1)
+    ExecOutcome::sni(1, 0, 0) // MSR reg: 1S
 }
 
 /// MSR (immediate): Move rotated immediate to PSR with field mask.
@@ -807,7 +843,7 @@ fn execute_msr_imm(regs: &mut Registers, instr: u32) -> ExecOutcome {
     let value = imm8.rotate_right(rotate);
 
     apply_msr(regs, value, mask, spsr);
-    ExecOutcome::cycles(1)
+    ExecOutcome::sni(1, 0, 0) // MSR imm: 1S
 }
 
 /// Apply MSR value to CPSR or SPSR with field mask.
@@ -934,11 +970,11 @@ fn execute_halfword_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u
     }
 
     if result_branch {
-        ExecOutcome::branch(3)
+        ExecOutcome::branch_sni(2, 2, 1) // LDRH PC: 2S + 2N + 1I
     } else if l {
-        ExecOutcome::cycles(3) // 1S + 1N + 1I
+        ExecOutcome::sni(1, 1, 1) // LDRH/LDRSB/LDRSH: 1S + 1N + 1I
     } else {
-        ExecOutcome::cycles(2) // 2N
+        ExecOutcome::sni(0, 2, 0) // STRH: 2N
     }
 }
 
@@ -1041,22 +1077,20 @@ fn execute_block_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32)
     }
 
     // Cycle timing per GBATek:
-    // LDM: nS + 1N + 1I (+ 1S + 1N if PC loaded)
+    // LDM: nS + 1N + 1I (+ 1S + 1N if PC loaded for pipeline refill)
     // STM: (n-1)S + 2N
-    let cycles = if l {
-        if branch_occurred {
-            (reg_count + 2) as u8 + 2 // extra for PC
-        } else {
-            (reg_count + 2) as u8
-        }
-    } else {
-        (reg_count + 1) as u8
-    };
-
     if branch_occurred {
-        ExecOutcome::branch(cycles)
+        // LDM with PC: (n+1)S + 2N + 1I
+        let n = reg_count as u8;
+        ExecOutcome::branch_sni(n + 1, 2, 1)
+    } else if l {
+        // LDM: nS + 1N + 1I
+        let n = reg_count as u8;
+        ExecOutcome::sni(n, 1, 1)
     } else {
-        ExecOutcome::cycles(cycles)
+        // STM: (n-1)S + 2N
+        let n = reg_count as u8;
+        ExecOutcome::sni(n.saturating_sub(1), 2, 0)
     }
 }
 
@@ -1088,7 +1122,7 @@ fn execute_swap<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32) -> ExecOu
     }
 
     // Cycle timing: 1S + 2N + 1I
-    ExecOutcome::cycles(4)
+    ExecOutcome::sni(1, 2, 1)
 }
 
 #[cfg(test)]
@@ -2147,7 +2181,7 @@ mod tests {
         let stmia = arm_block_transfer(0xE, false, true, false, true, false, 0, 0);
         let outcome = execute(&mut regs, &mut bus, stmia);
         // Should complete without crashing; base unchanged since no registers transferred
-        assert!(outcome.cycles > 0);
+        assert!(outcome.total_flat_cycles() > 0);
     }
 
     #[test]
@@ -2471,5 +2505,123 @@ mod tests {
             "STRH should NOT trigger undefined, got: {outcome:?}"
         );
         assert_eq!(bus.read16(0x40), 0x1234);
+    }
+
+    // -------------------------------------------------------------------------
+    // S/N/I cycle decomposition tests (GBATek ARM7TDMI timing)
+    // -------------------------------------------------------------------------
+
+    /// ARM data-processing (register): 1S per GBATek.
+    #[test]
+    fn arm_data_processing_sni_is_1s() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        // MOV R0, #42 (immediate data processing, no register shift)
+        let instr = 0xE3A0_002A; // MOV R0, #42
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 1, "data-processing should be 1S");
+        assert_eq!(outcome.nonseq, 0, "data-processing should have 0N");
+        assert_eq!(outcome.internal, 0, "data-processing should have 0I");
+    }
+
+    /// ARM branch: 2S + 1N per GBATek.
+    #[test]
+    fn arm_branch_sni_is_2s_1n() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x1000);
+        regs.r[15] = 0x100;
+        // B #0 (branch to PC+8, offset=0)
+        let instr = 0xEA00_0000;
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 2, "branch should be 2S");
+        assert_eq!(outcome.nonseq, 1, "branch should have 1N");
+        assert_eq!(outcome.internal, 0, "branch should have 0I");
+    }
+
+    /// ARM BX: 2S + 1N per GBATek.
+    #[test]
+    fn arm_bx_sni_is_2s_1n() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x1000);
+        regs.r[0] = 0x200;
+        // BX R0
+        let instr = 0xE12F_FF10;
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 2, "BX should be 2S");
+        assert_eq!(outcome.nonseq, 1, "BX should have 1N");
+        assert_eq!(outcome.internal, 0, "BX should have 0I");
+    }
+
+    /// ARM LDR: 1S + 1N + 1I per GBATek.
+    #[test]
+    fn arm_ldr_sni_is_1s_1n_1i() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40;
+        bus.write32(0x40, 0x1234);
+        // LDR R0, [R1] (immediate offset 0)
+        let instr = 0xE591_0000;
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 1, "LDR should be 1S");
+        assert_eq!(outcome.nonseq, 1, "LDR should have 1N");
+        assert_eq!(outcome.internal, 1, "LDR should have 1I");
+    }
+
+    /// ARM STR: 2N per GBATek.
+    #[test]
+    fn arm_str_sni_is_2n() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0xDEAD;
+        regs.r[1] = 0x40;
+        // STR R0, [R1]
+        let instr = 0xE581_0000;
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 0, "STR should be 0S");
+        assert_eq!(outcome.nonseq, 2, "STR should have 2N");
+        assert_eq!(outcome.internal, 0, "STR should have 0I");
+    }
+
+    /// ARM SWP: 1S + 2N + 1I per GBATek.
+    #[test]
+    fn arm_swp_sni_is_1s_2n_1i() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0x40;
+        regs.r[1] = 0xBEEF;
+        bus.write32(0x40, 0xCAFE);
+        let instr = arm_swap(0xE, false, 0, 2, 1);
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 1, "SWP should be 1S");
+        assert_eq!(outcome.nonseq, 2, "SWP should have 2N");
+        assert_eq!(outcome.internal, 1, "SWP should have 1I");
+    }
+
+    /// ARM MUL (simple, Rs=1 → early termination 1 cycle): 1S + 1I per GBATek.
+    #[test]
+    fn arm_mul_sni_has_seq_and_internal() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 5; // Rm
+        regs.r[1] = 1; // Rs (small → early termination, m=1)
+        // MUL R2, R0, R1: cond 0000 00 0 0 Rd Rs 1001 Rm
+        let instr = 0xE000_2190; // MUL R2, R0, R1
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 1, "MUL should have 1S");
+        assert!(outcome.internal >= 1, "MUL should have at least 1I");
+        assert_eq!(outcome.nonseq, 0, "MUL should have 0N");
+    }
+
+    /// ARM condition-false (skipped): 1S per GBATek.
+    #[test]
+    fn arm_condition_false_sni_is_1s() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        // EQ = 0000, requires Z=1. With default Z=0, this instruction is skipped.
+        let instr = 0x03A0_002A; // MOVEQ R0, #42
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 1, "skipped instruction should be 1S");
+        assert_eq!(outcome.nonseq, 0, "skipped instruction should have 0N");
+        assert_eq!(outcome.internal, 0, "skipped instruction should have 0I");
     }
 }

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -1529,7 +1529,7 @@ mod tests {
         let slow_cycles = cpu.step(&mut slow_bus);
         assert_eq!(
             slow_cycles, 3,
-            "MOV with SlowBus (S=3) should cost 3, but step() doesn't use bus timing yet"
+            "MOV (1S) with SlowBus (s_cycles=3) should resolve to 3 cycles"
         );
     }
 }

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -249,7 +249,7 @@ impl Arm7tdmi {
                 self.prefetch_thumb[1] = self.prefetch_thumb[2];
                 self.prefetch_thumb[2] = bus.read16(exec_pc.wrapping_add(6));
             }
-            outcome.cycles as u32
+            outcome.resolve_cycles(bus.s_cycles(exec_pc), bus.n_cycles(exec_pc))
         } else {
             // PC during ARM execution should read as exec_pc + 8.
             self.regs.r[15] = exec_pc.wrapping_add(8);
@@ -283,7 +283,7 @@ impl Arm7tdmi {
                 self.prefetch_arm[1] = self.prefetch_arm[2];
                 self.prefetch_arm[2] = bus.read32(exec_pc.wrapping_add(12));
             }
-            outcome.cycles as u32
+            outcome.resolve_cycles(bus.s_cycles(exec_pc), bus.n_cycles(exec_pc))
         };
 
         self.cycles = self.cycles.wrapping_add(cycles as u64);
@@ -1453,5 +1453,83 @@ mod tests {
         );
         // PC should advance past the SWI (exec_pc + 4 for ARM).
         assert_eq!(cpu.regs.r[15], 0x04, "PC should advance past the SWI");
+    }
+
+    // -----------------------------------------------------------------------
+    // step() cycle resolution via Bus timing
+    // -----------------------------------------------------------------------
+
+    /// A custom bus with configurable access costs, used to verify that
+    /// step() resolves S/N/I counts through the bus timing methods.
+    struct SlowBus {
+        inner: RamBus,
+        s_cost: u32,
+        n_cost: u32,
+    }
+
+    impl SlowBus {
+        fn new(s_cost: u32, n_cost: u32) -> Self {
+            Self {
+                inner: RamBus::new(0x1000),
+                s_cost,
+                n_cost,
+            }
+        }
+    }
+
+    impl Bus for SlowBus {
+        fn read32(&mut self, addr: u32) -> u32 {
+            self.inner.read32(addr)
+        }
+        fn read16(&mut self, addr: u32) -> u16 {
+            self.inner.read16(addr)
+        }
+        fn read8(&mut self, addr: u32) -> u8 {
+            self.inner.read8(addr)
+        }
+        fn write32(&mut self, addr: u32, value: u32) {
+            self.inner.write32(addr, value);
+        }
+        fn write16(&mut self, addr: u32, value: u16) {
+            self.inner.write16(addr, value);
+        }
+        fn write8(&mut self, addr: u32, value: u8) {
+            self.inner.write8(addr, value);
+        }
+        fn n_cycles(&self, _addr: u32) -> u32 {
+            self.n_cost
+        }
+        fn s_cycles(&self, _addr: u32) -> u32 {
+            self.s_cost
+        }
+    }
+
+    /// With a RamBus (all costs = 1), a MOV immediate (1S) should cost 1 cycle.
+    /// With a SlowBus (S=3, N=5), the same MOV should cost 3 cycles.
+    #[test]
+    fn step_resolves_sni_via_bus_timing() {
+        // MOV R0, #42 in ARM (data processing, 1S)
+        let mov_instr: u32 = 0xE3A0_002A;
+
+        // Fast bus: S=1, N=1 → total = 1*1 = 1
+        let mut cpu = Arm7tdmi::new();
+        let mut fast_bus = RamBus::new(0x1000);
+        fast_bus.write_word(0x00, mov_instr);
+        cpu.regs.r[15] = 0x00;
+        cpu.prefetch_valid = false;
+        let fast_cycles = cpu.step(&mut fast_bus);
+        assert_eq!(fast_cycles, 1, "MOV with RamBus (S=1) should cost 1");
+
+        // Slow bus: S=3, N=5 → total = 1*3 = 3
+        let mut cpu = Arm7tdmi::new();
+        let mut slow_bus = SlowBus::new(3, 5);
+        slow_bus.inner.write_word(0x00, mov_instr);
+        cpu.regs.r[15] = 0x00;
+        cpu.prefetch_valid = false;
+        let slow_cycles = cpu.step(&mut slow_bus);
+        assert_eq!(
+            slow_cycles, 3,
+            "MOV with SlowBus (S=3) should cost 3, but step() doesn't use bus timing yet"
+        );
     }
 }

--- a/src/gba/cpu/bus.rs
+++ b/src/gba/cpu/bus.rs
@@ -28,6 +28,12 @@ pub trait Bus {
 
     /// Write a single byte.
     fn write8(&mut self, addr: u32, value: u8);
+
+    /// Non-sequential access cycle cost for the given address.
+    fn n_cycles(&self, addr: u32) -> u32;
+
+    /// Sequential access cycle cost for the given address.
+    fn s_cycles(&self, addr: u32) -> u32;
 }
 
 /// Flat, little-endian RAM-only bus used in unit tests and as a stub for the
@@ -115,6 +121,14 @@ impl Bus for RamBus {
         let i = self.idx(addr);
         self.bytes[i] = value;
     }
+
+    fn n_cycles(&self, _addr: u32) -> u32 {
+        1
+    }
+
+    fn s_cycles(&self, _addr: u32) -> u32 {
+        1
+    }
 }
 
 #[cfg(test)]
@@ -154,5 +168,19 @@ mod tests {
     #[should_panic(expected = "RamBus size must be greater than zero")]
     fn ram_bus_rejects_zero_size() {
         let _ = RamBus::new(0);
+    }
+
+    #[test]
+    fn ram_bus_n_cycles_returns_1() {
+        let bus = RamBus::new(0x100);
+        assert_eq!(bus.n_cycles(0x0000_0000), 1);
+        assert_eq!(bus.n_cycles(0x0800_0000), 1);
+    }
+
+    #[test]
+    fn ram_bus_s_cycles_returns_1() {
+        let bus = RamBus::new(0x100);
+        assert_eq!(bus.s_cycles(0x0000_0000), 1);
+        assert_eq!(bus.s_cycles(0x0800_0000), 1);
     }
 }

--- a/src/gba/cpu/thumb.rs
+++ b/src/gba/cpu/thumb.rs
@@ -1055,7 +1055,7 @@ fn exec_format19(regs: &mut Registers, instr: u16) -> ExecOutcome {
     regs.r[14] = old_pc | 1; // Set bit 0 to indicate return to Thumb
     regs.r[15] = target & !1;
     ExecOutcome {
-        seq: 3,
+        seq: 2,
         nonseq: 1,
         internal: 0,
         branched: true,

--- a/src/gba/cpu/thumb.rs
+++ b/src/gba/cpu/thumb.rs
@@ -80,7 +80,9 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOut
                 exec_format8(regs, bus, instr)
             } else {
                 ExecOutcome {
-                    cycles: 1,
+                    seq: 1,
+                    nonseq: 0,
+                    internal: 0,
                     branched: false,
                     swi: false,
                     undefined: false,
@@ -108,7 +110,9 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOut
                 ExecOutcome::undefined()
             } else {
                 ExecOutcome {
-                    cycles: 1,
+                    seq: 1,
+                    nonseq: 0,
+                    internal: 0,
                     branched: false,
                     swi: false,
                     undefined: false,
@@ -126,7 +130,9 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOut
         // Format 19: 1111x — Long branch with link
         0b11110 | 0b11111 => exec_format19(regs, instr),
         _ => ExecOutcome {
-            cycles: 1,
+            seq: 1,
+            nonseq: 0,
+            internal: 0,
             branched: false,
             swi: false,
             undefined: false,
@@ -181,7 +187,9 @@ fn exec_format1(regs: &mut Registers, instr: u16) -> ExecOutcome {
     regs.r[rd] = result;
     regs.set_nzcv(result & 0x8000_0000 != 0, result == 0, carry, regs.v_flag());
     ExecOutcome {
-        cycles: 1,
+        seq: 1,
+        nonseq: 0,
+        internal: 0,
         branched: false,
         swi: false,
         undefined: false,
@@ -213,7 +221,9 @@ fn exec_format2(regs: &mut Registers, instr: u16) -> ExecOutcome {
     regs.r[rd] = result;
     regs.set_nzcv(result & 0x8000_0000 != 0, result == 0, carry, overflow);
     ExecOutcome {
-        cycles: 1,
+        seq: 1,
+        nonseq: 0,
+        internal: 0,
         branched: false,
         swi: false,
         undefined: false,
@@ -255,7 +265,9 @@ fn exec_format3(regs: &mut Registers, instr: u16) -> ExecOutcome {
         _ => unreachable!(),
     }
     ExecOutcome {
-        cycles: 1,
+        seq: 1,
+        nonseq: 0,
+        internal: 0,
         branched: false,
         swi: false,
         undefined: false,
@@ -406,8 +418,21 @@ fn exec_format4(regs: &mut Registers, instr: u16) -> ExecOutcome {
         regs.r[rd] = result;
     }
     regs.set_nzcv(result & 0x8000_0000 != 0, result == 0, carry, overflow);
+
+    // GBATek: 1S+1I for shift-by-register (opcodes 2-4,7),
+    //         1S+mI for MUL (opcode 0xD), else 1S.
+    let internal = match op {
+        0x2 | 0x3 | 0x4 | 0x7 => 1, // register shifts: +1I
+        0xD => {
+            let (cycles, _) = super::arm::multiply_cycles_and_full(b, true);
+            cycles - 1 // subtract the 1S already counted
+        }
+        _ => 0,
+    };
     ExecOutcome {
-        cycles: 1,
+        seq: 1,
+        nonseq: 0,
+        internal,
         branched: false,
         swi: false,
         undefined: false,
@@ -433,7 +458,9 @@ fn exec_format5(regs: &mut Registers, instr: u16) -> ExecOutcome {
             if rd == 15 {
                 regs.r[15] &= !1;
                 return ExecOutcome {
-                    cycles: 3,
+                    seq: 2,
+                    nonseq: 1,
+                    internal: 0,
                     branched: true,
                     swi: false,
                     undefined: false,
@@ -451,7 +478,9 @@ fn exec_format5(regs: &mut Registers, instr: u16) -> ExecOutcome {
             if rd == 15 {
                 regs.r[15] &= !1;
                 return ExecOutcome {
-                    cycles: 3,
+                    seq: 2,
+                    nonseq: 1,
+                    internal: 0,
                     branched: true,
                     swi: false,
                     undefined: false,
@@ -468,7 +497,9 @@ fn exec_format5(regs: &mut Registers, instr: u16) -> ExecOutcome {
                 regs.set_thumb(false);
             }
             return ExecOutcome {
-                cycles: 3,
+                seq: 2,
+                nonseq: 1,
+                internal: 0,
                 branched: true,
                 swi: false,
                 undefined: false,
@@ -477,7 +508,9 @@ fn exec_format5(regs: &mut Registers, instr: u16) -> ExecOutcome {
         _ => unreachable!(),
     }
     ExecOutcome {
-        cycles: 1,
+        seq: 1,
+        nonseq: 0,
+        internal: 0,
         branched: false,
         swi: false,
         undefined: false,
@@ -496,7 +529,9 @@ fn exec_format6<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
     let addr = pc.wrapping_add(imm << 2);
     regs.r[rd] = bus.read32(addr);
     ExecOutcome {
-        cycles: 3,
+        seq: 1,
+        nonseq: 1,
+        internal: 1,
         branched: false,
         swi: false,
         undefined: false,
@@ -535,7 +570,9 @@ fn exec_format7<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         }
     }
     ExecOutcome {
-        cycles: if l { 3 } else { 2 },
+        seq: if l { 1 } else { 0 },
+        nonseq: if l { 1 } else { 2 },
+        internal: if l { 1 } else { 0 },
         branched: false,
         swi: false,
         undefined: false,
@@ -563,7 +600,9 @@ fn exec_format8<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         // STRH
         bus.write16(thumb_store_halfword_addr(addr), regs.r[rd] as u16);
         return ExecOutcome {
-            cycles: 2,
+            seq: 0,
+            nonseq: 2,
+            internal: 0,
             branched: false,
             swi: false,
             undefined: false,
@@ -592,7 +631,9 @@ fn exec_format8<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         _ => unreachable!(),
     };
     ExecOutcome {
-        cycles: 3,
+        seq: 1,
+        nonseq: 1,
+        internal: 1,
         branched: false,
         swi: false,
         undefined: false,
@@ -631,7 +672,9 @@ fn exec_format9<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         bus.write32(thumb_store_word_addr(addr), regs.r[rd]);
     }
     ExecOutcome {
-        cycles: if l { 3 } else { 2 },
+        seq: if l { 1 } else { 0 },
+        nonseq: if l { 1 } else { 2 },
+        internal: if l { 1 } else { 0 },
         branched: false,
         swi: false,
         undefined: false,
@@ -661,7 +704,9 @@ fn exec_format10<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
         bus.write16(thumb_store_halfword_addr(addr), regs.r[rd] as u16);
     }
     ExecOutcome {
-        cycles: if l { 3 } else { 2 },
+        seq: if l { 1 } else { 0 },
+        nonseq: if l { 1 } else { 2 },
+        internal: if l { 1 } else { 0 },
         branched: false,
         swi: false,
         undefined: false,
@@ -688,7 +733,9 @@ fn exec_format11<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
         bus.write32(thumb_store_word_addr(addr), regs.r[rd]);
     }
     ExecOutcome {
-        cycles: if l { 3 } else { 2 },
+        seq: if l { 1 } else { 0 },
+        nonseq: if l { 1 } else { 2 },
+        internal: if l { 1 } else { 0 },
         branched: false,
         swi: false,
         undefined: false,
@@ -711,7 +758,9 @@ fn exec_format12(regs: &mut Registers, instr: u16) -> ExecOutcome {
     };
     regs.r[rd] = base.wrapping_add(offset);
     ExecOutcome {
-        cycles: 1,
+        seq: 1,
+        nonseq: 0,
+        internal: 0,
         branched: false,
         swi: false,
         undefined: false,
@@ -732,7 +781,9 @@ fn exec_format13(regs: &mut Registers, instr: u16) -> ExecOutcome {
         regs.r[13] = regs.r[13].wrapping_add(offset);
     }
     ExecOutcome {
-        cycles: 1,
+        seq: 1,
+        nonseq: 0,
+        internal: 0,
         branched: false,
         swi: false,
         undefined: false,
@@ -785,11 +836,37 @@ fn exec_format14<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
         regs.r[13] = sp;
     }
 
-    ExecOutcome {
-        cycles: 3,
-        branched,
-        swi: false,
-        undefined: false,
+    let n = count as u8;
+    if branched {
+        // POP {PC}: (n+1)S + 2N + 1I
+        ExecOutcome {
+            seq: n + 1,
+            nonseq: 2,
+            internal: 1,
+            branched: true,
+            swi: false,
+            undefined: false,
+        }
+    } else if load {
+        // POP: nS + 1N + 1I
+        ExecOutcome {
+            seq: n,
+            nonseq: 1,
+            internal: 1,
+            branched: false,
+            swi: false,
+            undefined: false,
+        }
+    } else {
+        // PUSH: (n-1)S + 2N
+        ExecOutcome {
+            seq: n.saturating_sub(1),
+            nonseq: 2,
+            internal: 0,
+            branched: false,
+            swi: false,
+            undefined: false,
+        }
     }
 }
 
@@ -852,15 +929,37 @@ fn exec_format15<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
     // Writeback uses original base, not potentially modified regs.r[rb]
     regs.r[rb] = base.wrapping_add(count * 4);
 
-    ExecOutcome {
-        cycles: if l {
-            (count + 2) as u8
-        } else {
-            (count + 1) as u8
-        },
-        branched,
-        swi: false,
-        undefined: false,
+    let n = count as u8;
+    if branched {
+        // LDMIA with PC: (n+1)S + 2N + 1I
+        ExecOutcome {
+            seq: n + 1,
+            nonseq: 2,
+            internal: 1,
+            branched: true,
+            swi: false,
+            undefined: false,
+        }
+    } else if l {
+        // LDMIA: nS + 1N + 1I
+        ExecOutcome {
+            seq: n,
+            nonseq: 1,
+            internal: 1,
+            branched: false,
+            swi: false,
+            undefined: false,
+        }
+    } else {
+        // STMIA: (n-1)S + 2N
+        ExecOutcome {
+            seq: n.saturating_sub(1),
+            nonseq: 2,
+            internal: 0,
+            branched: false,
+            swi: false,
+            undefined: false,
+        }
     }
 }
 
@@ -871,9 +970,11 @@ fn exec_format15<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
 fn exec_format16(regs: &mut Registers, instr: u16) -> ExecOutcome {
     let cond = ((instr >> 8) & 0xF) as u8;
     if cond == 0xF {
-        // SWI in Thumb is encoded here (1101_1111_xxxxxxxx).
+        // SWI in Thumb: 2S + 1N
         return ExecOutcome {
-            cycles: 3,
+            seq: 2,
+            nonseq: 1,
+            internal: 0,
             branched: true,
             swi: true,
             undefined: false,
@@ -881,7 +982,9 @@ fn exec_format16(regs: &mut Registers, instr: u16) -> ExecOutcome {
     }
     if !condition_met(regs.cpsr, cond) {
         return ExecOutcome {
-            cycles: 1,
+            seq: 1,
+            nonseq: 0,
+            internal: 0,
             branched: false,
             swi: false,
             undefined: false,
@@ -890,7 +993,9 @@ fn exec_format16(regs: &mut Registers, instr: u16) -> ExecOutcome {
     let offset = ((instr & 0xFF) as i8) as i32 * 2;
     regs.r[15] = (regs.r[15] as i32).wrapping_add(offset) as u32;
     ExecOutcome {
-        cycles: 3,
+        seq: 2,
+        nonseq: 1,
+        internal: 0,
         branched: true,
         swi: false,
         undefined: false,
@@ -907,7 +1012,9 @@ fn exec_format18(regs: &mut Registers, instr: u16) -> ExecOutcome {
     let signed = ((offset11 << 21) >> 21) << 1;
     regs.r[15] = (regs.r[15] as i32).wrapping_add(signed) as u32;
     ExecOutcome {
-        cycles: 3,
+        seq: 2,
+        nonseq: 1,
+        internal: 0,
         branched: true,
         swi: false,
         undefined: false,
@@ -933,7 +1040,9 @@ fn exec_format19(regs: &mut Registers, instr: u16) -> ExecOutcome {
         let offset = ((sign_ext | offset11) << 12) as i32;
         regs.r[14] = (regs.r[15] as i32).wrapping_add(offset) as u32;
         return ExecOutcome {
-            cycles: 1,
+            seq: 1,
+            nonseq: 0,
+            internal: 0,
             branched: false,
             swi: false,
             undefined: false,
@@ -946,7 +1055,9 @@ fn exec_format19(regs: &mut Registers, instr: u16) -> ExecOutcome {
     regs.r[14] = old_pc | 1; // Set bit 0 to indicate return to Thumb
     regs.r[15] = target & !1;
     ExecOutcome {
-        cycles: 4,
+        seq: 3,
+        nonseq: 1,
+        internal: 0,
         branched: true,
         swi: false,
         undefined: false,
@@ -1539,5 +1650,52 @@ mod tests {
             !outcome.undefined,
             "Unconditional B should NOT trigger undefined, got: {outcome:?}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // S/N/I cycle decomposition tests (GBATek Thumb timing)
+    // -----------------------------------------------------------------------
+
+    /// Thumb Format 1 (shift immediate): 1S per GBATek.
+    #[test]
+    fn thumb_format1_sni_is_1s() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[0] = 0xFF;
+        // LSL R1, R0, #2
+        let instr: u16 = 0x0081; // 00000_00010_000_001
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 1, "Thumb shift should be 1S");
+        assert_eq!(outcome.nonseq, 0);
+        assert_eq!(outcome.internal, 0);
+    }
+
+    /// Thumb Format 6 (PC-relative load): 1S + 1N + 1I per GBATek.
+    #[test]
+    fn thumb_pc_relative_load_sni_is_1s_1n_1i() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x200);
+        regs.r[15] = 0x100;
+        bus.write32(0x100, 0xDEAD_BEEF);
+        // LDR R0, [PC, #0]
+        let instr: u16 = 0x4800; // 01001_000_00000000
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 1, "PC-relative LDR should be 1S");
+        assert_eq!(outcome.nonseq, 1, "PC-relative LDR should have 1N");
+        assert_eq!(outcome.internal, 1, "PC-relative LDR should have 1I");
+    }
+
+    /// Thumb unconditional branch: 2S + 1N per GBATek.
+    #[test]
+    fn thumb_unconditional_branch_sni_is_2s_1n() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x200);
+        regs.r[15] = 0x100;
+        // B #8 (offset=4, <<1 = 8)
+        let instr: u16 = 0b11100_00000000100;
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert_eq!(outcome.seq, 2, "Thumb branch should be 2S");
+        assert_eq!(outcome.nonseq, 1, "Thumb branch should have 1N");
+        assert_eq!(outcome.internal, 0);
     }
 }

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -4,7 +4,7 @@ use crate::platform::app_context::AppContext;
 use crate::platform::emulator::Emulator;
 use std::path::PathBuf;
 
-const MAX_CYCLES: u64 = 120_000_000;
+const MAX_CYCLES: u64 = 480_000_000;
 const IDLE_PROBE_STABLE_PC_THRESHOLD: u32 = 1;
 // The suite ends in `idle: b idle` (ARM `b .`, opcode 0xEAFFFFFE).
 const ARM_BRANCH_SELF_OPCODE: u32 = 0xEAFF_FFFE;
@@ -491,124 +491,172 @@ pub fn run_armwrestler() -> ArmWrestlerResult {
     // edge-detection (XOR with previous state) requires a clean release
     // between successive presses.
     //
-    // Frame schedule:
-    //   ARM tests (enter from menu item 0, chain Test0–Test4):
-    //     Frame 2: START (menu → Test0)
-    //     Frame 4: capture[0], START (→ Test1)
-    //     Frame 6: capture[1], START (→ Test2)
-    //     Frame 8: capture[2], START (→ Test3)
-    //     Frame 10: capture[3], START (→ Test4)
-    //     Frame 12: capture[4], START (→ menu, TESTNUM wraps)
-    //   Navigate to THUMB ALU (menu item 3 via DOWN×3):
-    //     Frame 14: DOWN (CURSEL 0→1)
-    //     Frame 16: DOWN (CURSEL 1→2)
-    //     Frame 18: DOWN (CURSEL 2→3)
-    //   THUMB tests (enter from menu item 3, chain _test0–_test2):
-    //     Frame 20: START (menu → _tmbmain → _test0 init)
-    //     Frame 22-23: wait (THUMB entry does extra VSync before rendering)
-    //     Frame 24: capture[5], START (→ _test1)
-    //     Frame 26: capture[6], START (→ _test2)
-    //     Frame 28: capture[7] → done
+    // Instead of hard-coding frame numbers (fragile under timing changes),
+    // we use a "wait until screen CRC changes" approach: press a button,
+    // then keep running frames until the screen content changes from
+    // what it was before the press.
 
-    let mut frame_count: u32 = 0;
     let mut cycles: u64 = 0;
     let mut page_crcs: Vec<u32> = Vec::new();
-    let mut button_state: u8 = 0;
-    let max_frames: u32 = 35;
 
-    // Advance to first VBlank (frame 0 is the initial partial frame)
-    assert!(
-        run_until_frame_ready(&mut gba, &mut cycles),
-        "armwrestler: CPU halted or timed out before first frame"
-    );
-    gba.clear_ready_to_render();
-    frame_count += 1;
-
-    while frame_count < max_frames && page_crcs.len() < ARMWRESTLER_TEST_PAGE_COUNT {
-        // Apply button state for this frame
-        gba.set_joypad_button_states(0, button_state);
-
-        // Run to next VBlank
+    // Boot: run frames until the menu is fully rendered and stable.
+    // The ROM takes some frames to initialize; during this time the screen is black.
+    // Wait for a non-black stable screen (same CRC for 5 consecutive frames, not the
+    // blank-screen CRC).
+    let mut menu_crc = 0u32;
+    let mut stable = 0u32;
+    for _ in 0..120 {
         assert!(
             run_until_frame_ready(&mut gba, &mut cycles),
-            "armwrestler: CPU halted or timed out at frame {frame_count}"
+            "armwrestler: halted during boot"
         );
         gba.clear_ready_to_render();
-        frame_count += 1;
-
-        match frame_count {
-            // --- ARM test chain (pages 0–4) ---
-            2 => button_state = BTN_START,
-            3 => button_state = 0,
-            4 => {
-                let crc = gba.screen_crc32();
-                page_crcs.push(crc);
-                maybe_write_armwrestler_png(&gba, 0, crc);
-                button_state = BTN_START;
+        let crc = gba.screen_crc32();
+        if crc == menu_crc {
+            stable += 1;
+            if stable >= 5 {
+                break;
             }
-            5 => button_state = 0,
-            6 => {
-                let crc = gba.screen_crc32();
-                page_crcs.push(crc);
-                maybe_write_armwrestler_png(&gba, 1, crc);
-                button_state = BTN_START;
-            }
-            7 => button_state = 0,
-            8 => {
-                let crc = gba.screen_crc32();
-                page_crcs.push(crc);
-                maybe_write_armwrestler_png(&gba, 2, crc);
-                button_state = BTN_START;
-            }
-            9 => button_state = 0,
-            10 => {
-                let crc = gba.screen_crc32();
-                page_crcs.push(crc);
-                maybe_write_armwrestler_png(&gba, 3, crc);
-                button_state = BTN_START;
-            }
-            11 => button_state = 0,
-            12 => {
-                let crc = gba.screen_crc32();
-                page_crcs.push(crc);
-                maybe_write_armwrestler_png(&gba, 4, crc);
-                // Press START to return from Test4 to menu
-                button_state = BTN_START;
-            }
-            13 => button_state = 0,
-            // --- Navigate menu DOWN×3 to THUMB ALU (item 3) ---
-            14 => button_state = BTN_DOWN,
-            15 => button_state = 0,
-            16 => button_state = BTN_DOWN,
-            17 => button_state = 0,
-            18 => button_state = BTN_DOWN,
-            19 => button_state = 0,
-            // --- Enter THUMB tests ---
-            20 => button_state = BTN_START,
-            21 => button_state = 0,
-            // Frames 22-23: THUMB entry does an extra VSync before rendering _test0
-            24 => {
-                let crc = gba.screen_crc32();
-                page_crcs.push(crc);
-                maybe_write_armwrestler_png(&gba, 5, crc);
-                button_state = BTN_START;
-            }
-            25 => button_state = 0,
-            26 => {
-                let crc = gba.screen_crc32();
-                page_crcs.push(crc);
-                maybe_write_armwrestler_png(&gba, 6, crc);
-                button_state = BTN_START;
-            }
-            27 => button_state = 0,
-            28 => {
-                let crc = gba.screen_crc32();
-                page_crcs.push(crc);
-                maybe_write_armwrestler_png(&gba, 7, crc);
-                button_state = 0;
-            }
-            _ => {}
+        } else {
+            menu_crc = crc;
+            stable = 1;
         }
+    }
+    // The menu CRC from boot might be an intermediate state (e.g., before cursor renders).
+    // Run a few more frames to let the menu fully settle.
+    for _ in 0..10 {
+        assert!(
+            run_until_frame_ready(&mut gba, &mut cycles),
+            "armwrestler: halted during boot settle"
+        );
+        gba.clear_ready_to_render();
+    }
+
+    // Helper: press a button and wait for screen to stabilize at a new value.
+    // Holds button for 2 frames (to ensure the ROM's VSync polling catches it),
+    // then waits for a CRC different from prev_crc that stays the same for 2 consecutive frames.
+    let press_and_wait = |gba: &mut Gba, cycles: &mut u64, button: u8, prev_crc: u32| -> u32 {
+        // Hold button for 2 frames (ensures ROM's VBlank-based input poll catches it)
+        gba.set_joypad_button_states(0, button);
+        for _ in 0..2 {
+            assert!(run_until_frame_ready(gba, cycles), "halted during press");
+            gba.clear_ready_to_render();
+        }
+        // Release
+        gba.set_joypad_button_states(0, 0);
+        // Wait for stable new screen (same CRC for 3 consecutive frames, different from prev)
+        let mut last_crc = 0u32;
+        let mut stable_count = 0u32;
+        for _ in 0..60 {
+            assert!(
+                run_until_frame_ready(gba, cycles),
+                "halted waiting for stable"
+            );
+            gba.clear_ready_to_render();
+            let crc = gba.screen_crc32();
+            if crc != prev_crc {
+                if crc == last_crc {
+                    stable_count += 1;
+                    if stable_count >= 3 {
+                        return crc;
+                    }
+                } else {
+                    stable_count = 1;
+                    last_crc = crc;
+                }
+            } else {
+                stable_count = 0;
+                last_crc = 0;
+            }
+        }
+        gba.screen_crc32()
+    };
+
+    // --- ARM test chain (pages 0–4): enter with START, advance with START ---
+
+    // Armwrestler shows a title/splash that looks identical to the interactive menu.
+    // Press START once to transition from title→menu (visual doesn't change), then
+    // the next START enters the selected test.
+    gba.set_joypad_button_states(0, BTN_START);
+    for _ in 0..2 {
+        assert!(
+            run_until_frame_ready(&mut gba, &mut cycles),
+            "halted during title dismiss"
+        );
+        gba.clear_ready_to_render();
+    }
+    gba.set_joypad_button_states(0, 0);
+    // Wait a few frames for the menu to become interactive
+    for _ in 0..5 {
+        assert!(
+            run_until_frame_ready(&mut gba, &mut cycles),
+            "halted after title dismiss"
+        );
+        gba.clear_ready_to_render();
+    }
+    let mut current_crc = gba.screen_crc32();
+
+    // Enter ARM ALU (menu item 0 is already selected)
+    current_crc = press_and_wait(&mut gba, &mut cycles, BTN_START, current_crc);
+    page_crcs.push(current_crc);
+    maybe_write_armwrestler_png(&gba, 0, current_crc);
+
+    for page_idx in 1..5 {
+        current_crc = press_and_wait(&mut gba, &mut cycles, BTN_START, current_crc);
+        page_crcs.push(current_crc);
+        maybe_write_armwrestler_png(&gba, page_idx, current_crc);
+    }
+
+    // After page 4, press START to return to menu.
+    // Use press_and_wait to detect when we're back at the menu screen.
+    let returned_crc = press_and_wait(&mut gba, &mut cycles, BTN_START, current_crc);
+    let _menu_after_arm = returned_crc;
+
+    // Additional settling time: the ROM needs extra frames to fully reset its
+    // internal state after the test chain completes. Without this, subsequent
+    // button presses are ignored.
+    for _ in 0..10 {
+        assert!(
+            run_until_frame_ready(&mut gba, &mut cycles),
+            "halted during post-ARM settle"
+        );
+        gba.clear_ready_to_render();
+    }
+
+    // --- Navigate menu DOWN×3 to THUMB ALU (item 3) ---
+    // Cursor is at item 0 after returning from ARM ALU chain.
+    // Need 3 DOWNs to reach item 3. Use 2-frame hold + 4-frame release gap
+    // to ensure the ROM's edge detection registers each press separately.
+    for _ in 0..3 {
+        gba.set_joypad_button_states(0, BTN_DOWN);
+        for _ in 0..2 {
+            assert!(
+                run_until_frame_ready(&mut gba, &mut cycles),
+                "halted during DOWN"
+            );
+            gba.clear_ready_to_render();
+        }
+        gba.set_joypad_button_states(0, 0);
+        for _ in 0..4 {
+            assert!(
+                run_until_frame_ready(&mut gba, &mut cycles),
+                "halted after DOWN"
+            );
+            gba.clear_ready_to_render();
+        }
+    }
+    // Update current_crc to whatever the menu looks like now
+    current_crc = gba.screen_crc32();
+
+    // --- Enter THUMB tests with START ---
+    current_crc = press_and_wait(&mut gba, &mut cycles, BTN_START, current_crc);
+    page_crcs.push(current_crc);
+    maybe_write_armwrestler_png(&gba, 5, current_crc);
+
+    for page_idx in 6..8 {
+        current_crc = press_and_wait(&mut gba, &mut cycles, BTN_START, current_crc);
+        page_crcs.push(current_crc);
+        maybe_write_armwrestler_png(&gba, page_idx, current_crc);
     }
 
     ArmWrestlerResult { page_crcs, cycles }

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -534,7 +534,7 @@ pub fn run_armwrestler() -> ArmWrestlerResult {
 
     // Helper: press a button and wait for screen to stabilize at a new value.
     // Holds button for 2 frames (to ensure the ROM's VSync polling catches it),
-    // then waits for a CRC different from prev_crc that stays the same for 2 consecutive frames.
+    // then waits for a CRC different from prev_crc that stays the same for 3 consecutive frames.
     let press_and_wait = |gba: &mut Gba, cycles: &mut u64, button: u8, prev_crc: u32| -> u32 {
         // Hold button for 2 frames (ensures ROM's VBlank-based input poll catches it)
         gba.set_joypad_button_states(0, button);


### PR DESCRIPTION
## Summary

Refactors `ExecOutcome` from a flat `cycles: u8` field to separate `seq`, `nonseq`, and `internal` fields per GBATek ARM7TDMI instruction timing documentation. This is sub-issue 1 of #2385.

## Changes

### Core S/N/I Model (`src/gba/cpu/arm.rs`)
- `ExecOutcome` struct: `seq: u8`, `nonseq: u8`, `internal: u8`
- Constructors: `sni()`, `branch_sni()`, `swi_sni()`, `undefined()`
- `resolve_cycles(s_cost, n_cost)` → `seq*s_cost + nonseq*n_cost + internal`
- `total_flat_cycles()` → `seq + nonseq + internal` (for unit test buses)

### Bus Trait Extension (`src/gba/cpu/bus.rs`)
- `n_cycles()` / `s_cycles()` added to `Bus` trait
- `RamBus` returns 1 for both (preserves existing unit test behavior)

### GbaBus Integration (`src/gba/bus/mod.rs`)
- Implements `Bus` trait, delegating to existing `n_cycles_width`/`s_cycles_width`
- ROM costs: N=5, S=3 (halfword); IWRAM: 1; EWRAM: 3

### ARM/Thumb Handler Updates
- All ARM instruction handlers updated with correct S/N/I per GBATek
- All Thumb format handlers updated similarly
- Register-shift data processing: +1I
- Multiply: Booth early-termination timing

### Integration Test Adaptation (`gba_suite_runner.rs`)
- `MAX_CYCLES` 120M → 480M (ROM code now costs 3-5x per instruction)
- Armwrestler runner rewritten: CRC-based navigation instead of frame-number-based
- Handles title-screen dismiss and post-test-chain settle timing

## Testing

- 11 new unit tests for S/N/I correctness
- 164/164 GBA CPU unit tests pass
- 28/28 GBA integration tests pass (same CRCs as before)
- All fuzz tests produce identical results
- 31 pre-existing GB mealybug failures (unrelated)
- wasm-pack: ChromeDriver infrastructure issue (pre-existing on main)

Closes #2393
