### PR TITLE
Fix GBA DMA Game Pak access masks

### DIFF
--- a/src/gba/bus/dma.rs
+++ b/src/gba/bus/dma.rs
@@ -43,6 +43,10 @@ const DMA_IRQ_BITS: [u16; NUM_CHANNELS] = [
     irq_bits::DMA3,
 ];
 
+const DMA_SOURCE_MASKS: [u32; NUM_CHANNELS] = [0x07FF_FFFE, 0x0FFF_FFFE, 0x0FFF_FFFE, 0x0FFF_FFFE];
+const DMA_DESTINATION_MASKS: [u32; NUM_CHANNELS] =
+    [0x07FF_FFFE, 0x07FF_FFFE, 0x07FF_FFFE, 0x0FFF_FFFE];
+
 /// Sound FIFO A address — destination for channel 1 in Special mode.
 pub const REG_FIFO_A: u32 = 0x0400_00A0;
 /// Sound FIFO B address — destination for channel 2 in Special mode.
@@ -284,6 +288,8 @@ impl DmaController {
             }
             _ => {}
         }
+        c.sad &= DMA_SOURCE_MASKS[chan];
+        c.dad &= DMA_DESTINATION_MASKS[chan];
         true
     }
 
@@ -323,10 +329,12 @@ impl DmaController {
                 // Re-use the halfword path so enable rising-edge detection
                 // and pending-arming kick in correctly.
                 let merged = (((c.cnt_h as u32) & mask) | byte) as u16;
-                self.write16(addr & !1, merged);
+                return self.write16(addr & !1, merged);
             }
             _ => {}
         }
+        c.sad &= DMA_SOURCE_MASKS[chan];
+        c.dad &= DMA_DESTINATION_MASKS[chan];
         true
     }
 
@@ -991,8 +999,9 @@ mod tests {
         d.write8(0x0400_00B1, 0x34); // SAD[15:8]
         d.write8(0x0400_00B2, 0x56); // SAD[23:16]
         d.write8(0x0400_00B3, 0x78); // SAD[31:24]
-        assert_eq!(d.channels[0].sad, 0x7856_3412);
-        // Same for DAD and CNT_L.
+        assert_eq!(d.channels[0].sad, 0x7856_3412 & DMA_SOURCE_MASKS[0]);
+        // Same for DAD and CNT_L. Address registers preserve byte writes
+        // within the hardware-visible masked address range.
         d.write8(0x0400_00B4, 0xAA);
         d.write8(0x0400_00B5, 0xBB);
         assert_eq!(d.channels[0].dad & 0xFFFF, 0xBBAA);

--- a/src/gba/bus/dma.rs
+++ b/src/gba/bus/dma.rs
@@ -43,6 +43,10 @@ const DMA_IRQ_BITS: [u16; NUM_CHANNELS] = [
     irq_bits::DMA3,
 ];
 
+// GBATek "DMA Transfer Channels": DMA0 source/destination are internal-memory
+// only (27 address bits), DMA1/2 sources may use the full 28-bit bus but their
+// destinations are internal-memory only, and DMA3 may use the full 28-bit bus
+// for both. Bit 0 is always cleared because GBA DMA is 16/32-bit aligned.
 const DMA_SOURCE_MASKS: [u32; NUM_CHANNELS] = [0x07FF_FFFE, 0x0FFF_FFFE, 0x0FFF_FFFE, 0x0FFF_FFFE];
 const DMA_DESTINATION_MASKS: [u32; NUM_CHANNELS] =
     [0x07FF_FFFE, 0x07FF_FFFE, 0x07FF_FFFE, 0x0FFF_FFFE];

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -1614,6 +1614,64 @@ mod tests {
         assert_eq!(&bus.sram_snapshot()[..3], b"NES");
     }
 
+    fn write_dma_registers(
+        bus: &mut GbaBus,
+        channel: u32,
+        source: u32,
+        destination: u32,
+        count: u16,
+        cnt_h: u16,
+    ) {
+        let base = 0x0400_00B0 + channel * 12;
+        bus.write32(base, source);
+        bus.write32(base + 4, destination);
+        bus.write16(base + 8, count);
+        bus.write16(base + 10, cnt_h);
+    }
+
+    #[test]
+    fn dma0_source_masks_game_pak_rom_to_internal_memory() {
+        let mut bus = GbaBus::new();
+        bus.load_bios(&0x1122_3344u32.to_le_bytes());
+        bus.load_rom(&0xAABB_CCDDu32.to_le_bytes());
+        bus.write32(0x0200_0000, 0);
+
+        write_dma_registers(&mut bus, 0, 0x0800_0000, 0x0200_0000, 1, 0x8000 | 0x0400);
+
+        assert_eq!(bus.read32(0x0200_0000), 0x1122_3344);
+    }
+
+    #[test]
+    fn dma0_to_dma2_destination_masks_game_pak_sram_to_internal_memory() {
+        for channel in 0..=2 {
+            let mut bus = GbaBus::new();
+            bus.write32(0x0200_0000, 0xD8D8_D8D8);
+            bus.write8(0x0E00_0000, 0x66);
+
+            write_dma_registers(
+                &mut bus,
+                channel,
+                0x0200_0000,
+                0x0E00_0000,
+                1,
+                0x8000 | 0x0400,
+            );
+
+            assert_eq!(bus.read32(0x0E00_0000), 0x6666_6666);
+        }
+    }
+
+    #[test]
+    fn dma3_destination_can_reach_game_pak_sram() {
+        let mut bus = GbaBus::new();
+        bus.write32(0x0200_0000, 0xD8D8_D8D8);
+        bus.write8(0x0E00_0000, 0x66);
+
+        write_dma_registers(&mut bus, 3, 0x0200_0000, 0x0E00_0000, 1, 0x8000 | 0x0400);
+
+        assert_eq!(bus.read32(0x0E00_0000), 0xD8D8_D8D8);
+    }
+
     #[test]
     fn dma_immediate_fires_via_cpu_io_writes() {
         // Acceptance: CPU programs DMA via I/O writes; transfer happens

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -43,11 +43,11 @@ armwrestler_page7=0x562A5C65
 # mgba-emu/suite (https://github.com/mgba-emu/suite)
 # 14 sub-suites exercising memory, I/O, timing, shifter, carry, multiply,
 # BIOS math, DMA, SIO, misc edge cases, and video.
-# Scores (passing/total): Memory 1379/1552, I/O read 83/130, Timing 378/2020,
+# Scores (passing/total, embedded BIOS): Memory 1439/1552, I/O read 83/130, Timing 378/2020,
 # Timers 356/936, Timer IRQ 0/90, Shifter 140/140, Carry 93/93,
 # Multiply long 72/72, BIOS math 615/615, DMA 1040/1256, SIO read 90/90,
 # SIO timing 0/4, Misc. edge 3/12, Video (sub-menu only).
-mgba_memory=0x22984983
+mgba_memory=0x7588A3AE
 mgba_io_read=0x5A3CD2D5
 mgba_timing=0x71629F50
 mgba_timers=0xCA2894C9

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -332,7 +332,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("armwrestler_page7"), Some(&0x562A_5C65));
 
     // mgba-emu/suite keys
-    assert_eq!(approvals.get("mgba_memory"), Some(&0x2298_4983));
+    assert_eq!(approvals.get("mgba_memory"), Some(&0x7588_A3AE));
     assert_eq!(approvals.get("mgba_io_read"), Some(&0x5A3C_D2D5));
     assert_eq!(approvals.get("mgba_timing"), Some(&0x7162_9F50));
     assert_eq!(approvals.get("mgba_timers"), Some(&0xCA28_94C9));


### PR DESCRIPTION
## Summary

- Mask GBA DMA source and destination address latches per channel so invalid Game Pak accesses resolve like hardware.
- Add focused regressions for DMA0 Game Pak ROM source masking, DMA0-2 SRAM destination masking, and the DMA3 SRAM destination guard.
- Update the mGBA Memory diagnostic approval after the embedded BIOS score improves from 1379/1552 to 1439/1552.

Fixes #2555

## Validation

- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/test-dir.sh src/gba --skip-integration: 905 passed, 0 failed, 2 ignored
- cargo test --no-default-features --lib: 10375 passed, 0 failed, 30 ignored
- wasm-pack test --headless --chrome --no-default-features --features wasm: 54 passed
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py": 179, 105, and 44 passed
- npm test: 298 passed
- cargo test --no-default-features gba_mgba_memory_diagnostics_reports_mgba_log -- --nocapture: passed with CRC 0x7588A3AE and END: 1439/1552
