### PR TITLE
fix(gba/apu): wire timer overflow to DMA FIFO replenishment

### DIFF
--- a/src/gba/apu/apu.rs
+++ b/src/gba/apu/apu.rs
@@ -861,11 +861,6 @@ impl Apu {
             if self.sample_acc >= self.cycles_per_sample {
                 self.sample_acc -= self.cycles_per_sample;
                 if self.pending_sample.is_none() {
-                    // Advance PCM FIFOs once per output sample.
-                    // NOTE: Full DMA/timer-driven FIFO advance will be wired
-                    // in Phase 4 (DMA controller integration).
-                    self.fifo_a.advance();
-                    self.fifo_b.advance();
                     self.pending_sample = Some(self.mix());
                 }
             }

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -394,7 +394,8 @@ impl GbaBus {
     /// cycles. Any pending IRQs are routed into [`Self::ic`]. PPU
     /// V-Blank/H-Blank edges are propagated to the DMA controller.
     pub fn step(&mut self, cycles: u32) {
-        self.timers.step(cycles, &mut self.ic);
+        let overflow_mask = self.timers.step(cycles, &mut self.ic);
+        self.handle_timer_overflow_fifo(overflow_mask);
         self.sio.step(cycles, &mut self.ic);
         self.apu.tick(cycles);
         let events = self.ppu.step(
@@ -415,7 +416,8 @@ impl GbaBus {
             if cycles == 0 {
                 break;
             }
-            self.timers.step(cycles, &mut self.ic);
+            let overflow_mask = self.timers.step(cycles, &mut self.ic);
+            self.handle_timer_overflow_fifo(overflow_mask);
             self.apu.tick(cycles);
             let events = self.ppu.step(
                 cycles,
@@ -439,6 +441,35 @@ impl GbaBus {
         }
         for _ in 0..events.hblank_starts {
             self.notify_hblank();
+        }
+    }
+
+    /// When a timer overflows, advance the corresponding FIFO sample and
+    /// request DMA replenishment if the FIFO is running low.
+    ///
+    /// Per GBATek: SOUNDCNT_H bit 10 selects the timer for FIFO A (0=TM0, 1=TM1),
+    /// and bit 14 selects the timer for FIFO B.
+    fn handle_timer_overflow_fifo(&mut self, overflow_mask: u8) {
+        if overflow_mask == 0 {
+            return;
+        }
+
+        let soundcnt_h = self.apu.soundcnt_h;
+        let fifo_a_timer = if soundcnt_h & 0x0400 != 0 { 1 } else { 0 };
+        let fifo_b_timer = if soundcnt_h & 0x4000 != 0 { 1 } else { 0 };
+
+        if overflow_mask & (1 << fifo_a_timer) != 0 {
+            self.apu.fifo_a.advance();
+            if self.apu.fifo_a.len() <= 16 {
+                self.dma.notify_fifo(0);
+            }
+        }
+
+        if overflow_mask & (1 << fifo_b_timer) != 0 {
+            self.apu.fifo_b.advance();
+            if self.apu.fifo_b.len() <= 16 {
+                self.dma.notify_fifo(1);
+            }
         }
     }
 
@@ -1841,5 +1872,50 @@ mod tests {
             !bus.halt_requested(),
             "write32 with HALTCNT byte 0x80 → stop mode"
         );
+    }
+
+    #[test]
+    fn timer_overflow_advances_fifo_a_and_triggers_dma() {
+        // Configure FIFO A to use Timer 0 (SOUNDCNT_H bit 10 = 0).
+        let mut bus = GbaBus::new();
+
+        // Push some samples into FIFO A.
+        bus.apu.fifo_a.push(10);
+        bus.apu.fifo_a.push(20);
+        bus.apu.fifo_a.push(30);
+        assert_eq!(bus.apu.fifo_a.current, 0); // not yet advanced
+
+        // SOUNDCNT_H: FIFO A uses timer 0 (bit 10 = 0), enable A right (bit 8).
+        bus.apu.soundcnt_h = 0x0100;
+
+        // Set Timer 0 reload to 0xFFFF and enable (overflows after 1 tick at prescaler=1).
+        bus.timers.write_cnt_l(0, 0xFFFF);
+        bus.timers.write_cnt_h(0, 0x0080); // enable, prescaler=1
+
+        // Step 1 cycle — should overflow TM0 and advance FIFO A.
+        bus.step(1);
+
+        assert_eq!(bus.apu.fifo_a.current, 10, "FIFO A should have advanced");
+    }
+
+    #[test]
+    fn timer1_overflow_advances_fifo_b_when_configured() {
+        // Configure FIFO B to use Timer 1 (SOUNDCNT_H bit 14 = 1).
+        let mut bus = GbaBus::new();
+
+        bus.apu.fifo_b.push(42);
+        bus.apu.fifo_b.push(43);
+        assert_eq!(bus.apu.fifo_b.current, 0);
+
+        // SOUNDCNT_H: FIFO B uses timer 1 (bit 14 = 1), enable B right (bit 12).
+        bus.apu.soundcnt_h = 0x5000; // bit 14 + bit 12
+
+        // Enable Timer 1 to overflow immediately.
+        bus.timers.write_cnt_l(1, 0xFFFF);
+        bus.timers.write_cnt_h(1, 0x0080);
+
+        bus.step(1);
+
+        assert_eq!(bus.apu.fifo_b.current, 42, "FIFO B should have advanced");
     }
 }

--- a/src/gba/bus/timer.rs
+++ b/src/gba/bus/timer.rs
@@ -105,7 +105,9 @@ impl Timers {
 
     /// Advance all timers by `cycles` CPU cycles. Any overflows are routed to
     /// the supplied [`InterruptController`].
-    pub fn step(&mut self, cycles: u32, ic: &mut InterruptController) {
+    ///
+    /// Returns a bitmask of timers that overflowed (bit 0 = TM0, bit 1 = TM1, etc.).
+    pub fn step(&mut self, cycles: u32, ic: &mut InterruptController) -> u8 {
         // Track per-timer overflow counts so cascade can chain through TM1..TM3.
         let mut overflows = [0u32; 4];
         for (i, t) in self.channels.iter_mut().enumerate() {
@@ -138,11 +140,16 @@ impl Timers {
             overflows[i] = advance_ticks(t, cascade_ticks);
         }
         // Raise IRQs for timers whose overflow IRQ bit is set.
+        let mut overflow_mask = 0u8;
         for i in 0..4 {
-            if overflows[i] > 0 && self.channels[i].irq_on_overflow() {
-                ic.raise(TIMER_IRQ_BITS[i]);
+            if overflows[i] > 0 {
+                overflow_mask |= 1 << i;
+                if self.channels[i].irq_on_overflow() {
+                    ic.raise(TIMER_IRQ_BITS[i]);
+                }
             }
         }
+        overflow_mask
     }
 }
 

--- a/src/gba/ppu/obj.rs
+++ b/src/gba/ppu/obj.rs
@@ -78,6 +78,7 @@ fn obj_size(shape: u8, size: u8) -> (u32, u32) {
 /// Given a pixel coordinate (`pixel_col`, `pixel_row`) in sprite-local space,
 /// looks up the tile data considering mapping mode and color depth.
 /// Returns the palette index (0 = transparent).
+#[allow(clippy::too_many_arguments)]
 fn fetch_obj_pixel(
     tile_id: usize,
     obj_width: u32,


### PR DESCRIPTION
## Summary

Fixes missing audio during the GBA proprietary BIOS boot animation. Timer overflows now trigger DMA FIFO sample advance and replenishment for Direct Sound channels A and B.

## Root Cause

`Timers::step()` raised IRQs on overflow but never notified the DMA controller to refill the audio FIFOs. The APU had a placeholder that auto-advanced FIFOs every output sample (incorrect — should only advance on timer overflow).

## Changes

- **timer.rs**: `Timers::step()` now returns a `u8` overflow bitmask (bit per timer)
- **bus/mod.rs**: New `handle_timer_overflow_fifo()` checks SOUNDCNT_H bits 10/14 to determine which timer drives FIFO A/B, advances the FIFO sample, and triggers DMA refill when buffer is half-empty
- **apu.rs**: Removed incorrect placeholder auto-advance from APU tick

## Testing

- 2 new unit tests: timer0→FIFO A and timer1→FIFO B wiring
- All 10147 existing tests pass
- Clippy clean, fmt clean

## References

- GBATek DMA Sound: https://problemkaputt.de/gbatek.htm#gbasoundchannelaandbdmasound
- GBATek Sound Controller: https://problemkaputt.de/gbatek.htm#gbasoundcontroller

Closes #2433