### PR TITLE
Improve GB LCDC TILE_SEL timing

### DIFF
--- a/references/retrospective-neser.md
+++ b/references/retrospective-neser.md
@@ -58,3 +58,43 @@ Each entry captures what went well, what to improve, and which skills were used.
 ### Navigator feedback
 
 No feedback provided.
+
+---
+
+## 2026-05-17 - PR #2414: Improve GB LCDC TILE_SEL timing
+
+**Repository:** rmstdope/neser
+**PR URL:** https://github.com/rmstdope/neser/pull/2414
+**Linked issues:** #2353, #2412
+
+### Customizations used
+
+| Type | Name | Purpose |
+| --- | --- | --- |
+| Skill | `test-driven-development` | Kept each timing slice anchored to focused tests and RED/GREEN/REFACTOR gates. |
+| Skill | `gb-hardware-research` | Guided Game Boy PPU/LCDC timing investigation against Pan Docs and hardware-oriented behavior. |
+| Skill | `rust-developer` | Guided Rust implementation and validation work. |
+| Skill | `rust-code-refactoring` | Supported small cleanup steps after functional fixes. |
+| Skill | `github-issue-designer` | Structured follow-up issue #2412 with explicit remaining scope and acceptance criteria. |
+| Skill | `github-administration` | Supported issue creation, PR creation, branch push, and CI verification through `gh`. |
+| Skill | `self-learning-skills` | Captured required issue-creation feedback; navigator had no additional feedback. |
+| Agent | `code-review` | Reviewed the branch before PR creation; a post-rebase review attempt timed out, so local checks and CI were used as final validation. |
+| Agent | `Iteration Retrospective Gatherer` | Produced this retrospective content after PR creation. |
+| Instructions | Repository workflow instructions | Enforced small increments, issue linkage, review-first PR workflow, and required pre-PR checks. |
+
+### What went well
+
+- The TDD slices kept a difficult hardware-timing problem manageable: each OBJ/window TILE_SEL case added a focused pixel FIFO test before the production timing adjustment.
+- The follow-up issue split was useful: #2353 delivered the DMG non-window CRC and several DMG window slices, while #2412 explicitly preserves the remaining DMG OAM X=8 and CGB/CGB-D work.
+- The GitHub administration workflow caught a stale base before PR creation; rebasing onto `origin/main` before opening the PR avoided carrying avoidable merge churn into review.
+- Full local checks plus PR CI provided a strong handoff after the branch was rebased and force-pushed.
+
+### What to improve
+
+- The TILE_SEL work had many narrow timing commits. For similar PPU timing issues, create an explicit timing matrix early: BG/window, low/high byte, visible/off-left OBJ, delayed/stalled fetch, and model variant.
+- A broad OAM X=4 OBJ penalty change regressed accepted mealybug and Mooneye timing before it was narrowed back. Future timing work should isolate global scheduler changes from local LCDC sampling fixes unless a test proves the scheduler itself is wrong.
+- The retrospective agent could generate the entry but could not write the file directly. Keep the manual append step in mind when the agent reports that limitation.
+
+### Navigator feedback
+
+No additional feedback.

--- a/references/retrospective-neser.md
+++ b/references/retrospective-neser.md
@@ -1,0 +1,60 @@
+# Retrospective — neser
+
+Structured retrospective entries for AI-assisted workflows on the neser project.
+Each entry captures what went well, what to improve, and which skills were used.
+
+---
+
+## 2026-05-13 — #2347 Fix mealybug m2_win_en_toggle CGB-C and CGB-D (PR #2364)
+
+### What went well
+- Root-cause identification was accurate and evidence-based: pixel analysis (PIL/Python) surfaced the real bug (wrong CGB DMG-compat palette for non-Nintendo licensees) rather than following the misleading PPU timing framing in the issue title.
+- TDD cycle was tight and clean: RED (failing test asserting reference CRC computed from real hardware PNG) → GREEN (remove 3 lines) → REFACTOR (rubber-duck review found nothing to change). Fix was proportional to the defect.
+- Using SameBoy `cgb_boot.asm` and Pan Docs as primary spec references grounded the fix at algorithm level, not cargo-culted observed behavior.
+- The `gb-hardware-research` skill's "prefer written spec over emulator implementation" principle steered verification correctly.
+
+### What to improve
+- **Branching from sibling PR instead of main**: Branching from #2363 instead of `main` introduced rebase overhead after #2363 merged. The rule is to always branch from the latest main; if a dependency on an open PR is unavoidable, that constraint must be flagged explicitly and agreed with the navigator before branching.
+- **Dead-path utilities after refactor**: `is_nintendo_licensee()` remains in the module but is no longer called by `get_palette_id()`. The REFACTOR phase should flag dead-path utilities for cleanup or re-scoping rather than leaving them as silent noise.
+- **Issue title vs. evidence mismatch**: The issue title implied a PPU/timing bug; the actual cause was a palette initialization bug. Surface title-vs-evidence mismatches early (during planning) so investigation doesn't follow a misleading framing.
+
+### Skills used
+- `test-driven-development`
+- `gb-hardware-research` (for spec verification)
+- `self-learning-skills` (this retrospective)
+
+---
+
+## 2026-05-13 — PR #2372: Fix mealybug BGP FIFO
+
+**Repository:** rmstdope/neser
+**PR URL:** https://github.com/rmstdope/neser/pull/2372
+**Linked issues:** #2348
+
+### Customizations used
+
+| Type | Name | Purpose |
+| --- | --- | --- |
+| Skill | `gb-hardware-research` | Grounded Game Boy rendering behavior against hardware-oriented evidence. |
+| Skill | `test-driven-development` | Structured the workflow around RED->GREEN->REFACTOR phase gates. |
+| Skill | `rust-developer` | Guided Rust implementation and validation work. |
+| Skill | `rust-code-refactoring` | Supported focused cleanup after functional changes. |
+| Skill | `github-administration` | Supported issue/PR workflow administration. |
+| Skill | `self-learning-skills` | Captured this retrospective and learning outcome. |
+| Agent | `code-review` | Provided review-oriented feedback on the implementation. |
+| Instructions | `copilot-instructions.md` | Applied repository workflow rules, including TDD and retrospective expectations. |
+
+### What went well
+
+- Multiple relevant skills were combined effectively: hardware research for Game Boy behavior, TDD for workflow structure, Rust skills for implementation, and code review for validation.
+- After the TDD phase gate was re-established, the workflow followed RED->GREEN->REFACTOR discipline for the remaining work.
+- The retrospective correctly identified that the existing TDD skill instructions already cover the resumed/compacted workflow issue, so no unnecessary skill documentation update was made.
+
+### What to improve
+
+- A resumed/compacted workflow briefly advanced a TDD RED->GREEN step before explicitly re-establishing the TDD phase gate; on resume, restate the current phase and next allowed action before making implementation progress.
+- The workflow should treat compaction/resume boundaries as process checkpoints: reload or restate active skills and gates before continuing code changes.
+
+### Navigator feedback
+
+No feedback provided.

--- a/src/gb/bus/bus.rs
+++ b/src/gb/bus/bus.rs
@@ -14,6 +14,17 @@ pub trait GbBus {
     /// `DmgBus` overrides this to tick the timer and propagate interrupts.
     fn tick(&mut self, _m_cycles: u8) {}
 
+    /// Perform one CPU write M-cycle.
+    ///
+    /// The default keeps the historical behavior: advance all peripherals for
+    /// one complete M-cycle, then perform the write. Full bus implementations
+    /// can override this when a device needs the write at its bus phase inside
+    /// the M-cycle.
+    fn write_cpu_m_cycle(&mut self, addr: u16, val: u8) {
+        self.tick(1);
+        self.write(addr, val);
+    }
+
     /// Notify the bus that the CPU is about to fetch and execute a new instruction.
     ///
     /// Called BEFORE the M1 bus tick.  The default implementation is a no-op;

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -126,8 +126,13 @@ pub struct CgbBus {
 }
 
 impl CgbBus {
-    fn needs_mode3_lcdc_write_phase(&self, addr: u16) -> bool {
-        addr == 0xFF40 && self.ppu.is_lcd_enabled() && self.ppu.mode() == PpuMode::PixelTransfer
+    fn needs_mode3_lcdc_write_phase(&self, addr: u16, val: u8) -> bool {
+        const LCDC_TILE_DATA: u8 = 0x10;
+
+        addr == 0xFF40
+            && self.ppu.is_lcd_enabled()
+            && self.ppu.mode() == PpuMode::PixelTransfer
+            && self.ppu.read_register(0xFF40) & LCDC_TILE_DATA != val & LCDC_TILE_DATA
     }
 
     /// Create a new CGB bus.
@@ -1117,7 +1122,7 @@ impl GbBus for CgbBus {
     }
 
     fn write_cpu_m_cycle(&mut self, addr: u16, val: u8) {
-        if self.needs_mode3_lcdc_write_phase(addr) {
+        if self.needs_mode3_lcdc_write_phase(addr, val) {
             let double = self.tick_before_ppu(1);
             let dots_per_mcycle = Self::dots_per_mcycle(double);
             let dots_before_write = dots_per_mcycle.saturating_sub(1);

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -126,6 +126,10 @@ pub struct CgbBus {
 }
 
 impl CgbBus {
+    fn needs_mode3_lcdc_write_phase(&self, addr: u16) -> bool {
+        addr == 0xFF40 && self.ppu.is_lcd_enabled() && self.ppu.mode() == PpuMode::PixelTransfer
+    }
+
     /// Create a new CGB bus.
     ///
     /// When `skip_boot_rom` is `false` (default hardware behavior), the boot ROM
@@ -451,6 +455,17 @@ impl CgbBus {
     /// timer (bit 12 of the 16-bit internal counter = DIV bit 4, or bit 13 in
     /// double-speed mode = DIV bit 5).
     pub fn tick(&mut self, m_cycles: u8) {
+        let double = self.tick_before_ppu(m_cycles);
+        let dots_per_mcycle = Self::dots_per_mcycle(double);
+        self.ppu.tick_dots(u32::from(m_cycles) * dots_per_mcycle);
+        self.tick_after_ppu(m_cycles, double);
+    }
+
+    fn dots_per_mcycle(double_speed: bool) -> u32 {
+        if double_speed { 2 } else { 4 }
+    }
+
+    fn tick_before_ppu(&mut self, m_cycles: u8) -> bool {
         self.if_reg |= self.ppu.take_pending_interrupts();
 
         let double = self.is_double_speed();
@@ -491,10 +506,10 @@ impl CgbBus {
                 }
             }
         }
+        double
+    }
 
-        let dots_per_mcycle: u32 = if double { 2 } else { 4 };
-        self.ppu.tick_dots(u32::from(m_cycles) * dots_per_mcycle);
-
+    fn tick_after_ppu(&mut self, m_cycles: u8, double: bool) {
         if double {
             // In double-speed mode the APU runs at normal speed (half the CPU M-cycle
             // rate). CH3 wave-position timing requires 1-APU-cycle-per-M-cycle
@@ -1101,6 +1116,22 @@ impl GbBus for CgbBus {
         CgbBus::tick(self, m_cycles);
     }
 
+    fn write_cpu_m_cycle(&mut self, addr: u16, val: u8) {
+        if self.needs_mode3_lcdc_write_phase(addr) {
+            let double = self.tick_before_ppu(1);
+            let dots_per_mcycle = Self::dots_per_mcycle(double);
+            let dots_before_write = dots_per_mcycle.saturating_sub(1);
+            self.ppu.tick_dots(dots_before_write);
+            self.write(addr, val);
+            self.ppu
+                .tick_dots(dots_per_mcycle.saturating_sub(dots_before_write));
+            self.tick_after_ppu(1, double);
+        } else {
+            self.tick(1);
+            self.write(addr, val);
+        }
+    }
+
     fn try_speed_switch(&mut self) -> bool {
         CgbBus::try_speed_switch(self)
     }
@@ -1458,6 +1489,25 @@ mod tests {
                 "debugger read ${addr:04X}"
             );
         }
+    }
+
+    #[test]
+    fn test_lcdc_write_cpu_m_cycle_applies_ppu_write_at_t3_during_mode3() {
+        let mut bus = make_bus_post_boot();
+        enable_lcd(&mut bus);
+        while bus.ppu.dot() < 84 {
+            bus.tick(1);
+        }
+        assert_eq!(bus.ppu.mode(), PpuMode::PixelTransfer);
+
+        let write_cycle_start_dot = bus.ppu.dot();
+        bus.write_cpu_m_cycle(0xFF40, 0x00);
+
+        assert_eq!(
+            bus.ppu.dot(),
+            write_cycle_start_dot + 3,
+            "CGB LCDC writes should disable the PPU at T3, before the last dot of the CPU write M-cycle"
+        );
     }
 
     // ── HDMA register read/write through bus ─────────────────────────────────

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -4,7 +4,7 @@ use crate::gb::bus::GbBus;
 use crate::gb::cartridge::GbCartridge;
 use crate::gb::input::joypad::Joypad;
 use crate::gb::model::{CgbModel, DmgBootVariant, DmgModel};
-use crate::gb::ppu::Ppu;
+use crate::gb::ppu::{Ppu, timing::PpuMode};
 use crate::gb::timer::Timer;
 
 /// Full DMG memory bus.
@@ -94,6 +94,10 @@ pub struct DmgBus {
 }
 
 impl DmgBus {
+    fn needs_mode3_lcdc_write_phase(&self, addr: u16) -> bool {
+        addr == 0xFF40 && self.ppu.is_lcd_enabled() && self.ppu.mode() == PpuMode::PixelTransfer
+    }
+
     pub fn new(cart: Box<dyn GbCartridge>, model: DmgModel) -> Self {
         // The boot ROM and initial div_counter depend on the hardware variant.
         // Production (DMG-A/B/C) scroll-animation ROM: div_counter = 5036.
@@ -228,6 +232,12 @@ impl DmgBus {
     /// The APU frame sequencer is clocked by DIV-APU falling edges from the
     /// timer (bit 12 of the 16-bit internal counter = DIV bit 4).
     pub fn tick(&mut self, m_cycles: u8) {
+        self.tick_before_ppu(m_cycles);
+        self.ppu.tick_dots(u32::from(m_cycles) * 4);
+        self.tick_after_ppu(m_cycles);
+    }
+
+    fn tick_before_ppu(&mut self, m_cycles: u8) {
         // Propagate PPU interrupts accumulated during the previous tick.
         self.if_reg |= self.ppu.take_pending_interrupts();
 
@@ -302,7 +312,9 @@ impl DmgBus {
                 }
             }
         }
-        self.ppu.tick_dots(u32::from(m_cycles) * 4);
+    }
+
+    fn tick_after_ppu(&mut self, m_cycles: u8) {
         // PPU interrupts are now buffered in ppu.pending_interrupts and
         // will be propagated to IF at the start of the NEXT tick() call.
         self.apu.tick(m_cycles);
@@ -608,6 +620,19 @@ impl GbBus for DmgBus {
         DmgBus::tick(self, m_cycles);
     }
 
+    fn write_cpu_m_cycle(&mut self, addr: u16, val: u8) {
+        if self.needs_mode3_lcdc_write_phase(addr) {
+            self.tick_before_ppu(1);
+            self.ppu.tick_dots(3);
+            self.write(addr, val);
+            self.ppu.tick_dots(1);
+            self.tick_after_ppu(1);
+        } else {
+            self.tick(1);
+            self.write(addr, val);
+        }
+    }
+
     fn notify_idu_glitch(&mut self, addr: u16) {
         if matches!(addr, 0xFE00..=0xFEFF)
             && let Some(row) = self.ppu.current_oam_row()
@@ -831,6 +856,25 @@ mod tests {
             stat & 0x03,
             0x00,
             "STAT mode should be HBlank (0) on first scanline after LCD enable"
+        );
+    }
+
+    #[test]
+    fn test_lcdc_write_cpu_m_cycle_applies_ppu_write_at_t3_during_mode3() {
+        let mut bus = make_bus();
+        bus.write(0xFF40, 0x91);
+        while bus.ppu.dot() < 84 {
+            bus.tick(1);
+        }
+        assert_eq!(bus.ppu.mode(), PpuMode::PixelTransfer);
+
+        let write_cycle_start_dot = bus.ppu.dot();
+        bus.write_cpu_m_cycle(0xFF40, 0x00);
+
+        assert_eq!(
+            bus.ppu.dot(),
+            write_cycle_start_dot + 3,
+            "LCDC writes should disable the PPU at T3, before the last dot of the CPU write M-cycle"
         );
     }
 

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -94,8 +94,13 @@ pub struct DmgBus {
 }
 
 impl DmgBus {
-    fn needs_mode3_lcdc_write_phase(&self, addr: u16) -> bool {
-        addr == 0xFF40 && self.ppu.is_lcd_enabled() && self.ppu.mode() == PpuMode::PixelTransfer
+    fn needs_mode3_lcdc_write_phase(&self, addr: u16, val: u8) -> bool {
+        const LCDC_TILE_DATA: u8 = 0x10;
+
+        addr == 0xFF40
+            && self.ppu.is_lcd_enabled()
+            && self.ppu.mode() == PpuMode::PixelTransfer
+            && self.ppu.read_register(0xFF40) & LCDC_TILE_DATA != val & LCDC_TILE_DATA
     }
 
     pub fn new(cart: Box<dyn GbCartridge>, model: DmgModel) -> Self {
@@ -621,7 +626,7 @@ impl GbBus for DmgBus {
     }
 
     fn write_cpu_m_cycle(&mut self, addr: u16, val: u8) {
-        if self.needs_mode3_lcdc_write_phase(addr) {
+        if self.needs_mode3_lcdc_write_phase(addr, val) {
             self.tick_before_ppu(1);
             self.ppu.tick_dots(3);
             self.write(addr, val);

--- a/src/gb/cpu/sm83.rs
+++ b/src/gb/cpu/sm83.rs
@@ -258,8 +258,7 @@ impl<B: GbBus> Sm83<B> {
     fn write(&mut self, addr: u16, val: u8) {
         self.last_write_addr = Some(addr);
         self.cycles += 1;
-        self.bus.tick(1);
-        self.bus.write(addr, val);
+        self.bus.write_cpu_m_cycle(addr, val);
         trace_cpu!(2; "      write ${:04X} = ${:02X}", addr, val);
     }
 
@@ -1323,6 +1322,59 @@ mod tests {
 
     fn cpu_with(program: &[u8]) -> Sm83<TestBus> {
         Sm83::new(TestBus::new(program))
+    }
+
+    struct WritePhaseSpyBus {
+        mem: [u8; 0x10000],
+        dot: u64,
+        write_dot_mod4: Option<u8>,
+    }
+
+    impl WritePhaseSpyBus {
+        fn new(program: &[u8]) -> Self {
+            let mut mem = [0u8; 0x10000];
+            mem[..program.len()].copy_from_slice(program);
+            Self {
+                mem,
+                dot: 0,
+                write_dot_mod4: None,
+            }
+        }
+    }
+
+    impl GbBus for WritePhaseSpyBus {
+        fn read(&mut self, addr: u16) -> u8 {
+            self.mem[addr as usize]
+        }
+
+        fn write(&mut self, addr: u16, val: u8) {
+            self.write_dot_mod4 = Some((self.dot % 4) as u8);
+            self.mem[addr as usize] = val;
+        }
+
+        fn tick(&mut self, m_cycles: u8) {
+            self.dot += u64::from(m_cycles) * 4;
+        }
+
+        fn write_cpu_m_cycle(&mut self, addr: u16, val: u8) {
+            self.dot += 3;
+            self.write(addr, val);
+            self.dot += 1;
+        }
+    }
+
+    #[test]
+    fn test_cpu_writes_reach_bus_at_t3_of_m_cycle() {
+        let mut cpu = Sm83::new(WritePhaseSpyBus::new(&[0xE0, 0x40]));
+        cpu.regs.a = 0x91;
+
+        cpu.execute();
+
+        assert_eq!(
+            cpu.bus.write_dot_mod4,
+            Some(3),
+            "SM83 writes should reach the bus at T3 of the write M-cycle"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/gb/ppu/bg_fifo.rs
+++ b/src/gb/ppu/bg_fifo.rs
@@ -1,0 +1,154 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DmgLayer {
+    Background,
+    Window,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct DmgPixelFetch {
+    pub layer: DmgLayer,
+    pub x: u32,
+    pub scanline: u8,
+    pub scx: u8,
+    pub scy: u8,
+    pub wx: u8,
+    pub wy: u8,
+    pub window_line: u8,
+    pub map_lcdc: u8,
+    pub low_lcdc: u8,
+    pub high_lcdc: u8,
+}
+
+pub(super) fn fetch_dmg_pixel(vram: &[u8; 0x2000], fetch: DmgPixelFetch) -> Option<u8> {
+    let (map_base, tile_x, tile_y, pixel_x, pixel_y) = match fetch.layer {
+        DmgLayer::Background => {
+            let bg_x = fetch.scx.wrapping_add(fetch.x as u8);
+            let bg_y = fetch.scy.wrapping_add(fetch.scanline);
+            let map_base = if fetch.map_lcdc & 0x08 != 0 {
+                0x1C00
+            } else {
+                0x1800
+            };
+            (
+                map_base,
+                (bg_x / 8) as usize,
+                (bg_y / 8) as usize,
+                bg_x % 8,
+                bg_y % 8,
+            )
+        }
+        DmgLayer::Window => {
+            if fetch.map_lcdc & 0x20 == 0 || fetch.scanline < fetch.wy {
+                return None;
+            }
+            let win_x_start = fetch.wx.saturating_sub(7);
+            if fetch.x < u32::from(win_x_start) {
+                return None;
+            }
+            let win_x = (fetch.x as u8).wrapping_sub(win_x_start);
+            let win_y = fetch.window_line;
+            let map_base = if fetch.map_lcdc & 0x40 != 0 {
+                0x1C00
+            } else {
+                0x1800
+            };
+            (
+                map_base,
+                (win_x / 8) as usize,
+                (win_y / 8) as usize,
+                win_x % 8,
+                win_y % 8,
+            )
+        }
+    };
+
+    let tile_index = vram[map_base + tile_y * 32 + tile_x];
+    let low_addr = tile_data_addr(tile_index, pixel_y, fetch.low_lcdc);
+    let high_addr = tile_data_addr(tile_index, pixel_y, fetch.high_lcdc) + 1;
+    let bit = 7 - pixel_x;
+    Some(((vram[high_addr] >> bit) & 1) << 1 | ((vram[low_addr] >> bit) & 1))
+}
+
+fn tile_data_addr(tile_index: u8, row: u8, lcdc: u8) -> usize {
+    let tile_start = if lcdc & 0x10 != 0 {
+        usize::from(tile_index) * 16
+    } else {
+        (0x1000i32 + i32::from(tile_index as i8) * 16) as usize
+    };
+    tile_start + usize::from(row) * 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blank_vram() -> [u8; 0x2000] {
+        [0; 0x2000]
+    }
+
+    fn vram_with_mixed_tile_select_sources() -> [u8; 0x2000] {
+        let mut vram = blank_vram();
+        vram[0x1800] = 0x01;
+        vram[0x1010] = 0x80;
+        vram[0x1011] = 0x00;
+        vram[0x0010] = 0x00;
+        vram[0x0011] = 0x80;
+        vram
+    }
+
+    #[test]
+    fn background_fetch_samples_tile_select_independently_for_low_and_high_bytes() {
+        let vram = vram_with_mixed_tile_select_sources();
+
+        let colour = fetch_dmg_pixel(
+            &vram,
+            DmgPixelFetch {
+                layer: DmgLayer::Background,
+                x: 0,
+                scanline: 0,
+                scx: 0,
+                scy: 0,
+                wx: 7,
+                wy: 0,
+                window_line: 0,
+                map_lcdc: 0x81,
+                low_lcdc: 0x81,
+                high_lcdc: 0x91,
+            },
+        );
+
+        assert_eq!(
+            colour,
+            Some(3),
+            "low byte should come from signed tile data while high byte comes from unsigned tile data"
+        );
+    }
+
+    #[test]
+    fn window_fetch_samples_tile_select_independently_for_low_and_high_bytes() {
+        let vram = vram_with_mixed_tile_select_sources();
+
+        let colour = fetch_dmg_pixel(
+            &vram,
+            DmgPixelFetch {
+                layer: DmgLayer::Window,
+                x: 0,
+                scanline: 0,
+                scx: 0,
+                scy: 0,
+                wx: 7,
+                wy: 0,
+                window_line: 0,
+                map_lcdc: 0xA1,
+                low_lcdc: 0xA1,
+                high_lcdc: 0xB1,
+            },
+        );
+
+        assert_eq!(
+            colour,
+            Some(3),
+            "window fetches should use the same independent low/high TILE_SEL sampling as BG fetches"
+        );
+    }
+}

--- a/src/gb/ppu/mod.rs
+++ b/src/gb/ppu/mod.rs
@@ -1,4 +1,5 @@
 pub mod background;
+mod bg_fifo;
 mod obj_fifo;
 mod pixel_fifo;
 #[allow(clippy::module_inception)]

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -640,6 +640,21 @@ impl PixelFifoRenderer {
                 new,
             );
             self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
+        } else if self
+            .should_set_lcdc_tile_data_at_window_obj_stalled_boundary(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                new,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
         } else if !window_fetch_active
             && self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new)
         {
@@ -866,6 +881,22 @@ impl PixelFifoRenderer {
             && self.next_x == OBJ_PIXELS_PER_FETCH - 1
             && bg_phase == OBJ_PIXELS_PER_FETCH - 1
             && self.pending_obj_stall_dots > 0
+    }
+
+    fn should_set_lcdc_tile_data_at_window_obj_stalled_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_on =
+            previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        tile_data_turning_on
+            && self.window_active
+            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH * 2 + 1)
+            && self.next_x == OBJ_PIXELS_PER_FETCH
+            && bg_phase == 0
+            && self.pending_obj_stall_dots == 0
     }
 
     fn should_restore_lcdc_tile_data_after_window_left_edge_obj(
@@ -2632,6 +2663,34 @@ mod tests {
         assert_eq!(
             following_fetch_colour, 1,
             "the following window fetch should keep the delayed low byte and restored high byte"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn on_screen_obj_window_set_at_stalled_boundary_mixes_current_fetch_first_pixel() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 8;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.leftmost_obj_oam_x = Some(17);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "an on-screen OBJ TILE_SEL set at the stalled boundary should leave the first current-window pixel with the previous low byte and new high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -723,8 +723,8 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
         tile_data_turning_off
             && self.window_active
-            && bg_phase == 0
-            && self.next_x == OBJ_PIXELS_PER_FETCH
+            && bg_phase <= 1
+            && self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(bg_phase)
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -1894,6 +1894,40 @@ mod tests {
         assert_eq!(
             current_tile_colour, 1,
             "a window TILE_SEL restore at the tile boundary should keep the previous low byte and sample the restored high byte"
+        );
+        assert_eq!(
+            following_tile_colour, 0,
+            "the following window fetch should use the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn window_restore_one_pixel_after_boundary_mixes_current_fetch_bitplanes() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 1;
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 9;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (following_tile_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 1,
+            "a window TILE_SEL restore one pixel after the boundary should keep the previous low byte and sample the restored high byte"
         );
         assert_eq!(
             following_tile_colour, 0,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -626,6 +626,21 @@ impl PixelFifoRenderer {
             self.lcdc_tile_data_edge
                 .record_write(current_fetch_start, current_fetch_end, new, new);
             self.record_next_lcdc_tile_data_write(next_fetch_start, bg_phase, previous, new);
+        } else if self
+            .should_set_lcdc_tile_data_in_delayed_window_obj_fetch(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                previous,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                previous,
+                new,
+            );
         } else if self.should_set_lcdc_tile_data_at_window_obj_late_stall(previous, new, bg_phase) {
             self.lcdc_tile_data_edge.record_write(
                 current_fetch_start,
@@ -906,6 +921,22 @@ impl PixelFifoRenderer {
             && self.next_x == OBJ_PIXELS_PER_FETCH
             && bg_phase == 0
             && self.pending_obj_stall_dots == 0
+    }
+
+    fn should_set_lcdc_tile_data_in_delayed_window_obj_fetch(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_on =
+            previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        tile_data_turning_on
+            && self.window_active
+            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH + 4)
+            && self.next_x == 4
+            && bg_phase == 4
+            && self.pending_obj_stall_dots > 0
     }
 
     fn should_set_lcdc_tile_data_after_off_left_window_obj_boundary(
@@ -2441,6 +2472,82 @@ mod tests {
             screen_buffer.get_pixel(8, 0),
             (170, 170, 170),
             "the first following window pixel should mix the set low byte with the restored high byte"
+        );
+    }
+
+    #[test]
+    fn delayed_obj_window_set_mixes_first_stalled_fetch_pixel() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA3;
+        registers.bgp = 0xE4;
+        registers.obp0 = 0xFF;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = oam_with_sprite_at(16, 12, 1, 0);
+        let mut screen_buffer = ScreenBuffer::new();
+        let mut dot: u16 = 80;
+
+        renderer.begin_scanline(0, 80, &oam, &registers, false, false);
+        let deadline = dot.saturating_add(256);
+        while !(renderer.next_x == 4 && renderer.pending_obj_stall_dots == 3) {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(dot < deadline, "renderer did not reach the OAM X=12 stall");
+        }
+        renderer.record_lcdc_write_with_window(
+            0xA3,
+            0xB3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xB3;
+
+        let deadline = dot.saturating_add(256);
+        while !(renderer.next_x == 9 && renderer.pending_obj_stall_dots == 0) {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(
+                dot < deadline,
+                "renderer did not reach the OAM X=12 restore point"
+            );
+        }
+        renderer.record_lcdc_write_with_window(
+            0xB3,
+            0xA3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (85, 85, 85),
+            "the first delayed window pixel should mix the previous low byte with the set high byte"
         );
     }
 

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -648,6 +648,19 @@ impl PixelFifoRenderer {
                 new,
                 new,
             );
+        } else if self.should_set_lcdc_tile_data_after_window_low_byte(previous, new, bg_phase) {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                new,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
         } else if self.next_x == current_fetch_start {
             if window_fetch_active {
                 self.lcdc_tile_data_edge.record_write(
@@ -773,6 +786,17 @@ impl PixelFifoRenderer {
         let tile_data_turning_on =
             previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
         tile_data_turning_on && self.window_active && bg_phase == 1 && self.next_x == bg_phase
+    }
+
+    fn should_set_lcdc_tile_data_after_window_low_byte(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_on =
+            previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        tile_data_turning_on && self.window_active && bg_phase == 2 && self.next_x == bg_phase
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -1944,6 +1968,38 @@ mod tests {
         assert_eq!(
             following_tile_colour, 3,
             "the following window fetch should also use the new TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn window_tile_select_set_two_pixels_after_boundary_mixes_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 2;
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+        let (following_tile_colour, _, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 2,
+            "a window TILE_SEL set two pixels after the boundary should keep the previous low byte and sample the new high byte"
+        );
+        assert_eq!(
+            following_tile_colour, 3,
+            "the following window fetch should use the new TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -579,7 +579,21 @@ impl PixelFifoRenderer {
             self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
         }
 
-        if self.next_x == current_fetch_start {
+        if !window_fetch_active && self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new) {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                previous,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                previous,
+                previous,
+            );
+            self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
+        } else if self.next_x == current_fetch_start {
             if window_fetch_active {
                 self.lcdc_tile_data_edge.record_write(
                     current_fetch_start,
@@ -587,20 +601,6 @@ impl PixelFifoRenderer {
                     new,
                     new,
                 );
-            } else if self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new) {
-                self.lcdc_tile_data_edge.record_write(
-                    current_fetch_start,
-                    current_fetch_end,
-                    previous,
-                    previous,
-                );
-                self.lcdc_tile_data_edge.record_write(
-                    next_fetch_start,
-                    next_fetch_start.saturating_add(7),
-                    previous,
-                    previous,
-                );
-                self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
             } else {
                 self.lcdc_tile_data_edge.record_write(
                     current_fetch_start,
@@ -639,15 +639,24 @@ impl PixelFifoRenderer {
     fn should_delay_lcdc_tile_data_by_extra_fetch(&self, previous_lcdc: u8, new_lcdc: u8) -> bool {
         let tile_data_turning_on =
             previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
-        let visible_left_edge_obj = self.leftmost_obj_oam_x == Some(8);
-        tile_data_turning_on && visible_left_edge_obj && self.next_x == 0
+        tile_data_turning_on
+            && self
+                .left_edge_obj_tile_data_delay_start_x()
+                .is_some_and(|start_x| self.next_x == start_x)
     }
 
     fn should_cancel_delayed_lcdc_tile_data_fetch(&self, previous_lcdc: u8, new_lcdc: u8) -> bool {
         let tile_data_turning_off =
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
-        let visible_left_edge_obj = self.leftmost_obj_oam_x == Some(8);
-        tile_data_turning_off && visible_left_edge_obj && self.next_x < 8
+        tile_data_turning_off
+            && self.left_edge_obj_tile_data_delay_start_x().is_some()
+            && self.next_x < 8
+    }
+
+    fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
+        self.leftmost_obj_oam_x
+            .filter(|&oam_x| matches!(oam_x, 8 | 9))
+            .map(|oam_x| oam_x - 8)
     }
 
     fn record_visible_left_edge_delayed_lcdc_tile_data_fetch(&mut self, lcdc: u8) {
@@ -1363,6 +1372,34 @@ mod tests {
         assert_eq!(
             delayed_fetch_colour, 0,
             "restoring TILE_SEL before the delayed fetch starts should keep that fetch on the previous sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_delays_tile_select_following_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 1;
+        renderer.pending_obj_stall_dots = 10;
+        renderer.leftmost_obj_oam_x = Some(9);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 5;
+        renderer.pending_obj_stall_dots = 6;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (next_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            next_tile_colour, 0,
+            "an OBJ fetch starting one pixel in should keep the following BG tile on the previous TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -626,6 +626,20 @@ impl PixelFifoRenderer {
             self.lcdc_tile_data_edge
                 .record_write(current_fetch_start, current_fetch_end, new, new);
             self.record_next_lcdc_tile_data_write(next_fetch_start, bg_phase, previous, new);
+        } else if self.should_set_lcdc_tile_data_at_window_obj_late_stall(previous, new, bg_phase) {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                previous,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                previous,
+                new,
+            );
+            self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
         } else if !window_fetch_active
             && self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new)
         {
@@ -836,6 +850,22 @@ impl PixelFifoRenderer {
         let tile_data_turning_on =
             previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
         tile_data_turning_on && self.window_active && bg_phase == 2 && self.next_x == bg_phase
+    }
+
+    fn should_set_lcdc_tile_data_at_window_obj_late_stall(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_on =
+            previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        tile_data_turning_on
+            && self.window_active
+            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH + 7)
+            && self.next_x == OBJ_PIXELS_PER_FETCH - 1
+            && bg_phase == OBJ_PIXELS_PER_FETCH - 1
+            && self.pending_obj_stall_dots > 0
     }
 
     fn should_restore_lcdc_tile_data_after_window_left_edge_obj(
@@ -2501,6 +2531,34 @@ mod tests {
         assert_eq!(
             following_fetch_colour, 0,
             "the following window fetch should use the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_window_set_at_late_stall_mixes_current_fetch_first_pixel() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 7;
+        renderer.pending_obj_stall_dots = 5;
+        renderer.leftmost_obj_oam_x = Some(15);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "a late near-left-edge OBJ TILE_SEL set should leave the first current-window pixel with the previous low byte and new high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -575,6 +575,10 @@ impl PixelFifoRenderer {
         let current_fetch_start = self.next_x.saturating_sub(bg_phase);
         let current_fetch_end = current_fetch_start.saturating_add(7);
         let next_fetch_start = current_fetch_start.saturating_add(8);
+        if self.should_cancel_delayed_lcdc_tile_data_fetch(previous, new) {
+            self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
+        }
+
         if self.next_x == current_fetch_start {
             if window_fetch_active {
                 self.lcdc_tile_data_edge.record_write(
@@ -596,12 +600,7 @@ impl PixelFifoRenderer {
                     previous,
                     previous,
                 );
-                self.lcdc_tile_data_edge.record_write(
-                    next_fetch_start.saturating_add(8),
-                    next_fetch_start.saturating_add(15),
-                    new,
-                    new,
-                );
+                self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
             } else {
                 self.lcdc_tile_data_edge.record_write(
                     current_fetch_start,
@@ -642,6 +641,23 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
         let visible_left_edge_obj = self.leftmost_obj_oam_x == Some(8);
         tile_data_turning_on && visible_left_edge_obj && self.next_x == 0
+    }
+
+    fn should_cancel_delayed_lcdc_tile_data_fetch(&self, previous_lcdc: u8, new_lcdc: u8) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        let visible_left_edge_obj = self.leftmost_obj_oam_x == Some(8);
+        tile_data_turning_off && visible_left_edge_obj && self.next_x < 8
+    }
+
+    fn record_visible_left_edge_delayed_lcdc_tile_data_fetch(&mut self, lcdc: u8) {
+        let delayed_fetch_start = OBJ_PIXELS_PER_FETCH * 2;
+        self.lcdc_tile_data_edge.record_write(
+            delayed_fetch_start,
+            delayed_fetch_start.saturating_add(OBJ_PIXELS_PER_FETCH - 1),
+            lcdc,
+            lcdc,
+        );
     }
 
     fn record_next_lcdc_tile_data_write(
@@ -1306,6 +1322,47 @@ mod tests {
         assert_eq!(
             next_tile_colour, 0,
             "a visible-left-edge OBJ fetch should keep the following BG tile on the previous TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn visible_left_edge_obj_restore_cancels_delayed_tile_select_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(8);
+        let scx = 3;
+        renderer.record_lcdc_write(0x81, 0x91, scx, false, false);
+        renderer.next_x = 5;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write(0x91, 0x81, scx, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.scx = scx;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(5, &vram, &oam, &registers, 0);
+        let (next_fetch_colour, _, _) = renderer.dmg_pixel_layers(13, &vram, &oam, &registers, 0);
+        let (delayed_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(21, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 3,
+            "a restore at the SCX-shifted boundary should still let that fetch use the previous TILE_SEL sample"
+        );
+        assert_eq!(
+            next_fetch_colour, 0,
+            "the fetch after the restore should use the restored TILE_SEL sample"
+        );
+        assert_eq!(
+            delayed_fetch_colour, 0,
+            "restoring TILE_SEL before the delayed fetch starts should keep that fetch on the previous sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -594,6 +594,21 @@ impl PixelFifoRenderer {
                 new,
                 new,
             );
+        } else if self
+            .should_restore_lcdc_tile_data_at_window_obj_stalled_boundary(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                new,
+                previous,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                previous,
+                new,
+            );
         } else if !window_fetch_active
             && self.should_restore_lcdc_tile_data_at_obj_stalled_boundary(previous, new, bg_phase)
         {
@@ -858,6 +873,22 @@ impl PixelFifoRenderer {
             && delayed_boundary_phase.is_some_and(|phase| {
                 self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(phase) && bg_phase == phase
             })
+    }
+
+    fn should_restore_lcdc_tile_data_at_window_obj_stalled_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        tile_data_turning_off
+            && self.window_active
+            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH * 2)
+            && self.next_x == OBJ_PIXELS_PER_FETCH
+            && bg_phase == 0
+            && self.pending_obj_stall_dots > 0
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -2464,6 +2495,42 @@ mod tests {
         assert_eq!(
             following_fetch_colour, 0,
             "the following window fetch should use the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn on_screen_obj_window_restore_at_stalled_boundary_mixes_current_and_following_fetches() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 8;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.leftmost_obj_oam_x = Some(16);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.pending_obj_stall_dots = 3;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "a stalled on-screen OBJ restore should leave the current window fetch with the restored low byte and delayed high byte"
+        );
+        assert_eq!(
+            following_fetch_colour, 1,
+            "the following window fetch should keep the delayed low byte and restored high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -23,6 +23,8 @@ const DMG_OBJ_FETCH_LOW_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 4;
 const CGB_DMG_COMPAT_OBJ_FETCH_LOW_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 6;
 const DMG_OBJ_FETCH_HIGH_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 1;
 const CGB_DMG_COMPAT_OBJ_FETCH_HIGH_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 3;
+const OFF_LEFT_WINDOW_DELAYED_OBJ_X: u8 = OBJ_PIXELS_PER_FETCH - 3;
+const OFF_LEFT_WINDOW_EXTRA_STALL_DOTS: u16 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LcdcBgEnableEdgeTiming {
@@ -378,10 +380,29 @@ impl PixelFifoRenderer {
                 .iter()
                 .map(|&index| oam[index * 4 + 1])
                 .min();
+            self.extend_off_left_window_obj_stall(registers);
         } else {
             self.sprite_indices.clear();
             self.obj_stall_events.clear();
             self.leftmost_obj_oam_x = None;
+        }
+    }
+
+    fn extend_off_left_window_obj_stall(&mut self, registers: &Registers) {
+        let window_starts_at_left_edge =
+            registers.lcdc & 0x20 != 0 && self.scanline >= registers.wy && registers.wx <= 7;
+        if !window_starts_at_left_edge
+            || self.leftmost_obj_oam_x != Some(OFF_LEFT_WINDOW_DELAYED_OBJ_X)
+        {
+            return;
+        }
+
+        if let Some(event) = self
+            .obj_stall_events
+            .first_mut()
+            .filter(|event| event.x == 0)
+        {
+            event.dots = event.dots.saturating_add(OFF_LEFT_WINDOW_EXTRA_STALL_DOTS);
         }
     }
 
@@ -626,6 +647,15 @@ impl PixelFifoRenderer {
             self.lcdc_tile_data_edge
                 .record_write(current_fetch_start, current_fetch_end, new, new);
             self.record_next_lcdc_tile_data_write(next_fetch_start, bg_phase, previous, new);
+        } else if window_fetch_active
+            && self.should_set_lcdc_tile_data_at_off_left_window_start(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                new,
+            );
         } else if self
             .should_set_lcdc_tile_data_in_delayed_window_obj_fetch(previous, new, bg_phase)
         {
@@ -921,6 +951,20 @@ impl PixelFifoRenderer {
             && self.next_x == OBJ_PIXELS_PER_FETCH
             && bg_phase == 0
             && self.pending_obj_stall_dots == 0
+    }
+
+    fn should_set_lcdc_tile_data_at_off_left_window_start(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_on =
+            previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        tile_data_turning_on
+            && self.leftmost_obj_oam_x == Some(OFF_LEFT_WINDOW_DELAYED_OBJ_X)
+            && self.next_x == 0
+            && bg_phase == 0
     }
 
     fn should_set_lcdc_tile_data_in_delayed_window_obj_fetch(
@@ -2474,6 +2518,79 @@ mod tests {
             screen_buffer.get_pixel(8, 0),
             (170, 170, 170),
             "the first following window pixel should mix the set low byte with the restored high byte"
+        );
+    }
+
+    #[test]
+    fn off_left_obj_window_set_delays_first_visible_pixels() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA3;
+        registers.bgp = 0xE4;
+        registers.obp0 = 0xFF;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = oam_with_sprite_at(16, 5, 1, 0);
+        let mut screen_buffer = ScreenBuffer::new();
+        let mut dot: u16 = 80;
+
+        renderer.begin_scanline(0, 80, &oam, &registers, false, false);
+        while dot < 104 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+        }
+        renderer.record_lcdc_write_with_window(
+            0xA3,
+            0xB3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xB3;
+        while dot < 112 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+        }
+        renderer.record_lcdc_write_with_window(
+            0xB3,
+            0xA3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+
+        assert_eq!(
+            screen_buffer.get_pixel(0, 0),
+            (85, 85, 85),
+            "the first visible window pixel should wait long enough to mix the previous low byte with the set high byte"
+        );
+        assert_eq!(
+            screen_buffer.get_pixel(1, 0),
+            (85, 85, 85),
+            "the second visible window pixel should wait long enough to keep the set high byte"
         );
     }
 

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -518,6 +518,7 @@ impl PixelFifoRenderer {
         };
     }
 
+    #[cfg(test)]
     pub fn record_lcdc_write(
         &mut self,
         previous: u8,
@@ -529,6 +530,7 @@ impl PixelFifoRenderer {
         self.record_lcdc_write_with_window(previous, new, scx, cgb_mode, dmg_compat, 166, 144);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn record_lcdc_write_with_window(
         &mut self,
         previous: u8,
@@ -823,12 +825,10 @@ impl PixelFifoRenderer {
                     new,
                 );
             }
-        } else if self
+        } else if !self
             .lcdc_tile_data_edge
             .has_latched_range(current_fetch_start, current_fetch_end)
         {
-            return;
-        } else {
             if !self
                 .lcdc_tile_data_edge
                 .has_range(current_fetch_start, current_fetch_end)

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -583,6 +583,25 @@ impl PixelFifoRenderer {
                     new,
                     new,
                 );
+            } else if self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new) {
+                self.lcdc_tile_data_edge.record_write(
+                    current_fetch_start,
+                    current_fetch_end,
+                    previous,
+                    previous,
+                );
+                self.lcdc_tile_data_edge.record_write(
+                    next_fetch_start,
+                    next_fetch_start.saturating_add(7),
+                    previous,
+                    previous,
+                );
+                self.lcdc_tile_data_edge.record_write(
+                    next_fetch_start.saturating_add(8),
+                    next_fetch_start.saturating_add(15),
+                    new,
+                    new,
+                );
             } else {
                 self.lcdc_tile_data_edge.record_write(
                     current_fetch_start,
@@ -616,6 +635,13 @@ impl PixelFifoRenderer {
             }
             self.record_next_lcdc_tile_data_write(next_fetch_start, bg_phase, previous, new);
         }
+    }
+
+    fn should_delay_lcdc_tile_data_by_extra_fetch(&self, previous_lcdc: u8, new_lcdc: u8) -> bool {
+        let tile_data_turning_on =
+            previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        let visible_left_edge_obj = self.leftmost_obj_oam_x == Some(8);
+        tile_data_turning_on && visible_left_edge_obj && self.next_x == 0
     }
 
     fn record_next_lcdc_tile_data_write(
@@ -1254,6 +1280,34 @@ mod tests {
             renderer.lcdc_bg_map_edge.lcdc_for_bg_fetch(16, 0x8B) & 0x08,
             0x08
         );
+    }
+
+    #[test]
+    fn visible_left_edge_obj_delays_tile_select_following_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(8);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 5;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (next_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            next_tile_colour, 0,
+            "a visible-left-edge OBJ fetch should keep the following BG tile on the previous TILE_SEL sample"
+        );
+        assert!(!is_sprite);
     }
 
     #[test]

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -23,7 +23,8 @@ const DMG_OBJ_FETCH_LOW_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 4;
 const CGB_DMG_COMPAT_OBJ_FETCH_LOW_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 6;
 const DMG_OBJ_FETCH_HIGH_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 1;
 const CGB_DMG_COMPAT_OBJ_FETCH_HIGH_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 3;
-const OFF_LEFT_WINDOW_DELAYED_OBJ_X: u8 = OBJ_PIXELS_PER_FETCH - 3;
+const OFF_LEFT_WINDOW_DELAYED_OBJ_X_START: u8 = OBJ_PIXELS_PER_FETCH - 3;
+const OFF_LEFT_WINDOW_DELAYED_OBJ_X_END: u8 = OBJ_PIXELS_PER_FETCH - 2;
 const OFF_LEFT_WINDOW_EXTRA_STALL_DOTS: u16 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -392,7 +393,9 @@ impl PixelFifoRenderer {
         let window_starts_at_left_edge =
             registers.lcdc & 0x20 != 0 && self.scanline >= registers.wy && registers.wx <= 7;
         if !window_starts_at_left_edge
-            || self.leftmost_obj_oam_x != Some(OFF_LEFT_WINDOW_DELAYED_OBJ_X)
+            || !self
+                .leftmost_obj_oam_x
+                .is_some_and(is_off_left_window_delayed_obj_x)
         {
             return;
         }
@@ -910,7 +913,9 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
         tile_data_turning_off
             && self.window_active
-            && self.leftmost_obj_oam_x == Some(OFF_LEFT_WINDOW_DELAYED_OBJ_X)
+            && self
+                .leftmost_obj_oam_x
+                .is_some_and(is_off_left_window_delayed_obj_x)
             && self.next_x == OBJ_PIXELS_PER_FETCH
             && bg_phase == 0
     }
@@ -992,7 +997,9 @@ impl PixelFifoRenderer {
         let tile_data_turning_on =
             previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
         tile_data_turning_on
-            && self.leftmost_obj_oam_x == Some(OFF_LEFT_WINDOW_DELAYED_OBJ_X)
+            && self
+                .leftmost_obj_oam_x
+                .is_some_and(is_off_left_window_delayed_obj_x)
             && self.next_x == 0
             && bg_phase == 0
     }
@@ -1599,6 +1606,10 @@ impl Default for PixelFifoRenderer {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn is_off_left_window_delayed_obj_x(oam_x: u8) -> bool {
+    (OFF_LEFT_WINDOW_DELAYED_OBJ_X_START..=OFF_LEFT_WINDOW_DELAYED_OBJ_X_END).contains(&oam_x)
 }
 
 #[cfg(test)]
@@ -2645,6 +2656,103 @@ mod tests {
             screen_buffer.get_pixel(8, 0),
             (170, 170, 170),
             "the first following window tile should remain on the set TILE_SEL sample after the restore at its boundary"
+        );
+    }
+
+    #[test]
+    fn later_off_left_obj_window_set_delays_first_visible_pixels() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA3;
+        registers.bgp = 0x6C;
+        registers.obp0 = 0xFF;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = oam_with_sprite_at(16, 6, 1, 0);
+        let mut screen_buffer = ScreenBuffer::new();
+        let mut dot: u16 = 80;
+
+        renderer.begin_scanline(0, 80, &oam, &registers, false, false);
+        while dot < 104 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+        }
+        renderer.record_lcdc_write_with_window(
+            0xA3,
+            0xB3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xB3;
+        while dot < 112 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+        }
+        renderer.record_lcdc_write_with_window(
+            0xB3,
+            0xA3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xA3;
+        let deadline = dot.saturating_add(64);
+        while renderer.next_x <= 8 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(
+                dot < deadline,
+                "renderer did not output the first following window tile pixel"
+            );
+        }
+
+        assert_eq!(
+            screen_buffer.get_pixel(0, 0),
+            (85, 85, 85),
+            "the first visible window pixel should wait through the later off-left OBJ stall"
+        );
+        assert_eq!(
+            screen_buffer.get_pixel(1, 0),
+            (85, 85, 85),
+            "the second visible window pixel should wait through the later off-left OBJ stall"
+        );
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (170, 170, 170),
+            "the following tile should stay on the set TILE_SEL sample after the restore"
         );
     }
 

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -675,7 +675,7 @@ impl PixelFifoRenderer {
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
         self.leftmost_obj_oam_x
-            .filter(|&oam_x| (8..=13).contains(&oam_x))
+            .filter(|&oam_x| (8..=14).contains(&oam_x))
             .map(|oam_x| oam_x - 8)
     }
 
@@ -1568,6 +1568,40 @@ mod tests {
         assert_eq!(
             current_fetch_colour, 0,
             "a restore two pixels after the delayed BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
+        );
+        assert_eq!(
+            following_fetch_colour, 1,
+            "the following fetch should keep the delayed low-byte TILE_SEL sample and use the restored high-byte sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_restore_three_pixels_after_boundary_updates_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 6;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(14);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 11;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(12, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 0,
+            "a restore three pixels after the delayed BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
         );
         assert_eq!(
             following_fetch_colour, 1,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -548,8 +548,13 @@ impl PixelFifoRenderer {
         let waiting_on_obj_fetch = self.is_waiting_on_obj_fetch();
         let window_fetch_active =
             previous & 0x20 != 0 && self.scanline >= wy && self.next_x == wx.saturating_sub(7);
+        let tile_data_fetch_phase = if window_fetch_active || self.window_active {
+            self.next_x.saturating_sub(wx.saturating_sub(7)) & 0x07
+        } else {
+            scx.wrapping_add(self.next_x) & 0x07
+        };
         self.record_lcdc_obj_size_write(previous, new, cgb_mode, dmg_compat);
-        self.record_lcdc_tile_data_write(previous, new, scx, window_fetch_active);
+        self.record_lcdc_tile_data_write(previous, new, tile_data_fetch_phase, window_fetch_active);
         if let Some(model) = ObjFetchModel::for_dmg_render_path(cgb_mode, dmg_compat) {
             self.record_lcdc_obj_enable_write(model, previous, new);
         }
@@ -590,14 +595,13 @@ impl PixelFifoRenderer {
         &mut self,
         previous: u8,
         new: u8,
-        scx: u8,
+        bg_phase: u8,
         window_fetch_active: bool,
     ) {
         if previous & LCDC_TILE_DATA == new & LCDC_TILE_DATA {
             return;
         }
 
-        let bg_phase = scx.wrapping_add(self.next_x) & 0x07;
         let current_fetch_start = self.next_x.saturating_sub(bg_phase);
         let current_fetch_end = current_fetch_start.saturating_add(7);
         let next_fetch_start = current_fetch_start.saturating_add(8);
@@ -2237,6 +2241,37 @@ mod tests {
         assert_eq!(
             colour_index, 3,
             "a TILE_SEL write at WX=7 should apply to the first window tile fetch, not a preceding BG tile"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn record_lcdc_write_at_scrolled_window_boundary_uses_window_phase() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 8;
+        renderer.lcdc_tile_data_edge.record_write(0, 7, 0xA1, 0xA1);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 7, false, false, 15, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.scx = 7;
+        registers.bgp = 0xE4;
+        registers.wx = 15;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (bg_colour, is_sprite, _) = renderer.dmg_pixel_layers(7, &vram, &oam, &registers, 0);
+        let (window_colour, _, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            bg_colour, 0,
+            "window TILE_SEL sampling must not bleed into the preceding BG pixel"
+        );
+        assert_eq!(
+            window_colour, 3,
+            "a TILE_SEL write at a WX>7 window boundary should use window phase, not SCX-shifted BG phase"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -933,7 +933,7 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
         let delayed_fetch_phase = self
             .leftmost_obj_oam_x
-            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 4..=OBJ_PIXELS_PER_FETCH + 5).contains(&oam_x))
+            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 4..=OBJ_PIXELS_PER_FETCH + 6).contains(&oam_x))
             .map(|oam_x| oam_x - OBJ_PIXELS_PER_FETCH);
         tile_data_turning_on
             && self.window_active
@@ -2631,6 +2631,87 @@ mod tests {
             screen_buffer.get_pixel(9, 0),
             (85, 85, 85),
             "the second later delayed window pixel should keep the set high byte"
+        );
+    }
+
+    #[test]
+    fn delayed_obj_window_set_after_high_phase_mixes_first_stalled_fetch_pixels() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA3;
+        registers.bgp = 0xE4;
+        registers.obp0 = 0xFF;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = oam_with_sprite_at(16, 14, 1, 0);
+        let mut screen_buffer = ScreenBuffer::new();
+        let mut dot: u16 = 80;
+
+        renderer.begin_scanline(0, 80, &oam, &registers, false, false);
+        let deadline = dot.saturating_add(256);
+        while !(renderer.next_x == 6 && renderer.pending_obj_stall_dots == 4) {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(dot < deadline, "renderer did not reach the OAM X=14 stall");
+        }
+        renderer.record_lcdc_write_with_window(
+            0xA3,
+            0xB3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xB3;
+
+        let deadline = dot.saturating_add(256);
+        while !(renderer.next_x == 10 && renderer.pending_obj_stall_dots == 0) {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(
+                dot < deadline,
+                "renderer did not reach the OAM X=14 restore point"
+            );
+        }
+        renderer.record_lcdc_write_with_window(
+            0xB3,
+            0xA3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (85, 85, 85),
+            "the first high-phase delayed window pixel should mix the previous low byte with the set high byte"
+        );
+        assert_eq!(
+            screen_buffer.get_pixel(9, 0),
+            (85, 85, 85),
+            "the second high-phase delayed window pixel should keep the set high byte"
         );
     }
 

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -655,7 +655,7 @@ impl PixelFifoRenderer {
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
         self.leftmost_obj_oam_x
-            .filter(|&oam_x| (8..=10).contains(&oam_x))
+            .filter(|&oam_x| (8..=11).contains(&oam_x))
             .map(|oam_x| oam_x - 8)
     }
 
@@ -1410,11 +1410,11 @@ mod tests {
         renderer.active = true;
         renderer.scanline = 0;
         renderer.next_x = 2;
-        renderer.pending_obj_stall_dots = 10;
+        renderer.pending_obj_stall_dots = 9;
         renderer.leftmost_obj_oam_x = Some(10);
         renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
         renderer.next_x = 5;
-        renderer.pending_obj_stall_dots = 7;
+        renderer.pending_obj_stall_dots = 6;
         renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
         let mut registers = Registers::new();
         registers.lcdc = 0x81;
@@ -1428,6 +1428,34 @@ mod tests {
         assert_eq!(
             next_tile_colour, 0,
             "an OBJ fetch starting two pixels in should keep both bitplanes of the following BG tile on the previous TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_delays_tile_select_even_after_high_byte_phase() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 3;
+        renderer.pending_obj_stall_dots = 8;
+        renderer.leftmost_obj_oam_x = Some(11);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 5;
+        renderer.pending_obj_stall_dots = 6;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (next_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            next_tile_colour, 0,
+            "an OBJ fetch starting three pixels in should keep both bitplanes of the following BG tile on the previous TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -675,7 +675,7 @@ impl PixelFifoRenderer {
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
         self.leftmost_obj_oam_x
-            .filter(|&oam_x| (8..=14).contains(&oam_x))
+            .filter(|&oam_x| (8..=15).contains(&oam_x))
             .map(|oam_x| oam_x - 8)
     }
 
@@ -1602,6 +1602,40 @@ mod tests {
         assert_eq!(
             current_fetch_colour, 0,
             "a restore three pixels after the delayed BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
+        );
+        assert_eq!(
+            following_fetch_colour, 1,
+            "the following fetch should keep the delayed low-byte TILE_SEL sample and use the restored high-byte sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_restore_four_pixels_after_boundary_updates_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 7;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(15);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 12;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(13, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 0,
+            "a restore four pixels after the delayed BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
         );
         assert_eq!(
             following_fetch_colour, 1,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -24,7 +24,7 @@ const CGB_DMG_COMPAT_OBJ_FETCH_LOW_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 6;
 const DMG_OBJ_FETCH_HIGH_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 1;
 const CGB_DMG_COMPAT_OBJ_FETCH_HIGH_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 3;
 const OFF_LEFT_WINDOW_DELAYED_OBJ_X_START: u8 = OBJ_PIXELS_PER_FETCH - 3;
-const OFF_LEFT_WINDOW_DELAYED_OBJ_X_END: u8 = OBJ_PIXELS_PER_FETCH - 2;
+const OFF_LEFT_WINDOW_DELAYED_OBJ_X_END: u8 = OBJ_PIXELS_PER_FETCH - 1;
 const OFF_LEFT_WINDOW_EXTRA_STALL_DOTS: u16 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2748,6 +2748,103 @@ mod tests {
             screen_buffer.get_pixel(1, 0),
             (85, 85, 85),
             "the second visible window pixel should wait through the later off-left OBJ stall"
+        );
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (170, 170, 170),
+            "the following tile should stay on the set TILE_SEL sample after the restore"
+        );
+    }
+
+    #[test]
+    fn final_off_left_obj_window_set_delays_first_visible_pixels() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA3;
+        registers.bgp = 0x6C;
+        registers.obp0 = 0xFF;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = oam_with_sprite_at(16, 7, 1, 0);
+        let mut screen_buffer = ScreenBuffer::new();
+        let mut dot: u16 = 80;
+
+        renderer.begin_scanline(0, 80, &oam, &registers, false, false);
+        while dot < 104 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+        }
+        renderer.record_lcdc_write_with_window(
+            0xA3,
+            0xB3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xB3;
+        while dot < 112 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+        }
+        renderer.record_lcdc_write_with_window(
+            0xB3,
+            0xA3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xA3;
+        let deadline = dot.saturating_add(64);
+        while renderer.next_x <= 8 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(
+                dot < deadline,
+                "renderer did not output the first following window tile pixel"
+            );
+        }
+
+        assert_eq!(
+            screen_buffer.get_pixel(0, 0),
+            (85, 85, 85),
+            "the first visible window pixel should wait through the final off-left OBJ stall"
+        );
+        assert_eq!(
+            screen_buffer.get_pixel(1, 0),
+            (85, 85, 85),
+            "the second visible window pixel should wait through the final off-left OBJ stall"
         );
         assert_eq!(
             screen_buffer.get_pixel(8, 0),

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -751,7 +751,7 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
         tile_data_turning_off
             && self.window_active
-            && bg_phase == 2
+            && (2..=3).contains(&bg_phase)
             && self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(bg_phase)
     }
 
@@ -1990,6 +1990,40 @@ mod tests {
         assert_eq!(
             current_tile_colour, 3,
             "a window TILE_SEL restore two pixels after the boundary should not alter the current fetch"
+        );
+        assert_eq!(
+            following_tile_colour, 0,
+            "the following window fetch should use the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn window_restore_three_pixels_after_boundary_keeps_current_fetch_latched() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 3;
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 11;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (following_tile_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 3,
+            "a window TILE_SEL restore three pixels after the boundary should not alter the current fetch"
         );
         assert_eq!(
             following_tile_colour, 0,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -496,13 +496,28 @@ impl PixelFifoRenderer {
         cgb_mode: bool,
         dmg_compat: bool,
     ) {
+        self.record_lcdc_write_with_window(previous, new, scx, cgb_mode, dmg_compat, 166, 144);
+    }
+
+    pub fn record_lcdc_write_with_window(
+        &mut self,
+        previous: u8,
+        new: u8,
+        scx: u8,
+        cgb_mode: bool,
+        dmg_compat: bool,
+        wx: u8,
+        wy: u8,
+    ) {
         if !self.active || self.next_x as u32 >= ScreenBuffer::WIDTH {
             return;
         }
 
         let waiting_on_obj_fetch = self.is_waiting_on_obj_fetch();
+        let window_fetch_active =
+            previous & 0x20 != 0 && self.scanline >= wy && self.next_x == wx.saturating_sub(7);
         self.record_lcdc_obj_size_write(previous, new, cgb_mode, dmg_compat);
-        self.record_lcdc_tile_data_write(previous, new, scx);
+        self.record_lcdc_tile_data_write(previous, new, scx, window_fetch_active);
         if let Some(model) = ObjFetchModel::for_dmg_render_path(cgb_mode, dmg_compat) {
             self.record_lcdc_obj_enable_write(model, previous, new);
         }
@@ -539,7 +554,13 @@ impl PixelFifoRenderer {
             .record_write(self.next_x, previous, new, timing);
     }
 
-    fn record_lcdc_tile_data_write(&mut self, previous: u8, new: u8, scx: u8) {
+    fn record_lcdc_tile_data_write(
+        &mut self,
+        previous: u8,
+        new: u8,
+        scx: u8,
+        window_fetch_active: bool,
+    ) {
         if previous & LCDC_TILE_DATA == new & LCDC_TILE_DATA {
             return;
         }
@@ -548,19 +569,28 @@ impl PixelFifoRenderer {
         let current_fetch_start = self.next_x.saturating_sub(bg_phase);
         let current_fetch_end = current_fetch_start.saturating_add(7);
         if self.next_x == current_fetch_start {
-            self.lcdc_tile_data_edge.record_write(
-                current_fetch_start,
-                current_fetch_end,
-                previous,
-                previous,
-            );
-            let next_fetch_start = current_fetch_start.saturating_add(8);
-            self.lcdc_tile_data_edge.record_write(
-                next_fetch_start,
-                next_fetch_start.saturating_add(7),
-                new,
-                new,
-            );
+            if window_fetch_active {
+                self.lcdc_tile_data_edge.record_write(
+                    current_fetch_start,
+                    current_fetch_end,
+                    new,
+                    new,
+                );
+            } else {
+                self.lcdc_tile_data_edge.record_write(
+                    current_fetch_start,
+                    current_fetch_end,
+                    previous,
+                    previous,
+                );
+                let next_fetch_start = current_fetch_start.saturating_add(8);
+                self.lcdc_tile_data_edge.record_write(
+                    next_fetch_start,
+                    next_fetch_start.saturating_add(7),
+                    new,
+                    new,
+                );
+            }
         } else if !self
             .lcdc_tile_data_edge
             .has_latched_range(current_fetch_start, current_fetch_end)
@@ -1267,6 +1297,60 @@ mod tests {
         assert_eq!(
             next_tile_colour, 3,
             "the next BG fetch should sample the new TILE_SEL value for both bitplanes"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn record_lcdc_write_at_left_window_boundary_updates_current_window_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (colour_index, is_sprite, _) = renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            colour_index, 3,
+            "a TILE_SEL write at WX=7 should apply to the first window tile fetch, not a preceding BG tile"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn record_lcdc_write_after_window_boundary_updates_following_window_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 8;
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (next_tile_colour, _, _) = renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 0,
+            "after the window has started, a boundary write must not alter the already-latched window tile"
+        );
+        assert_eq!(
+            next_tile_colour, 3,
+            "the following window fetch should sample the new TILE_SEL value"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -725,6 +725,21 @@ impl PixelFifoRenderer {
                 previous,
             );
             self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
+        } else if self
+            .should_restore_lcdc_tile_data_at_off_left_window_boundary(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                previous,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
         } else if self.should_restore_lcdc_tile_data_at_window_boundary(previous, new, bg_phase) {
             self.lcdc_tile_data_edge.record_write(
                 current_fetch_start,
@@ -883,6 +898,21 @@ impl PixelFifoRenderer {
             && self.window_active
             && bg_phase <= 1
             && self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(bg_phase)
+    }
+
+    fn should_restore_lcdc_tile_data_at_off_left_window_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        tile_data_turning_off
+            && self.window_active
+            && self.leftmost_obj_oam_x == Some(OFF_LEFT_WINDOW_DELAYED_OBJ_X)
+            && self.next_x == OBJ_PIXELS_PER_FETCH
+            && bg_phase == 0
     }
 
     fn should_restore_lcdc_tile_data_after_window_low_byte(
@@ -2526,7 +2556,7 @@ mod tests {
         let mut renderer = PixelFifoRenderer::new();
         let mut registers = Registers::new();
         registers.lcdc = 0xA3;
-        registers.bgp = 0xE4;
+        registers.bgp = 0x6C;
         registers.obp0 = 0xFF;
         registers.wx = 7;
         registers.wy = 0;
@@ -2581,6 +2611,25 @@ mod tests {
             registers.wx,
             registers.wy,
         );
+        registers.lcdc = 0xA3;
+        let deadline = dot.saturating_add(64);
+        while renderer.next_x <= 8 {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(
+                dot < deadline,
+                "renderer did not output the first following window tile pixel"
+            );
+        }
 
         assert_eq!(
             screen_buffer.get_pixel(0, 0),
@@ -2591,6 +2640,11 @@ mod tests {
             screen_buffer.get_pixel(1, 0),
             (85, 85, 85),
             "the second visible window pixel should wait long enough to keep the set high byte"
+        );
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (170, 170, 170),
+            "the first following window tile should remain on the set TILE_SEL sample after the restore at its boundary"
         );
     }
 

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -883,11 +883,17 @@ impl PixelFifoRenderer {
     ) -> bool {
         let tile_data_turning_off =
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        let stalled_boundary_phase = self
+            .leftmost_obj_oam_x
+            .filter(|&oam_x| {
+                (OBJ_PIXELS_PER_FETCH * 2..=OBJ_PIXELS_PER_FETCH * 2 + 1).contains(&oam_x)
+            })
+            .map(|oam_x| oam_x - OBJ_PIXELS_PER_FETCH * 2);
         tile_data_turning_off
             && self.window_active
-            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH * 2)
-            && self.next_x == OBJ_PIXELS_PER_FETCH
-            && bg_phase == 0
+            && stalled_boundary_phase.is_some_and(|phase| {
+                self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(phase) && bg_phase == phase
+            })
             && self.pending_obj_stall_dots > 0
     }
 
@@ -2527,6 +2533,43 @@ mod tests {
         assert_eq!(
             current_fetch_colour, 2,
             "a stalled on-screen OBJ restore should leave the current window fetch with the restored low byte and delayed high byte"
+        );
+        assert_eq!(
+            following_fetch_colour, 1,
+            "the following window fetch should keep the delayed low byte and restored high byte"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn on_screen_obj_window_restore_after_stalled_boundary_mixes_current_and_following_fetches() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 8;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.leftmost_obj_oam_x = Some(17);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 9;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "an on-screen OBJ restore after the stalled boundary should leave the current window fetch with the restored low byte and delayed high byte"
         );
         assert_eq!(
             following_fetch_colour, 1,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -199,6 +199,14 @@ impl LcdcTileDataEdge {
             })
     }
 
+    fn has_latched_range(&self, start_x: u8, end_x: u8) -> bool {
+        self.ranges.iter().any(|range| {
+            range.start_x == start_x
+                && range.end_x == end_x
+                && range.low_lcdc & LCDC_TILE_DATA == range.high_lcdc & LCDC_TILE_DATA
+        })
+    }
+
     fn clear_consumed(&mut self, next_x: u8) {
         self.ranges.retain(|range| range.end_x != next_x);
     }
@@ -539,13 +547,27 @@ impl PixelFifoRenderer {
         let bg_phase = scx.wrapping_add(self.next_x) & 0x07;
         let current_fetch_start = self.next_x.saturating_sub(bg_phase);
         let current_fetch_end = current_fetch_start.saturating_add(7);
-        let (start_x, low_lcdc, high_lcdc) = if self.next_x == current_fetch_start {
-            (current_fetch_start, previous, previous)
-        } else {
-            (self.next_x, previous, new)
-        };
-        self.lcdc_tile_data_edge
-            .record_write(start_x, current_fetch_end, low_lcdc, high_lcdc);
+        if self.next_x == current_fetch_start {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                previous,
+            );
+            let next_fetch_start = current_fetch_start.saturating_add(8);
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
+        } else if !self
+            .lcdc_tile_data_edge
+            .has_latched_range(current_fetch_start, current_fetch_end)
+        {
+            self.lcdc_tile_data_edge
+                .record_write(self.next_x, current_fetch_end, previous, new);
+        }
     }
 
     fn record_lcdc_obj_enable_write(&mut self, model: ObjFetchModel, previous: u8, new: u8) {
@@ -1250,6 +1272,36 @@ mod tests {
     }
 
     #[test]
+    fn paired_lcdc_writes_while_visible_tile_is_latched_update_following_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 5;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(5, &vram, &oam, &registers, 0);
+        let (next_tile_colour, _, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 0,
+            "later TILE_SEL writes during output of an already-latched tile must not alter that visible tile"
+        );
+        assert_eq!(
+            next_tile_colour, 3,
+            "the following fetch should retain the TILE_SEL sample from the earlier write until its bitplanes are latched"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
     fn record_lcdc_write_mid_tile_does_not_bleed_tile_data_samples_into_next_tile() {
         let mut renderer = PixelFifoRenderer::new();
         renderer.active = true;
@@ -1276,14 +1328,11 @@ mod tests {
     }
 
     #[test]
-    fn record_lcdc_write_uses_latest_tile_data_samples_for_overlapping_tile_ranges() {
+    fn recorded_tile_data_samples_use_latest_overlapping_range() {
         let mut renderer = PixelFifoRenderer::new();
-        renderer.active = true;
         renderer.scanline = 0;
-        renderer.next_x = 0;
-        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
-        renderer.next_x = 3;
-        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        renderer.lcdc_tile_data_edge.record_write(0, 7, 0x81, 0x91);
+        renderer.lcdc_tile_data_edge.record_write(3, 7, 0x91, 0x81);
         let mut registers = Registers::new();
         registers.lcdc = 0x81;
         registers.bgp = 0xE4;
@@ -1299,7 +1348,7 @@ mod tests {
 
         assert_eq!(
             colour_index, 2,
-            "overlapping tile-data ranges should use the most recent LCDC write"
+            "overlapping tile-data ranges should use the most recent recorded sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -655,7 +655,7 @@ impl PixelFifoRenderer {
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
         self.leftmost_obj_oam_x
-            .filter(|&oam_x| matches!(oam_x, 8 | 9))
+            .filter(|&oam_x| (8..=10).contains(&oam_x))
             .map(|oam_x| oam_x - 8)
     }
 
@@ -1400,6 +1400,34 @@ mod tests {
         assert_eq!(
             next_tile_colour, 0,
             "an OBJ fetch starting one pixel in should keep the following BG tile on the previous TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_delays_tile_select_even_after_low_byte_phase() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 2;
+        renderer.pending_obj_stall_dots = 10;
+        renderer.leftmost_obj_oam_x = Some(10);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 5;
+        renderer.pending_obj_stall_dots = 7;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (next_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            next_tile_colour, 0,
+            "an OBJ fetch starting two pixels in should keep both bitplanes of the following BG tile on the previous TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -207,6 +207,12 @@ impl LcdcTileDataEdge {
         })
     }
 
+    fn has_range(&self, start_x: u8, end_x: u8) -> bool {
+        self.ranges
+            .iter()
+            .any(|range| range.start_x == start_x && range.end_x == end_x)
+    }
+
     fn clear_consumed(&mut self, next_x: u8) {
         self.ranges.retain(|range| range.end_x != next_x);
     }
@@ -568,6 +574,7 @@ impl PixelFifoRenderer {
         let bg_phase = scx.wrapping_add(self.next_x) & 0x07;
         let current_fetch_start = self.next_x.saturating_sub(bg_phase);
         let current_fetch_end = current_fetch_start.saturating_add(7);
+        let next_fetch_start = current_fetch_start.saturating_add(8);
         if self.next_x == current_fetch_start {
             if window_fetch_active {
                 self.lcdc_tile_data_edge.record_write(
@@ -583,7 +590,6 @@ impl PixelFifoRenderer {
                     previous,
                     previous,
                 );
-                let next_fetch_start = current_fetch_start.saturating_add(8);
                 self.lcdc_tile_data_edge.record_write(
                     next_fetch_start,
                     next_fetch_start.saturating_add(7),
@@ -591,24 +597,45 @@ impl PixelFifoRenderer {
                     new,
                 );
             }
-        } else if !self
+        } else if self
             .lcdc_tile_data_edge
             .has_latched_range(current_fetch_start, current_fetch_end)
         {
-            self.lcdc_tile_data_edge.record_write(
-                current_fetch_start,
-                current_fetch_end,
-                previous,
-                previous,
-            );
-            let next_fetch_start = current_fetch_start.saturating_add(8);
-            self.lcdc_tile_data_edge.record_write(
-                next_fetch_start,
-                next_fetch_start.saturating_add(7),
-                new,
-                new,
-            );
+            return;
+        } else {
+            if !self
+                .lcdc_tile_data_edge
+                .has_range(current_fetch_start, current_fetch_end)
+            {
+                self.lcdc_tile_data_edge.record_write(
+                    current_fetch_start,
+                    current_fetch_end,
+                    previous,
+                    previous,
+                );
+            }
+            self.record_next_lcdc_tile_data_write(next_fetch_start, bg_phase, previous, new);
         }
+    }
+
+    fn record_next_lcdc_tile_data_write(
+        &mut self,
+        next_fetch_start: u8,
+        bg_phase: u8,
+        previous: u8,
+        new: u8,
+    ) {
+        let (low_lcdc, high_lcdc) = if bg_phase <= 1 {
+            (new, new)
+        } else {
+            (previous, new)
+        };
+        self.lcdc_tile_data_edge.record_write(
+            next_fetch_start,
+            next_fetch_start.saturating_add(7),
+            low_lcdc,
+            high_lcdc,
+        );
     }
 
     fn record_lcdc_obj_enable_write(&mut self, model: ObjFetchModel, previous: u8, new: u8) {
@@ -1420,6 +1447,42 @@ mod tests {
         assert_eq!(
             next_tile_colour, 3,
             "the following BG fetch should sample the new TILE_SEL value"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn paired_lcdc_writes_late_in_visible_tile_mix_following_fetches() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 2;
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 10;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(3, &vram, &oam, &registers, 0);
+        let (next_tile_colour, _, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (following_tile_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 0,
+            "late TILE_SEL writes must not alter the rest of the visible tile"
+        );
+        assert_eq!(
+            next_tile_colour, 2,
+            "the following fetch should keep the previous low byte and sample the new high byte"
+        );
+        assert_eq!(
+            following_tile_colour, 1,
+            "the restore write should let the next fetch keep the new low byte and sample the previous high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -579,7 +579,20 @@ impl PixelFifoRenderer {
             self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
         }
 
-        if !window_fetch_active && self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new) {
+        if !window_fetch_active
+            && self.should_restore_lcdc_tile_data_at_delayed_boundary(previous, new)
+        {
+            self.lcdc_tile_data_edge
+                .record_write(current_fetch_start, current_fetch_end, new, new);
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
+        } else if !window_fetch_active
+            && self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new)
+        {
             self.lcdc_tile_data_edge.record_write(
                 current_fetch_start,
                 current_fetch_end,
@@ -651,6 +664,18 @@ impl PixelFifoRenderer {
         tile_data_turning_off
             && self.left_edge_obj_tile_data_delay_start_x().is_some()
             && self.next_x < 8
+    }
+
+    fn should_restore_lcdc_tile_data_at_delayed_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+    ) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        tile_data_turning_off
+            && self.left_edge_obj_tile_data_delay_start_x().is_some()
+            && self.next_x == OBJ_PIXELS_PER_FETCH
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -1456,6 +1481,40 @@ mod tests {
         assert_eq!(
             next_tile_colour, 0,
             "an OBJ fetch starting three pixels in should keep both bitplanes of the following BG tile on the previous TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_restore_at_boundary_updates_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 3;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(11);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 8;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (delayed_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 0,
+            "a restore at the delayed BG boundary should update the current fetch to the restored TILE_SEL sample"
+        );
+        assert_eq!(
+            delayed_fetch_colour, 0,
+            "the delayed following fetch should also stay on the restored TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -818,7 +818,7 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
         let near_left_restore_phase = self
             .leftmost_obj_oam_x
-            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH..=OBJ_PIXELS_PER_FETCH + 1).contains(&oam_x))
+            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH..=OBJ_PIXELS_PER_FETCH + 2).contains(&oam_x))
             .map(|oam_x| oam_x - 3);
         tile_data_turning_off
             && self.window_active
@@ -2225,6 +2225,37 @@ mod tests {
         assert_eq!(
             following_tile_colour, 2,
             "a near-left-edge OBJ stall should leave the following window fetch with the restored low byte and delayed high byte"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_window_restore_after_low_byte_mixes_following_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 2;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(10);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 7;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (following_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            following_tile_colour, 2,
+            "a near-left-edge OBJ restore after the low-byte phase should leave the following window fetch with the restored low byte and delayed high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -851,8 +851,8 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
         let delayed_boundary_phase = self
             .leftmost_obj_oam_x
-            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 3..=OBJ_PIXELS_PER_FETCH + 5).contains(&oam_x))
-            .map(|oam_x| oam_x - (OBJ_PIXELS_PER_FETCH + 3));
+            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 3..=OBJ_PIXELS_PER_FETCH + 6).contains(&oam_x))
+            .map(|oam_x| (oam_x - (OBJ_PIXELS_PER_FETCH + 3)).min(2));
         tile_data_turning_off
             && self.window_active
             && delayed_boundary_phase.is_some_and(|phase| {
@@ -2386,6 +2386,43 @@ mod tests {
         assert_eq!(
             current_fetch_colour, 2,
             "a near-left-edge OBJ restore later after the delayed window boundary should leave the current window fetch with the restored low byte and delayed high byte"
+        );
+        assert_eq!(
+            following_fetch_colour, 0,
+            "the following window fetch should use the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_window_restore_after_high_phase_updates_current_and_following_fetches() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 6;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(14);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 10;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(12, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "a near-left-edge OBJ restore after the high-byte phase should leave the current window fetch with the restored low byte and delayed high byte"
         );
         assert_eq!(
             following_fetch_colour, 0,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -15,6 +15,7 @@ const INITIAL_BGP: u8 = 0xFC;
 const LCDC_BG_WINDOW_ENABLE: u8 = 0x01;
 const LCDC_OBJ_ENABLE: u8 = 0x02;
 const LCDC_BG_MAP: u8 = 0x08;
+const LCDC_TILE_DATA: u8 = 0x10;
 const OBJ_PIXELS_PER_FETCH: u8 = 8;
 const CGB_DMG_COMPAT_OBJ_ENABLE_EDGE_PIXELS: u8 = 2;
 const DMG_OBJ_FETCH_ABORT_COMPLETES_WHEN_DOTS_REMAINING: u16 = 2;
@@ -158,6 +159,51 @@ impl LcdcBgMapEdge {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+struct LcdcTileDataRange {
+    start_x: u8,
+    end_x: u8,
+    low_lcdc: u8,
+    high_lcdc: u8,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct LcdcTileDataEdge {
+    ranges: Vec<LcdcTileDataRange>,
+}
+
+impl LcdcTileDataEdge {
+    fn record_write(&mut self, start_x: u8, end_x: u8, low_lcdc: u8, high_lcdc: u8) {
+        if start_x > end_x || low_lcdc & LCDC_TILE_DATA == high_lcdc & LCDC_TILE_DATA {
+            return;
+        }
+
+        self.ranges.push(LcdcTileDataRange {
+            start_x,
+            end_x,
+            low_lcdc,
+            high_lcdc,
+        });
+    }
+
+    fn lcdc_for_tile_data(&self, x: u32, current_lcdc: u8) -> (u8, u8) {
+        self.ranges
+            .iter()
+            .rev()
+            .find(|range| u32::from(range.start_x) <= x && x <= u32::from(range.end_x))
+            .map_or((current_lcdc, current_lcdc), |range| {
+                (
+                    (current_lcdc & !LCDC_TILE_DATA) | (range.low_lcdc & LCDC_TILE_DATA),
+                    (current_lcdc & !LCDC_TILE_DATA) | (range.high_lcdc & LCDC_TILE_DATA),
+                )
+            })
+    }
+
+    fn clear_consumed(&mut self, next_x: u8) {
+        self.ranges.retain(|range| range.end_x != next_x);
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct LcdcObjEnableEdge {
     active: bool,
@@ -240,6 +286,8 @@ pub struct PixelFifoRenderer {
     #[serde(default)]
     lcdc_bg_map_edge: LcdcBgMapEdge,
     #[serde(default)]
+    lcdc_tile_data_edge: LcdcTileDataEdge,
+    #[serde(default)]
     lcdc_obj_enable_edge: LcdcObjEnableEdge,
 }
 
@@ -268,6 +316,7 @@ impl PixelFifoRenderer {
             leftmost_obj_oam_x: None,
             lcdc_bg_enable_edge: LcdcBgEnableEdge::default(),
             lcdc_bg_map_edge: LcdcBgMapEdge::default(),
+            lcdc_tile_data_edge: LcdcTileDataEdge::default(),
             lcdc_obj_enable_edge: LcdcObjEnableEdge::default(),
         }
     }
@@ -291,6 +340,7 @@ impl PixelFifoRenderer {
         self.bgp_edge_value = registers.bgp;
         self.lcdc_bg_enable_edge = LcdcBgEnableEdge::default();
         self.lcdc_bg_map_edge = LcdcBgMapEdge::default();
+        self.lcdc_tile_data_edge = LcdcTileDataEdge::default();
         self.lcdc_obj_enable_edge = LcdcObjEnableEdge::default();
         self.fine_scroll_delay_dots = u16::from(registers.scx & 0x07);
         self.pending_obj_stall_dots = 0;
@@ -387,6 +437,7 @@ impl PixelFifoRenderer {
         self.lcdc_bg_enable_edge.clear_consumed(self.next_x);
         self.lcdc_obj_enable_edge.clear_consumed(self.next_x);
         self.lcdc_bg_map_edge.clear_consumed(self.next_x);
+        self.lcdc_tile_data_edge.clear_consumed(self.next_x);
         self.clear_consumed_obj_fetch_lcdc_ranges();
         self.next_x = self.next_x.saturating_add(1);
         if self.next_x as u32 >= ScreenBuffer::WIDTH {
@@ -443,6 +494,7 @@ impl PixelFifoRenderer {
 
         let waiting_on_obj_fetch = self.is_waiting_on_obj_fetch();
         self.record_lcdc_obj_size_write(previous, new, cgb_mode, dmg_compat);
+        self.record_lcdc_tile_data_write(previous, new, scx);
         if let Some(model) = ObjFetchModel::for_dmg_render_path(cgb_mode, dmg_compat) {
             self.record_lcdc_obj_enable_write(model, previous, new);
         }
@@ -477,6 +529,18 @@ impl PixelFifoRenderer {
         };
         self.lcdc_bg_enable_edge
             .record_write(self.next_x, previous, new, timing);
+    }
+
+    fn record_lcdc_tile_data_write(&mut self, previous: u8, new: u8, scx: u8) {
+        if previous & LCDC_TILE_DATA == new & LCDC_TILE_DATA {
+            return;
+        }
+
+        let bg_phase = scx.wrapping_add(self.next_x) & 0x07;
+        let current_fetch_start = self.next_x.saturating_sub(bg_phase);
+        let current_fetch_end = current_fetch_start.saturating_add(7);
+        self.lcdc_tile_data_edge
+            .record_write(self.next_x, current_fetch_end, previous, new);
     }
 
     fn record_lcdc_obj_enable_write(&mut self, model: ObjFetchModel, previous: u8, new: u8) {
@@ -786,6 +850,9 @@ impl PixelFifoRenderer {
         let win_enabled = lcdc & 0x20 != 0;
 
         let bg_idx = if bg_window_enabled {
+            let (low_lcdc, high_lcdc) = self
+                .lcdc_tile_data_edge
+                .lcdc_for_tile_data(x, bg_fetch_lcdc);
             bg_fifo::fetch_dmg_pixel(
                 vram,
                 DmgPixelFetch {
@@ -798,8 +865,8 @@ impl PixelFifoRenderer {
                     wy: registers.wy,
                     window_line,
                     map_lcdc: bg_fetch_lcdc,
-                    low_lcdc: bg_fetch_lcdc,
-                    high_lcdc: bg_fetch_lcdc,
+                    low_lcdc,
+                    high_lcdc,
                 },
             )
             .unwrap_or(0)
@@ -808,6 +875,7 @@ impl PixelFifoRenderer {
         };
 
         let bw_idx = if bg_window_enabled && win_enabled {
+            let (low_lcdc, high_lcdc) = self.lcdc_tile_data_edge.lcdc_for_tile_data(x, lcdc);
             match bg_fifo::fetch_dmg_pixel(
                 vram,
                 DmgPixelFetch {
@@ -820,8 +888,8 @@ impl PixelFifoRenderer {
                     wy: registers.wy,
                     window_line,
                     map_lcdc: lcdc,
-                    low_lcdc: lcdc,
-                    high_lcdc: lcdc,
+                    low_lcdc,
+                    high_lcdc,
                 },
             ) {
                 Some(idx) => {
@@ -968,6 +1036,14 @@ mod tests {
         oam
     }
 
+    fn vram_with_mixed_bg_tile_select_sources() -> [u8; 0x2000] {
+        let mut vram = [0u8; 0x2000];
+        vram[0x1800] = 0x01;
+        vram[0x1010] = 0x80;
+        vram[0x0011] = 0x80;
+        vram
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn tick_renderer(
         renderer: &mut PixelFifoRenderer,
@@ -1092,6 +1168,117 @@ mod tests {
             renderer.lcdc_bg_map_edge.lcdc_for_bg_fetch(32, 0xDB) & 0x08,
             0x08
         );
+    }
+
+    #[test]
+    fn recorded_tile_data_samples_mix_bg_low_and_high_bitplanes() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.scanline = 0;
+        renderer.lcdc_tile_data_edge.record_write(0, 7, 0x81, 0x91);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x91;
+        registers.bgp = 0xE4;
+        let vram = vram_with_mixed_bg_tile_select_sources();
+        let oam = [0u8; 0xA0];
+
+        let (colour_index, is_sprite, _) = renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+
+        assert_eq!(colour_index, 3);
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn recorded_tile_data_samples_mix_window_low_and_high_bitplanes() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.lcdc_tile_data_edge.record_write(0, 7, 0xA1, 0xB1);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_mixed_bg_tile_select_sources();
+        let oam = [0u8; 0xA0];
+
+        let (colour_index, is_sprite, _) = renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+
+        assert_eq!(colour_index, 3);
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn record_lcdc_write_mixes_bg_tile_data_samples_for_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x91;
+        registers.bgp = 0xE4;
+        let vram = vram_with_mixed_bg_tile_select_sources();
+        let oam = [0u8; 0xA0];
+
+        let (colour_index, is_sprite, _) = renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+
+        assert_eq!(colour_index, 3);
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn record_lcdc_write_mid_tile_does_not_bleed_tile_data_samples_into_next_tile() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 1;
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x91;
+        registers.bgp = 0xE4;
+        let mut vram = vram_with_mixed_bg_tile_select_sources();
+        vram[0x1801] = 0x02;
+        vram[0x1020] = 0x80;
+        vram[0x0020] = 0x00;
+        vram[0x0021] = 0x80;
+        let oam = [0u8; 0xA0];
+
+        let (colour_index, is_sprite, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            colour_index, 2,
+            "the next tile should use the current TILE_SEL for both bitplanes"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn record_lcdc_write_uses_latest_tile_data_samples_for_overlapping_tile_ranges() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 3;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let mut vram = [0u8; 0x2000];
+        vram[0x1800] = 0x01;
+        vram[0x1010] = 0x04;
+        vram[0x1011] = 0x04;
+        vram[0x0010] = 0x00;
+        vram[0x0011] = 0x04;
+        let oam = [0u8; 0xA0];
+
+        let (colour_index, is_sprite, _) = renderer.dmg_pixel_layers(5, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            colour_index, 2,
+            "overlapping tile-data ranges should use the most recent LCDC write"
+        );
+        assert!(!is_sprite);
     }
 
     #[test]

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -655,6 +655,15 @@ impl PixelFifoRenderer {
                 new,
                 new,
             );
+        } else if self
+            .should_set_lcdc_tile_data_after_off_left_window_obj_boundary(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                previous,
+            );
         } else if !window_fetch_active
             && self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new)
         {
@@ -897,6 +906,21 @@ impl PixelFifoRenderer {
             && self.next_x == OBJ_PIXELS_PER_FETCH
             && bg_phase == 0
             && self.pending_obj_stall_dots == 0
+    }
+
+    fn should_set_lcdc_tile_data_after_off_left_window_obj_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_on =
+            previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        tile_data_turning_on
+            && self.window_active
+            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH / 2)
+            && self.next_x == 1
+            && bg_phase == 1
     }
 
     fn should_restore_lcdc_tile_data_after_window_left_edge_obj(
@@ -1534,6 +1558,36 @@ mod tests {
             dmg_compat,
             screen_buffer,
         );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn tick_dmg_until_next_x(
+        renderer: &mut PixelFifoRenderer,
+        dot: &mut u16,
+        target_next_x: u8,
+        vram: &[u8; 0x2000],
+        oam: &[u8; 0xA0],
+        registers: &Registers,
+        screen_buffer: &mut ScreenBuffer,
+    ) {
+        let deadline = dot.saturating_add(256);
+        while renderer.next_x < target_next_x {
+            tick_renderer(
+                renderer,
+                *dot,
+                vram,
+                oam,
+                registers,
+                false,
+                false,
+                screen_buffer,
+            );
+            *dot = dot.saturating_add(1);
+            assert!(
+                *dot < deadline,
+                "renderer did not reach next_x={target_next_x}"
+            );
+        }
     }
 
     #[test]
@@ -2328,6 +2382,66 @@ mod tests {
             "a visible-left-edge OBJ stall should leave the following window fetch with the restored low byte and delayed high byte"
         );
         assert!(!is_sprite);
+    }
+
+    #[test]
+    fn off_left_obj_window_restore_after_boundary_mixes_first_following_pixel() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA3;
+        registers.bgp = 0xE4;
+        registers.obp0 = 0xFF;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = oam_with_sprite_at(16, 4, 0, 0);
+        let mut screen_buffer = ScreenBuffer::new();
+        let mut dot = 80;
+
+        renderer.begin_scanline(0, 80, &oam, &registers, false, false);
+        tick_dmg_until_next_x(
+            &mut renderer,
+            &mut dot,
+            1,
+            &vram,
+            &oam,
+            &registers,
+            &mut screen_buffer,
+        );
+        renderer.record_lcdc_write_with_window(
+            0xA3,
+            0xB3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xB3;
+        tick_dmg_until_next_x(
+            &mut renderer,
+            &mut dot,
+            9,
+            &vram,
+            &oam,
+            &registers,
+            &mut screen_buffer,
+        );
+        renderer.record_lcdc_write_with_window(
+            0xB3,
+            0xA3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (170, 170, 170),
+            "the first following window pixel should mix the set low byte with the restored high byte"
+        );
     }
 
     #[test]

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -931,11 +931,13 @@ impl PixelFifoRenderer {
     ) -> bool {
         let tile_data_turning_on =
             previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        let delayed_fetch_phase = self
+            .leftmost_obj_oam_x
+            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 4..=OBJ_PIXELS_PER_FETCH + 5).contains(&oam_x))
+            .map(|oam_x| oam_x - OBJ_PIXELS_PER_FETCH);
         tile_data_turning_on
             && self.window_active
-            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH + 4)
-            && self.next_x == 4
-            && bg_phase == 4
+            && delayed_fetch_phase.is_some_and(|phase| self.next_x == phase && bg_phase == phase)
             && self.pending_obj_stall_dots > 0
     }
 
@@ -2548,6 +2550,87 @@ mod tests {
             screen_buffer.get_pixel(8, 0),
             (85, 85, 85),
             "the first delayed window pixel should mix the previous low byte with the set high byte"
+        );
+    }
+
+    #[test]
+    fn delayed_obj_window_set_later_mixes_first_stalled_fetch_pixels() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA3;
+        registers.bgp = 0xE4;
+        registers.obp0 = 0xFF;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = oam_with_sprite_at(16, 13, 1, 0);
+        let mut screen_buffer = ScreenBuffer::new();
+        let mut dot: u16 = 80;
+
+        renderer.begin_scanline(0, 80, &oam, &registers, false, false);
+        let deadline = dot.saturating_add(256);
+        while !(renderer.next_x == 5 && renderer.pending_obj_stall_dots == 3) {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(dot < deadline, "renderer did not reach the OAM X=13 stall");
+        }
+        renderer.record_lcdc_write_with_window(
+            0xA3,
+            0xB3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+        registers.lcdc = 0xB3;
+
+        let deadline = dot.saturating_add(256);
+        while !(renderer.next_x == 10 && renderer.pending_obj_stall_dots == 0) {
+            tick_renderer(
+                &mut renderer,
+                dot,
+                &vram,
+                &oam,
+                &registers,
+                false,
+                false,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(
+                dot < deadline,
+                "renderer did not reach the OAM X=13 restore point"
+            );
+        }
+        renderer.record_lcdc_write_with_window(
+            0xB3,
+            0xA3,
+            registers.scx,
+            false,
+            false,
+            registers.wx,
+            registers.wy,
+        );
+
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (85, 85, 85),
+            "the first later delayed window pixel should mix the previous low byte with the set high byte"
+        );
+        assert_eq!(
+            screen_buffer.get_pixel(9, 0),
+            (85, 85, 85),
+            "the second later delayed window pixel should keep the set high byte"
         );
     }
 

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -816,11 +816,14 @@ impl PixelFifoRenderer {
     ) -> bool {
         let tile_data_turning_off =
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        let near_left_restore_phase = self
+            .leftmost_obj_oam_x
+            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH..=OBJ_PIXELS_PER_FETCH + 1).contains(&oam_x))
+            .map(|oam_x| oam_x - 3);
         tile_data_turning_off
             && self.window_active
-            && bg_phase == 5
-            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH)
-            && self.next_x == 5
+            && near_left_restore_phase
+                .is_some_and(|phase| self.next_x == phase && bg_phase == phase)
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -2191,6 +2194,37 @@ mod tests {
         assert_eq!(
             following_tile_colour, 2,
             "a visible-left-edge OBJ stall should leave the following window fetch with the restored low byte and delayed high byte"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_window_restore_mixes_following_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 1;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(9);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 6;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (following_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            following_tile_colour, 2,
+            "a near-left-edge OBJ stall should leave the following window fetch with the restored low byte and delayed high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -580,7 +580,7 @@ impl PixelFifoRenderer {
         }
 
         if !window_fetch_active
-            && self.should_restore_lcdc_tile_data_at_delayed_boundary(previous, new)
+            && self.should_restore_lcdc_tile_data_in_delayed_fetch(previous, new)
         {
             self.lcdc_tile_data_edge
                 .record_write(current_fetch_start, current_fetch_end, new, new);
@@ -666,7 +666,7 @@ impl PixelFifoRenderer {
             && self.next_x < 8
     }
 
-    fn should_restore_lcdc_tile_data_at_delayed_boundary(
+    fn should_restore_lcdc_tile_data_in_delayed_fetch(
         &self,
         previous_lcdc: u8,
         new_lcdc: u8,
@@ -675,12 +675,12 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
         tile_data_turning_off
             && self.left_edge_obj_tile_data_delay_start_x().is_some()
-            && self.next_x == OBJ_PIXELS_PER_FETCH
+            && (OBJ_PIXELS_PER_FETCH..OBJ_PIXELS_PER_FETCH * 2).contains(&self.next_x)
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
         self.leftmost_obj_oam_x
-            .filter(|&oam_x| (8..=11).contains(&oam_x))
+            .filter(|&oam_x| (8..=12).contains(&oam_x))
             .map(|oam_x| oam_x - 8)
     }
 
@@ -1515,6 +1515,34 @@ mod tests {
         assert_eq!(
             delayed_fetch_colour, 0,
             "the delayed following fetch should also stay on the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_restore_after_boundary_updates_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 4;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(12);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 9;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(10, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 0,
+            "a restore after the delayed BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -612,6 +612,19 @@ impl PixelFifoRenderer {
                 previous,
             );
             self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
+        } else if self.should_restore_lcdc_tile_data_at_window_boundary(previous, new, bg_phase) {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                new,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
         } else if self.next_x == current_fetch_start {
             if window_fetch_active {
                 self.lcdc_tile_data_edge.record_write(
@@ -698,6 +711,20 @@ impl PixelFifoRenderer {
             && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH * 2)
             && self.next_x == OBJ_PIXELS_PER_FETCH
             && self.pending_obj_stall_dots > 0
+    }
+
+    fn should_restore_lcdc_tile_data_at_window_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        tile_data_turning_off
+            && self.window_active
+            && bg_phase == 0
+            && self.next_x == OBJ_PIXELS_PER_FETCH
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -1837,6 +1864,40 @@ mod tests {
         assert_eq!(
             next_tile_colour, 3,
             "the following window fetch should sample the new TILE_SEL value"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn window_restore_at_tile_boundary_mixes_current_fetch_bitplanes() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.window_active = true;
+        renderer.next_x = 8;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (following_tile_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 1,
+            "a window TILE_SEL restore at the tile boundary should keep the previous low byte and sample the restored high byte"
+        );
+        assert_eq!(
+            following_tile_colour, 0,
+            "the following window fetch should use the restored TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -580,6 +580,17 @@ impl PixelFifoRenderer {
         }
 
         if !window_fetch_active
+            && self.should_restore_lcdc_tile_data_at_obj_stalled_boundary(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge
+                .record_write(current_fetch_start, current_fetch_end, new, new);
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                previous,
+                previous,
+            );
+        } else if !window_fetch_active
             && self.should_restore_lcdc_tile_data_in_delayed_fetch(previous, new)
         {
             self.lcdc_tile_data_edge
@@ -671,6 +682,22 @@ impl PixelFifoRenderer {
         tile_data_turning_off
             && self.left_edge_obj_tile_data_delay_start_x().is_some()
             && (OBJ_PIXELS_PER_FETCH..OBJ_PIXELS_PER_FETCH * 2).contains(&self.next_x)
+    }
+
+    fn should_restore_lcdc_tile_data_at_obj_stalled_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        tile_data_turning_off
+            && !self.window_active
+            && bg_phase == 0
+            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH * 2)
+            && self.next_x == OBJ_PIXELS_PER_FETCH
+            && self.pending_obj_stall_dots > 0
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -1640,6 +1667,39 @@ mod tests {
         assert_eq!(
             following_fetch_colour, 1,
             "the following fetch should keep the delayed low-byte TILE_SEL sample and use the restored high-byte sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn on_screen_obj_restore_at_stalled_boundary_preserves_following_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 8;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.leftmost_obj_oam_x = Some(16);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.pending_obj_stall_dots = 3;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 0,
+            "a restore at an OBJ-stalled BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
+        );
+        assert_eq!(
+            following_fetch_colour, 3,
+            "the following fetch should keep the TILE_SEL sample latched before the OBJ stall"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -639,6 +639,15 @@ impl PixelFifoRenderer {
                 new,
                 new,
             );
+        } else if self.should_set_lcdc_tile_data_after_window_boundary(previous, new, bg_phase) {
+            self.lcdc_tile_data_edge
+                .record_write(current_fetch_start, current_fetch_end, new, new);
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
         } else if self.next_x == current_fetch_start {
             if window_fetch_active {
                 self.lcdc_tile_data_edge.record_write(
@@ -753,6 +762,17 @@ impl PixelFifoRenderer {
             && self.window_active
             && (2..=3).contains(&bg_phase)
             && self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(bg_phase)
+    }
+
+    fn should_set_lcdc_tile_data_after_window_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_on =
+            previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
+        tile_data_turning_on && self.window_active && bg_phase == 1 && self.next_x == bg_phase
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -1892,6 +1912,38 @@ mod tests {
         assert_eq!(
             next_tile_colour, 3,
             "the following window fetch should sample the new TILE_SEL value"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn window_tile_select_set_one_pixel_after_boundary_updates_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 1;
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+        let (following_tile_colour, _, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 3,
+            "a window TILE_SEL set one pixel after the boundary should update the current fetch"
+        );
+        assert_eq!(
+            following_tile_colour, 3,
+            "the following window fetch should also use the new TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -595,8 +595,19 @@ impl PixelFifoRenderer {
             .lcdc_tile_data_edge
             .has_latched_range(current_fetch_start, current_fetch_end)
         {
-            self.lcdc_tile_data_edge
-                .record_write(self.next_x, current_fetch_end, previous, new);
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                previous,
+            );
+            let next_fetch_start = current_fetch_start.saturating_add(8);
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
         }
     }
 
@@ -1381,6 +1392,34 @@ mod tests {
         assert_eq!(
             next_tile_colour, 3,
             "the following fetch should retain the TILE_SEL sample from the earlier write until its bitplanes are latched"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn record_lcdc_write_mid_visible_tile_updates_following_bg_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 1;
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x91;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(2, &vram, &oam, &registers, 0);
+        let (next_tile_colour, _, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 0,
+            "a TILE_SEL write after the visible tile has started output must not alter the rest of that tile"
+        );
+        assert_eq!(
+            next_tile_colour, 3,
+            "the following BG fetch should sample the new TILE_SEL value"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -661,6 +661,15 @@ impl PixelFifoRenderer {
                 new,
                 new,
             );
+        } else if self
+            .should_restore_lcdc_tile_data_after_window_left_edge_obj(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                previous,
+            );
         } else if self.next_x == current_fetch_start {
             if window_fetch_active {
                 self.lcdc_tile_data_edge.record_write(
@@ -797,6 +806,21 @@ impl PixelFifoRenderer {
         let tile_data_turning_on =
             previous_lcdc & LCDC_TILE_DATA == 0 && new_lcdc & LCDC_TILE_DATA != 0;
         tile_data_turning_on && self.window_active && bg_phase == 2 && self.next_x == bg_phase
+    }
+
+    fn should_restore_lcdc_tile_data_after_window_left_edge_obj(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        tile_data_turning_off
+            && self.window_active
+            && bg_phase == 5
+            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH)
+            && self.next_x == 5
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -2136,6 +2160,37 @@ mod tests {
         assert_eq!(
             following_tile_colour, 0,
             "the following window fetch should use the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn visible_left_edge_obj_window_restore_mixes_following_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(8);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.window_active = true;
+        renderer.next_x = 5;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (following_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            following_tile_colour, 2,
+            "a visible-left-edge OBJ stall should leave the following window fetch with the restored low byte and delayed high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -851,7 +851,7 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
         let delayed_boundary_phase = self
             .leftmost_obj_oam_x
-            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 3..=OBJ_PIXELS_PER_FETCH + 4).contains(&oam_x))
+            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 3..=OBJ_PIXELS_PER_FETCH + 5).contains(&oam_x))
             .map(|oam_x| oam_x - (OBJ_PIXELS_PER_FETCH + 3));
         tile_data_turning_off
             && self.window_active
@@ -2352,6 +2352,44 @@ mod tests {
         assert_eq!(
             current_fetch_colour, 2,
             "a near-left-edge OBJ restore after the delayed window boundary should leave the current window fetch with the restored low byte and delayed high byte"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_window_restore_later_after_boundary_updates_current_and_following_fetches()
+     {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 5;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(13);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 10;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(11, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "a near-left-edge OBJ restore later after the delayed window boundary should leave the current window fetch with the restored low byte and delayed high byte"
+        );
+        assert_eq!(
+            following_fetch_colour, 0,
+            "the following window fetch should use the restored TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::background;
+use super::bg_fifo::{self, DmgLayer, DmgPixelFetch};
 use super::obj_fifo::ObjFetchModel;
 use super::registers::Registers;
 use super::rendering::{self, cgb_palette_lookup, dmg_palette_index};
@@ -785,27 +786,43 @@ impl PixelFifoRenderer {
         let win_enabled = lcdc & 0x20 != 0;
 
         let bg_idx = if bg_window_enabled {
-            background::fetch_bg_pixel(
-                x,
-                self.scanline,
+            bg_fifo::fetch_dmg_pixel(
                 vram,
-                bg_fetch_lcdc,
-                registers.scx,
-                registers.scy,
+                DmgPixelFetch {
+                    layer: DmgLayer::Background,
+                    x,
+                    scanline: self.scanline,
+                    scx: registers.scx,
+                    scy: registers.scy,
+                    wx: registers.wx,
+                    wy: registers.wy,
+                    window_line,
+                    map_lcdc: bg_fetch_lcdc,
+                    low_lcdc: bg_fetch_lcdc,
+                    high_lcdc: bg_fetch_lcdc,
+                },
             )
+            .unwrap_or(0)
         } else {
             0
         };
 
         let bw_idx = if bg_window_enabled && win_enabled {
-            match window::fetch_window_pixel(
-                x,
-                self.scanline,
+            match bg_fifo::fetch_dmg_pixel(
                 vram,
-                lcdc,
-                registers.wx,
-                registers.wy,
-                window_line,
+                DmgPixelFetch {
+                    layer: DmgLayer::Window,
+                    x,
+                    scanline: self.scanline,
+                    scx: registers.scx,
+                    scy: registers.scy,
+                    wx: registers.wx,
+                    wy: registers.wy,
+                    window_line,
+                    map_lcdc: lcdc,
+                    low_lcdc: lcdc,
+                    high_lcdc: lcdc,
+                },
             ) {
                 Some(idx) => {
                     self.window_active = true;

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -625,6 +625,20 @@ impl PixelFifoRenderer {
                 new,
                 new,
             );
+        } else if self.should_restore_lcdc_tile_data_after_window_low_byte(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                previous,
+                previous,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
         } else if self.next_x == current_fetch_start {
             if window_fetch_active {
                 self.lcdc_tile_data_edge.record_write(
@@ -724,6 +738,20 @@ impl PixelFifoRenderer {
         tile_data_turning_off
             && self.window_active
             && bg_phase <= 1
+            && self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(bg_phase)
+    }
+
+    fn should_restore_lcdc_tile_data_after_window_low_byte(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        tile_data_turning_off
+            && self.window_active
+            && bg_phase == 2
             && self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(bg_phase)
     }
 
@@ -1928,6 +1956,40 @@ mod tests {
         assert_eq!(
             current_tile_colour, 1,
             "a window TILE_SEL restore one pixel after the boundary should keep the previous low byte and sample the restored high byte"
+        );
+        assert_eq!(
+            following_tile_colour, 0,
+            "the following window fetch should use the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn window_restore_two_pixels_after_boundary_keeps_current_fetch_latched() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 2;
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 10;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+        let (following_tile_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 3,
+            "a window TILE_SEL restore two pixels after the boundary should not alter the current fetch"
         );
         assert_eq!(
             following_tile_colour, 0,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -851,7 +851,7 @@ impl PixelFifoRenderer {
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
         let delayed_boundary_phase = self
             .leftmost_obj_oam_x
-            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 3..=OBJ_PIXELS_PER_FETCH + 6).contains(&oam_x))
+            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 3..=OBJ_PIXELS_PER_FETCH + 7).contains(&oam_x))
             .map(|oam_x| (oam_x - (OBJ_PIXELS_PER_FETCH + 3)).min(2));
         tile_data_turning_off
             && self.window_active
@@ -2423,6 +2423,43 @@ mod tests {
         assert_eq!(
             current_fetch_colour, 2,
             "a near-left-edge OBJ restore after the high-byte phase should leave the current window fetch with the restored low byte and delayed high byte"
+        );
+        assert_eq!(
+            following_fetch_colour, 0,
+            "the following window fetch should use the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_window_restore_at_late_stall_updates_current_and_following_fetches() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 7;
+        renderer.pending_obj_stall_dots = 5;
+        renderer.leftmost_obj_oam_x = Some(15);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 10;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(14, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "a late near-left-edge OBJ restore should leave the current window fetch with the restored low byte and delayed high byte"
         );
         assert_eq!(
             following_fetch_colour, 0,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -849,11 +849,15 @@ impl PixelFifoRenderer {
     ) -> bool {
         let tile_data_turning_off =
             previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        let delayed_boundary_phase = self
+            .leftmost_obj_oam_x
+            .filter(|&oam_x| (OBJ_PIXELS_PER_FETCH + 3..=OBJ_PIXELS_PER_FETCH + 4).contains(&oam_x))
+            .map(|oam_x| oam_x - (OBJ_PIXELS_PER_FETCH + 3));
         tile_data_turning_off
             && self.window_active
-            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH + 3)
-            && self.next_x == OBJ_PIXELS_PER_FETCH
-            && bg_phase == 0
+            && delayed_boundary_phase.is_some_and(|phase| {
+                self.next_x == OBJ_PIXELS_PER_FETCH.saturating_add(phase) && bg_phase == phase
+            })
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -2317,6 +2321,37 @@ mod tests {
         assert_eq!(
             current_fetch_colour, 2,
             "a near-left-edge OBJ restore at the delayed window boundary should leave the current window fetch with the restored low byte and delayed high byte"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_window_restore_after_delayed_boundary_mixes_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 4;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(12);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 9;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(10, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "a near-left-edge OBJ restore after the delayed window boundary should leave the current window fetch with the restored low byte and delayed high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -174,7 +174,7 @@ struct LcdcTileDataEdge {
 
 impl LcdcTileDataEdge {
     fn record_write(&mut self, start_x: u8, end_x: u8, low_lcdc: u8, high_lcdc: u8) {
-        if start_x > end_x || low_lcdc & LCDC_TILE_DATA == high_lcdc & LCDC_TILE_DATA {
+        if start_x > end_x {
             return;
         }
 
@@ -539,8 +539,13 @@ impl PixelFifoRenderer {
         let bg_phase = scx.wrapping_add(self.next_x) & 0x07;
         let current_fetch_start = self.next_x.saturating_sub(bg_phase);
         let current_fetch_end = current_fetch_start.saturating_add(7);
+        let (start_x, low_lcdc, high_lcdc) = if self.next_x == current_fetch_start {
+            (current_fetch_start, previous, previous)
+        } else {
+            (self.next_x, previous, new)
+        };
         self.lcdc_tile_data_edge
-            .record_write(self.next_x, current_fetch_end, previous, new);
+            .record_write(start_x, current_fetch_end, low_lcdc, high_lcdc);
     }
 
     fn record_lcdc_obj_enable_write(&mut self, model: ObjFetchModel, previous: u8, new: u8) {
@@ -1044,6 +1049,15 @@ mod tests {
         vram
     }
 
+    fn vram_with_blank_signed_and_solid_unsigned_tiles() -> [u8; 0x2000] {
+        let mut vram = [0u8; 0x2000];
+        vram[0x1800] = 0x00;
+        vram[0x1801] = 0x00;
+        vram[0x0000] = 0xFF;
+        vram[0x0001] = 0xFF;
+        vram
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn tick_renderer(
         renderer: &mut PixelFifoRenderer,
@@ -1208,7 +1222,7 @@ mod tests {
     }
 
     #[test]
-    fn record_lcdc_write_mixes_bg_tile_data_samples_for_current_fetch() {
+    fn record_lcdc_write_after_visible_bg_tile_latch_updates_next_fetch() {
         let mut renderer = PixelFifoRenderer::new();
         renderer.active = true;
         renderer.scanline = 0;
@@ -1217,12 +1231,21 @@ mod tests {
         let mut registers = Registers::new();
         registers.lcdc = 0x91;
         registers.bgp = 0xE4;
-        let vram = vram_with_mixed_bg_tile_select_sources();
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
         let oam = [0u8; 0xA0];
 
-        let (colour_index, is_sprite, _) = renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+        let (next_tile_colour, _, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
 
-        assert_eq!(colour_index, 3);
+        assert_eq!(
+            current_tile_colour, 0,
+            "a TILE_SEL write after the visible tile has been latched must not alter that tile"
+        );
+        assert_eq!(
+            next_tile_colour, 3,
+            "the next BG fetch should sample the new TILE_SEL value for both bitplanes"
+        );
         assert!(!is_sprite);
     }
 

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -680,7 +680,7 @@ impl PixelFifoRenderer {
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
         self.leftmost_obj_oam_x
-            .filter(|&oam_x| (8..=12).contains(&oam_x))
+            .filter(|&oam_x| (8..=13).contains(&oam_x))
             .map(|oam_x| oam_x - 8)
     }
 
@@ -1543,6 +1543,34 @@ mod tests {
         assert_eq!(
             current_fetch_colour, 0,
             "a restore after the delayed BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_restore_two_pixels_after_boundary_updates_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 5;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(13);
+        renderer.record_lcdc_write(0x81, 0x91, 0, false, false);
+        renderer.next_x = 10;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write(0x91, 0x81, 0, false, false);
+        let mut registers = Registers::new();
+        registers.lcdc = 0x81;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(11, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 0,
+            "a restore two pixels after the delayed BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -579,7 +579,22 @@ impl PixelFifoRenderer {
             self.record_visible_left_edge_delayed_lcdc_tile_data_fetch(new);
         }
 
-        if !window_fetch_active
+        if self
+            .should_restore_lcdc_tile_data_at_window_obj_delayed_boundary(previous, new, bg_phase)
+        {
+            self.lcdc_tile_data_edge.record_write(
+                current_fetch_start,
+                current_fetch_end,
+                new,
+                previous,
+            );
+            self.lcdc_tile_data_edge.record_write(
+                next_fetch_start,
+                next_fetch_start.saturating_add(7),
+                new,
+                new,
+            );
+        } else if !window_fetch_active
             && self.should_restore_lcdc_tile_data_at_obj_stalled_boundary(previous, new, bg_phase)
         {
             self.lcdc_tile_data_edge
@@ -824,6 +839,21 @@ impl PixelFifoRenderer {
             && self.window_active
             && near_left_restore_phase
                 .is_some_and(|phase| self.next_x == phase && bg_phase == phase)
+    }
+
+    fn should_restore_lcdc_tile_data_at_window_obj_delayed_boundary(
+        &self,
+        previous_lcdc: u8,
+        new_lcdc: u8,
+        bg_phase: u8,
+    ) -> bool {
+        let tile_data_turning_off =
+            previous_lcdc & LCDC_TILE_DATA != 0 && new_lcdc & LCDC_TILE_DATA == 0;
+        tile_data_turning_off
+            && self.window_active
+            && self.leftmost_obj_oam_x == Some(OBJ_PIXELS_PER_FETCH + 3)
+            && self.next_x == OBJ_PIXELS_PER_FETCH
+            && bg_phase == 0
     }
 
     fn left_edge_obj_tile_data_delay_start_x(&self) -> Option<u8> {
@@ -2256,6 +2286,37 @@ mod tests {
         assert_eq!(
             following_tile_colour, 2,
             "a near-left-edge OBJ restore after the low-byte phase should leave the following window fetch with the restored low byte and delayed high byte"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn near_left_edge_obj_window_restore_at_delayed_boundary_mixes_current_fetch() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.next_x = 3;
+        renderer.pending_obj_stall_dots = 3;
+        renderer.leftmost_obj_oam_x = Some(11);
+        renderer.record_lcdc_write_with_window(0xA1, 0xB1, 0, false, false, 7, 0);
+        renderer.next_x = 8;
+        renderer.pending_obj_stall_dots = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xA1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xA1;
+        registers.bgp = 0xE4;
+        registers.wx = 7;
+        registers.wy = 0;
+        let vram = vram_with_blank_signed_and_solid_unsigned_tiles();
+        let oam = [0u8; 0xA0];
+
+        let (current_fetch_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(9, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_fetch_colour, 2,
+            "a near-left-edge OBJ restore at the delayed window boundary should leave the current window fetch with the restored low byte and delayed high byte"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -584,12 +584,7 @@ impl PixelFifoRenderer {
         {
             self.lcdc_tile_data_edge
                 .record_write(current_fetch_start, current_fetch_end, new, new);
-            self.lcdc_tile_data_edge.record_write(
-                next_fetch_start,
-                next_fetch_start.saturating_add(7),
-                new,
-                new,
-            );
+            self.record_next_lcdc_tile_data_write(next_fetch_start, bg_phase, previous, new);
         } else if !window_fetch_active
             && self.should_delay_lcdc_tile_data_by_extra_fetch(previous, new)
         {
@@ -1567,10 +1562,16 @@ mod tests {
 
         let (current_fetch_colour, is_sprite, _) =
             renderer.dmg_pixel_layers(11, &vram, &oam, &registers, 0);
+        let (following_fetch_colour, _, _) =
+            renderer.dmg_pixel_layers(16, &vram, &oam, &registers, 0);
 
         assert_eq!(
             current_fetch_colour, 0,
             "a restore two pixels after the delayed BG boundary should update the in-progress fetch to the restored TILE_SEL sample"
+        );
+        assert_eq!(
+            following_fetch_colour, 1,
+            "the following fetch should keep the delayed low-byte TILE_SEL sample and use the restored high-byte sample"
         );
         assert!(!is_sprite);
     }

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -529,12 +529,14 @@ impl Ppu {
             );
         }
         if addr == 0xFF40 {
-            self.pixel_fifo.record_lcdc_write(
+            self.pixel_fifo.record_lcdc_write_with_window(
                 self.registers.lcdc,
                 val,
                 self.registers.scx,
                 self.cgb_mode,
                 self.dmg_compat,
+                self.registers.wx,
+                self.registers.wy,
             );
         }
         let was_enabled = self.registers.lcd_enabled();

--- a/src/gb/ppu/sprites.rs
+++ b/src/gb/ppu/sprites.rs
@@ -304,6 +304,8 @@ const OAM_X_OFFSCREEN: u8 = 168;
 /// Maximum tile-wait penalty when a sprite is the first on its BG tile.
 /// Per Pan Docs: tile_wait = max(MAX_TILE_WAIT − pos_in_tile, 0).
 const MAX_TILE_WAIT: u16 = 5;
+const OFF_LEFT_HALF_OBJ_X: u8 = 4;
+const OFF_LEFT_HALF_OBJ_WAIT: u16 = 2;
 
 /// Calculate Mode 3 OBJ penalty dots for the sprites on the current scanline.
 ///
@@ -391,6 +393,9 @@ fn push_obj_penalty_event(events: &mut Vec<ObjPenaltyEvent>, event: ObjPenaltyEv
 fn tile_wait_penalty(oam_x: u8, bg_x: i16) -> u16 {
     if oam_x == 0 {
         return MAX_TILE_WAIT;
+    }
+    if oam_x == OFF_LEFT_HALF_OBJ_X {
+        return OFF_LEFT_HALF_OBJ_WAIT;
     }
     let pos_in_tile = bg_x.rem_euclid(BG_TILE_WIDTH) as u16;
     MAX_TILE_WAIT.saturating_sub(pos_in_tile)
@@ -710,10 +715,11 @@ mod tests {
     }
 
     #[test]
-    fn test_obj_penalty_single_sprite_at_x4_is_7_dots() {
-        // OAM X=4 → screen_x=-4, bg_x=-4, pos_in_tile=4, right=3, wait=1, total=7
+    fn test_obj_penalty_single_sprite_at_x4_is_8_dots() {
+        // OAM X=4 is partly off-left; the first visible pixel remains pending one dot longer
+        // than the plain tile-position formula would suggest.
         let (oam, indices) = penalty_sprites(&[4]);
-        assert_eq!(calculate_obj_penalty(&indices, &oam, 0), 7);
+        assert_eq!(calculate_obj_penalty(&indices, &oam, 0), 8);
     }
 
     #[test]

--- a/src/gb/ppu/sprites.rs
+++ b/src/gb/ppu/sprites.rs
@@ -304,8 +304,6 @@ const OAM_X_OFFSCREEN: u8 = 168;
 /// Maximum tile-wait penalty when a sprite is the first on its BG tile.
 /// Per Pan Docs: tile_wait = max(MAX_TILE_WAIT − pos_in_tile, 0).
 const MAX_TILE_WAIT: u16 = 5;
-const OFF_LEFT_HALF_OBJ_X: u8 = 4;
-const OFF_LEFT_HALF_OBJ_WAIT: u16 = 2;
 
 /// Calculate Mode 3 OBJ penalty dots for the sprites on the current scanline.
 ///
@@ -393,9 +391,6 @@ fn push_obj_penalty_event(events: &mut Vec<ObjPenaltyEvent>, event: ObjPenaltyEv
 fn tile_wait_penalty(oam_x: u8, bg_x: i16) -> u16 {
     if oam_x == 0 {
         return MAX_TILE_WAIT;
-    }
-    if oam_x == OFF_LEFT_HALF_OBJ_X {
-        return OFF_LEFT_HALF_OBJ_WAIT;
     }
     let pos_in_tile = bg_x.rem_euclid(BG_TILE_WIDTH) as u16;
     MAX_TILE_WAIT.saturating_sub(pos_in_tile)
@@ -715,11 +710,10 @@ mod tests {
     }
 
     #[test]
-    fn test_obj_penalty_single_sprite_at_x4_is_8_dots() {
-        // OAM X=4 is partly off-left; the first visible pixel remains pending one dot longer
-        // than the plain tile-position formula would suggest.
+    fn test_obj_penalty_single_sprite_at_x4_is_7_dots() {
+        // OAM X=4 -> screen_x=-4, bg_x=-4, pos_in_tile=4, wait=1, total=7.
         let (oam, indices) = penalty_sprites(&[4]);
-        assert_eq!(calculate_obj_penalty(&indices, &oam, 0), 8);
+        assert_eq!(calculate_obj_penalty(&indices, &oam, 0), 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Part of #2353.

This PR improves DMG LCDC.4 TILE_SEL timing during Mode 3 by sampling tile-data selection at the fetcher byte level, timing Mode-3 LCDC.4 writes at the correct bus phase, and adding focused pixel FIFO coverage for the fixed OBJ/window timing slices.

## What changed

- Added DMG BG/window fetch helpers for separate low/high tile-data byte LCDC.4 sampling.
- Split Mode-3 LCDC write timing for LCDC.4 changes on DMG/CGB buses.
- Added targeted pixel FIFO tests for mid-tile, OBJ-stalled, near-left, window-boundary, and delayed/off-left window OBJ TILE_SEL cases.
- Addressed review feedback so WX>7 window-boundary TILE_SEL writes use the window fetch phase instead of the SCX-shifted BG phase.
- Preserved existing accepted BGP/BG-enable/BG-map/OBJ timing by scoping the bus write-phase split to LCDC.4 changes only.
- Left the remaining original #2353 scope in follow-up issue #2412.
- Added `references/retrospective-neser.md` intentionally for the required AI-assisted workflow retrospective.

## Current TILE_SEL status

- DMG non-window `m3_lcdc_tile_sel_change_dmg_b` matches reference CRC `0x2CFB252D`.
- DMG window `m3_lcdc_tile_sel_win_change_dmg_b` is improved but not complete; latest capture CRC is `0x150B945D`.
- CGB/CGB-D TILE_SEL variants remain open and are tracked in #2412.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/gb/bus src/gb/ppu`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`
- `NESER_CAPTURE_SCREEN=1 cargo test --no-default-features --lib m3_lcdc_tile_sel -- --include-ignored --nocapture --test-threads=1`

## Follow-up

Remaining #2353 work is tracked in #2412.
