### PR TITLE
Fix GBA CPU LDR/LDRH/LDRSB/LDRSH to PC cycle timing (2S+2N+1I)

### DIFF
--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -643,13 +643,13 @@ fn execute_single_data_transfer<B: Bus>(
     }
 
     if result_branch {
-        // LDR PC: 2S(code) + 1N(data) + 1I
+        // LDR PC: 2S(code) + 1N(code) + 1N(data) + 1I
         let width = if b_byte {
             WidthClass::HalfwordOrByte
         } else {
             WidthClass::Word
         };
-        ExecOutcome::branch_data_access(2, 0, 1, 0, 1, addr, width)
+        ExecOutcome::branch_data_access(2, 1, 1, 0, 1, addr, width)
     } else if l {
         // LDR: 1S(code) + 1N(data) + 1I
         let width = if b_byte {
@@ -1073,8 +1073,8 @@ fn execute_halfword_transfer<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u
     }
 
     if result_branch {
-        // LDRH PC: 2S(code) + 1N(data) + 1I
-        ExecOutcome::branch_data_access(2, 0, 1, 0, 1, addr, WidthClass::HalfwordOrByte)
+        // LDRH PC: 2S(code) + 1N(code) + 1N(data) + 1I
+        ExecOutcome::branch_data_access(2, 1, 1, 0, 1, addr, WidthClass::HalfwordOrByte)
     } else if l {
         // LDRH/LDRSB/LDRSH: 1S(code) + 1N(data) + 1I
         ExecOutcome::data_access(1, 0, 1, 0, 1, addr, WidthClass::HalfwordOrByte)
@@ -2743,6 +2743,42 @@ mod tests {
         assert_eq!(outcome.data_nonseq, 1, "LDR should have 1N(data)");
         assert_eq!(outcome.internal, 1, "LDR should have 1I");
         assert_eq!(outcome.total_flat_cycles(), 3);
+    }
+
+    /// ARM LDR PC: 2S + 2N + 1I per GBATek (one extra N vs normal LDR).
+    #[test]
+    fn arm_ldr_pc_sni_is_2s_2n_1i() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40;
+        bus.write32(0x40, 0x50);
+        // LDR R15, [R1] (immediate offset 0)
+        let instr = 0xE591_F000;
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(outcome.branched, "LDR PC should be a branch");
+        assert_eq!(outcome.seq, 2, "LDR PC should be 2S(code)");
+        assert_eq!(outcome.nonseq, 1, "LDR PC should have 1N(code)");
+        assert_eq!(outcome.data_nonseq, 1, "LDR PC should have 1N(data)");
+        assert_eq!(outcome.internal, 1, "LDR PC should have 1I");
+        assert_eq!(outcome.total_flat_cycles(), 5, "LDR PC total: 2S+2N+1I=5");
+    }
+
+    /// ARM LDRH PC: 2S + 2N + 1I per GBATek (one extra N vs normal LDRH).
+    #[test]
+    fn arm_ldrh_pc_sni_is_2s_2n_1i() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        regs.r[1] = 0x40;
+        bus.write16(0x40, 0x50);
+        // LDRH R15, [R1] — P=1, U=1, W=0, L=1, S=0, H=1, Rd=15
+        let instr = arm_halfword_imm(0xE, true, true, false, true, 1, 15, false, true, 0);
+        let outcome = execute(&mut regs, &mut bus, instr);
+        assert!(outcome.branched, "LDRH PC should be a branch");
+        assert_eq!(outcome.seq, 2, "LDRH PC should be 2S(code)");
+        assert_eq!(outcome.nonseq, 1, "LDRH PC should have 1N(code)");
+        assert_eq!(outcome.data_nonseq, 1, "LDRH PC should have 1N(data)");
+        assert_eq!(outcome.internal, 1, "LDRH PC should have 1I");
+        assert_eq!(outcome.total_flat_cycles(), 5, "LDRH PC total: 2S+2N+1I=5");
     }
 
     /// ARM STR: 2N per GBATek.


### PR DESCRIPTION
## Summary

Fixes #2562.

LDR, LDRH, LDRSB, and LDRSH instructions that load into PC (R15) were
reporting 2S+1N+1I but GBATek specifies 2S+2N+1I.

## Root Cause

Both execute_single_data_transfer and execute_halfword_transfer called
branch_data_access(2, 0, 1, 0, 1, ...) with code_nonseq=0. The
pipeline refill after a load-to-PC requires one non-sequential code
cycle, matching the pattern used by ARM branch instructions
(branch_sni(2, 1, 0)).

## Changes

- arm.rs line 652 (LDR/LDRB PC): code_nonseq 0 → 1
- arm.rs line 1077 (LDRH/LDRSB/LDRSH PC): code_nonseq 0 → 1
- Two new unit tests locking the correct 2S+2N+1I timing

## Validation

- New tests arm_ldr_pc_sni_is_2s_2n_1i and arm_ldrh_pc_sni_is_2s_2n_1i pass
- All 152 GBA CPU unit tests pass
- Full test suite: 10454 passed, 0 failed
- clippy, fmt, wasm-pack, Python, and npm checks all clean