### PR TITLE
Fix CGB m2_win_en_toggle interrupt timing

### DIFF
--- a/src/gb/cpu/sm83.rs
+++ b/src/gb/cpu/sm83.rs
@@ -600,10 +600,11 @@ impl<B: GbBus> Sm83<B> {
         self.bus.notify_idu_glitch(sp0);
         self.write(self.regs.sp, pc_hi);
 
-        // Re-read IE after the high-byte push: if SP landed on $FFFF (the IE
-        // register), the push just overwrote IE.  Recompute the live interrupt
-        // queue with the new IE against the *original* IF (not yet cleared).
-        let mut interrupt_queue = self.bus.read(0xFFFF) & if_ & 0x1F;
+        // Re-read IE and IF after the high-byte push: if SP landed on $FFFF
+        // (IE), or a higher-priority interrupt became pending during dispatch,
+        // the vector selection uses the live queue rather than the queue that
+        // originally accepted the interrupt.
+        let mut interrupt_queue = self.bus.read(0xFFFF) & self.bus.read(0xFF0F) & 0x1F;
 
         // Push PC low byte onto the stack (M4).
         let sp1 = self.regs.sp;
@@ -1342,6 +1343,39 @@ mod tests {
         }
     }
 
+    struct LateInterruptBus {
+        mem: [u8; 0x10000],
+        ticks: u8,
+    }
+
+    impl LateInterruptBus {
+        fn new() -> Self {
+            let mut mem = [0u8; 0x10000];
+            mem[0xFFFF] = 0x03; // IE: VBlank + STAT enabled
+            mem[0xFF0F] = 0x02; // IF: STAT pending at dispatch start
+            Self { mem, ticks: 0 }
+        }
+    }
+
+    impl GbBus for LateInterruptBus {
+        fn read(&mut self, addr: u16) -> u8 {
+            self.mem[addr as usize]
+        }
+
+        fn write(&mut self, addr: u16, val: u8) {
+            self.mem[addr as usize] = val;
+        }
+
+        fn tick(&mut self, m_cycles: u8) {
+            for _ in 0..m_cycles {
+                self.ticks = self.ticks.saturating_add(1);
+                if self.ticks == 3 {
+                    self.mem[0xFF0F] |= 0x01; // VBlank becomes pending during dispatch
+                }
+            }
+        }
+    }
+
     impl GbBus for WritePhaseSpyBus {
         fn read(&mut self, addr: u16) -> u8 {
             self.mem[addr as usize]
@@ -1959,6 +1993,26 @@ mod tests {
             new_if & 0x01,
             0,
             "VBlank IF bit should be cleared after dispatch"
+        );
+    }
+
+    #[test]
+    fn test_interrupt_dispatch_uses_late_higher_priority_request() {
+        let mut cpu = Sm83::new(LateInterruptBus::new());
+        cpu.ime = true;
+        cpu.regs.pc = 0x1000;
+        cpu.regs.sp = 0xFFFE;
+
+        cpu.execute();
+
+        assert_eq!(
+            cpu.regs.pc, 0x0040,
+            "A higher-priority VBlank request that appears during dispatch should win over the initially pending STAT request"
+        );
+        assert_eq!(
+            cpu.bus.mem[0xFF0F] & 0x03,
+            0x02,
+            "Dispatch should clear only VBlank IF and leave the original STAT request pending"
         );
     }
 

--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -292,7 +292,14 @@ mealybug_ignored_dmg_b!(test_m3_wx_6_change_dmg_b, "m3_wx_6_change", "2579");
 // CGB-C tests (reference: expected/CPU CGB C/)
 // ============================================================================
 
-mealybug_ignored_cgb_c!(test_m2_win_en_toggle_cgb_c, "m2_win_en_toggle", "2576");
+#[test]
+fn test_m2_win_en_toggle_cgb_c() {
+    let bytes = read_rom_from_zip("m2_win_en_toggle.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_cgb_c");
+    const EXPECTED_CRC: u32 = 0x5BB7_9D8A;
+    assert_mealybug_crc("m2_win_en_toggle_cgb_c", crc, EXPECTED_CRC);
+}
 
 #[test]
 fn test_m3_bgp_change_cgb_c() {
@@ -515,7 +522,14 @@ mealybug_ignored_cgb_c!(test_m3_wx_6_change_cgb_c, "m3_wx_6_change", "2579");
 // CGB-D tests (reference: expected/CPU CGB D/)
 // ============================================================================
 
-mealybug_ignored_cgb_d!(test_m2_win_en_toggle_cgb_d, "m2_win_en_toggle", "2576");
+#[test]
+fn test_m2_win_en_toggle_cgb_d() {
+    let bytes = read_rom_from_zip("m2_win_en_toggle.gb");
+    let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
+    let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, "m2_win_en_toggle_cgb_d");
+    const EXPECTED_CRC: u32 = 0x5BB7_9D8A;
+    assert_mealybug_crc("m2_win_en_toggle_cgb_d", crc, EXPECTED_CRC);
+}
 
 #[test]
 fn test_m3_bgp_change_cgb_d() {

--- a/src/gb/ppu/timing.rs
+++ b/src/gb/ppu/timing.rs
@@ -269,7 +269,7 @@ impl Timing {
         }
 
         // At frame wrap (scan 153 → scan 0, dot=0), fire the Mode 2 IRQ source.
-        // On real DMG, this fires 4 T-cycles later than the dot-452 path (i.e., at the
+        // On real hardware, this fires 4 T-cycles later than the dot-452 path (i.e., at the
         // actual moment scan 0 begins), which is required for intr_1_2_timing-GS to pass.
         if self.dot == 0 && self.scanline == 0 {
             self.mode_for_irq = 2;
@@ -857,8 +857,8 @@ mod tests {
 
     #[test]
     fn test_mode_for_irq_becomes_2_at_frame_wrap_dot_0_scanline_0() {
-        // At the frame wrap (dot=0 of scanline 0 in frame 2+), the Mode 2 STAT source fires.
-        // Full first frame: 452 + 456 * 153 = 70220 dots.
+        // At the frame wrap (dot=0 of scanline 0 in frame 2+), the Mode 2 STAT source fires
+        // on both DMG and CGB. Full first frame: 452 + 456 * 153 = 70220 dots.
         let mut timing = Timing::new();
         tick_n(&mut timing, 452 + 456 * 153, 0xFF);
         assert_eq!(timing.scanline, 0);


### PR DESCRIPTION
## Summary

Fixes #2576.

The CGB m2_win_en_toggle failure was caused by SM83 interrupt dispatch selecting the interrupt vector from the queue captured at dispatch start. On CGB, STAT can become pending just before VBlank, and VBlank can become pending while the CPU is already in the interrupt dispatch sequence. Hardware-compatible behavior is to select the vector from the live IE and IF queue late in dispatch, so the higher-priority VBlank request wins while the original STAT request remains pending for the next handler.

## Changes

- Update SM83 interrupt dispatch to re-read both IE and IF before vector selection.
- Add a CPU regression test for a late higher-priority VBlank request arriving during an initially STAT-triggered dispatch.
- Enable the mealybug m2_win_en_toggle CGB-C and CGB-D integration tests with the verified reference CRC.
- Clarify the frame-wrap Mode 2 timing comment to note that the frame-wrap source applies to both DMG and CGB timing.

## Validation

- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- ./scripts/test-dir.sh src/gb/cpu src/gb/ppu src/gb/integration_tests --skip-integration
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test

Also verified:

- m2_win_en_toggle CGB-C and CGB-D captures are pixel-identical to the checked-in mealybug references.
- Enabled mealybug test suite: 60 passed, 19 ignored.
