### PR TITLE
Fix mealybug m3_obp0_change CGB-C rendering

### DIFF
--- a/references/retrospective-neser.md
+++ b/references/retrospective-neser.md
@@ -182,3 +182,40 @@ No feedback provided.
 #### What to improve
 
 No feedback provided.
+
+---
+
+## 2026-05-20 — PR #2581: Fix mealybug m3_obp0_change CGB-C rendering
+
+**Repository:** rmstdope/neser
+**PR URL:** https://github.com/rmstdope/neser/pull/2581
+**Linked issues:** #2580
+
+### Customizations used
+
+| Type | Name | Purpose |
+| --- | --- | --- |
+| Skill | `gb-hardware-research` | Guided model-specific GB/CGB PPU behavior investigation. |
+| Skill | `bug-hunter` | Supported focused bug diagnosis and regression-oriented fix validation. |
+| Skill | `test-driven-development` | Guided RED/GREEN/REFACTOR workflow and reference CRC activation. |
+| Skill | `rust-developer` | Supported Rust implementation and required check validation. |
+| Agent | `code-review` | Provided fallback changed-file review before PR handoff. |
+| Agent | `Iteration Retrospective Gatherer` | Produced the retrospective content after PR creation; manual append was required. |
+| Instructions | Repository workflow instructions | Applied issue assignment, branch, TDD, validation, and PR workflow expectations. |
+
+### What went well
+
+- The selected skills matched the problem well: `gb-hardware-research` was appropriate for CGB-C DMG-compat PPU palette behavior, while `bug-hunter` and `test-driven-development` anchored the fix in reproducible coverage.
+- Activating the Mealybug `m3_obp0_change` CGB-C reference CRC `0x7484_BAF1` created a hardware-test regression guard for the exact edge case being fixed.
+- Focused OBP0/OBP1 unit tests complemented the Mealybug acceptance test, giving both narrow behavior coverage and high-level compatibility validation.
+- The `code-review` fallback agent found one useful test isolation improvement before the PR handoff.
+
+### What to improve
+
+- The retrospective agent could generate the entry but could not write the file directly. Keep the manual append step in mind when the agent reports that limitation.
+- For future GB PPU timing/palette fixes, capture the exact edge-behavior rationale in the code or PR when the fix is made, especially when model-specific CGB-C behavior changes at an OBJ fetch boundary.
+- The workflow involved several active skills. Summarizing each skill's concrete contribution before PR creation made the retrospective more reliable and should remain part of future handoffs.
+
+### Navigator feedback
+
+Pending — navigator unavailable during retrospective collection.

--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -447,7 +447,14 @@ fn test_m3_lcdc_win_map_change2_cgb_c() {
     const EXPECTED_CRC: u32 = 0x0A03_88F2;
     assert_mealybug_crc("m3_lcdc_win_map_change2_cgb_c", crc, EXPECTED_CRC);
 }
-mealybug_ignored_cgb_c!(test_m3_obp0_change_cgb_c, "m3_obp0_change", "2580");
+#[test]
+fn test_m3_obp0_change_cgb_c() {
+    let bytes = read_rom_from_zip("m3_obp0_change.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m3_obp0_change_cgb_c");
+    const EXPECTED_CRC: u32 = 0x7484_BAF1;
+    assert_mealybug_crc("m3_obp0_change_cgb_c", crc, EXPECTED_CRC);
+}
 #[test]
 fn test_m3_scx_high_5_bits_cgb_c() {
     let bytes = read_rom_from_zip("m3_scx_high_5_bits.gb");

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -1232,11 +1232,12 @@ impl PixelFifoRenderer {
         self.obp0_edge_active = true;
         self.obp0_edge_x = self.next_x;
         // Unlike BGP (which affects background pixels), OBP0 affects sprite pixels.
-        // The model-specific timing rule applies regardless of whether a sprite
-        // fetch is in progress: CGB-D picks up the new value immediately;
-        // CGB-C latches it one pixel late (uses the previous value).
+        // If an OBJ fetch is delaying this pixel, the OBP write lands before
+        // the pixel is pushed to LCD, so the delayed pixel sees the new value.
+        // Otherwise CGB-D picks up the new value immediately; CGB-C latches it
+        // one pixel late (uses the previous value).
         // At pixel 0 the write always takes effect immediately on all models.
-        self.obp0_edge_value = if self.next_x == 0 {
+        self.obp0_edge_value = if self.next_x == 0 || self.is_waiting_on_obj_fetch() {
             new
         } else {
             match cgb_model {
@@ -1263,7 +1264,7 @@ impl PixelFifoRenderer {
 
         self.obp1_edge_active = true;
         self.obp1_edge_x = self.next_x;
-        self.obp1_edge_value = if self.next_x == 0 {
+        self.obp1_edge_value = if self.next_x == 0 || self.is_waiting_on_obj_fetch() {
             new
         } else {
             match cgb_model {
@@ -6377,6 +6378,7 @@ mod tests {
         let mut renderer = PixelFifoRenderer::new();
         renderer.active = true;
         renderer.next_x = 0;
+        renderer.obj_stall_events.clear();
         renderer.pending_obj_stall_dots = 1;
 
         renderer.record_lcdc_write(0x93, 0x92, 0, true, true);
@@ -6585,7 +6587,9 @@ mod tests {
             &mut screen_buffer,
         );
 
-        // Record OBP0 write (prev=0xE4→white, new=0x00→black) — CGB-C model
+        // Record OBP0 write with no OBJ fetch delay (prev=0xE4→white, new=0x00→black).
+        renderer.pending_obj_stall_dots = 0;
+        renderer.obj_stall_events.clear();
         renderer.record_obp0_write(0xE4, 0x00, true, true, CgbModel::CgbC);
         registers.obp0 = 0x00;
 
@@ -6604,6 +6608,52 @@ mod tests {
             screen_buffer.get_pixel(8, 0),
             (255, 255, 255),
             "CGB-C: OBP0 write at the pixel boundary should use the *previous* palette value"
+        );
+    }
+
+    #[test]
+    fn cgb_c_obp0_write_during_obj_fetch_delay_uses_new_value_at_delayed_pixel() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0x83;
+        registers.bgp = 0x00;
+        registers.obp0 = 0xE4;
+        let oam = oam_with_sprite_at(16, 16, 1, 0);
+        let vram = vram_with_solid_obj_tile();
+        let mut screen_buffer = ScreenBuffer::new();
+
+        renderer.begin_scanline(0, 80, &oam, &registers, true, true);
+        let mut dot = 80u16;
+
+        tick_cgb_compat_until_next_x(
+            &mut renderer,
+            &mut dot,
+            8,
+            &vram,
+            &oam,
+            &registers,
+            &mut screen_buffer,
+        );
+
+        renderer.obj_stall_events.clear();
+        renderer.pending_obj_stall_dots = 1;
+        renderer.record_obp0_write(0xE4, 0x00, true, true, CgbModel::CgbC);
+        registers.obp0 = 0x00;
+
+        tick_cgb_compat_until_next_x(
+            &mut renderer,
+            &mut dot,
+            9,
+            &vram,
+            &oam,
+            &registers,
+            &mut screen_buffer,
+        );
+
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (0, 0, 0),
+            "CGB-C: OBP0 writes during OBJ fetch delay should affect the delayed pixel"
         );
     }
 
@@ -6698,7 +6748,9 @@ mod tests {
             assert!(dot < deadline, "renderer did not reach next_x=8");
         }
 
-        // Record OBP1 write (prev=0xE4→white, new=0x00→black) — CGB-C model
+        // Record OBP1 write with no OBJ fetch delay (prev=0xE4→white, new=0x00→black).
+        renderer.pending_obj_stall_dots = 0;
+        renderer.obj_stall_events.clear();
         renderer.record_obp1_write(0xE4, 0x00, true, true, CgbModel::CgbC);
         registers.obp1 = 0x00;
 
@@ -6727,6 +6779,78 @@ mod tests {
             screen_buffer.get_pixel(8, 0),
             (255, 255, 255),
             "CGB-C: OBP1 write at the pixel boundary should use the *previous* palette value"
+        );
+    }
+
+    #[test]
+    fn cgb_c_obp1_write_during_obj_fetch_delay_uses_new_value_at_delayed_pixel() {
+        let mut renderer = PixelFifoRenderer::new();
+        let mut registers = Registers::new();
+        registers.lcdc = 0x83;
+        registers.bgp = 0x00;
+        registers.obp0 = 0x00;
+        registers.obp1 = 0xE4;
+        let mut obj_palette_ram = [0u8; 64];
+        obj_palette_ram[10] = 0xFF;
+        obj_palette_ram[11] = 0x7F;
+
+        let oam = oam_with_sprite_at(16, 16, 1, 0x10);
+        let vram = vram_with_solid_obj_tile();
+        let vram_bank1 = [0u8; 0x2000];
+        let bg_palette_ram = [0u8; 64];
+        let mut screen_buffer = ScreenBuffer::new();
+
+        renderer.begin_scanline(0, 80, &oam, &registers, true, true);
+        let mut dot = 80u16;
+
+        let deadline = dot.saturating_add(512);
+        while renderer.next_x < 8 {
+            renderer.tick(
+                dot,
+                &vram,
+                &vram_bank1,
+                &oam,
+                &registers,
+                &bg_palette_ram,
+                &obj_palette_ram,
+                0,
+                true,
+                false,
+                true,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(dot < deadline, "renderer did not reach next_x=8");
+        }
+
+        renderer.pending_obj_stall_dots = 1;
+        renderer.record_obp1_write(0xE4, 0x00, true, true, CgbModel::CgbC);
+        registers.obp1 = 0x00;
+
+        let deadline = dot.saturating_add(512);
+        while renderer.next_x < 9 {
+            renderer.tick(
+                dot,
+                &vram,
+                &vram_bank1,
+                &oam,
+                &registers,
+                &bg_palette_ram,
+                &obj_palette_ram,
+                0,
+                true,
+                false,
+                true,
+                &mut screen_buffer,
+            );
+            dot = dot.saturating_add(1);
+            assert!(dot < deadline, "renderer did not reach next_x=9");
+        }
+
+        assert_eq!(
+            screen_buffer.get_pixel(8, 0),
+            (0, 0, 0),
+            "CGB-C: OBP1 writes during OBJ fetch delay should affect the delayed pixel"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #2580.

This activates the Mealybug CGB-C m3_obp0_change regression against the real reference CRC and fixes OBP0/OBP1 edge handling for CGB DMG-compat sprites delayed by OBJ fetch stalls.

## Changes

- Enables test_m3_obp0_change_cgb_c with reference CRC 0x7484_BAF1.
- Makes OBP0 and OBP1 writes during OBJ fetch delay affect the delayed pixel on CGB-C.
- Keeps CGB-C non-delayed write-boundary behavior and CGB-D immediate behavior covered by unit tests.

## Validation

- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- ./scripts/test-dir.sh src/gb/ppu src/gb/integration_tests
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test
- NESER_CAPTURE_SCREEN=1 cargo test --no-default-features --lib m3_obp0_change -- --nocapture
- compare -metric AE target/mealybug-captures/m3_obp0_change_cgb_c.png roms/gb/automated_tests/mealybug-tearoom-tests/expected/CPU CGB C/m3_obp0_change.png /dev/null returned 0
