### PR TITLE
Support all GBA keyboard buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ To launch a specific ROM directly (skipping the browser):
 cargo run --release -- path/to/rom.nes
 ```
 
+### Native emulator keyboard controls
+
+NES and Game Boy use the same primary layout: `W/A/S/D` for the D-pad, `R` for B,
+`T` for A, `4` for Select, and `5` for Start. Game Boy and Game Boy Advance also
+accept the arrow keys as D-pad aliases. Game Boy Advance adds `Q` for L and `E`
+for R.
+
+NES player 2 uses `I/J/K/L` for the D-pad, `P` for B, `O` for A, `9` for Select,
+and `0` for Start.
+
 ### ROM Browser
 
 The ROM browser scans configured search paths for NES ROMs and displays them in a cover art grid with metadata from TheGamesDB.

--- a/src/frontends/native/app_state.rs
+++ b/src/frontends/native/app_state.rs
@@ -253,6 +253,7 @@ impl NativeAppState {
                 Console::GameBoy(_) | Console::GameBoyAdvance(_) => (false, false),
             };
             return Some(help_overlay_text(
+                console,
                 self.gamepad_count,
                 self.four_score_enabled,
                 port1_is_power_pad,
@@ -272,6 +273,7 @@ impl NativeAppState {
 }
 
 fn help_overlay_text(
+    console: &Console,
     gamepad_count: usize,
     four_score: bool,
     port1_is_power_pad: bool,
@@ -301,6 +303,10 @@ F6/F7: Save/Load state";
     };
 
     let mut controllers = String::new();
+
+    if matches!(console, Console::GameBoyAdvance(_)) {
+        return format!("{hotkeys}{}", gba_keyboard_section());
+    }
 
     for port in 1..=max_ports {
         let port_u8 = port as u8;
@@ -347,8 +353,8 @@ fn joypad_keyboard_section(port: usize, slot: usize) -> String {
         format!(
             "\n\nPort {port}: Keyboard\n\
 W/A/S/D: D-Pad\n\
-R: A\n\
-T: B\n\
+R: B\n\
+T: A\n\
 4: Select\n\
 5: Start"
         )
@@ -362,6 +368,18 @@ P: B\n\
 0: Start"
         )
     }
+}
+
+fn gba_keyboard_section() -> &'static str {
+    "\n\nGBA Keyboard\n\
+W/A/S/D: D-Pad\n\
+Arrow keys: D-Pad\n\
+Q: L\n\
+E: R\n\
+R: B\n\
+T: A\n\
+4: Select\n\
+5: Start"
 }
 
 fn cart_switch_overlay_text(cart_switch: &CartridgeSwitchState) -> String {
@@ -471,6 +489,10 @@ mod tests {
         Console::Nes(Box::new(Nes::new(AppContext::new_with_config(
             Config::default(),
         ))))
+    }
+
+    fn make_gba_console() -> Console {
+        Console::new_gba(AppContext::new_with_config(Config::default()))
     }
 
     // ── overlay_text: help overlay ────────────────────────────────────────────
@@ -1088,6 +1110,33 @@ mod tests {
         assert!(
             !text.contains("Power Pad"),
             "Help overlay should not show Power Pad section for default joypads, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_help_overlay_lists_gba_keyboard_shoulders() {
+        let state = NativeAppState {
+            help_overlay_visible: true,
+            ..NativeAppState::default()
+        };
+
+        let text = state.overlay_text(&make_gba_console(), None).unwrap();
+
+        assert!(
+            text.contains("Q: L"),
+            "GBA help overlay should list Q as L shoulder, got:\n{text}"
+        );
+        assert!(
+            text.contains("E: R"),
+            "GBA help overlay should list E as R shoulder, got:\n{text}"
+        );
+        assert!(
+            text.contains("R: B"),
+            "GBA help overlay should list R as B, got:\n{text}"
+        );
+        assert!(
+            text.contains("T: A"),
+            "GBA help overlay should list T as A, got:\n{text}"
         );
     }
 }

--- a/src/frontends/native/app_state.rs
+++ b/src/frontends/native/app_state.rs
@@ -305,7 +305,11 @@ F6/F7: Save/Load state";
     let mut controllers = String::new();
 
     if matches!(console, Console::GameBoyAdvance(_)) {
-        return format!("{hotkeys}{}", gba_keyboard_section());
+        return format!("{hotkeys}{}", gba_keyboard_section(gamepad_count));
+    }
+
+    if matches!(console, Console::GameBoy(_)) {
+        return format!("{hotkeys}{}", gameboy_keyboard_section(gamepad_count));
     }
 
     for port in 1..=max_ports {
@@ -370,8 +374,31 @@ P: B\n\
     }
 }
 
-fn gba_keyboard_section() -> &'static str {
-    "\n\nGBA Keyboard\n\
+fn gameboy_keyboard_section(gamepad_count: usize) -> String {
+    let controller = if gamepad_count == 0 {
+        "Keyboard".to_string()
+    } else {
+        "Gamepad + Keyboard aliases".to_string()
+    };
+    format!(
+        "\n\nGame Boy: {controller}\n\
+W/A/S/D: D-Pad\n\
+Arrow keys: D-Pad\n\
+R: B\n\
+T: A\n\
+4: Select\n\
+5: Start"
+    )
+}
+
+fn gba_keyboard_section(gamepad_count: usize) -> String {
+    let controller = if gamepad_count == 0 {
+        "Keyboard".to_string()
+    } else {
+        "Gamepad + Keyboard shoulders/aliases".to_string()
+    };
+    format!(
+        "\n\nGBA: {controller}\n\
 W/A/S/D: D-Pad\n\
 Arrow keys: D-Pad\n\
 Q: L\n\
@@ -380,6 +407,7 @@ R: B\n\
 T: A\n\
 4: Select\n\
 5: Start"
+    )
 }
 
 fn cart_switch_overlay_text(cart_switch: &CartridgeSwitchState) -> String {
@@ -493,6 +521,10 @@ mod tests {
 
     fn make_gba_console() -> Console {
         Console::new_gba(AppContext::new_with_config(Config::default()))
+    }
+
+    fn make_gameboy_console() -> Console {
+        Console::new_gameboy(AppContext::new_with_config(Config::default()))
     }
 
     // ── overlay_text: help overlay ────────────────────────────────────────────
@@ -1137,6 +1169,73 @@ mod tests {
         assert!(
             text.contains("T: A"),
             "GBA help overlay should list T as A, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_help_overlay_lists_gba_gamepad_and_keyboard_when_gamepad_connected() {
+        let state = NativeAppState {
+            help_overlay_visible: true,
+            gamepad_count: 1,
+            ..NativeAppState::default()
+        };
+
+        let text = state.overlay_text(&make_gba_console(), None).unwrap();
+
+        assert!(
+            text.contains("Gamepad + Keyboard shoulders/aliases"),
+            "GBA help overlay should mention connected gamepad plus keyboard-only controls, got:\n{text}"
+        );
+        assert!(
+            text.contains("Q: L") && text.contains("E: R"),
+            "GBA help overlay should still list keyboard shoulders with a gamepad connected, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_help_overlay_lists_gameboy_arrow_key_aliases() {
+        let state = NativeAppState {
+            help_overlay_visible: true,
+            ..NativeAppState::default()
+        };
+
+        let text = state.overlay_text(&make_gameboy_console(), None).unwrap();
+
+        assert!(
+            text.contains("Game Boy: Keyboard"),
+            "Game Boy help overlay should use a Game Boy-specific section, got:\n{text}"
+        );
+        assert!(
+            text.contains("Arrow keys: D-Pad"),
+            "Game Boy help overlay should list arrow-key D-pad aliases, got:\n{text}"
+        );
+        assert!(
+            !text.contains("Q: L") && !text.contains("E: R"),
+            "Game Boy help overlay should not list GBA shoulders, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn test_help_overlay_lists_gameboy_gamepad_and_keyboard_when_gamepad_connected() {
+        let state = NativeAppState {
+            help_overlay_visible: true,
+            gamepad_count: 1,
+            ..NativeAppState::default()
+        };
+
+        let text = state.overlay_text(&make_gameboy_console(), None).unwrap();
+
+        assert!(
+            text.contains("Game Boy: Gamepad + Keyboard aliases"),
+            "Game Boy help overlay should mention connected gamepad plus keyboard aliases, got:\n{text}"
+        );
+        assert!(
+            text.contains("Arrow keys: D-Pad"),
+            "Game Boy help overlay should still list arrow-key D-pad aliases with a gamepad connected, got:\n{text}"
+        );
+        assert!(
+            !text.contains("Keyboard shoulders/aliases"),
+            "Game Boy help overlay should not use GBA shoulder wording, got:\n{text}"
         );
     }
 }

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -62,10 +62,7 @@ pub fn handle_key_pressed(
             handle_unmodified_key(console, key_code, app_state, audio)
         }
         Console::GameBoy(_) => handle_gameboy_key_pressed(console, key_code, app_state, audio),
-        Console::GameBoyAdvance(_) => {
-            // GBA input not yet implemented - use game boy handler for now
-            handle_gameboy_key_pressed(console, key_code, app_state, audio)
-        }
+        Console::GameBoyAdvance(_) => handle_gba_key_pressed(console, key_code, app_state, audio),
     }
 }
 
@@ -94,8 +91,7 @@ pub fn handle_key_released(
             }
         }
         Console::GameBoyAdvance(_) => {
-            // GBA input not yet implemented - use Game Boy handler for now
-            if let Some(btn_id) = gameboy_key_to_button_id(key_code) {
+            if let Some(btn_id) = gba_key_to_button_id(key_code) {
                 console.set_button(0, btn_id, false);
             }
         }
@@ -158,6 +154,18 @@ fn gameboy_key_to_button_id(key_code: KeyCode) -> Option<u8> {
     }
 }
 
+/// Maps a key code to a GBA button ID.
+///
+/// Extends the Game Boy/NES-style keyboard layout with Q=L and E=R,
+/// matching the native NES/SNES shoulder-button positions.
+fn gba_key_to_button_id(key_code: KeyCode) -> Option<u8> {
+    match key_code {
+        KeyCode::KeyQ => Some(8), // L
+        KeyCode::KeyE => Some(9), // R
+        _ => gameboy_key_to_button_id(key_code),
+    }
+}
+
 /// Attempts to handle a key press that is identical for all console types.
 ///
 /// Returns `Some(KeyOutcome::Continue)` for Escape and Space (which mutate
@@ -210,6 +218,31 @@ fn handle_gameboy_key_pressed(
     app_state: &mut NativeAppState,
     audio: Option<&dyn EmulatorAudio>,
 ) -> KeyOutcome {
+    handle_single_joypad_key_pressed(
+        console,
+        key_code,
+        app_state,
+        audio,
+        gameboy_key_to_button_id,
+    )
+}
+
+fn handle_gba_key_pressed(
+    console: &mut Console,
+    key_code: KeyCode,
+    app_state: &mut NativeAppState,
+    audio: Option<&dyn EmulatorAudio>,
+) -> KeyOutcome {
+    handle_single_joypad_key_pressed(console, key_code, app_state, audio, gba_key_to_button_id)
+}
+
+fn handle_single_joypad_key_pressed(
+    console: &mut Console,
+    key_code: KeyCode,
+    app_state: &mut NativeAppState,
+    audio: Option<&dyn EmulatorAudio>,
+    key_to_button_id: fn(KeyCode) -> Option<u8>,
+) -> KeyOutcome {
     // Generic hotkeys that work for any system.
     if app_state.modifiers.control_key() {
         return match key_code {
@@ -245,7 +278,7 @@ fn handle_gameboy_key_pressed(
         KeyCode::F10 => return KeyOutcome::StepOver,
         KeyCode::F11 => return KeyOutcome::StepInto,
         _ => {
-            if let Some(btn_id) = gameboy_key_to_button_id(key_code) {
+            if let Some(btn_id) = key_to_button_id(key_code) {
                 console.set_button(0, btn_id, true);
             }
         }
@@ -639,6 +672,17 @@ mod tests {
         Console::Nes(Box::new(make_nes_four_score()))
     }
 
+    fn make_gba_console() -> Console {
+        Console::new_gba(AppContext::new_with_config(Config::default()))
+    }
+
+    fn gba_keyinput(console: &Console) -> u16 {
+        let Console::GameBoyAdvance(gba) = console else {
+            panic!("expected GBA console");
+        };
+        gba.bus().keypad.read_keyinput()
+    }
+
     fn make_state() -> NativeAppState {
         NativeAppState::default()
     }
@@ -664,6 +708,17 @@ mod tests {
     const BIT_DOWN: u8 = 1 << Button::Down as u8;
     const BIT_LEFT: u8 = 1 << Button::Left as u8;
     const BIT_RIGHT: u8 = 1 << Button::Right as u8;
+
+    const GBA_KEY_A: u16 = 1 << 0;
+    const GBA_KEY_B: u16 = 1 << 1;
+    const GBA_KEY_SELECT: u16 = 1 << 2;
+    const GBA_KEY_START: u16 = 1 << 3;
+    const GBA_KEY_RIGHT: u16 = 1 << 4;
+    const GBA_KEY_LEFT: u16 = 1 << 5;
+    const GBA_KEY_UP: u16 = 1 << 6;
+    const GBA_KEY_DOWN: u16 = 1 << 7;
+    const GBA_KEY_R: u16 = 1 << 8;
+    const GBA_KEY_L: u16 = 1 << 9;
 
     // ── Mock audio ────────────────────────────────────────────────────────────
 
@@ -1791,6 +1846,94 @@ mod tests {
             console.get_joypad_button_states(0) & BIT_RIGHT,
             0,
             "Releasing D should clear GB Right button"
+        );
+    }
+
+    #[test]
+    fn gba_keyboard_maps_all_ten_buttons() {
+        let cases = [
+            (KeyCode::KeyT, GBA_KEY_A, "T should press GBA A"),
+            (KeyCode::KeyR, GBA_KEY_B, "R should press GBA B"),
+            (KeyCode::Digit4, GBA_KEY_SELECT, "4 should press GBA Select"),
+            (KeyCode::Digit5, GBA_KEY_START, "5 should press GBA Start"),
+            (KeyCode::KeyW, GBA_KEY_UP, "W should press GBA Up"),
+            (KeyCode::KeyS, GBA_KEY_DOWN, "S should press GBA Down"),
+            (KeyCode::KeyA, GBA_KEY_LEFT, "A should press GBA Left"),
+            (KeyCode::KeyD, GBA_KEY_RIGHT, "D should press GBA Right"),
+            (KeyCode::KeyQ, GBA_KEY_L, "Q should press GBA L"),
+            (KeyCode::KeyE, GBA_KEY_R, "E should press GBA R"),
+            (KeyCode::ArrowUp, GBA_KEY_UP, "ArrowUp should press GBA Up"),
+            (
+                KeyCode::ArrowDown,
+                GBA_KEY_DOWN,
+                "ArrowDown should press GBA Down",
+            ),
+            (
+                KeyCode::ArrowLeft,
+                GBA_KEY_LEFT,
+                "ArrowLeft should press GBA Left",
+            ),
+            (
+                KeyCode::ArrowRight,
+                GBA_KEY_RIGHT,
+                "ArrowRight should press GBA Right",
+            ),
+        ];
+
+        for (key, mask, message) in cases {
+            let mut console = make_gba_console();
+            let mut state = make_state();
+            handle_key_pressed(&mut console, key, &mut state, None);
+            assert_eq!(gba_keyinput(&console) & mask, 0, "{message}");
+        }
+    }
+
+    #[test]
+    fn gba_keyboard_releases_l_and_r_shoulders() {
+        let mut console = make_gba_console();
+        let mut state = make_state();
+
+        handle_key_pressed(&mut console, KeyCode::KeyQ, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyE, &mut state, None);
+
+        assert_eq!(
+            gba_keyinput(&console) & GBA_KEY_L,
+            0,
+            "Q should press GBA L"
+        );
+        assert_eq!(
+            gba_keyinput(&console) & GBA_KEY_R,
+            0,
+            "E should press GBA R"
+        );
+
+        handle_key_released(&mut console, KeyCode::KeyQ, 0, false);
+        handle_key_released(&mut console, KeyCode::KeyE, 0, false);
+
+        assert_ne!(
+            gba_keyinput(&console) & GBA_KEY_L,
+            0,
+            "releasing Q should clear GBA L"
+        );
+        assert_ne!(
+            gba_keyinput(&console) & GBA_KEY_R,
+            0,
+            "releasing E should clear GBA R"
+        );
+    }
+
+    #[test]
+    fn gameboy_q_and_e_do_not_map_to_buttons() {
+        let mut console = make_gameboy_console();
+        let mut state = make_state();
+
+        handle_key_pressed(&mut console, KeyCode::KeyQ, &mut state, None);
+        handle_key_pressed(&mut console, KeyCode::KeyE, &mut state, None);
+
+        assert_eq!(
+            console.get_joypad_button_states(0),
+            0,
+            "Game Boy keyboard mapping should remain eight-button only"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add native GBA keyboard routing for all 10 keypad buttons, including Q=L and E=R shoulder buttons.
- Keep Game Boy keyboard routing eight-button-only.
- Update native help overlay and README controls documentation to match the actual NES-like layout.

## Testing

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- CARGO_TEST_ARGS="--features native" ./scripts/test-dir.sh src/frontends/native --skip-integration
- ./scripts/test-dir.sh src/gba/input --skip-integration
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test

## Known pre-existing check failure

- cargo test --no-default-features --lib fails on this branch and on clean origin/main with the same unrelated GB/GBA integration failures: missing local GBA suite ROMs, an existing mgba_timing CRC mismatch, and Mealybug GB integration failures.
