### PR TITLE
GBA CPU: raise undefined for coprocessor opcodes

### DIFF
--- a/src/gba/cpu/arm.rs
+++ b/src/gba/cpu/arm.rs
@@ -260,12 +260,13 @@ pub fn execute<B: Bus>(regs: &mut Registers, bus: &mut B, instr: u32) -> ExecOut
             execute_block_transfer(regs, bus, instr)
         }
         0b101 => execute_branch(regs, instr),
+        0b110 => ExecOutcome::undefined(), // LDC/STC: no coprocessor on GBA
         0b111 => {
             // SWI is encoded as 1111_xxxx_xxxx_xxxx_xxxx_xxxx_xxxx
             if (instr >> 24) & 0xF == 0xF {
                 return ExecOutcome::swi_sni(2, 1, 0); // 2S + 1N
             }
-            ExecOutcome::sni(1, 0, 0) // 1S: coprocessor (treated as NOP)
+            ExecOutcome::undefined() // CDP/MCR/MRC: no coprocessor on GBA
         }
         _ => ExecOutcome::sni(1, 0, 0), // 1S: unrecognized
     }
@@ -2535,6 +2536,112 @@ mod tests {
     /// Encode BKPT: cond 0001 0010 imm12 0111 imm4
     fn arm_bkpt(cond: u8) -> u32 {
         ((cond as u32) << 28) | (0b0001_0010 << 20) | (0b0111 << 4)
+    }
+
+    /// Encode LDC/STC: cond 110PUNWL Rn Cd Pn offset.
+    fn arm_coprocessor_transfer(cond: u8, load: bool) -> u32 {
+        ((cond as u32) << 28)
+            | (0b110 << 25)
+            | (1 << 24) // P=1
+            | (1 << 23) // U=1
+            | ((load as u32) << 20)
+            | (1 << 16) // Rn=R1
+            | (2 << 12) // Cd=C2
+            | (3 << 8) // Pn=P3
+    }
+
+    /// Encode CDP: cond 1110 cp-opc Cn Cd Pn cp Cm, with bit 4 clear.
+    fn arm_cdp(cond: u8) -> u32 {
+        ((cond as u32) << 28) | (0b1110 << 24) | (1 << 20) | (2 << 16) | (3 << 12) | (4 << 8) | 5
+    }
+
+    /// Encode MCR/MRC: cond 1110 opc L Cn Rd Pn cp 1 Cm.
+    fn arm_coprocessor_reg_transfer(cond: u8, load: bool) -> u32 {
+        ((cond as u32) << 28)
+            | (0b1110 << 24)
+            | (1 << 21)
+            | ((load as u32) << 20)
+            | (2 << 16) // Cn=C2
+            | (3 << 12) // Rd=R3
+            | (4 << 8) // Pn=P4
+            | (1 << 4)
+            | 5 // Cm=C5
+    }
+
+    #[test]
+    fn arm_ldc_triggers_undefined_without_coprocessor() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_coprocessor_transfer(0xE, true);
+        let outcome = execute(&mut regs, &mut bus, instr);
+
+        assert!(
+            outcome.undefined,
+            "LDC should trigger undefined on GBA without a coprocessor, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_stc_triggers_undefined_without_coprocessor() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_coprocessor_transfer(0xE, false);
+        let outcome = execute(&mut regs, &mut bus, instr);
+
+        assert!(
+            outcome.undefined,
+            "STC should trigger undefined on GBA without a coprocessor, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_cdp_triggers_undefined_without_coprocessor() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_cdp(0xE);
+        let outcome = execute(&mut regs, &mut bus, instr);
+
+        assert!(
+            outcome.undefined,
+            "CDP should trigger undefined on GBA without a coprocessor, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_mcr_triggers_undefined_without_coprocessor() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_coprocessor_reg_transfer(0xE, false);
+        let outcome = execute(&mut regs, &mut bus, instr);
+
+        assert!(
+            outcome.undefined,
+            "MCR should trigger undefined on GBA without a coprocessor, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_mrc_triggers_undefined_without_coprocessor() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_coprocessor_reg_transfer(0xE, true);
+        let outcome = execute(&mut regs, &mut bus, instr);
+
+        assert!(
+            outcome.undefined,
+            "MRC should trigger undefined on GBA without a coprocessor, got: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn arm_coprocessor_opcode_with_failed_condition_is_skipped() {
+        let mut regs = make_regs();
+        let mut bus = RamBus::new(0x100);
+        let instr = arm_coprocessor_reg_transfer(0x0, true); // MRCEQ
+        let outcome = execute(&mut regs, &mut bus, instr);
+
+        assert!(!outcome.undefined);
+        assert_eq!(outcome, ExecOutcome::sni(1, 0, 0));
     }
 
     #[test]

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -351,10 +351,35 @@ impl Arm7tdmi {
 mod tests {
     use super::*;
     use crate::gba::cpu::bus::RamBus;
-    use crate::gba::cpu::registers::FLAG_Z;
+    use crate::gba::cpu::registers::{FLAG_F, FLAG_Z};
 
     fn write_arm_word(bus: &mut RamBus, addr: u32, word: u32) {
         bus.write_word(addr, word);
+    }
+
+    fn assert_arm_undefined_dispatch(instr: u32) {
+        let mut cpu = Arm7tdmi::new();
+        cpu.regs.switch_mode(CpuMode::User);
+        cpu.regs.cpsr &= !(FLAG_I | FLAG_F);
+        cpu.regs.r[15] = 0x100;
+        let cpsr_before = cpu.regs.cpsr;
+
+        let mut bus = RamBus::new(0x200);
+        write_arm_word(&mut bus, 0x100, instr);
+
+        cpu.step(&mut bus);
+
+        assert_eq!(cpu.regs.mode(), CpuMode::Undefined);
+        assert_eq!(cpu.regs.spsr(), cpsr_before);
+        assert_eq!(cpu.regs.r[14], 0x100 + 4);
+        assert!(cpu.regs.i_flag(), "IRQ must be masked");
+        assert_eq!(
+            cpu.regs.cpsr & FLAG_F,
+            cpsr_before & FLAG_F,
+            "FIQ mask state must be preserved"
+        );
+        assert!(!cpu.regs.thumb(), "undefined exception enters ARM state");
+        assert_eq!(cpu.regs.r[15], ExceptionVector::Undefined as u32);
     }
 
     #[test]
@@ -680,6 +705,59 @@ mod tests {
         );
         assert!(!cpu.regs.thumb(), "T bit should be clear (ARM state)");
         assert_eq!(cpu.regs.r[15], ExceptionVector::Undefined as u32);
+    }
+
+    #[test]
+    fn coprocessor_transfer_dispatches_undefined_exception() {
+        // LDC p3, c2, [r1]: no GBA coprocessor acknowledges the transfer.
+        let ldc = (0xE_u32 << 28)
+            | (0b110 << 25)
+            | (1 << 24)
+            | (1 << 23)
+            | (1 << 20)
+            | (1 << 16)
+            | (2 << 12)
+            | (3 << 8);
+
+        assert_arm_undefined_dispatch(ldc);
+    }
+
+    #[test]
+    fn coprocessor_register_transfer_dispatches_undefined_exception() {
+        // MRC p4, #1, r3, c2, c5: no GBA coprocessor acknowledges the transfer.
+        let mrc = (0xE_u32 << 28)
+            | (0b1110 << 24)
+            | (1 << 21)
+            | (1 << 20)
+            | (2 << 16)
+            | (3 << 12)
+            | (4 << 8)
+            | (1 << 4)
+            | 5;
+
+        assert_arm_undefined_dispatch(mrc);
+    }
+
+    #[test]
+    fn swi_still_dispatches_to_supervisor_exception() {
+        let mut cpu = Arm7tdmi::new();
+        cpu.regs.switch_mode(CpuMode::User);
+        cpu.regs.cpsr &= !(FLAG_I | FLAG_F);
+        cpu.regs.r[15] = 0x100;
+        let cpsr_before = cpu.regs.cpsr;
+
+        let mut bus = RamBus::new(0x200);
+        write_arm_word(&mut bus, 0x100, 0xEF00_0000);
+
+        cpu.step(&mut bus);
+
+        assert_eq!(cpu.regs.mode(), CpuMode::Supervisor);
+        assert_eq!(cpu.regs.spsr(), cpsr_before);
+        assert_eq!(cpu.regs.r[14], 0x100 + 4);
+        assert!(cpu.regs.i_flag(), "IRQ must be masked");
+        assert_eq!(cpu.regs.cpsr & FLAG_F, cpsr_before & FLAG_F);
+        assert!(!cpu.regs.thumb(), "SWI enters ARM state");
+        assert_eq!(cpu.regs.r[15], ExceptionVector::SoftwareInterrupt as u32);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Treat GBA ARM LDC/STC coprocessor transfer opcodes as Undefined Instruction exceptions.
- Treat non-SWI CDP/MCR/MRC coprocessor opcodes as Undefined Instruction exceptions.
- Add decoder and step-level regression coverage for coprocessor UND dispatch, failed-condition skip behavior, and SWI dispatch preservation.

Fixes #2565

## Validation

- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/test-dir.sh src/gba/cpu
- wasm-pack test --headless --chrome --no-default-features --features wasm
- Python unittest discovery for scripts, metadata-scraper, and nes-rom-db-scraper
- npm test

## Known pre-existing local failure

- cargo test --no-default-features --lib has one local failure: gba_mgba_suite_passes reports mgba_timing expected 0xD49CDB49 actual 0xDEEFA167.
- The same single-test failure reproduces on the clean main worktree, and 0xDEEFA167 is already the Linux-approved value in the approvals file, so this is not introduced by this branch.
