### PR TITLE
feat(gba): implement OBJ sprite rendering with priority compositing

### DIFF
--- a/src/gba/bus/io.rs
+++ b/src/gba/bus/io.rs
@@ -819,6 +819,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &[0u8; 1024],
         );
 
         assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
@@ -868,6 +869,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &[0u8; 1024],
         );
 
         assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
@@ -920,6 +922,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &[0u8; 1024],
         );
 
         assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
@@ -972,6 +975,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &[0u8; 1024],
         );
 
         assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
@@ -1025,6 +1029,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &[0u8; 1024],
         );
 
         assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
@@ -1075,6 +1080,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &[0u8; 1024],
         );
 
         assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);
@@ -1125,6 +1131,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &[0u8; 1024],
         );
 
         assert_eq!(&p.framebuffer()[0..3], &[0xFF, 0, 0]);

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -402,6 +402,7 @@ impl GbaBus {
             &mut self.ic,
             self.vram.as_slice(),
             self.pram.as_slice(),
+            self.oam.as_slice(),
         );
         self.handle_ppu_events(events);
         self.run_pending_dma();
@@ -421,6 +422,7 @@ impl GbaBus {
                 &mut self.ic,
                 self.vram.as_slice(),
                 self.pram.as_slice(),
+                self.oam.as_slice(),
             );
             self.handle_ppu_events(events);
             self.run_pending_dma();

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -1040,7 +1040,8 @@ impl Ppu {
         }
 
         let mapping_1d = self.dispcnt & dispcnt::OBJ_MAPPING_1D != 0;
-        let obj_scanline = obj::render_obj_scanline(y, oam, vram, pram, mapping_1d);
+        let bitmap_mode = self.mode() >= 3;
+        let obj_scanline = obj::render_obj_scanline(y, oam, vram, pram, mapping_1d, bitmap_mode);
 
         for x in 0..(SCREEN_WIDTH as usize) {
             let px = &obj_scanline.pixels[x];
@@ -1049,6 +1050,9 @@ impl Ppu {
                 color::write_pixel(&mut self.framebuffer, dst, px.color);
             }
         }
+
+        // TODO: Wire obj_scanline.obj_window into the PPU window system
+        // once full windowing (WIN0/WIN1/WINOBJ) is implemented.
     }
 
     /// Backdrop fill — uses palette entry 0 from PRAM. Used for modes
@@ -2434,6 +2438,181 @@ mod tests {
             &ppu.framebuffer()[0..3],
             &[0, 0xFF, 0],
             "Mode 1: BG2 affine (priority 0) on top of BG0 text (priority 1)"
+        );
+    }
+
+    /// Helper to set up a visible OBJ in OAM at position (x, y) with given tile
+    /// and priority. Uses 4bpp, shape=0 size=0 (8x8), 1D mapping.
+    fn setup_obj_in_oam(oam: &mut [u8], obj_idx: usize, x: u16, y: u8, tile: u16, priority: u8) {
+        let base = obj_idx * 8;
+        let attr0 = y as u16; // normal mode, 4bpp, shape=0
+        let attr1 = x & 0x1FF; // size=0 (8x8)
+        let attr2 = (tile & 0x3FF) | ((priority as u16 & 3) << 10);
+        oam[base] = attr0 as u8;
+        oam[base + 1] = (attr0 >> 8) as u8;
+        oam[base + 2] = attr1 as u8;
+        oam[base + 3] = (attr1 >> 8) as u8;
+        oam[base + 4] = attr2 as u8;
+        oam[base + 5] = (attr2 >> 8) as u8;
+    }
+
+    #[test]
+    fn obj_renders_when_enabled_in_mode0() {
+        let mut ppu = Ppu::new();
+        let mut ic = make_ic();
+        let vram = make_vram();
+        let pram = make_pram();
+        let mut oam = make_oam();
+
+        // Enable mode 0 + OBJ + 1D mapping.
+        ppu.write_dispcnt(dispcnt::OBJ_ENABLE | dispcnt::OBJ_MAPPING_1D);
+
+        // Place OBJ 0 at (100, 0), tile 1, priority 0.
+        setup_obj_in_oam(&mut oam, 0, 100, 0, 1, 0);
+
+        // Fill OBJ tile 1 in VRAM (4bpp at OBJ base 0x10000).
+        let tile_base = 0x1_0000 + 32;
+        let mut vram = vram;
+        for byte in &mut vram[tile_base..tile_base + 32] {
+            *byte = 0x11; // palette index 1 in both nibbles
+        }
+
+        // Set OBJ palette color 1 (at PRAM offset 0x200 + 1*2).
+        let mut pram = pram;
+        pram[0x202] = 0x1F; // red (BGR555: 0x001F)
+        pram[0x203] = 0x00;
+
+        // Step one full frame.
+        ppu.step(
+            CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+            &oam,
+        );
+
+        // Check pixel at (100, 0) — should be red.
+        let dst = 100 * BYTES_PER_PIXEL;
+        assert_eq!(
+            &ppu.framebuffer()[dst..dst + 3],
+            &[0xFF, 0, 0],
+            "OBJ should render red pixel at x=100"
+        );
+    }
+
+    #[test]
+    fn obj_disabled_does_not_render() {
+        let mut ppu = Ppu::new();
+        let mut ic = make_ic();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+        let mut oam = make_oam();
+
+        // Enable mode 0 with 1D mapping but NO OBJ_ENABLE.
+        ppu.write_dispcnt(dispcnt::OBJ_MAPPING_1D);
+
+        setup_obj_in_oam(&mut oam, 0, 100, 0, 1, 0);
+        let tile_base = 0x1_0000 + 32;
+        for byte in &mut vram[tile_base..tile_base + 32] {
+            *byte = 0x11;
+        }
+        pram[0x202] = 0x1F;
+        pram[0x203] = 0x00;
+
+        ppu.step(
+            CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+            &oam,
+        );
+
+        // Pixel at (100, 0) should be backdrop (black = 0,0,0).
+        let dst = 100 * BYTES_PER_PIXEL;
+        assert_eq!(
+            &ppu.framebuffer()[dst..dst + 3],
+            &[0, 0, 0],
+            "OBJ should not render when OBJ_ENABLE is off"
+        );
+    }
+
+    #[test]
+    fn obj_priority_compositing_with_bg() {
+        let mut ppu = Ppu::new();
+        let mut ic = make_ic();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+        let mut oam = make_oam();
+
+        // Mode 0, enable BG0 + OBJ + 1D mapping.
+        ppu.write_dispcnt(dispcnt::BG0_ENABLE | dispcnt::OBJ_ENABLE | dispcnt::OBJ_MAPPING_1D);
+
+        // BG0: charblock 0, screenblock 8, priority 1.
+        // BGCNT: priority=1, charblock=0, screenblock=8
+        let bgcnt = 1 | (8 << 8); // prio=1, screenblock=8
+        ppu.write_bg_cnt(0, bgcnt);
+
+        // Fill BG0 tile 1 (charblock 0) with palette index 2 (green).
+        let tile_base = 32; // tile 1
+        for byte in &mut vram[tile_base..tile_base + 32] {
+            *byte = 0x22;
+        }
+        // Screenblock 8 (offset 0x4000): set first tile map entry to tile 1.
+        let sb_base = 8 * 0x800;
+        vram[sb_base] = 1; // tile_id = 1
+        vram[sb_base + 1] = 0; // no flip, palette bank 0
+
+        // Set BG palette color 2 at PRAM offset 2*2=4.
+        pram[4] = 0xE0; // green (BGR555: 0x03E0)
+        pram[5] = 0x03;
+
+        // OBJ at (0, 0), tile 1, priority 0 (higher than BG0's priority 1).
+        setup_obj_in_oam(&mut oam, 0, 0, 0, 1, 0);
+        let obj_tile_base = 0x1_0000 + 32;
+        for byte in &mut vram[obj_tile_base..obj_tile_base + 32] {
+            *byte = 0x11; // palette index 1
+        }
+        pram[0x202] = 0x1F; // red (BGR555: 0x001F)
+        pram[0x203] = 0x00;
+
+        ppu.step(
+            CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+            &oam,
+        );
+
+        // OBJ prio 0 should be on top of BG0 prio 1 → red pixel.
+        assert_eq!(
+            &ppu.framebuffer()[0..3],
+            &[0xFF, 0, 0],
+            "OBJ priority 0 should draw on top of BG priority 1"
+        );
+
+        // Now test OBJ with lower priority than BG.
+        let mut ppu2 = Ppu::new();
+        ppu2.write_dispcnt(dispcnt::BG0_ENABLE | dispcnt::OBJ_ENABLE | dispcnt::OBJ_MAPPING_1D);
+        // BG0 at priority 0, same charblock/screenblock.
+        let bgcnt2 = 8 << 8; // prio=0, screenblock=8
+        ppu2.write_bg_cnt(0, bgcnt2);
+
+        // OBJ at priority 2 (lower than BG0 priority 0).
+        setup_obj_in_oam(&mut oam, 0, 0, 0, 1, 2);
+
+        ppu2.step(
+            CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME,
+            &mut ic,
+            &vram,
+            &pram,
+            &oam,
+        );
+
+        // BG0 prio 0 should be on top of OBJ prio 2 → green pixel.
+        assert_eq!(
+            &ppu2.framebuffer()[0..3],
+            &[0, 0xFF, 0],
+            "BG priority 0 should be on top of OBJ priority 2"
         );
     }
 }

--- a/src/gba/ppu/mod.rs
+++ b/src/gba/ppu/mod.rs
@@ -41,6 +41,7 @@
 
 pub mod affine;
 pub mod color;
+pub mod obj;
 
 use self::affine::BgAffine;
 use super::bus::interrupt::{InterruptController, bits as irq_bits};
@@ -90,6 +91,8 @@ pub mod dispcnt {
     pub const BG3_ENABLE: u16 = 1 << 11;
     /// Display OBJ (DISPCNT[12]).
     pub const OBJ_ENABLE: u16 = 1 << 12;
+    /// OBJ character VRAM mapping: 1 = 1D, 0 = 2D (DISPCNT[6]).
+    pub const OBJ_MAPPING_1D: u16 = 1 << 6;
 }
 
 /// `DISPSTAT` bit masks used by the PPU.
@@ -458,6 +461,7 @@ impl Ppu {
         ic: &mut InterruptController,
         vram: &[u8],
         pram: &[u8],
+        oam: &[u8],
     ) -> PpuStepEvents {
         let mut events = PpuStepEvents::default();
         let mut remaining = cycles;
@@ -473,7 +477,7 @@ impl Ppu {
                     // signalling H-Blank so DMA HBlank transfers see the
                     // updated framebuffer (sprite/affine state will use
                     // this hook in later increments).
-                    self.render_scanline(self.vcount as u32, vram, pram);
+                    self.render_scanline(self.vcount as u32, vram, pram, oam);
                     // Increment affine internal reference points after each
                     // visible scanline (ref_x += PB, ref_y += PD).
                     for aff in &mut self.bg_affine {
@@ -551,7 +555,7 @@ impl Ppu {
     }
 
     /// Render scanline `y` (0..160) into the framebuffer.
-    fn render_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8]) {
+    fn render_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8], oam: &[u8]) {
         if self.forced_blank() {
             // Forced blank → output white per GBATek.
             let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
@@ -562,11 +566,11 @@ impl Ppu {
             return;
         }
         match self.mode() {
-            0 => self.render_mode0_scanline(y, vram, pram),
-            1 => self.render_mode1_scanline(y, vram, pram),
-            2 => self.render_mode2_scanline(y, vram, pram),
-            3 => self.render_mode3_scanline(y, vram, pram),
-            4 => self.render_mode4_scanline(y, vram, pram),
+            0 => self.render_mode0_scanline(y, vram, pram, oam),
+            1 => self.render_mode1_scanline(y, vram, pram, oam),
+            2 => self.render_mode2_scanline(y, vram, pram, oam),
+            3 => self.render_mode3_scanline(y, vram, pram, oam),
+            4 => self.render_mode4_scanline(y, vram, pram, oam),
             _ => self.render_backdrop_scanline(y, pram),
         }
     }
@@ -574,7 +578,7 @@ impl Ppu {
     /// Mode 0: render enabled text-mode BG layers (BG0–BG3) with priority
     /// compositing. Lower BGCNT priority value = on top; at equal priority,
     /// lower BG number wins.
-    fn render_mode0_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8]) {
+    fn render_mode0_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8], oam: &[u8]) {
         // Collect enabled text-mode BGs.
         let bg_enables = [
             self.dispcnt & dispcnt::BG0_ENABLE != 0,
@@ -583,29 +587,10 @@ impl Ppu {
             self.dispcnt & dispcnt::BG3_ENABLE != 0,
         ];
 
-        if !bg_enables.iter().any(|&e| e) {
-            self.render_backdrop_scanline(y, pram);
-            return;
-        }
-
-        // Build render order: paint from lowest visual priority (behind) to
-        // highest (on top). Higher BGCNT priority value = behind; at equal
-        // priority, higher BG number = behind. So sort descending by
-        // (priority, bg_number).
-        let mut layers: [(u16, usize); 4] = [(0, 0); 4];
-        let mut count = 0;
-        for (i, &enabled) in bg_enables.iter().enumerate() {
-            if enabled {
-                layers[count] = (self.bg_cnt[i] & 3, i);
-                count += 1;
-            }
-        }
-        // Sort: higher priority value first (behind), then higher bg number.
-        layers[..count].sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)));
-
-        // Fill with backdrop first.
         let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
         let backdrop = self.backdrop_bgr555(pram);
+
+        // Fill with backdrop first.
         let (br, bg, bb) = color::bgr555_to_rgb888(backdrop);
         for x in 0..(SCREEN_WIDTH as usize) {
             let dst = row_start + x * BYTES_PER_PIXEL;
@@ -614,16 +599,49 @@ impl Ppu {
             self.framebuffer[dst + 2] = bb;
         }
 
-        // Render each BG layer from behind to front; non-transparent pixels
-        // overwrite whatever was painted below.
-        for &(_, bg_idx) in &layers[..count] {
-            self.render_text_bg_layer(bg_idx, y, vram, pram, row_start, backdrop);
+        if !bg_enables.iter().any(|&e| e) && self.dispcnt & dispcnt::OBJ_ENABLE == 0 {
+            return;
         }
+
+        // Track per-pixel priority for OBJ compositing (4 = backdrop/no BG).
+        let mut pixel_priority = [4u8; SCREEN_WIDTH as usize];
+
+        if bg_enables.iter().any(|&e| e) {
+            // Build render order: paint from lowest visual priority (behind) to
+            // highest (on top). Higher BGCNT priority value = behind; at equal
+            // priority, higher BG number = behind.
+            let mut layers: [(u16, usize); 4] = [(0, 0); 4];
+            let mut count = 0;
+            for (i, &enabled) in bg_enables.iter().enumerate() {
+                if enabled {
+                    layers[count] = (self.bg_cnt[i] & 3, i);
+                    count += 1;
+                }
+            }
+            layers[..count].sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)));
+
+            for &(prio, bg_idx) in &layers[..count] {
+                self.render_text_bg_layer_with_priority(
+                    bg_idx,
+                    y,
+                    vram,
+                    pram,
+                    row_start,
+                    backdrop,
+                    prio as u8,
+                    &mut pixel_priority,
+                );
+            }
+        }
+
+        self.overlay_obj_pixels(y, vram, pram, oam, row_start, &pixel_priority);
     }
 
     /// Render a single 4bpp text-mode BG layer onto the framebuffer row
     /// at `row_start`. Transparent pixels (palette index 0) are skipped.
-    fn render_text_bg_layer(
+    /// Updates `pixel_priority` for each opaque pixel written.
+    #[allow(clippy::too_many_arguments, clippy::needless_range_loop)]
+    fn render_text_bg_layer_with_priority(
         &mut self,
         bg_idx: usize,
         y: u32,
@@ -631,6 +649,8 @@ impl Ppu {
         pram: &[u8],
         row_start: usize,
         backdrop: u16,
+        bg_prio: u8,
+        pixel_priority: &mut [u8; SCREEN_WIDTH as usize],
     ) {
         let bgcnt = self.bg_cnt[bg_idx];
 
@@ -714,6 +734,7 @@ impl Ppu {
 
             let dst = row_start + x * BYTES_PER_PIXEL;
             color::write_pixel(&mut self.framebuffer, dst, bgr555);
+            pixel_priority[x] = bg_prio;
         }
     }
 
@@ -722,6 +743,7 @@ impl Ppu {
     /// parameters for the per-pixel texture coordinate calculation.
     ///
     /// `affine_idx` is 0 for BG2, 1 for BG3.
+    #[allow(clippy::too_many_arguments, clippy::needless_range_loop)]
     fn render_affine_bg_layer(
         &mut self,
         bg_idx: usize,
@@ -729,6 +751,8 @@ impl Ppu {
         vram: &[u8],
         pram: &[u8],
         row_start: usize,
+        bg_prio: u8,
+        pixel_priority: &mut [u8; SCREEN_WIDTH as usize],
     ) {
         let bgcnt = self.bg_cnt[bg_idx];
         let aff = self.bg_affine[affine_idx];
@@ -799,36 +823,17 @@ impl Ppu {
 
             let dst = row_start + x * BYTES_PER_PIXEL;
             color::write_pixel(&mut self.framebuffer, dst, bgr555);
+            pixel_priority[x] = bg_prio;
         }
     }
 
     /// Mode 2: affine tile backgrounds (BG2 and BG3 only).
-    fn render_mode2_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8]) {
+    fn render_mode2_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8], oam: &[u8]) {
         let bg_enables = [
             self.dispcnt & dispcnt::BG2_ENABLE != 0,
             self.dispcnt & dispcnt::BG3_ENABLE != 0,
         ];
 
-        if !bg_enables.iter().any(|&e| e) {
-            self.render_backdrop_scanline(y, pram);
-            return;
-        }
-
-        // Build render order: paint from lowest visual priority (behind) to
-        // highest (on top). BG2 = affine_idx 0, BG3 = affine_idx 1.
-        let mut layers: [(u16, usize, usize); 2] = [(0, 0, 0); 2];
-        let mut count = 0;
-        let bg_indices = [2usize, 3usize];
-        for (i, &bg_idx) in bg_indices.iter().enumerate() {
-            if bg_enables[i] {
-                layers[count] = (self.bg_cnt[bg_idx] & 3, bg_idx, i);
-                count += 1;
-            }
-        }
-        // Sort: higher priority value first (behind), then higher bg number.
-        layers[..count].sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)));
-
-        // Fill with backdrop first.
         let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
         let backdrop = self.backdrop_bgr555(pram);
         let (br, bg, bb) = color::bgr555_to_rgb888(backdrop);
@@ -839,37 +844,48 @@ impl Ppu {
             self.framebuffer[dst + 2] = bb;
         }
 
-        for &(_, bg_idx, affine_idx) in &layers[..count] {
-            self.render_affine_bg_layer(bg_idx, affine_idx, vram, pram, row_start);
+        if !bg_enables.iter().any(|&e| e) && self.dispcnt & dispcnt::OBJ_ENABLE == 0 {
+            return;
         }
+
+        let mut pixel_priority = [4u8; SCREEN_WIDTH as usize];
+
+        if bg_enables.iter().any(|&e| e) {
+            let mut layers: [(u16, usize, usize); 2] = [(0, 0, 0); 2];
+            let mut count = 0;
+            let bg_indices = [2usize, 3usize];
+            for (i, &bg_idx) in bg_indices.iter().enumerate() {
+                if bg_enables[i] {
+                    layers[count] = (self.bg_cnt[bg_idx] & 3, bg_idx, i);
+                    count += 1;
+                }
+            }
+            layers[..count].sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)));
+
+            for &(prio, bg_idx, affine_idx) in &layers[..count] {
+                self.render_affine_bg_layer(
+                    bg_idx,
+                    affine_idx,
+                    vram,
+                    pram,
+                    row_start,
+                    prio as u8,
+                    &mut pixel_priority,
+                );
+            }
+        }
+
+        self.overlay_obj_pixels(y, vram, pram, oam, row_start, &pixel_priority);
     }
 
     /// Mode 1: BG0/BG1 regular text + BG2 affine.
-    fn render_mode1_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8]) {
+    fn render_mode1_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8], oam: &[u8]) {
         let bg_enables = [
             self.dispcnt & dispcnt::BG0_ENABLE != 0,
             self.dispcnt & dispcnt::BG1_ENABLE != 0,
             self.dispcnt & dispcnt::BG2_ENABLE != 0,
         ];
 
-        if !bg_enables.iter().any(|&e| e) {
-            self.render_backdrop_scanline(y, pram);
-            return;
-        }
-
-        // Mix regular and affine BGs. Build a unified priority list.
-        // Each entry: (priority, bg_idx, is_affine).
-        let mut layers: [(u16, usize, bool); 3] = [(0, 0, false); 3];
-        let mut count = 0;
-        for (i, &bg_idx) in [0usize, 1, 2].iter().enumerate() {
-            if bg_enables[i] {
-                layers[count] = (self.bg_cnt[bg_idx] & 3, bg_idx, bg_idx == 2);
-                count += 1;
-            }
-        }
-        layers[..count].sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)));
-
-        // Fill backdrop.
         let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
         let backdrop = self.backdrop_bgr555(pram);
         let (br, bg, bb) = color::bgr555_to_rgb888(backdrop);
@@ -880,14 +896,50 @@ impl Ppu {
             self.framebuffer[dst + 2] = bb;
         }
 
-        for &(_, bg_idx, is_affine) in &layers[..count] {
-            if is_affine {
-                // BG2 → affine_idx 0
-                self.render_affine_bg_layer(bg_idx, 0, vram, pram, row_start);
-            } else {
-                self.render_text_bg_layer(bg_idx, y, vram, pram, row_start, backdrop);
+        if !bg_enables.iter().any(|&e| e) && self.dispcnt & dispcnt::OBJ_ENABLE == 0 {
+            return;
+        }
+
+        let mut pixel_priority = [4u8; SCREEN_WIDTH as usize];
+
+        if bg_enables.iter().any(|&e| e) {
+            let mut layers: [(u16, usize, bool); 3] = [(0, 0, false); 3];
+            let mut count = 0;
+            for (i, &bg_idx) in [0usize, 1, 2].iter().enumerate() {
+                if bg_enables[i] {
+                    layers[count] = (self.bg_cnt[bg_idx] & 3, bg_idx, bg_idx == 2);
+                    count += 1;
+                }
+            }
+            layers[..count].sort_by(|a, b| b.0.cmp(&a.0).then(b.1.cmp(&a.1)));
+
+            for &(prio, bg_idx, is_affine) in &layers[..count] {
+                if is_affine {
+                    self.render_affine_bg_layer(
+                        bg_idx,
+                        0,
+                        vram,
+                        pram,
+                        row_start,
+                        prio as u8,
+                        &mut pixel_priority,
+                    );
+                } else {
+                    self.render_text_bg_layer_with_priority(
+                        bg_idx,
+                        y,
+                        vram,
+                        pram,
+                        row_start,
+                        backdrop,
+                        prio as u8,
+                        &mut pixel_priority,
+                    );
+                }
             }
         }
+
+        self.overlay_obj_pixels(y, vram, pram, oam, row_start, &pixel_priority);
     }
 
     /// Mode 3: 240×160 direct 15-bit bitmap starting at the base of
@@ -895,20 +947,26 @@ impl Ppu {
     /// the scanline is filled with the backdrop color (palette entry 0
     /// in PRAM) per GBATek — every pixel is "no BG/OBJ pixel drawn", so
     /// the backdrop shows through.
-    fn render_mode3_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8]) {
-        if !self.bg2_enabled() {
+    #[allow(clippy::needless_range_loop)]
+    fn render_mode3_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8], oam: &[u8]) {
+        let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
+        let bg2_prio = (self.bg_cnt[2] & 3) as u8;
+        let mut pixel_priority = [4u8; SCREEN_WIDTH as usize];
+
+        if self.bg2_enabled() {
+            let line_byte_offset = (y as usize) * (SCREEN_WIDTH as usize) * 2;
+            for x in 0..(SCREEN_WIDTH as usize) {
+                let src = line_byte_offset + x * 2;
+                let bgr555 = u16::from_le_bytes([vram[src], vram[src + 1]]);
+                let dst = row_start + x * BYTES_PER_PIXEL;
+                color::write_pixel(&mut self.framebuffer, dst, bgr555);
+                pixel_priority[x] = bg2_prio;
+            }
+        } else {
             self.render_backdrop_scanline(y, pram);
-            return;
         }
-        let line_byte_offset = (y as usize) * (SCREEN_WIDTH as usize) * 2;
-        for x in 0..(SCREEN_WIDTH as usize) {
-            let src = line_byte_offset + x * 2;
-            // VRAM is at least 96 KB; mode 3 uses the first 240*160*2 =
-            // 76 800 bytes which always fits.
-            let bgr555 = u16::from_le_bytes([vram[src], vram[src + 1]]);
-            let dst = ((y as usize) * (SCREEN_WIDTH as usize) + x) * BYTES_PER_PIXEL;
-            color::write_pixel(&mut self.framebuffer, dst, bgr555);
-        }
+
+        self.overlay_obj_pixels(y, vram, pram, oam, row_start, &pixel_priority);
     }
 
     /// Mode 4: 240×160 8-bit paletted bitmap. Each byte in VRAM is a
@@ -921,43 +979,75 @@ impl Ppu {
     /// - Frame 1: 0x0600A000 - 0x060135FF (38,400 bytes)
     ///
     /// DISPCNT bit 4 selects the displayed frame.
-    fn render_mode4_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8]) {
-        if !self.bg2_enabled() {
+    #[allow(clippy::needless_range_loop)]
+    fn render_mode4_scanline(&mut self, y: u32, vram: &[u8], pram: &[u8], oam: &[u8]) {
+        let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
+        let bg2_prio = (self.bg_cnt[2] & 3) as u8;
+        let mut pixel_priority = [4u8; SCREEN_WIDTH as usize];
+
+        if self.bg2_enabled() {
+            let backdrop = self.backdrop_bgr555(pram);
+            let frame_base = if self.frame_select() {
+                0xA000usize
+            } else {
+                0x0000usize
+            };
+
+            let line_byte_offset = frame_base + (y as usize) * (SCREEN_WIDTH as usize);
+
+            for x in 0..(SCREEN_WIDTH as usize) {
+                let src = line_byte_offset + x;
+                let pal_index = if src < vram.len() { vram[src] } else { 0 };
+
+                let bgr555 = if pal_index == 0 {
+                    backdrop
+                } else {
+                    let pal_offset = (pal_index as usize) * 2;
+                    if pal_offset + 1 < pram.len() {
+                        u16::from_le_bytes([pram[pal_offset], pram[pal_offset + 1]])
+                    } else {
+                        backdrop
+                    }
+                };
+
+                let dst = row_start + x * BYTES_PER_PIXEL;
+                color::write_pixel(&mut self.framebuffer, dst, bgr555);
+                // All bitmap pixels have BG2's priority.
+                pixel_priority[x] = bg2_prio;
+            }
+        } else {
             self.render_backdrop_scanline(y, pram);
+        }
+
+        self.overlay_obj_pixels(y, vram, pram, oam, row_start, &pixel_priority);
+    }
+
+    /// Overlay OBJ pixels on top of the BG-composited framebuffer row.
+    /// An OBJ pixel with priority P draws on top of any BG pixel with
+    /// priority >= P (lower number = higher priority; OBJ wins at same level).
+    #[allow(clippy::needless_range_loop)]
+    fn overlay_obj_pixels(
+        &mut self,
+        y: u32,
+        vram: &[u8],
+        pram: &[u8],
+        oam: &[u8],
+        row_start: usize,
+        pixel_priority: &[u8; SCREEN_WIDTH as usize],
+    ) {
+        if self.dispcnt & dispcnt::OBJ_ENABLE == 0 {
             return;
         }
 
-        let backdrop = self.backdrop_bgr555(pram);
-
-        // Frame base address: Frame 0 at 0x0000, Frame 1 at 0xA000
-        let frame_base = if self.frame_select() {
-            0xA000usize
-        } else {
-            0x0000usize
-        };
-
-        let line_byte_offset = frame_base + (y as usize) * (SCREEN_WIDTH as usize);
-        let row_start = (y as usize) * (SCREEN_WIDTH as usize) * BYTES_PER_PIXEL;
+        let mapping_1d = self.dispcnt & dispcnt::OBJ_MAPPING_1D != 0;
+        let obj_scanline = obj::render_obj_scanline(y, oam, vram, pram, mapping_1d);
 
         for x in 0..(SCREEN_WIDTH as usize) {
-            let src = line_byte_offset + x;
-            let pal_index = if src < vram.len() { vram[src] } else { 0 };
-
-            // Palette index 0 uses palette entry 0 (the backdrop color)
-            let bgr555 = if pal_index == 0 {
-                backdrop
-            } else {
-                // Each palette entry is 2 bytes (BGR555) in PRAM
-                let pal_offset = (pal_index as usize) * 2;
-                if pal_offset + 1 < pram.len() {
-                    u16::from_le_bytes([pram[pal_offset], pram[pal_offset + 1]])
-                } else {
-                    backdrop
-                }
-            };
-
-            let dst = row_start + x * BYTES_PER_PIXEL;
-            color::write_pixel(&mut self.framebuffer, dst, bgr555);
+            let px = &obj_scanline.pixels[x];
+            if px.opaque && px.priority <= pixel_priority[x] {
+                let dst = row_start + x * BYTES_PER_PIXEL;
+                color::write_pixel(&mut self.framebuffer, dst, px.color);
+            }
         }
     }
 
@@ -1003,6 +1093,19 @@ mod tests {
         vec![0; 1024]
     }
 
+    fn make_oam() -> Vec<u8> {
+        // All OBJs hidden (obj_mode=2 in attr0 bits 8-9) to avoid ghost sprites.
+        let mut oam = vec![0u8; 1024];
+        for i in 0..128 {
+            let offset = i * 8;
+            // attr0: set bits 8-9 to 0b10 (hidden mode)
+            let attr0 = 0x0200u16;
+            oam[offset] = attr0 as u8;
+            oam[offset + 1] = (attr0 >> 8) as u8;
+        }
+        oam
+    }
+
     #[test]
     fn new_ppu_has_zeroed_state_and_blank_framebuffer() {
         let ppu = Ppu::new();
@@ -1037,7 +1140,7 @@ mod tests {
     fn step_advances_line_cycle_within_scanline() {
         let mut ppu = Ppu::new();
         let mut ic = make_ic();
-        ppu.step(500, &mut ic, &make_vram(), &make_pram());
+        ppu.step(500, &mut ic, &make_vram(), &make_pram(), &make_oam());
         assert_eq!(ppu.read_vcount(), 0);
         // No H-Blank yet at cycle 500.
         assert_eq!(ppu.read_dispstat() & dispstat::HBLANK_FLAG, 0);
@@ -1047,9 +1150,15 @@ mod tests {
     fn hblank_flag_sets_at_cycle_1006() {
         let mut ppu = Ppu::new();
         let mut ic = make_ic();
-        ppu.step(HBLANK_START_CYCLE - 1, &mut ic, &make_vram(), &make_pram());
+        ppu.step(
+            HBLANK_START_CYCLE - 1,
+            &mut ic,
+            &make_vram(),
+            &make_pram(),
+            &make_oam(),
+        );
         assert_eq!(ppu.read_dispstat() & dispstat::HBLANK_FLAG, 0);
-        ppu.step(1, &mut ic, &make_vram(), &make_pram());
+        ppu.step(1, &mut ic, &make_vram(), &make_pram(), &make_oam());
         assert_ne!(ppu.read_dispstat() & dispstat::HBLANK_FLAG, 0);
     }
 
@@ -1057,7 +1166,13 @@ mod tests {
     fn hblank_flag_clears_when_scanline_advances() {
         let mut ppu = Ppu::new();
         let mut ic = make_ic();
-        ppu.step(CYCLES_PER_SCANLINE, &mut ic, &make_vram(), &make_pram());
+        ppu.step(
+            CYCLES_PER_SCANLINE,
+            &mut ic,
+            &make_vram(),
+            &make_pram(),
+            &make_oam(),
+        );
         assert_eq!(ppu.read_vcount(), 1);
         // After crossing the scanline boundary the H-Blank flag is gone.
         assert_eq!(ppu.read_dispstat() & dispstat::HBLANK_FLAG, 0);
@@ -1068,12 +1183,24 @@ mod tests {
         let mut ppu = Ppu::new();
         let mut ic = make_ic();
         // Without H-Blank IRQ enable bit, no IRQ should be raised.
-        ppu.step(HBLANK_START_CYCLE, &mut ic, &make_vram(), &make_pram());
+        ppu.step(
+            HBLANK_START_CYCLE,
+            &mut ic,
+            &make_vram(),
+            &make_pram(),
+            &make_oam(),
+        );
         assert_eq!(ic.if_flags & irq_bits::HBLANK, 0);
 
         // Enable + advance to next H-Blank → IRQ flagged.
         ppu.write_dispstat(dispstat::HBLANK_IRQ_ENABLE, &mut ic);
-        ppu.step(CYCLES_PER_SCANLINE, &mut ic, &make_vram(), &make_pram());
+        ppu.step(
+            CYCLES_PER_SCANLINE,
+            &mut ic,
+            &make_vram(),
+            &make_pram(),
+            &make_oam(),
+        );
         assert_ne!(ic.if_flags & irq_bits::HBLANK, 0);
     }
 
@@ -1085,10 +1212,10 @@ mod tests {
         let pram = make_pram();
         // Step up to the *start* of scanline 160 (V-Blank).
         let cycles = CYCLES_PER_SCANLINE * VISIBLE_SCANLINES;
-        ppu.step(cycles, &mut ic, &vram, &pram);
+        ppu.step(cycles, &mut ic, &vram, &pram, &make_oam());
         assert_eq!(ppu.read_vcount(), 160);
         // Step through H-Blank of scanline 160 — no visible H-Blank.
-        let events = ppu.step(HBLANK_START_CYCLE, &mut ic, &vram, &pram);
+        let events = ppu.step(HBLANK_START_CYCLE, &mut ic, &vram, &pram, &make_oam());
         assert_eq!(events.hblank_starts, 0);
     }
 
@@ -1106,6 +1233,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
         assert_eq!(events.hblank_starts, VISIBLE_SCANLINES);
         assert_eq!(events.vblank_starts, 1);
@@ -1123,6 +1251,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
         assert_eq!(events.vblank_starts, 2);
         assert_eq!(events.frames_completed, 2);
@@ -1136,7 +1265,7 @@ mod tests {
         let vram = make_vram();
         let pram = make_pram();
         let cycles = CYCLES_PER_SCANLINE * VISIBLE_SCANLINES;
-        let events = ppu.step(cycles, &mut ic, &vram, &pram);
+        let events = ppu.step(cycles, &mut ic, &vram, &pram, &make_oam());
         assert_eq!(ppu.read_vcount(), 160);
         assert_ne!(ppu.read_dispstat() & dispstat::VBLANK_FLAG, 0);
         assert_eq!(events.vblank_starts, 1);
@@ -1150,7 +1279,7 @@ mod tests {
         let mut ic = make_ic();
         ppu.write_dispstat(dispstat::VBLANK_IRQ_ENABLE, &mut ic);
         let cycles = CYCLES_PER_SCANLINE * VISIBLE_SCANLINES;
-        ppu.step(cycles, &mut ic, &make_vram(), &make_pram());
+        ppu.step(cycles, &mut ic, &make_vram(), &make_pram(), &make_oam());
         assert_ne!(ic.if_flags & irq_bits::VBLANK, 0);
     }
 
@@ -1162,7 +1291,7 @@ mod tests {
         let pram = make_pram();
         // Advance to the start of the final scanline (227).
         let cycles = CYCLES_PER_SCANLINE * (VBLANK_LAST_SCANLINE + 1);
-        ppu.step(cycles, &mut ic, &vram, &pram);
+        ppu.step(cycles, &mut ic, &vram, &pram, &make_oam());
         assert_eq!(ppu.read_vcount() as u32, VBLANK_LAST_SCANLINE + 1);
         assert_eq!(ppu.read_dispstat() & dispstat::VBLANK_FLAG, 0);
     }
@@ -1174,7 +1303,7 @@ mod tests {
         let vram = make_vram();
         let pram = make_pram();
         let total = CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME;
-        ppu.step(total, &mut ic, &vram, &pram);
+        ppu.step(total, &mut ic, &vram, &pram, &make_oam());
         assert_eq!(ppu.read_vcount(), 0);
         assert!(ppu.frame_ready());
         ppu.clear_frame_ready();
@@ -1210,7 +1339,13 @@ mod tests {
         let mut ppu = Ppu::new();
         let mut ic = make_ic();
         // Step to scanline 7.
-        ppu.step(CYCLES_PER_SCANLINE * 7, &mut ic, &make_vram(), &make_pram());
+        ppu.step(
+            CYCLES_PER_SCANLINE * 7,
+            &mut ic,
+            &make_vram(),
+            &make_pram(),
+            &make_oam(),
+        );
         assert_eq!(ppu.read_vcount(), 7);
         // Initial match flag is low (VCOUNT=7, LYC=0). Now enable VCount
         // IRQ and write LYC=7 — IRQ must fire on the rising edge of
@@ -1228,12 +1363,24 @@ mod tests {
         // LYC = 5, enable V-Count IRQ.
         ppu.write_dispstat(dispstat::VCOUNT_IRQ_ENABLE | (5 << 8), &mut ic);
         // Step to scanline 5.
-        ppu.step(CYCLES_PER_SCANLINE * 5, &mut ic, &make_vram(), &make_pram());
+        ppu.step(
+            CYCLES_PER_SCANLINE * 5,
+            &mut ic,
+            &make_vram(),
+            &make_pram(),
+            &make_oam(),
+        );
         assert_eq!(ppu.read_vcount(), 5);
         assert_ne!(ppu.read_dispstat() & dispstat::VCOUNT_FLAG, 0);
         assert_ne!(ic.if_flags & irq_bits::VCOUNT, 0);
         // Advance one more line — flag clears.
-        ppu.step(CYCLES_PER_SCANLINE, &mut ic, &make_vram(), &make_pram());
+        ppu.step(
+            CYCLES_PER_SCANLINE,
+            &mut ic,
+            &make_vram(),
+            &make_pram(),
+            &make_oam(),
+        );
         assert_eq!(ppu.read_vcount(), 6);
         assert_eq!(ppu.read_dispstat() & dispstat::VCOUNT_FLAG, 0);
     }
@@ -1258,6 +1405,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
         // Sample first pixel of scanline 0 — should be pure red.
         let fb = ppu.framebuffer();
@@ -1291,6 +1439,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
         assert_eq!(&ppu.framebuffer()[0..3], &[0xFF, 0, 0]);
     }
@@ -1308,6 +1457,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
         // Every pixel should be white.
         assert!(ppu.framebuffer().iter().all(|&b| b == 0xFF));
@@ -1329,6 +1479,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
         assert_eq!(&ppu.framebuffer()[0..3], &[0, 0, 0xFF]);
     }
@@ -1361,6 +1512,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // Assert: top-left output pixel should come from tile data, not backdrop.
@@ -1393,6 +1545,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // With H-flip set, source pixel 7 appears at output x=0.
@@ -1424,6 +1577,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // With V-flip set, source row 7 appears at output y=0.
@@ -1447,6 +1601,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
     }
 
@@ -1530,6 +1685,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // First pixel should be green (RGB888: 0, 255, 0).
@@ -1559,6 +1715,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // First pixel should be red (RGB888: 255, 0, 0).
@@ -1588,6 +1745,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // First pixel should be backdrop blue (RGB888: 0, 0, 255).
@@ -1614,6 +1772,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // First pixel should be green (RGB888: 0, 255, 0).
@@ -1645,6 +1804,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // First pixel should be from frame 1, which is green (RGB888: 0, 255, 0).
@@ -1680,6 +1840,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // First pixel = green from BG1.
@@ -1725,6 +1886,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // BG1 has lower priority number = on top, so pixel should be green.
@@ -1767,6 +1929,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // BG0 is transparent → BG1's red shows through.
@@ -1807,6 +1970,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // Equal priority: BG0 (lower number) wins → red.
@@ -1852,6 +2016,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // Internal refs should have been latched from the register values.
@@ -1882,9 +2047,10 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
         // Run 10 scanlines (each increments internal refs by PB/PD).
-        ppu.step(CYCLES_PER_SCANLINE * 10, &mut ic, &vram, &pram);
+        ppu.step(CYCLES_PER_SCANLINE * 10, &mut ic, &vram, &pram, &make_oam());
 
         let aff = ppu.bg_affine(0).unwrap();
         // After 10 scanlines: internal_x += PB*10 = 0x0010*10 = 0x00A0
@@ -1969,6 +2135,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // Pixel (0,0) should be green (from tile 1 at map 0,0).
@@ -2014,6 +2181,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // Should show backdrop (red), not tile color.
@@ -2061,6 +2229,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // Pixel (0,0) maps to texture (200, 0) which is outside 128x128.
@@ -2109,6 +2278,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // Texture x = 128 wraps to 0 in a 128-pixel map → should see tile.
@@ -2174,6 +2344,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // BG3 has priority 0 (on top), BG2 has priority 1 (behind).
@@ -2254,6 +2425,7 @@ mod tests {
             &mut ic,
             &vram,
             &pram,
+            &make_oam(),
         );
 
         // BG2 (priority 0, affine) should be on top of BG0 (priority 1, text).

--- a/src/gba/ppu/obj.rs
+++ b/src/gba/ppu/obj.rs
@@ -17,10 +17,6 @@
 /// Screen width in pixels.
 const SCREEN_WIDTH: usize = 240;
 
-/// OBJ VRAM base offset within the 96KB VRAM.
-/// Sprites use charblock 4 (0x10000) and 5 (0x14000).
-const OBJ_VRAM_BASE: usize = 0x1_0000;
-
 /// Number of OBJ entries in OAM.
 const OBJ_COUNT: usize = 128;
 
@@ -72,7 +68,8 @@ fn obj_size(shape: u8, size: u8) -> (u32, u32) {
         (2, 1) => (8, 32),
         (2, 2) => (16, 32),
         (2, 3) => (32, 64),
-        _ => (8, 8), // fallback
+        // Shape 3 is prohibited — return (0, 0) to signal skip.
+        _ => (0, 0),
     }
 }
 
@@ -80,17 +77,20 @@ fn obj_size(shape: u8, size: u8) -> (u32, u32) {
 ///
 /// - `y`: current scanline (0..160)
 /// - `oam`: 1KB OAM data
-/// - `vram`: 96KB VRAM (OBJ tiles at offset 0x10000)
+/// - `vram`: 96KB VRAM (OBJ tiles at offset `obj_vram_base`)
 /// - `pram`: 1KB palette RAM (OBJ palette at offset 0x200)
 /// - `obj_mapping_1d`: true if DISPCNT bit 6 is set (1D tile mapping)
+/// - `bitmap_mode`: true for modes 3-5 (OBJ tiles start at 0x14000 instead of 0x10000)
 pub fn render_obj_scanline(
     y: u32,
     oam: &[u8],
     vram: &[u8],
     pram: &[u8],
     obj_mapping_1d: bool,
+    bitmap_mode: bool,
 ) -> ObjScanline {
     let mut result = ObjScanline::default();
+    let obj_vram_base = if bitmap_mode { 0x1_4000 } else { 0x1_0000 };
 
     // Process OBJs in order 0..127. Lower number = higher priority at same
     // priority level, so first writer wins for each pixel.
@@ -135,6 +135,11 @@ pub fn render_obj_scanline(
         let shape = ((attr0 >> 14) & 3) as u8;
         let size_bits = ((attr1 >> 14) & 3) as u8;
         let (obj_width, obj_height) = obj_size(shape, size_bits);
+
+        // Shape 3 is prohibited — skip.
+        if obj_width == 0 || obj_height == 0 {
+            continue;
+        }
 
         // Y coordinate (attr0 bits 0-7), wraps at 256.
         let obj_y = (attr0 & 0xFF) as u32;
@@ -190,29 +195,26 @@ pub fn render_obj_scanline(
             let pixel_y = (sprite_row % 8) as usize;
 
             // Calculate tile offset based on mapping mode.
+            let col_stride = if is_8bpp { 2 } else { 1 }; // 8bpp tiles occupy 2 s-tile slots
             let tile_offset = if obj_mapping_1d {
-                // 1D: tiles are consecutive. Row stride = width_in_tiles.
+                // 1D: tiles are consecutive. Row stride = width_in_tiles * col_stride.
                 let width_in_tiles = obj_width / 8;
-                let stride = if is_8bpp {
-                    width_in_tiles * 2 // 8bpp tiles take 2 s-tile slots
-                } else {
-                    width_in_tiles
-                };
-                tile_id + (tile_row * stride + tile_col) as usize
+                let row_stride = width_in_tiles * col_stride;
+                tile_id + (tile_row * row_stride + tile_col * col_stride) as usize
             } else {
-                // 2D: tiles laid out in a 32-tile wide virtual bitmap.
-                let stride = if is_8bpp { 16 } else { 32 };
-                tile_id + (tile_row as usize) * stride + tile_col as usize
+                // 2D: tiles laid out in a 32-s-tile wide virtual bitmap.
+                // Row stride is always 32 s-tiles regardless of bpp.
+                tile_id + (tile_row as usize) * 32 + (tile_col * col_stride) as usize
             };
 
             // Get palette index from tile data.
             let palette_index = if is_8bpp {
                 // 8bpp: 64 bytes per tile, 1 byte per pixel.
-                let addr = OBJ_VRAM_BASE + tile_offset * 32 + pixel_y * 8 + pixel_x;
+                let addr = obj_vram_base + tile_offset * 32 + pixel_y * 8 + pixel_x;
                 vram.get(addr).copied().unwrap_or(0) as usize
             } else {
                 // 4bpp: 32 bytes per tile, 4 bits per pixel.
-                let addr = OBJ_VRAM_BASE + tile_offset * 32 + pixel_y * 4 + pixel_x / 2;
+                let addr = obj_vram_base + tile_offset * 32 + pixel_y * 4 + pixel_x / 2;
                 let byte = vram.get(addr).copied().unwrap_or(0);
                 if pixel_x & 1 == 0 {
                     (byte & 0x0F) as usize
@@ -266,6 +268,9 @@ pub fn render_obj_scanline(
 mod tests {
     use super::*;
 
+    /// OBJ VRAM base offset within the 96KB VRAM (charblock 4).
+    const OBJ_VRAM_BASE: usize = 0x1_0000;
+
     fn make_oam() -> Vec<u8> {
         vec![0u8; 1024]
     }
@@ -315,7 +320,7 @@ mod tests {
         let oam = make_oam();
         let vram = make_vram();
         let pram = make_pram();
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
         assert!(result.pixels.iter().all(|p| !p.opaque));
         assert!(result.obj_window.iter().all(|&w| !w));
     }
@@ -335,7 +340,7 @@ mod tests {
         fill_4bpp_tile(&mut vram, 1, 1);
         set_obj_color(&mut pram, 1, 0x001F); // red
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
         assert!(!result.pixels[100].opaque, "hidden OBJ should not render");
     }
 
@@ -357,7 +362,7 @@ mod tests {
         set_obj_color(&mut pram, 3, 0x03E0);
 
         // Render scanline 5 (first row of sprite).
-        let result = render_obj_scanline(5, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(5, &oam, &vram, &pram, true, false);
 
         // Pixels 10-17 should be green.
         for x in 10..18 {
@@ -388,7 +393,7 @@ mod tests {
         // Set OBJ palette color 5 = blue.
         set_obj_color(&mut pram, 5, 0x7C00);
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
 
         for x in 0..8 {
             assert!(result.pixels[x].opaque, "pixel {x} should be opaque");
@@ -426,7 +431,7 @@ mod tests {
         set_obj_color(&mut pram, 1, 0x001F); // red
         set_obj_color(&mut pram, 2, 0x03E0); // green
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
 
         // With h-flip, right side (index 2, green) appears on left.
         // Pixel 0-3 should be green (was right side), 4-7 should be red (was left side).
@@ -463,14 +468,14 @@ mod tests {
         set_obj_color(&mut pram, 2, 0x03E0); // green
 
         // With v-flip, row 7 (index 2) becomes the top row (scanline 0).
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
         assert_eq!(
             result.pixels[0].color, 0x03E0,
             "v-flip: scanline 0 should show row 7 data (green)"
         );
 
         // Scanline 7 should show original row 0 (index 1, red).
-        let result7 = render_obj_scanline(7, &oam, &vram, &pram, true);
+        let result7 = render_obj_scanline(7, &oam, &vram, &pram, true, false);
         assert_eq!(
             result7.pixels[0].color, 0x001F,
             "v-flip: scanline 7 should show row 0 data (red)"
@@ -493,7 +498,7 @@ mod tests {
         fill_4bpp_tile(&mut vram, 1, 2);
         set_obj_color(&mut pram, 2, 0x03E0); // green
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
         // OBJ 0 wins (lower index).
         assert_eq!(
             result.pixels[0].color, 0x001F,
@@ -516,7 +521,7 @@ mod tests {
         fill_4bpp_tile(&mut vram, 1, 2);
         set_obj_color(&mut pram, 2, 0x03E0);
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
         // OBJ 0 is transparent, so OBJ 1 should show through.
         assert_eq!(
             result.pixels[0].color, 0x03E0,
@@ -538,7 +543,7 @@ mod tests {
         fill_4bpp_tile(&mut vram, 1, 1);
         set_obj_color(&mut pram, 1, 0x001F);
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
 
         // OBJ Window should not produce visible pixels at x=100.
         assert!(
@@ -567,7 +572,7 @@ mod tests {
         set_obj_color(&mut pram, 3, 0x7C00); // blue
 
         // Scanline 8 = second tile row.
-        let result = render_obj_scanline(8, &oam, &vram, &pram, false);
+        let result = render_obj_scanline(8, &oam, &vram, &pram, false, false);
         assert!(
             result.pixels[0].opaque,
             "2D mapping should find tile at stride 32"
@@ -592,7 +597,7 @@ mod tests {
         set_obj_color(&mut pram, 4, 0x03E0); // green
 
         // Scanline 8 = second tile row.
-        let result = render_obj_scanline(8, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(8, &oam, &vram, &pram, true, false);
         assert!(
             result.pixels[0].opaque,
             "1D mapping should find tile at width stride"
@@ -613,7 +618,7 @@ mod tests {
         set_obj_color(&mut pram, 1, 0x001F);
 
         // Scanline 0: relative Y = (0 - 252) & 0xFF = 4. 4 < 8, so visible.
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
         assert!(
             result.pixels[0].opaque,
             "sprite at Y=252 should wrap to scanline 0"
@@ -639,7 +644,7 @@ mod tests {
         fill_4bpp_tile(&mut vram, 1, 1);
         set_obj_color(&mut pram, 1, 0x001F);
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
 
         // X=-4: pixels at screen 0,1,2,3 should be visible (sprite cols 4,5,6,7).
         assert!(
@@ -663,7 +668,7 @@ mod tests {
         fill_4bpp_tile(&mut vram, 0, 1);
         set_obj_color(&mut pram, 1, 0x001F);
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
         assert_eq!(result.pixels[0].priority, 2);
     }
 
@@ -683,7 +688,7 @@ mod tests {
         fill_4bpp_tile(&mut vram, 0, 1);
         set_obj_color(&mut pram, 1, 0x001F);
 
-        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true, false);
         // First 8 pixels should be opaque (tile 0).
         assert!(result.pixels[0].opaque);
         assert!(result.pixels[7].opaque);

--- a/src/gba/ppu/obj.rs
+++ b/src/gba/ppu/obj.rs
@@ -1,0 +1,691 @@
+//! GBA OBJ (sprite) rendering.
+//!
+//! Handles decoding OAM attributes, rendering regular (non-affine) sprites
+//! into a per-scanline buffer, and generating the OBJ Window mask.
+//!
+//! Per GBATek "LCD OBJ - OAM Attributes":
+//! - 128 OBJ entries × 3 attributes (6 bytes each, 8 bytes with affine fill)
+//! - Sprites use VRAM starting at 0x0601_0000 (charblock 4)
+//! - Tile indices in 32-byte units (s-tile sized)
+//! - 4bpp: 16 colors from one of 16 OBJ sub-palettes
+//! - 8bpp: 256 colors from the single OBJ palette
+//!
+//! References:
+//! - GBATek: <https://problemkaputt.de/gbatek.htm#lcdobjoamattributes>
+//! - TONC: <https://www.coranac.com/tonc/text/regobj.htm>
+
+/// Screen width in pixels.
+const SCREEN_WIDTH: usize = 240;
+
+/// OBJ VRAM base offset within the 96KB VRAM.
+/// Sprites use charblock 4 (0x10000) and 5 (0x14000).
+const OBJ_VRAM_BASE: usize = 0x1_0000;
+
+/// Number of OBJ entries in OAM.
+const OBJ_COUNT: usize = 128;
+
+/// A single pixel in the OBJ scanline buffer.
+#[derive(Clone, Copy, Default)]
+pub struct ObjPixel {
+    /// BGR555 color (only valid if `opaque` is true).
+    pub color: u16,
+    /// Whether this pixel is opaque (has a non-transparent sprite pixel).
+    pub opaque: bool,
+    /// OBJ priority (0-3, from attr2 bits 10-11).
+    pub priority: u8,
+    /// Whether this pixel is semi-transparent (OBJ mode 1).
+    pub semi_transparent: bool,
+}
+
+/// Per-scanline OBJ rendering result.
+pub struct ObjScanline {
+    /// The rendered OBJ pixels for this scanline.
+    pub pixels: [ObjPixel; SCREEN_WIDTH],
+    /// OBJ Window mask: true if an OBJ Window sprite covers this pixel.
+    pub obj_window: [bool; SCREEN_WIDTH],
+}
+
+impl Default for ObjScanline {
+    fn default() -> Self {
+        Self {
+            pixels: [ObjPixel::default(); SCREEN_WIDTH],
+            obj_window: [false; SCREEN_WIDTH],
+        }
+    }
+}
+
+/// Sprite size in pixels (width, height).
+fn obj_size(shape: u8, size: u8) -> (u32, u32) {
+    match (shape, size) {
+        // Square
+        (0, 0) => (8, 8),
+        (0, 1) => (16, 16),
+        (0, 2) => (32, 32),
+        (0, 3) => (64, 64),
+        // Wide (horizontal)
+        (1, 0) => (16, 8),
+        (1, 1) => (32, 8),
+        (1, 2) => (32, 16),
+        (1, 3) => (64, 32),
+        // Tall (vertical)
+        (2, 0) => (8, 16),
+        (2, 1) => (8, 32),
+        (2, 2) => (16, 32),
+        (2, 3) => (32, 64),
+        _ => (8, 8), // fallback
+    }
+}
+
+/// Render all OBJs for a single scanline.
+///
+/// - `y`: current scanline (0..160)
+/// - `oam`: 1KB OAM data
+/// - `vram`: 96KB VRAM (OBJ tiles at offset 0x10000)
+/// - `pram`: 1KB palette RAM (OBJ palette at offset 0x200)
+/// - `obj_mapping_1d`: true if DISPCNT bit 6 is set (1D tile mapping)
+pub fn render_obj_scanline(
+    y: u32,
+    oam: &[u8],
+    vram: &[u8],
+    pram: &[u8],
+    obj_mapping_1d: bool,
+) -> ObjScanline {
+    let mut result = ObjScanline::default();
+
+    // Process OBJs in order 0..127. Lower number = higher priority at same
+    // priority level, so first writer wins for each pixel.
+    for obj_idx in 0..OBJ_COUNT {
+        let base = obj_idx * 8;
+        if base + 5 >= oam.len() {
+            break;
+        }
+
+        let attr0 = u16::from_le_bytes([oam[base], oam[base + 1]]);
+        let attr1 = u16::from_le_bytes([oam[base + 2], oam[base + 3]]);
+        let attr2 = u16::from_le_bytes([oam[base + 4], oam[base + 5]]);
+
+        // Object mode (attr0 bits 8-9).
+        let obj_mode = (attr0 >> 8) & 3;
+
+        // Mode 2 = hidden (disabled), skip.
+        if obj_mode == 2 {
+            continue;
+        }
+
+        // Mode 1 = affine — skip for now (not implemented in this increment).
+        // Mode 3 = affine double-size — skip.
+        if obj_mode == 1 || obj_mode == 3 {
+            continue;
+        }
+
+        // GFX mode (attr0 bits 10-11).
+        let gfx_mode = (attr0 >> 10) & 3;
+        // Mode 3 = prohibited, skip.
+        if gfx_mode == 3 {
+            continue;
+        }
+
+        let is_obj_window = gfx_mode == 2;
+        let is_semi_transparent = gfx_mode == 1;
+
+        // Color mode: 0 = 4bpp, 1 = 8bpp.
+        let is_8bpp = (attr0 >> 13) & 1 != 0;
+
+        // Shape and size.
+        let shape = ((attr0 >> 14) & 3) as u8;
+        let size_bits = ((attr1 >> 14) & 3) as u8;
+        let (obj_width, obj_height) = obj_size(shape, size_bits);
+
+        // Y coordinate (attr0 bits 0-7), wraps at 256.
+        let obj_y = (attr0 & 0xFF) as u32;
+        // X coordinate (attr1 bits 0-8), sign-extended 9 bits.
+        let obj_x = {
+            let raw = (attr1 & 0x1FF) as i32;
+            if raw >= 256 { raw - 512 } else { raw }
+        };
+
+        // Check if this scanline intersects the sprite (wrapping Y at 256).
+        let rel_y = y.wrapping_sub(obj_y) & 0xFF;
+        if rel_y >= obj_height {
+            continue;
+        }
+
+        // Flip flags (non-affine only).
+        let h_flip = (attr1 >> 12) & 1 != 0;
+        let v_flip = (attr1 >> 13) & 1 != 0;
+
+        // Tile index (attr2 bits 0-9).
+        let tile_id = (attr2 & 0x03FF) as usize;
+        // Priority (attr2 bits 10-11).
+        let priority = ((attr2 >> 10) & 3) as u8;
+        // Palette bank (attr2 bits 12-15), used in 4bpp mode.
+        let palette_bank = ((attr2 >> 12) & 0xF) as usize;
+
+        // Apply vertical flip to the row within the sprite.
+        let sprite_row = if v_flip {
+            obj_height - 1 - rel_y
+        } else {
+            rel_y
+        };
+
+        // Render each pixel of this sprite on the current scanline.
+        for sprite_col in 0..obj_width {
+            let screen_x = obj_x + sprite_col as i32;
+            if screen_x < 0 || screen_x >= SCREEN_WIDTH as i32 {
+                continue;
+            }
+            let sx = screen_x as usize;
+
+            // Apply horizontal flip.
+            let pixel_col = if h_flip {
+                obj_width - 1 - sprite_col
+            } else {
+                sprite_col
+            };
+
+            // Calculate tile and pixel within tile.
+            let tile_col = pixel_col / 8;
+            let tile_row = sprite_row / 8;
+            let pixel_x = (pixel_col % 8) as usize;
+            let pixel_y = (sprite_row % 8) as usize;
+
+            // Calculate tile offset based on mapping mode.
+            let tile_offset = if obj_mapping_1d {
+                // 1D: tiles are consecutive. Row stride = width_in_tiles.
+                let width_in_tiles = obj_width / 8;
+                let stride = if is_8bpp {
+                    width_in_tiles * 2 // 8bpp tiles take 2 s-tile slots
+                } else {
+                    width_in_tiles
+                };
+                tile_id + (tile_row * stride + tile_col) as usize
+            } else {
+                // 2D: tiles laid out in a 32-tile wide virtual bitmap.
+                let stride = if is_8bpp { 16 } else { 32 };
+                tile_id + (tile_row as usize) * stride + tile_col as usize
+            };
+
+            // Get palette index from tile data.
+            let palette_index = if is_8bpp {
+                // 8bpp: 64 bytes per tile, 1 byte per pixel.
+                let addr = OBJ_VRAM_BASE + tile_offset * 32 + pixel_y * 8 + pixel_x;
+                vram.get(addr).copied().unwrap_or(0) as usize
+            } else {
+                // 4bpp: 32 bytes per tile, 4 bits per pixel.
+                let addr = OBJ_VRAM_BASE + tile_offset * 32 + pixel_y * 4 + pixel_x / 2;
+                let byte = vram.get(addr).copied().unwrap_or(0);
+                if pixel_x & 1 == 0 {
+                    (byte & 0x0F) as usize
+                } else {
+                    (byte >> 4) as usize
+                }
+            };
+
+            // Palette index 0 is transparent.
+            if palette_index == 0 {
+                continue;
+            }
+
+            // For OBJ Window mode, just set the mask bit.
+            if is_obj_window {
+                result.obj_window[sx] = true;
+                continue;
+            }
+
+            // First OBJ to write a pixel wins (lower OBJ number = higher priority).
+            if result.pixels[sx].opaque {
+                continue;
+            }
+
+            // Look up color from OBJ palette (starts at PRAM offset 0x200).
+            let pram_offset = if is_8bpp {
+                0x200 + palette_index * 2
+            } else {
+                0x200 + (palette_bank * 16 + palette_index) * 2
+            };
+
+            let bgr555 = if pram_offset + 1 < pram.len() {
+                u16::from_le_bytes([pram[pram_offset], pram[pram_offset + 1]])
+            } else {
+                0
+            };
+
+            result.pixels[sx] = ObjPixel {
+                color: bgr555,
+                opaque: true,
+                priority,
+                semi_transparent: is_semi_transparent,
+            };
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_oam() -> Vec<u8> {
+        vec![0u8; 1024]
+    }
+
+    fn make_vram() -> Vec<u8> {
+        vec![0u8; 96 * 1024]
+    }
+
+    fn make_pram() -> Vec<u8> {
+        vec![0u8; 1024]
+    }
+
+    /// Helper: write an OBJ_ATTR entry into OAM.
+    fn write_obj(oam: &mut [u8], idx: usize, attr0: u16, attr1: u16, attr2: u16) {
+        let base = idx * 8;
+        oam[base..base + 2].copy_from_slice(&attr0.to_le_bytes());
+        oam[base + 2..base + 4].copy_from_slice(&attr1.to_le_bytes());
+        oam[base + 4..base + 6].copy_from_slice(&attr2.to_le_bytes());
+    }
+
+    /// Helper: fill a 4bpp tile in OBJ VRAM with a single palette index.
+    fn fill_4bpp_tile(vram: &mut [u8], tile_id: usize, pal_idx: u8) {
+        let base = OBJ_VRAM_BASE + tile_id * 32;
+        let nibble_pair = pal_idx | (pal_idx << 4);
+        for i in 0..32 {
+            vram[base + i] = nibble_pair;
+        }
+    }
+
+    /// Helper: fill an 8bpp tile in OBJ VRAM with a single palette index.
+    fn fill_8bpp_tile(vram: &mut [u8], tile_id: usize, pal_idx: u8) {
+        let base = OBJ_VRAM_BASE + tile_id * 32;
+        for i in 0..64 {
+            vram[base + i] = pal_idx;
+        }
+    }
+
+    /// Helper: set an OBJ palette color.
+    fn set_obj_color(pram: &mut [u8], index: usize, bgr555: u16) {
+        let offset = 0x200 + index * 2;
+        pram[offset] = bgr555 as u8;
+        pram[offset + 1] = (bgr555 >> 8) as u8;
+    }
+
+    #[test]
+    fn empty_oam_produces_no_pixels() {
+        let oam = make_oam();
+        let vram = make_vram();
+        let pram = make_pram();
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        assert!(result.pixels.iter().all(|p| !p.opaque));
+        assert!(result.obj_window.iter().all(|&w| !w));
+    }
+
+    #[test]
+    fn hidden_obj_not_rendered() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // OBJ 0: hidden (obj_mode = 2 in attr0 bits 8-9).
+        // 8x8, at (100,0), 4bpp, tile 1.
+        let attr0 = 2 << 8; // y=0, obj_mode=2 (hidden)
+        let attr1 = 100; // x=100
+        let attr2 = 1; // tile 1
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+        fill_4bpp_tile(&mut vram, 1, 1);
+        set_obj_color(&mut pram, 1, 0x001F); // red
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        assert!(!result.pixels[100].opaque, "hidden OBJ should not render");
+    }
+
+    #[test]
+    fn basic_8x8_4bpp_sprite_renders() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // OBJ 0: 8x8, at (10, 5), 4bpp, tile 0, palette bank 0, priority 0.
+        let attr0 = 5; // y=5, normal mode, 4bpp, square shape
+        let attr1 = 10; // x=10, size=0 (8x8)
+        let attr2 = 0; // tile 0, priority 0, pal bank 0
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+
+        // Fill tile 0 with palette index 3.
+        fill_4bpp_tile(&mut vram, 0, 3);
+        // Set OBJ palette bank 0, color 3 = green.
+        set_obj_color(&mut pram, 3, 0x03E0);
+
+        // Render scanline 5 (first row of sprite).
+        let result = render_obj_scanline(5, &oam, &vram, &pram, true);
+
+        // Pixels 10-17 should be green.
+        for x in 10..18 {
+            assert!(result.pixels[x].opaque, "pixel {x} should be opaque");
+            assert_eq!(result.pixels[x].color, 0x03E0, "pixel {x} should be green");
+            assert_eq!(result.pixels[x].priority, 0);
+        }
+        // Pixel 9 should not be affected.
+        assert!(!result.pixels[9].opaque);
+        // Pixel 18 should not be affected.
+        assert!(!result.pixels[18].opaque);
+    }
+
+    #[test]
+    fn basic_8x8_8bpp_sprite_renders() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // OBJ 0: 8x8, at (0, 0), 8bpp (attr0 bit 13), tile 0.
+        let attr0 = 1 << 13; // y=0, 8bpp
+        let attr1 = 0; // x=0, size=0 (8x8)
+        let attr2 = 0; // tile 0
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+
+        // Fill tile 0 with palette index 5 (8bpp takes 2 s-tile slots).
+        fill_8bpp_tile(&mut vram, 0, 5);
+        // Set OBJ palette color 5 = blue.
+        set_obj_color(&mut pram, 5, 0x7C00);
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+
+        for x in 0..8 {
+            assert!(result.pixels[x].opaque, "pixel {x} should be opaque");
+            assert_eq!(result.pixels[x].color, 0x7C00, "pixel {x} should be blue");
+        }
+    }
+
+    #[test]
+    fn horizontal_flip_reverses_pixels() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // 8x8 sprite at (0,0), 4bpp, h-flip (attr1 bit 12).
+        let attr0 = 0;
+        let attr1 = 1 << 12; // h-flip
+        let attr2 = 0;
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+
+        // Fill tile 0: left half with index 1, right half with index 2.
+        let base = OBJ_VRAM_BASE;
+        for row in 0..8 {
+            for col in 0..4 {
+                let addr = base + row * 4 + col;
+                // 4bpp: 2 pixels per byte.
+                let px = col * 2;
+                if px < 4 {
+                    vram[addr] = 0x11; // index 1 for both nibbles
+                } else {
+                    vram[addr] = 0x22; // index 2 for both nibbles
+                }
+            }
+        }
+
+        set_obj_color(&mut pram, 1, 0x001F); // red
+        set_obj_color(&mut pram, 2, 0x03E0); // green
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+
+        // With h-flip, right side (index 2, green) appears on left.
+        // Pixel 0-3 should be green (was right side), 4-7 should be red (was left side).
+        assert_eq!(
+            result.pixels[0].color, 0x03E0,
+            "flipped: left should be green"
+        );
+        assert_eq!(
+            result.pixels[4].color, 0x001F,
+            "flipped: right should be red"
+        );
+    }
+
+    #[test]
+    fn vertical_flip_reverses_rows() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // 8x8 sprite at (0,0), 4bpp, v-flip (attr1 bit 13).
+        let attr0 = 0;
+        let attr1 = 1 << 13; // v-flip
+        let attr2 = 0;
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+
+        // Fill tile: row 0 with index 1, row 7 with index 2.
+        let base = OBJ_VRAM_BASE;
+        for col in 0..4 {
+            vram[base + col] = 0x11; // row 0: index 1
+            vram[base + 7 * 4 + col] = 0x22; // row 7: index 2
+        }
+
+        set_obj_color(&mut pram, 1, 0x001F); // red
+        set_obj_color(&mut pram, 2, 0x03E0); // green
+
+        // With v-flip, row 7 (index 2) becomes the top row (scanline 0).
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        assert_eq!(
+            result.pixels[0].color, 0x03E0,
+            "v-flip: scanline 0 should show row 7 data (green)"
+        );
+
+        // Scanline 7 should show original row 0 (index 1, red).
+        let result7 = render_obj_scanline(7, &oam, &vram, &pram, true);
+        assert_eq!(
+            result7.pixels[0].color, 0x001F,
+            "v-flip: scanline 7 should show row 0 data (red)"
+        );
+    }
+
+    #[test]
+    fn lower_obj_number_wins_same_pixel() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // OBJ 0: 8x8 at (0,0), tile 0, priority 0.
+        write_obj(&mut oam, 0, 0, 0, 0);
+        fill_4bpp_tile(&mut vram, 0, 1);
+        set_obj_color(&mut pram, 1, 0x001F); // red
+
+        // OBJ 1: 8x8 at (0,0), tile 1, priority 0.
+        write_obj(&mut oam, 1, 0, 0, 1);
+        fill_4bpp_tile(&mut vram, 1, 2);
+        set_obj_color(&mut pram, 2, 0x03E0); // green
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        // OBJ 0 wins (lower index).
+        assert_eq!(
+            result.pixels[0].color, 0x001F,
+            "OBJ 0 should win over OBJ 1"
+        );
+    }
+
+    #[test]
+    fn transparent_pixel_does_not_block() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // OBJ 0: 8x8 at (0,0), tile 0 — all transparent (palette index 0).
+        write_obj(&mut oam, 0, 0, 0, 0);
+        // Tile 0 left as zeros (transparent).
+
+        // OBJ 1: 8x8 at (0,0), tile 1 — opaque green.
+        write_obj(&mut oam, 1, 0, 0, 1);
+        fill_4bpp_tile(&mut vram, 1, 2);
+        set_obj_color(&mut pram, 2, 0x03E0);
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        // OBJ 0 is transparent, so OBJ 1 should show through.
+        assert_eq!(
+            result.pixels[0].color, 0x03E0,
+            "transparent OBJ 0 should not block OBJ 1"
+        );
+    }
+
+    #[test]
+    fn obj_window_sets_mask_not_pixel() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // OBJ 0: 8x8 at (100,0), gfx_mode=2 (OBJ Window), tile 1.
+        let attr0 = 2 << 10; // gfx_mode = 2
+        let attr1 = 100u16; // x=100
+        let attr2 = 1u16; // tile 1
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+        fill_4bpp_tile(&mut vram, 1, 1);
+        set_obj_color(&mut pram, 1, 0x001F);
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+
+        // OBJ Window should not produce visible pixels at x=100.
+        assert!(
+            !result.pixels[100].opaque,
+            "OBJ Window should not be visible"
+        );
+        // But should set the window mask.
+        assert!(result.obj_window[100], "OBJ Window should set mask bit");
+    }
+
+    #[test]
+    fn obj_2d_mapping_uses_32_tile_stride() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // 16x16 sprite (shape=0, size=1) at (0,0), 4bpp, tile 0.
+        let attr0 = 0; // square
+        let attr1 = 1 << 14; // size = 1 (16x16)
+        let attr2 = 0; // tile 0
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+
+        // In 2D mode with 4bpp, row 1 of tiles is at tile_id + 32.
+        // Fill tile at row 1, col 0 (offset 32) with palette index 3.
+        fill_4bpp_tile(&mut vram, 32, 3);
+        set_obj_color(&mut pram, 3, 0x7C00); // blue
+
+        // Scanline 8 = second tile row.
+        let result = render_obj_scanline(8, &oam, &vram, &pram, false);
+        assert!(
+            result.pixels[0].opaque,
+            "2D mapping should find tile at stride 32"
+        );
+        assert_eq!(result.pixels[0].color, 0x7C00);
+    }
+
+    #[test]
+    fn obj_1d_mapping_uses_width_stride() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // 16x16 sprite (shape=0, size=1) at (0,0), 4bpp, tile 0.
+        let attr0 = 0;
+        let attr1 = 1 << 14; // size = 1 (16x16)
+        let attr2 = 0; // tile 0
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+
+        // In 1D mode with 4bpp, 16px wide = 2 tiles. Row 1 at tile_id + 2.
+        fill_4bpp_tile(&mut vram, 2, 4);
+        set_obj_color(&mut pram, 4, 0x03E0); // green
+
+        // Scanline 8 = second tile row.
+        let result = render_obj_scanline(8, &oam, &vram, &pram, true);
+        assert!(
+            result.pixels[0].opaque,
+            "1D mapping should find tile at width stride"
+        );
+        assert_eq!(result.pixels[0].color, 0x03E0);
+    }
+
+    #[test]
+    fn sprite_wraps_y_at_256() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // OBJ at Y=252, 8x8. Should appear on scanlines 252-255 and 0-3.
+        let attr0 = 252u16; // y=252
+        write_obj(&mut oam, 0, attr0, 0, 0);
+        fill_4bpp_tile(&mut vram, 0, 1);
+        set_obj_color(&mut pram, 1, 0x001F);
+
+        // Scanline 0: relative Y = (0 - 252) & 0xFF = 4. 4 < 8, so visible.
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        assert!(
+            result.pixels[0].opaque,
+            "sprite at Y=252 should wrap to scanline 0"
+        );
+    }
+
+    #[test]
+    fn sprite_negative_x_partially_visible() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // Disable all OBJs by setting them to hidden mode, then enable just OBJ 0.
+        for i in 0..OBJ_COUNT {
+            write_obj(&mut oam, i, 2 << 8, 0, 0); // obj_mode=2 (hidden)
+        }
+
+        // OBJ 0: at X=508 (sign-extended: 508-512 = -4), Y=0, 8x8, tile 1.
+        let attr0 = 0;
+        let attr1 = 508u16; // 9-bit: 508, sign-extended = -4
+        let attr2 = 1u16; // tile 1
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+        fill_4bpp_tile(&mut vram, 1, 1);
+        set_obj_color(&mut pram, 1, 0x001F);
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+
+        // X=-4: pixels at screen 0,1,2,3 should be visible (sprite cols 4,5,6,7).
+        assert!(
+            result.pixels[0].opaque,
+            "partially visible sprite at negative X"
+        );
+        assert!(result.pixels[3].opaque);
+        // But only 4 pixels should be visible.
+        assert!(!result.pixels[4].opaque);
+    }
+
+    #[test]
+    fn priority_field_is_read_from_attr2() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // OBJ 0: priority 2 (attr2 bits 10-11 = 2).
+        let attr2 = 2 << 10;
+        write_obj(&mut oam, 0, 0, 0, attr2);
+        fill_4bpp_tile(&mut vram, 0, 1);
+        set_obj_color(&mut pram, 1, 0x001F);
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        assert_eq!(result.pixels[0].priority, 2);
+    }
+
+    #[test]
+    fn large_64x64_sprite_covers_area() {
+        let mut oam = make_oam();
+        let mut vram = make_vram();
+        let mut pram = make_pram();
+
+        // 64x64 (shape=0, size=3) at (0,0), 4bpp, tile 0, 1D mapping.
+        let attr0 = 0;
+        let attr1 = 3 << 14; // size = 3
+        let attr2 = 0;
+        write_obj(&mut oam, 0, attr0, attr1, attr2);
+
+        // Fill tile 0 only (first tile of row 0).
+        fill_4bpp_tile(&mut vram, 0, 1);
+        set_obj_color(&mut pram, 1, 0x001F);
+
+        let result = render_obj_scanline(0, &oam, &vram, &pram, true);
+        // First 8 pixels should be opaque (tile 0).
+        assert!(result.pixels[0].opaque);
+        assert!(result.pixels[7].opaque);
+    }
+}


### PR DESCRIPTION
## Summary

Implements regular (non-affine) OBJ sprite rendering for the GBA PPU, enabling sprites to display during the proprietary BIOS boot sequence and in games.

## Changes

- **New module** `src/gba/ppu/obj.rs`: Complete OBJ rendering pipeline
  - OAM attribute decoding for 128 entries (attr0/attr1/attr2)
  - All 12 sprite sizes (8x8 to 64x64) via shape/size lookup
  - 4bpp and 8bpp color modes with correct palette bank selection
  - Horizontal and vertical flip
  - 1D and 2D OBJ VRAM mapping (DISPCNT bit 6)
  - OBJ Window mode (gfx_mode=2) generates per-scanline mask
  - Priority-based rendering (lower OBJ number wins at same priority)

- **PPU integration** (`src/gba/ppu/mod.rs`):
  - Added OAM parameter to PPU step/render pipeline
  - Per-pixel BG priority tracking for correct OBJ compositing
  - OBJ overlay in all display modes (0-4)
  - `OBJ_MAPPING_1D` constant added to dispcnt module

- **Bus wiring** (`src/gba/bus/mod.rs`, `src/gba/bus/io.rs`):
  - Pass OAM slice to PPU step calls
  - Update test call sites

## Testing

- 15 new unit tests in obj.rs covering all rendering behaviors
- All 81 PPU tests pass (existing + new)
- Full test suite: 10120 tests pass
- Clippy clean, formatted

## Out of Scope (follow-up)

- Affine sprite rendering (rotation/scaling)
- Semi-transparent OBJ mode (alpha blending)
- Mosaic effect
- Per-scanline OBJ pixel limit

Closes #2425