### PR TITLE
feat(gba): separate code/data cycle accounting for timing accuracy

### DIFF
--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -24,6 +24,7 @@
 use super::bus::Bus;
 use super::registers::CpuMode;
 use super::registers::{FLAG_T, Registers, condition_met};
+use crate::gba::bus::WidthClass;
 
 fn is_cart_sram_region(addr: u32) -> bool {
     matches!((addr >> 24) & 0xF, 0xE | 0xF)
@@ -35,12 +36,20 @@ use super::registers::{FLAG_C, FLAG_N, FLAG_V, FLAG_Z};
 /// Outcome of executing one ARM instruction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExecOutcome {
-    /// Number of sequential (S) memory access cycles.
+    /// Number of sequential (S) code-fetch cycles (resolved at PC address).
     pub seq: u8,
-    /// Number of non-sequential (N) memory access cycles.
+    /// Number of non-sequential (N) code-fetch cycles (resolved at PC address).
     pub nonseq: u8,
     /// Number of internal (I) CPU-only cycles.
     pub internal: u8,
+    /// Number of sequential (S) data-access cycles (resolved at data_addr).
+    pub data_seq: u8,
+    /// Number of non-sequential (N) data-access cycles (resolved at data_addr).
+    pub data_nonseq: u8,
+    /// Address of the data access (used for resolving data cycle timing).
+    pub data_addr: u32,
+    /// Width of the data access.
+    pub data_width: WidthClass,
     /// `true` if PC was modified by the instruction (pipeline must refill).
     pub branched: bool,
     /// `true` if the instruction triggered a software interrupt (SWI).
@@ -50,23 +59,77 @@ pub struct ExecOutcome {
 }
 
 impl ExecOutcome {
-    /// Non-branching instruction with explicit S/N/I cycle counts.
+    /// Non-branching instruction with explicit S/N/I cycle counts (no data access).
     pub(super) fn sni(seq: u8, nonseq: u8, internal: u8) -> Self {
         Self {
             seq,
             nonseq,
             internal,
+            data_seq: 0,
+            data_nonseq: 0,
+            data_addr: 0,
+            data_width: WidthClass::Word,
             branched: false,
             swi: false,
             undefined: false,
         }
     }
-    /// Branching instruction with explicit S/N/I cycle counts.
+    /// Non-branching data-access instruction with separate code and data cycles.
+    pub(super) fn data_access(
+        code_seq: u8,
+        code_nonseq: u8,
+        internal: u8,
+        data_seq: u8,
+        data_nonseq: u8,
+        data_addr: u32,
+        data_width: WidthClass,
+    ) -> Self {
+        Self {
+            seq: code_seq,
+            nonseq: code_nonseq,
+            internal,
+            data_seq,
+            data_nonseq,
+            data_addr,
+            data_width,
+            branched: false,
+            swi: false,
+            undefined: false,
+        }
+    }
+    /// Branching data-access instruction with separate code and data cycles.
+    pub(super) fn branch_data_access(
+        code_seq: u8,
+        code_nonseq: u8,
+        internal: u8,
+        data_seq: u8,
+        data_nonseq: u8,
+        data_addr: u32,
+        data_width: WidthClass,
+    ) -> Self {
+        Self {
+            seq: code_seq,
+            nonseq: code_nonseq,
+            internal,
+            data_seq,
+            data_nonseq,
+            data_addr,
+            data_width,
+            branched: true,
+            swi: false,
+            undefined: false,
+        }
+    }
+    /// Branching instruction with explicit S/N/I cycle counts (no data access).
     pub(super) fn branch_sni(seq: u8, nonseq: u8, internal: u8) -> Self {
         Self {
             seq,
             nonseq,
             internal,
+            data_seq: 0,
+            data_nonseq: 0,
+            data_addr: 0,
+            data_width: WidthClass::Word,
             branched: true,
             swi: false,
             undefined: false,
@@ -78,6 +141,10 @@ impl ExecOutcome {
             seq,
             nonseq,
             internal,
+            data_seq: 0,
+            data_nonseq: 0,
+            data_addr: 0,
+            data_width: WidthClass::Word,
             branched: true,
             swi: true,
             undefined: false,
@@ -89,6 +156,10 @@ impl ExecOutcome {
             seq: 2,
             nonseq: 1,
             internal: 0,
+            data_seq: 0,
+            data_nonseq: 0,
+            data_addr: 0,
+            data_width: WidthClass::Word,
             branched: true,
             undefined: true,
             swi: false,
@@ -97,16 +168,27 @@ impl ExecOutcome {
 
     /// Resolve S/N/I cycle counts to a concrete total using bus timing.
     ///
-    /// `s_cost` is the sequential access cost and `n_cost` is the
-    /// non-sequential access cost. Internal cycles always cost 1.
-    pub fn resolve_cycles(&self, s_cost: u32, n_cost: u32) -> u32 {
-        (self.seq as u32) * s_cost + (self.nonseq as u32) * n_cost + (self.internal as u32)
+    /// Code cycles use `s_cost`/`n_cost` (resolved at PC).
+    /// Data cycles use `data_s_cost`/`data_n_cost` (resolved at data address).
+    /// Internal cycles always cost 1.
+    pub fn resolve_cycles(
+        &self,
+        s_cost: u32,
+        n_cost: u32,
+        data_s_cost: u32,
+        data_n_cost: u32,
+    ) -> u32 {
+        (self.seq as u32) * s_cost
+            + (self.nonseq as u32) * n_cost
+            + (self.data_seq as u32) * data_s_cost
+            + (self.data_nonseq as u32) * data_n_cost
+            + (self.internal as u32)
     }
 
-    /// Total flat cycles (seq + nonseq + internal) — convenience for
+    /// Total flat cycles (all seq + nonseq + internal) — convenience for
     /// unit-test buses where all access costs are 1.
     pub fn total_flat_cycles(&self) -> u8 {
-        self.seq + self.nonseq + self.internal
+        self.seq + self.nonseq + self.data_seq + self.data_nonseq + self.internal
     }
 }
 
@@ -561,11 +643,29 @@ fn execute_single_data_transfer<B: Bus>(
     }
 
     if result_branch {
-        ExecOutcome::branch_sni(2, 2, 1) // LDR PC: 2S + 2N + 1I
+        // LDR PC: 2S(code) + 1N(data) + 1I
+        let width = if b_byte {
+            WidthClass::HalfwordOrByte
+        } else {
+            WidthClass::Word
+        };
+        ExecOutcome::branch_data_access(2, 0, 1, 0, 1, addr, width)
     } else if l {
-        ExecOutcome::sni(1, 1, 1) // LDR: 1S + 1N + 1I
+        // LDR: 1S(code) + 1N(data) + 1I
+        let width = if b_byte {
+            WidthClass::HalfwordOrByte
+        } else {
+            WidthClass::Word
+        };
+        ExecOutcome::data_access(1, 0, 1, 0, 1, addr, width)
     } else {
-        ExecOutcome::sni(0, 2, 0) // STR: 2N
+        // STR: 1N(code) + 1N(data)
+        let width = if b_byte {
+            WidthClass::HalfwordOrByte
+        } else {
+            WidthClass::Word
+        };
+        ExecOutcome::data_access(0, 1, 0, 0, 1, addr, width)
     }
 }
 
@@ -973,11 +1073,14 @@ fn execute_halfword_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u
     }
 
     if result_branch {
-        ExecOutcome::branch_sni(2, 2, 1) // LDRH PC: 2S + 2N + 1I
+        // LDRH PC: 2S(code) + 1N(data) + 1I
+        ExecOutcome::branch_data_access(2, 0, 1, 0, 1, addr, WidthClass::HalfwordOrByte)
     } else if l {
-        ExecOutcome::sni(1, 1, 1) // LDRH/LDRSB/LDRSH: 1S + 1N + 1I
+        // LDRH/LDRSB/LDRSH: 1S(code) + 1N(data) + 1I
+        ExecOutcome::data_access(1, 0, 1, 0, 1, addr, WidthClass::HalfwordOrByte)
     } else {
-        ExecOutcome::sni(0, 2, 0) // STRH: 2N
+        // STRH: 1N(code) + 1N(data)
+        ExecOutcome::data_access(0, 1, 0, 0, 1, addr, WidthClass::HalfwordOrByte)
     }
 }
 
@@ -1080,20 +1183,42 @@ fn execute_block_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32)
     }
 
     // Cycle timing per GBATek:
-    // LDM: nS + 1N + 1I (+ 1S + 1N if PC loaded for pipeline refill)
-    // STM: (n-1)S + 2N
+    // LDM: 1S(code) + 1N(data) + (n-1)S(data) + 1I
+    // STM: 1N(code) + 1N(data) + (n-1)S(data)
+    // LDM with PC: 2S(code) + 1N(data) + (n-1)S(data) + 1I
     if branch_occurred {
-        // LDM with PC: (n+1)S + 2N + 1I
         let n = reg_count as u8;
-        ExecOutcome::branch_sni(n + 1, 2, 1)
+        ExecOutcome::branch_data_access(
+            2,
+            0,
+            1,
+            n.saturating_sub(1),
+            1,
+            start_addr,
+            WidthClass::Word,
+        )
     } else if l {
-        // LDM: nS + 1N + 1I
         let n = reg_count as u8;
-        ExecOutcome::sni(n, 1, 1)
+        ExecOutcome::data_access(
+            1,
+            0,
+            1,
+            n.saturating_sub(1),
+            1,
+            start_addr,
+            WidthClass::Word,
+        )
     } else {
-        // STM: (n-1)S + 2N
         let n = reg_count as u8;
-        ExecOutcome::sni(n.saturating_sub(1), 2, 0)
+        ExecOutcome::data_access(
+            0,
+            1,
+            0,
+            n.saturating_sub(1),
+            1,
+            start_addr,
+            WidthClass::Word,
+        )
     }
 }
 
@@ -1124,8 +1249,13 @@ fn execute_swap<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32) -> ExecOu
         regs.r[rd] = old_val;
     }
 
-    // Cycle timing: 1S + 2N + 1I
-    ExecOutcome::sni(1, 2, 1)
+    // Cycle timing: 1S(code) + 2N(data) + 1I
+    let width = if b_byte {
+        WidthClass::HalfwordOrByte
+    } else {
+        WidthClass::Word
+    };
+    ExecOutcome::data_access(1, 0, 1, 0, 2, addr, width)
 }
 
 #[cfg(test)]
@@ -2565,9 +2695,11 @@ mod tests {
         // LDR R0, [R1] (immediate offset 0)
         let instr = 0xE591_0000;
         let outcome = execute(&mut regs, &mut bus, instr);
-        assert_eq!(outcome.seq, 1, "LDR should be 1S");
-        assert_eq!(outcome.nonseq, 1, "LDR should have 1N");
+        assert_eq!(outcome.seq, 1, "LDR should be 1S(code)");
+        assert_eq!(outcome.nonseq, 0, "LDR should have 0N(code)");
+        assert_eq!(outcome.data_nonseq, 1, "LDR should have 1N(data)");
         assert_eq!(outcome.internal, 1, "LDR should have 1I");
+        assert_eq!(outcome.total_flat_cycles(), 3);
     }
 
     /// ARM STR: 2N per GBATek.
@@ -2580,9 +2712,11 @@ mod tests {
         // STR R0, [R1]
         let instr = 0xE581_0000;
         let outcome = execute(&mut regs, &mut bus, instr);
-        assert_eq!(outcome.seq, 0, "STR should be 0S");
-        assert_eq!(outcome.nonseq, 2, "STR should have 2N");
+        assert_eq!(outcome.seq, 0, "STR should be 0S(code)");
+        assert_eq!(outcome.nonseq, 1, "STR should have 1N(code)");
+        assert_eq!(outcome.data_nonseq, 1, "STR should have 1N(data)");
         assert_eq!(outcome.internal, 0, "STR should have 0I");
+        assert_eq!(outcome.total_flat_cycles(), 2);
     }
 
     /// ARM SWP: 1S + 2N + 1I per GBATek.
@@ -2595,9 +2729,11 @@ mod tests {
         bus.write32(0x40, 0xCAFE);
         let instr = arm_swap(0xE, false, 0, 2, 1);
         let outcome = execute(&mut regs, &mut bus, instr);
-        assert_eq!(outcome.seq, 1, "SWP should be 1S");
-        assert_eq!(outcome.nonseq, 2, "SWP should have 2N");
+        assert_eq!(outcome.seq, 1, "SWP should be 1S(code)");
+        assert_eq!(outcome.nonseq, 0, "SWP should have 0N(code)");
+        assert_eq!(outcome.data_nonseq, 2, "SWP should have 2N(data)");
         assert_eq!(outcome.internal, 1, "SWP should have 1I");
+        assert_eq!(outcome.total_flat_cycles(), 4);
     }
 
     /// ARM MUL (simple, Rs=1 → early termination 1 cycle): 1S + 1I per GBATek.

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -253,6 +253,8 @@ impl Arm7tdmi {
             outcome.resolve_cycles(
                 bus.s_cycles(exec_pc, WidthClass::HalfwordOrByte),
                 bus.n_cycles(exec_pc, WidthClass::HalfwordOrByte),
+                bus.s_cycles(outcome.data_addr, outcome.data_width),
+                bus.n_cycles(outcome.data_addr, outcome.data_width),
             )
         } else {
             // PC during ARM execution should read as exec_pc + 8.
@@ -290,6 +292,8 @@ impl Arm7tdmi {
             outcome.resolve_cycles(
                 bus.s_cycles(exec_pc, WidthClass::Word),
                 bus.n_cycles(exec_pc, WidthClass::Word),
+                bus.s_cycles(outcome.data_addr, outcome.data_width),
+                bus.n_cycles(outcome.data_addr, outcome.data_width),
             )
         };
 

--- a/src/gba/cpu/thumb.rs
+++ b/src/gba/cpu/thumb.rs
@@ -26,6 +26,7 @@ use super::bus::Bus;
 #[cfg(test)]
 use super::registers::{FLAG_C, FLAG_N, FLAG_V, FLAG_Z};
 use super::registers::{Registers, condition_met};
+use crate::gba::bus::WidthClass;
 
 fn is_cart_sram_region(addr: u32) -> bool {
     matches!((addr >> 24) & 0xF, 0xE | 0xF)
@@ -451,7 +452,8 @@ fn exec_format6<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
     let pc = regs.r[15] & !0x2;
     let addr = pc.wrapping_add(imm << 2);
     regs.r[rd] = bus.read32(addr);
-    ExecOutcome::sni(1, 1, 1)
+    // LDR: 1S(code) + 1N(data) + 1I
+    ExecOutcome::data_access(1, 0, 1, 0, 1, addr, WidthClass::Word)
 }
 
 // ---------------------------------------------------------------------------
@@ -485,7 +487,21 @@ fn exec_format7<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
             bus.write32(thumb_store_word_addr(addr), regs.r[rd]);
         }
     }
-    if l { ExecOutcome::sni(1, 1, 1) } else { ExecOutcome::sni(0, 2, 0) }
+    if l {
+        let width = if b {
+            WidthClass::HalfwordOrByte
+        } else {
+            WidthClass::Word
+        };
+        ExecOutcome::data_access(1, 0, 1, 0, 1, addr, width)
+    } else {
+        let width = if b {
+            WidthClass::HalfwordOrByte
+        } else {
+            WidthClass::Word
+        };
+        ExecOutcome::data_access(0, 1, 0, 0, 1, addr, width)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -506,9 +522,9 @@ fn exec_format8<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
     // S=1, H=0: LDSB (load signed byte)
     // S=1, H=1: LDSH (load signed halfword)
     if !s && !h {
-        // STRH
+        // STRH: 1N(code) + 1N(data)
         bus.write16(thumb_store_halfword_addr(addr), regs.r[rd] as u16);
-        return ExecOutcome::sni(0, 2, 0);
+        return ExecOutcome::data_access(0, 1, 0, 0, 1, addr, WidthClass::HalfwordOrByte);
     }
 
     regs.r[rd] = match (s, h) {
@@ -532,7 +548,8 @@ fn exec_format8<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
         }
         _ => unreachable!(),
     };
-    ExecOutcome::sni(1, 1, 1)
+    // Load: 1S(code) + 1N(data) + 1I
+    ExecOutcome::data_access(1, 0, 1, 0, 1, addr, WidthClass::HalfwordOrByte)
 }
 
 // ---------------------------------------------------------------------------
@@ -566,7 +583,21 @@ fn exec_format9<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecOu
     } else {
         bus.write32(thumb_store_word_addr(addr), regs.r[rd]);
     }
-    if l { ExecOutcome::sni(1, 1, 1) } else { ExecOutcome::sni(0, 2, 0) }
+    if l {
+        let width = if b {
+            WidthClass::HalfwordOrByte
+        } else {
+            WidthClass::Word
+        };
+        ExecOutcome::data_access(1, 0, 1, 0, 1, addr, width)
+    } else {
+        let width = if b {
+            WidthClass::HalfwordOrByte
+        } else {
+            WidthClass::Word
+        };
+        ExecOutcome::data_access(0, 1, 0, 0, 1, addr, width)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -591,7 +622,13 @@ fn exec_format10<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
     } else {
         bus.write16(thumb_store_halfword_addr(addr), regs.r[rd] as u16);
     }
-    if l { ExecOutcome::sni(1, 1, 1) } else { ExecOutcome::sni(0, 2, 0) }
+    if l {
+        // LDRH: 1S(code) + 1N(data) + 1I
+        ExecOutcome::data_access(1, 0, 1, 0, 1, addr, WidthClass::HalfwordOrByte)
+    } else {
+        // STRH: 1N(code) + 1N(data)
+        ExecOutcome::data_access(0, 1, 0, 0, 1, addr, WidthClass::HalfwordOrByte)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -613,7 +650,13 @@ fn exec_format11<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
     } else {
         bus.write32(thumb_store_word_addr(addr), regs.r[rd]);
     }
-    if l { ExecOutcome::sni(1, 1, 1) } else { ExecOutcome::sni(0, 2, 0) }
+    if l {
+        // LDR: 1S(code) + 1N(data) + 1I
+        ExecOutcome::data_access(1, 0, 1, 0, 1, addr, WidthClass::Word)
+    } else {
+        // STR: 1N(code) + 1N(data)
+        ExecOutcome::data_access(0, 1, 0, 0, 1, addr, WidthClass::Word)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -662,9 +705,11 @@ fn exec_format14<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
     let count = reg_list.count_ones() + if extra { 1 } else { 0 };
     let mut branched = false;
 
+    let data_addr;
     if !load {
         // PUSH: SP decremented first, then write low → high regs at low → high addresses.
         let mut sp = regs.r[13].wrapping_sub(count * 4);
+        data_addr = sp;
         regs.r[13] = sp;
         for i in 0..8 {
             if reg_list & (1 << i) != 0 {
@@ -679,6 +724,7 @@ fn exec_format14<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
     } else {
         // POP: read low → high regs from low → high addresses, then update SP.
         let mut sp = regs.r[13];
+        data_addr = sp;
         for i in 0..8 {
             if reg_list & (1 << i) != 0 {
                 regs.r[i] = bus.read32(sp & !0x3);
@@ -698,14 +744,22 @@ fn exec_format14<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
 
     let n = count as u8;
     if branched {
-        // POP {PC}: (n+1)S + 2N + 1I
-        ExecOutcome::branch_sni(n + 1, 2, 1)
+        // POP {PC}: 2S(code) + 1N(data) + (n-1)S(data) + 1I
+        ExecOutcome::branch_data_access(
+            2,
+            0,
+            1,
+            n.saturating_sub(1),
+            1,
+            data_addr,
+            WidthClass::Word,
+        )
     } else if load {
-        // POP: nS + 1N + 1I
-        ExecOutcome::sni(n, 1, 1)
+        // POP: 1S(code) + 1N(data) + (n-1)S(data) + 1I
+        ExecOutcome::data_access(1, 0, 1, n.saturating_sub(1), 1, data_addr, WidthClass::Word)
     } else {
-        // PUSH: (n-1)S + 2N
-        ExecOutcome::sni(n.saturating_sub(1), 2, 0)
+        // PUSH: 1N(code) + 1N(data) + (n-1)S(data)
+        ExecOutcome::data_access(0, 1, 0, n.saturating_sub(1), 1, data_addr, WidthClass::Word)
     }
 }
 
@@ -770,14 +824,14 @@ fn exec_format15<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u16) -> ExecO
 
     let n = count as u8;
     if branched {
-        // LDMIA with PC: (n+1)S + 2N + 1I
-        ExecOutcome::branch_sni(n + 1, 2, 1)
+        // LDMIA with PC: 2S(code) + 1N(data) + (n-1)S(data) + 1I
+        ExecOutcome::branch_data_access(2, 0, 1, n.saturating_sub(1), 1, base, WidthClass::Word)
     } else if l {
-        // LDMIA: nS + 1N + 1I
-        ExecOutcome::sni(n, 1, 1)
+        // LDMIA: 1S(code) + 1N(data) + (n-1)S(data) + 1I
+        ExecOutcome::data_access(1, 0, 1, n.saturating_sub(1), 1, base, WidthClass::Word)
     } else {
-        // STMIA: (n-1)S + 2N
-        ExecOutcome::sni(n.saturating_sub(1), 2, 0)
+        // STMIA: 1N(code) + 1N(data) + (n-1)S(data)
+        ExecOutcome::data_access(0, 1, 0, n.saturating_sub(1), 1, base, WidthClass::Word)
     }
 }
 
@@ -1456,9 +1510,13 @@ mod tests {
         // LDR R0, [PC, #0]
         let instr: u16 = 0x4800; // 01001_000_00000000
         let outcome = execute(&mut regs, &mut bus, instr);
-        assert_eq!(outcome.seq, 1, "PC-relative LDR should be 1S");
-        assert_eq!(outcome.nonseq, 1, "PC-relative LDR should have 1N");
+        assert_eq!(outcome.seq, 1, "PC-relative LDR should be 1S(code)");
+        assert_eq!(
+            outcome.data_nonseq, 1,
+            "PC-relative LDR should have 1N(data)"
+        );
         assert_eq!(outcome.internal, 1, "PC-relative LDR should have 1I");
+        assert_eq!(outcome.total_flat_cycles(), 3);
     }
 
     /// Thumb unconditional branch: 2S + 1N per GBATek.

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -42,21 +42,21 @@ armwrestler_page4=0x6795E0F8
 # mgba-emu/suite (https://github.com/mgba-emu/suite)
 # 14 sub-suites exercising memory, I/O, timing, shifter, carry, multiply,
 # BIOS math, DMA, SIO, misc edge cases, and video.
-# Scores (passing/total): Memory 1379/1552, I/O read 83/130, Timing 249/2020,
-# Timers 257/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
-# Multiply long 72/72, BIOS math 615/615, DMA 891/1256, SIO read 90/90,
-# SIO timing 0/4, Misc. edge 4/12, Video (sub-menu only).
+# Scores (passing/total): Memory 1379/1552, I/O read 83/130, Timing 378/2020,
+# Timers 356/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
+# Multiply long 72/72, BIOS math 615/615, DMA 1040/1256, SIO read 90/90,
+# SIO timing 0/4, Misc. edge 3/12, Video (sub-menu only).
 mgba_memory=0x22984983
 mgba_io_read=0x5A3CD2D5
-mgba_timing=0x697DA0C7
-mgba_timers=0xBC59F692
+mgba_timing=0x71629F50
+mgba_timers=0xCA2894C9
 mgba_timer_irq=0xD1FFFC47
 mgba_shifter=0x8B4A12AA
 mgba_carry=0xFD9E45E6
 mgba_multiply_long=0x699655AB
 mgba_bios_math=0x3C1B28DE
-mgba_dma=0x076FC108
+mgba_dma=0x7EC69695
 mgba_sio_read=0xF5D98687
 mgba_sio_timing=0xD95ACB03
-mgba_misc_edge=0xFF974835
+mgba_misc_edge=0x36ECDBF9
 mgba_video=0xAB7EC249

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -268,17 +268,17 @@ fn approvals_manifest_parses() {
     // mgba-emu/suite keys
     assert_eq!(approvals.get("mgba_memory"), Some(&0x2298_4983));
     assert_eq!(approvals.get("mgba_io_read"), Some(&0x5A3C_D2D5));
-    assert_eq!(approvals.get("mgba_timing"), Some(&0x697D_A0C7));
-    assert_eq!(approvals.get("mgba_timers"), Some(&0xBC59_F692));
+    assert_eq!(approvals.get("mgba_timing"), Some(&0x7162_9F50));
+    assert_eq!(approvals.get("mgba_timers"), Some(&0xCA28_94C9));
     assert_eq!(approvals.get("mgba_timer_irq"), Some(&0xD1FF_FC47));
     assert_eq!(approvals.get("mgba_shifter"), Some(&0x8B4A_12AA));
     assert_eq!(approvals.get("mgba_carry"), Some(&0xFD9E_45E6));
     assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
     assert_eq!(approvals.get("mgba_bios_math"), Some(&0x3C1B_28DE));
-    assert_eq!(approvals.get("mgba_dma"), Some(&0x076F_C108));
+    assert_eq!(approvals.get("mgba_dma"), Some(&0x7EC6_9695));
     assert_eq!(approvals.get("mgba_sio_read"), Some(&0xF5D9_8687));
     assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));
-    assert_eq!(approvals.get("mgba_misc_edge"), Some(&0xFF97_4835));
+    assert_eq!(approvals.get("mgba_misc_edge"), Some(&0x36EC_DBF9));
     assert_eq!(approvals.get("mgba_video"), Some(&0xAB7E_C249));
 }
 


### PR DESCRIPTION
## Summary

Extends ExecOutcome with data_seq/data_nonseq/data_addr/data_width fields to resolve data access cycles at the correct memory region timing instead of using PC (code fetch) address timing for everything.

## Changes

- ExecOutcome now tracks code vs data access cycles separately
- ARM LDR/STR/LDM/STM/SWP/halfword-transfer report data cycles with addr/width
- Thumb format 6-11, 14-15 (all loads/stores/push/pop) report data cycles
- step() resolves code cycles at PC address, data cycles at data_addr
- Updated CRC approvals for improved sub-suite pass counts

## Results (mgba-emu/suite improvements)

| Sub-suite | Before | After | Change |
|-----------|--------|-------|--------|
| Timing | 249/2020 | 378/2020 | +129 (+52%) |
| Timers | 257/936 | 356/936 | +99 (+39%) |
| DMA | 891/1256 | 1040/1256 | +149 (+17%) |
| Misc Edge | 4/12 | 3/12 | -1 (minor regression) |

The misc edge regression is likely from the DMA Prefetch test becoming more sensitive to correct timing. The overall gain is +376 tests across all suites.

Closes #2395