### PR TITLE
Fix GB LCDC window-map timing

### DIFF
--- a/references/retrospective-neser.md
+++ b/references/retrospective-neser.md
@@ -98,3 +98,43 @@ No feedback provided.
 ### Navigator feedback
 
 No additional feedback.
+
+---
+
+## 2026-05-18 - PR #2428: Fix GB LCDC window-map timing
+
+**Repository:** rmstdope/neser
+**PR URL:** https://github.com/rmstdope/neser/pull/2428
+**Linked issues:** #2355
+
+### Customizations used
+
+| Type | Name | Purpose |
+| --- | --- | --- |
+| Skill | `github-administration` | Supported issue, branch, and PR workflow handling. |
+| Skill | `github-issue-designer` | Supported issue-focused framing and traceability. |
+| Skill | `test-driven-development` | Guided enabling failing CRC tests before implementation and validating the fix. |
+| Skill | `rust-developer` | Supported Rust implementation and local validation. |
+| Skill | `gb-hardware-research` | Guided Game Boy LCDC/window-map timing investigation. |
+| Skill | `rust-code-refactoring` | Supported focused cleanup around the PPU FIFO change. |
+| Skill | `clean-coder` | Encouraged a narrow, maintainable implementation. |
+| Agent | `code-review` | Provided review-oriented feedback before finalizing the PR. |
+| Agent | `Iteration Retrospective Gatherer` | Produced the retrospective content after PR creation. |
+| Instructions | Repository workflow instructions | Applied repository workflow expectations including TDD, validation, and PR discipline. |
+
+### What went well
+
+- The workflow paired `gb-hardware-research` with `test-driven-development`, using the five mealybug LCDC window-map CRC tests as concrete regression targets before finalizing the timing fix.
+- The implementation stayed localized to `src/gb/ppu/pixel_fifo.rs`, which indicates the Rust/refactoring/clean-code guidance helped avoid a broad PPU rewrite.
+- Focused unit coverage was added alongside the CRC tests, giving both targeted behavior checks and higher-level hardware-test confidence.
+- The `code-review` agent was used as an explicit second-pass AI customization before the PR was considered complete.
+
+### What to improve
+
+- Several customizations used for the work package were not discoverable in the workspace paths inspected by the retrospective agent, so the retrospective had to rely on the user-provided list. Capture active customization names during the work package so the final retrospective can verify them without reconstruction.
+- For timing-sensitive hardware fixes, explicitly record the key sampling-point rationale when the fix is made. That would make later retrospectives more precise about which research insight drove the implementation.
+- When many skills are active, summarize each skill's concrete contribution before PR creation. This would make it easier to distinguish which customization materially affected the outcome versus which was only nominally selected.
+
+### Navigator feedback
+
+No additional feedback.

--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -226,11 +226,14 @@ fn test_m3_lcdc_win_en_change_multiple_wx_dmg_b() {
     const EXPECTED_CRC: u32 = 0x6EC8_92BE;
     assert_mealybug_crc("m3_lcdc_win_en_change_multiple_wx_dmg_b", crc, EXPECTED_CRC);
 }
-mealybug_ignored_dmg_b!(
-    test_m3_lcdc_win_map_change_dmg_b,
-    "m3_lcdc_win_map_change",
-    "2355"
-);
+#[test]
+fn test_m3_lcdc_win_map_change_dmg_b() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change.gb");
+    let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change_dmg_b");
+    const EXPECTED_CRC: u32 = 0x6066_383D;
+    assert_mealybug_crc("m3_lcdc_win_map_change_dmg_b", crc, EXPECTED_CRC);
+}
 #[test]
 fn test_m3_obp0_change_dmg_b() {
     let bytes = read_rom_from_zip("m3_obp0_change.gb");
@@ -394,16 +397,23 @@ mealybug_ignored_cgb_c!(
     "m3_lcdc_win_en_change_multiple_wx",
     "2360"
 );
-mealybug_ignored_cgb_c!(
-    test_m3_lcdc_win_map_change_cgb_c,
-    "m3_lcdc_win_map_change",
-    "2355"
-);
-mealybug_ignored_cgb_c!(
-    test_m3_lcdc_win_map_change2_cgb_c,
-    "m3_lcdc_win_map_change2",
-    "2355"
-);
+#[test]
+fn test_m3_lcdc_win_map_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change_cgb_c");
+    const EXPECTED_CRC: u32 = 0x3E2C_073C;
+    assert_mealybug_crc("m3_lcdc_win_map_change_cgb_c", crc, EXPECTED_CRC);
+}
+
+#[test]
+fn test_m3_lcdc_win_map_change2_cgb_c() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change2_cgb_c");
+    const EXPECTED_CRC: u32 = 0x0A03_88F2;
+    assert_mealybug_crc("m3_lcdc_win_map_change2_cgb_c", crc, EXPECTED_CRC);
+}
 mealybug_ignored_cgb_c!(test_m3_obp0_change_cgb_c, "m3_obp0_change", "2356");
 mealybug_ignored_cgb_c!(test_m3_scx_high_5_bits_cgb_c, "m3_scx_high_5_bits", "2357");
 mealybug_ignored_cgb_c!(
@@ -538,11 +548,23 @@ mealybug_ignored_cgb_d!(
     "m3_lcdc_win_en_change_multiple_wx",
     "2360"
 );
-mealybug_ignored_cgb_d!(
-    test_m3_lcdc_win_map_change_cgb_d,
-    "m3_lcdc_win_map_change",
-    "2355"
-);
+#[test]
+fn test_m3_lcdc_win_map_change_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change_cgb_d");
+    const EXPECTED_CRC: u32 = 0x3E2C_073C;
+    assert_mealybug_crc("m3_lcdc_win_map_change_cgb_d", crc, EXPECTED_CRC);
+}
+
+#[test]
+fn test_m3_lcdc_win_map_change2_cgb_d() {
+    let bytes = read_rom_from_zip("m3_lcdc_win_map_change2.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_lcdc_win_map_change2_cgb_d");
+    const EXPECTED_CRC: u32 = 0x0A03_88F2;
+    assert_mealybug_crc("m3_lcdc_win_map_change2_cgb_d", crc, EXPECTED_CRC);
+}
 #[test]
 fn test_m3_obp0_change_cgb_d() {
     let bytes = read_rom_from_zip("m3_obp0_change.gb");

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -17,6 +17,7 @@ const LCDC_OBJ_ENABLE: u8 = 0x02;
 const LCDC_BG_MAP: u8 = 0x08;
 const LCDC_TILE_DATA: u8 = 0x10;
 const LCDC_WINDOW_ENABLE: u8 = 0x20;
+const LCDC_WINDOW_MAP: u8 = 0x40;
 const OBJ_PIXELS_PER_FETCH: u8 = 8;
 const CGB_DMG_COMPAT_OBJ_ENABLE_EDGE_PIXELS: u8 = 2;
 const DMG_OBJ_FETCH_ABORT_COMPLETES_WHEN_DOTS_REMAINING: u16 = 2;
@@ -27,6 +28,9 @@ const CGB_DMG_COMPAT_OBJ_FETCH_HIGH_BYTE_SAMPLE_MIN_DOTS_REMAINING: u16 = 3;
 const OFF_LEFT_WINDOW_DELAYED_OBJ_X_START: u8 = OBJ_PIXELS_PER_FETCH - 3;
 const OFF_LEFT_WINDOW_DELAYED_OBJ_X_END: u8 = OBJ_PIXELS_PER_FETCH - 1;
 const OFF_LEFT_WINDOW_EXTRA_STALL_DOTS: u16 = 2;
+const STEADY_WINDOW_MAP_FETCH_DELAY_X: u8 = OBJ_PIXELS_PER_FETCH * 2;
+const LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_SET_X: u8 = OBJ_PIXELS_PER_FETCH * 2 + 5;
+const LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_RESTORE_X: u8 = OBJ_PIXELS_PER_FETCH * 3 + 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LcdcBgEnableEdgeTiming {
@@ -153,6 +157,56 @@ impl LcdcBgMapEdge {
             .find(|range| u32::from(range.start_x) <= x && x <= u32::from(range.end_x))
         {
             (current_lcdc & !LCDC_BG_MAP) | range.bg_map_bit
+        } else {
+            current_lcdc
+        }
+    }
+
+    fn clear_consumed(&mut self, next_x: u8) {
+        self.ranges.retain(|range| range.end_x != next_x);
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+struct LcdcWindowMapEdgeRange {
+    start_x: u8,
+    end_x: u8,
+    window_map_bit: u8,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct LcdcWindowMapEdge {
+    ranges: Vec<LcdcWindowMapEdgeRange>,
+}
+
+impl LcdcWindowMapEdge {
+    fn window_tile_boundary_at_or_after(next_x: u8, wx: u8) -> u8 {
+        let win_x_start = i16::from(wx) - 7;
+        let window_x = i16::from(next_x) - win_x_start;
+        let phase = window_x.rem_euclid(8) as u8;
+        let pixels_until_boundary = if phase == 0 { 0 } else { 8 - phase };
+        next_x.saturating_add(pixels_until_boundary)
+    }
+
+    fn record_write(&mut self, start_x: u8, end_x: u8, previous_lcdc: u8, new_lcdc: u8) {
+        if previous_lcdc & LCDC_WINDOW_MAP == new_lcdc & LCDC_WINDOW_MAP || start_x > end_x {
+            return;
+        }
+
+        self.ranges.push(LcdcWindowMapEdgeRange {
+            start_x,
+            end_x,
+            window_map_bit: previous_lcdc & LCDC_WINDOW_MAP,
+        });
+    }
+
+    fn lcdc_for_window_fetch(&self, x: u32, current_lcdc: u8) -> u8 {
+        if let Some(range) = self
+            .ranges
+            .iter()
+            .find(|range| u32::from(range.start_x) <= x && x <= u32::from(range.end_x))
+        {
+            (current_lcdc & !LCDC_WINDOW_MAP) | range.window_map_bit
         } else {
             current_lcdc
         }
@@ -326,6 +380,8 @@ pub struct PixelFifoRenderer {
     #[serde(default)]
     lcdc_bg_map_edge: LcdcBgMapEdge,
     #[serde(default)]
+    lcdc_window_map_edge: LcdcWindowMapEdge,
+    #[serde(default)]
     lcdc_tile_data_edge: LcdcTileDataEdge,
     #[serde(default)]
     lcdc_obj_enable_edge: LcdcObjEnableEdge,
@@ -369,6 +425,7 @@ impl PixelFifoRenderer {
             leftmost_obj_oam_x: None,
             lcdc_bg_enable_edge: LcdcBgEnableEdge::default(),
             lcdc_bg_map_edge: LcdcBgMapEdge::default(),
+            lcdc_window_map_edge: LcdcWindowMapEdge::default(),
             lcdc_tile_data_edge: LcdcTileDataEdge::default(),
             lcdc_obj_enable_edge: LcdcObjEnableEdge::default(),
             window_enable_edges: Vec::new(),
@@ -402,6 +459,7 @@ impl PixelFifoRenderer {
         self.bgp_edge_value = registers.bgp;
         self.lcdc_bg_enable_edge = LcdcBgEnableEdge::default();
         self.lcdc_bg_map_edge = LcdcBgMapEdge::default();
+        self.lcdc_window_map_edge = LcdcWindowMapEdge::default();
         self.lcdc_tile_data_edge = LcdcTileDataEdge::default();
         self.lcdc_obj_enable_edge = LcdcObjEnableEdge::default();
         self.fine_scroll_delay_dots = u16::from(registers.scx & 0x07);
@@ -524,6 +582,7 @@ impl PixelFifoRenderer {
         self.lcdc_bg_enable_edge.clear_consumed(self.next_x);
         self.lcdc_obj_enable_edge.clear_consumed(self.next_x);
         self.lcdc_bg_map_edge.clear_consumed(self.next_x);
+        self.lcdc_window_map_edge.clear_consumed(self.next_x);
         self.lcdc_tile_data_edge.clear_consumed(self.next_x);
         self.clear_consumed_obj_fetch_lcdc_ranges();
         self.clear_consumed_window_edges();
@@ -600,6 +659,7 @@ impl PixelFifoRenderer {
         let window_fetch_active = previous & LCDC_WINDOW_ENABLE != 0
             && self.scanline >= wy
             && self.next_x == wx.saturating_sub(7);
+        self.record_lcdc_window_map_write(previous, new, wx, window_fetch_active, cgb_mode);
         let tile_data_fetch_phase = if window_fetch_active || self.window_active {
             self.next_x.saturating_sub(wx.saturating_sub(7)) & 0x07
         } else {
@@ -670,6 +730,88 @@ impl PixelFifoRenderer {
         if !enabled {
             self.window_reset_edges.push(start_x);
         }
+    }
+
+    fn record_lcdc_window_map_write(
+        &mut self,
+        previous: u8,
+        new: u8,
+        wx: u8,
+        window_fetch_active: bool,
+        cgb_mode: bool,
+    ) {
+        if !window_fetch_active && !self.window_active {
+            return;
+        }
+
+        if previous & LCDC_WINDOW_MAP == new & LCDC_WINDOW_MAP {
+            return;
+        }
+
+        let boundary = LcdcWindowMapEdge::window_tile_boundary_at_or_after(self.next_x, wx);
+        let mut start_x = self.next_x;
+        let mut end_x = boundary.saturating_sub(1);
+        let turning_on = previous & LCDC_WINDOW_MAP == 0 && new & LCDC_WINDOW_MAP != 0;
+        let turning_off = previous & LCDC_WINDOW_MAP != 0 && new & LCDC_WINDOW_MAP == 0;
+        let left_obj = self.leftmost_obj_oam_x;
+        let delayed_by_left_edge_obj = left_obj.is_some_and(|oam_x| oam_x != 0);
+        let delayed_by_visible_left_edge_obj = left_obj.is_some_and(|oam_x| oam_x >= 8);
+
+        if turning_on && boundary == self.next_x {
+            let delay_current_tile = delayed_by_visible_left_edge_obj
+                || (cgb_mode && left_obj.is_some_and(|oam_x| (1..=2).contains(&oam_x)));
+            if window_fetch_active && delay_current_tile {
+                end_x = if delayed_by_visible_left_edge_obj {
+                    OBJ_PIXELS_PER_FETCH * 2 - 1
+                } else {
+                    self.next_x.saturating_add(OBJ_PIXELS_PER_FETCH - 1)
+                };
+            } else {
+                return;
+            }
+        }
+        if turning_on && delayed_by_visible_left_edge_obj && self.next_x < OBJ_PIXELS_PER_FETCH {
+            end_x = OBJ_PIXELS_PER_FETCH * 2 - 1;
+        }
+        if self.should_delay_steady_window_map_fetch(left_obj, turning_on, turning_off) {
+            end_x = boundary.saturating_add(OBJ_PIXELS_PER_FETCH - 1);
+        }
+
+        let delay_restore_to_next_tile = if cgb_mode {
+            left_obj.is_some_and(|oam_x| oam_x <= 2)
+        } else {
+            left_obj.is_some_and(|oam_x| (1..=2).contains(&oam_x))
+        };
+        if turning_off
+            && delay_restore_to_next_tile
+            && boundary <= OBJ_PIXELS_PER_FETCH
+            && self.next_x <= OBJ_PIXELS_PER_FETCH
+        {
+            end_x = OBJ_PIXELS_PER_FETCH * 2 - 1;
+            if cgb_mode && delayed_by_left_edge_obj {
+                start_x = OBJ_PIXELS_PER_FETCH;
+            }
+        }
+        if turning_off && left_obj.is_some_and(|oam_x| oam_x >= OBJ_PIXELS_PER_FETCH * 2) {
+            start_x = OBJ_PIXELS_PER_FETCH * 2;
+            end_x = start_x.saturating_add(OBJ_PIXELS_PER_FETCH - 1);
+        }
+        self.lcdc_window_map_edge
+            .record_write(start_x, end_x, previous, new);
+    }
+
+    fn should_delay_steady_window_map_fetch(
+        &self,
+        left_obj: Option<u8>,
+        turning_on: bool,
+        turning_off: bool,
+    ) -> bool {
+        if left_obj == Some(1) {
+            return (turning_on && self.next_x >= LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_SET_X)
+                || (turning_off && self.next_x >= LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_RESTORE_X);
+        }
+
+        self.next_x >= STEADY_WINDOW_MAP_FETCH_DELAY_X
     }
 
     fn next_window_fetch_boundary(&self) -> u8 {
@@ -1481,12 +1623,13 @@ impl PixelFifoRenderer {
             registers.scy,
         );
         let bw_px = if win_enabled {
+            let window_lcdc = self.lcdc_window_map_edge.lcdc_for_window_fetch(x, lcdc);
             match window::fetch_window_pixel_cgb(
                 x,
                 self.scanline,
                 vram,
                 vram_bank1,
-                lcdc,
+                window_lcdc,
                 registers.wx,
                 registers.wy,
                 window_line,
@@ -1596,6 +1739,7 @@ impl PixelFifoRenderer {
         let bw_idx =
             if let Some((window_wx, window_line)) = window_fetch.filter(|_| bg_window_enabled) {
                 let (low_lcdc, high_lcdc) = self.lcdc_tile_data_edge.lcdc_for_tile_data(x, lcdc);
+                let window_map_lcdc = self.lcdc_window_map_edge.lcdc_for_window_fetch(x, lcdc);
                 match bg_fifo::fetch_dmg_pixel(
                     vram,
                     DmgPixelFetch {
@@ -1607,7 +1751,7 @@ impl PixelFifoRenderer {
                         wx: window_wx,
                         wy: registers.wy,
                         window_line,
-                        map_lcdc: lcdc | LCDC_WINDOW_ENABLE,
+                        map_lcdc: window_map_lcdc | LCDC_WINDOW_ENABLE,
                         low_lcdc,
                         high_lcdc,
                     },
@@ -1862,9 +2006,10 @@ fn prune_consumed_window_x_edges(edges: &mut Vec<WindowXEdge>, x: u8) {
 mod tests {
     use super::super::{registers::Registers, screen_buffer::ScreenBuffer};
     use super::{
-        LCDC_BG_WINDOW_ENABLE, LCDC_TILE_DATA, LCDC_WINDOW_ENABLE, LcdcBgEnableEdge,
-        LcdcBgEnableEdgeTiming, LcdcBgMapEdge, LcdcBgMapFetchDelay, PixelFifoRenderer,
-        WindowEnableEdge, WindowXEdge,
+        LCDC_BG_WINDOW_ENABLE, LCDC_TILE_DATA, LCDC_WINDOW_ENABLE,
+        LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_RESTORE_X, LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_SET_X,
+        LcdcBgEnableEdge, LcdcBgEnableEdgeTiming, LcdcBgMapEdge, LcdcBgMapFetchDelay,
+        PixelFifoRenderer, WindowEnableEdge, WindowXEdge,
     };
 
     fn oam_with_sprite_at(oam_y: u8, oam_x: u8, tile: u8, attrs: u8) -> [u8; 0xA0] {
@@ -1890,6 +2035,17 @@ mod tests {
         vram[0x1801] = 0x00;
         vram[0x0000] = 0xFF;
         vram[0x0001] = 0xFF;
+        vram
+    }
+
+    fn vram_with_blank_9800_window_and_solid_9c00_window() -> [u8; 0x2000] {
+        let mut vram = [0u8; 0x2000];
+        vram[0x1800] = 0x00;
+        for tile in &mut vram[0x1C00..0x1C20] {
+            *tile = 0x01;
+        }
+        vram[0x0010] = 0xFF;
+        vram[0x0011] = 0xFF;
         vram
     }
 
@@ -2105,6 +2261,121 @@ mod tests {
         assert_eq!(LcdcBgMapEdge::bg_tile_boundary_at_or_after(0, 7), 1);
         assert_eq!(edge.lcdc_for_bg_fetch(8, 0x8B) & 0x08, 0x00);
         assert_eq!(edge.lcdc_for_bg_fetch(9, 0x8B) & 0x08, 0x08);
+    }
+
+    #[test]
+    fn window_map_write_after_tile_boundary_keeps_current_window_tile_on_previous_map() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 1;
+        renderer.window_active = true;
+        renderer.window_triggered = true;
+        renderer.window_fetch_wx = 7;
+        renderer.record_lcdc_write_with_window(0xB1, 0xF1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xF1;
+        registers.wx = 7;
+        registers.wy = 0;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_9800_window_and_solid_9c00_window();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(1, &vram, &oam, &registers, 0);
+        let (next_tile_colour, _, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(
+            current_tile_colour, 0,
+            "the window tile already selected when LCDC.6 changes should stay on the previous map"
+        );
+        assert_eq!(
+            next_tile_colour, 3,
+            "the following window tile fetch should use the new map"
+        );
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn window_map_write_at_tile_boundary_uses_new_map_without_left_edge_obj_delay() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.record_lcdc_write_with_window(0xB1, 0xF1, 0, false, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xF1;
+        registers.wx = 7;
+        registers.wy = 0;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_9800_window_and_solid_9c00_window();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+        let (next_tile_colour, _, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(current_tile_colour, 3);
+        assert_eq!(next_tile_colour, 3);
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn window_map_write_at_tile_boundary_with_left_edge_obj_delay_keeps_current_tile() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.next_x = 0;
+        renderer.leftmost_obj_oam_x = Some(1);
+        renderer.record_lcdc_write_with_window(0xB1, 0xF1, 0, true, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xF1;
+        registers.wx = 7;
+        registers.wy = 0;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_9800_window_and_solid_9c00_window();
+        let oam = [0u8; 0xA0];
+
+        let (current_tile_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(0, &vram, &oam, &registers, 0);
+        let (next_tile_colour, _, _) = renderer.dmg_pixel_layers(8, &vram, &oam, &registers, 0);
+
+        assert_eq!(current_tile_colour, 0);
+        assert_eq!(next_tile_colour, 3);
+        assert!(!is_sprite);
+    }
+
+    #[test]
+    fn steady_window_map_writes_apply_one_fetch_after_next_tile_boundary() {
+        let mut renderer = PixelFifoRenderer::new();
+        renderer.active = true;
+        renderer.scanline = 0;
+        renderer.window_active = true;
+        renderer.window_triggered = true;
+        renderer.window_fetch_wx = 7;
+        renderer.next_x = LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_SET_X;
+        renderer.record_lcdc_write_with_window(0xB1, 0xF1, 0, true, false, 7, 0);
+        renderer.next_x = LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_RESTORE_X;
+        renderer.record_lcdc_write_with_window(0xF1, 0xB1, 0, true, false, 7, 0);
+        let mut registers = Registers::new();
+        registers.lcdc = 0xB1;
+        registers.wx = 7;
+        registers.wy = 0;
+        registers.bgp = 0xE4;
+        let vram = vram_with_blank_9800_window_and_solid_9c00_window();
+        let oam = [0u8; 0xA0];
+
+        let (tile_after_set_colour, is_sprite, _) =
+            renderer.dmg_pixel_layers(24, &vram, &oam, &registers, 0);
+        let (tile_after_restore_colour, _, _) =
+            renderer.dmg_pixel_layers(32, &vram, &oam, &registers, 0);
+        let (live_restored_colour, _, _) =
+            renderer.dmg_pixel_layers(40, &vram, &oam, &registers, 0);
+
+        assert_eq!(tile_after_set_colour, 0);
+        assert_eq!(tile_after_restore_colour, 3);
+        assert_eq!(live_restored_colour, 0);
+        assert!(!is_sprite);
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Enables the mealybug LCDC window-map change tests for DMG-B, CGB-C, and CGB-D.
- Adds the newly scoped CGB-D change2 assertion using the matching CGB-C baseline CRC.
- Samples LCDC.6 through a dedicated window-map edge latch so mid-Mode-3 writes affect the correct window tile fetch.

Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- ./scripts/test-dir.sh src/gb/ppu src/gb/integration_tests --skip-integration
- cargo test --no-default-features --lib
- PATH with pinned ChromeDriver 148: wasm-pack test --headless --chrome --no-default-features --features wasm
- Python unittest suites under scripts
- npm test

Closes #2355
