### PR TITLE
Audit Mealybug expected PNG CRCs

### DIFF
--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -105,39 +105,42 @@ macro_rules! mealybug_cgb_d {
 
 /// Generate an ignored DMG-B mealybug test.
 macro_rules! mealybug_ignored_dmg_b {
-    ($name:ident, $rom_base:literal, $issue:literal) => {
+    ($name:ident, $rom_base:literal, $issue:literal, $expected_crc:expr) => {
         #[test]
         #[ignore = concat!("mealybug: PPU timing not yet accurate — tracked in #", $issue)]
         fn $name() {
             let bytes = read_rom_from_zip(concat!($rom_base, ".gb"));
             let mut gb = load_gb_rom_from_bytes(&bytes, DmgModel::DmgB);
-            run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, concat!($rom_base, "_dmg_b"));
+            let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, concat!($rom_base, "_dmg_b"));
+            assert_mealybug_crc(concat!($rom_base, "_dmg_b"), crc, $expected_crc);
         }
     };
 }
 
 /// Generate an ignored CGB-C mealybug test.
 macro_rules! mealybug_ignored_cgb_c {
-    ($name:ident, $rom_base:literal, $issue:literal) => {
+    ($name:ident, $rom_base:literal, $issue:literal, $expected_crc:expr) => {
         #[test]
         #[ignore = concat!("mealybug: PPU timing not yet accurate — tracked in #", $issue)]
         fn $name() {
             let bytes = read_rom_from_zip(concat!($rom_base, ".gb"));
             let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbC);
-            run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, concat!($rom_base, "_cgb_c"));
+            let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, concat!($rom_base, "_cgb_c"));
+            assert_mealybug_crc(concat!($rom_base, "_cgb_c"), crc, $expected_crc);
         }
     };
 }
 
 /// Generate an ignored CGB-D mealybug test.
 macro_rules! mealybug_ignored_cgb_d {
-    ($name:ident, $rom_base:literal, $issue:literal) => {
+    ($name:ident, $rom_base:literal, $issue:literal, $expected_crc:expr) => {
         #[test]
         #[ignore = concat!("mealybug: PPU timing not yet accurate — tracked in #", $issue)]
         fn $name() {
             let bytes = read_rom_from_zip(concat!($rom_base, ".gb"));
             let mut gb = load_cgb_rom_from_bytes(&bytes, CgbModel::CgbD);
-            run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, concat!($rom_base, "_cgb_d"));
+            let crc = run_to_breakpoint_and_crc(&mut gb, CYCLE_LIMIT, concat!($rom_base, "_cgb_d"));
+            assert_mealybug_crc(concat!($rom_base, "_cgb_d"), crc, $expected_crc);
         }
     };
 }
@@ -147,6 +150,331 @@ fn assert_mealybug_crc(capture_name: &str, crc: u32, expected_crc: u32) {
         crc, expected_crc,
         "{capture_name} CRC mismatch: got {crc:#010X}, expected {expected_crc:#010X}"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+
+    use crate::gb::ppu::screen_buffer::ScreenBuffer;
+
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    enum MealybugModel {
+        DmgB,
+        CgbC,
+        CgbD,
+    }
+
+    impl MealybugModel {
+        const fn suffix(self) -> &'static str {
+            match self {
+                Self::DmgB => "dmg_b",
+                Self::CgbC => "cgb_c",
+                Self::CgbD => "cgb_d",
+            }
+        }
+
+        const fn expected_dir(self) -> &'static str {
+            match self {
+                Self::DmgB => "DMG-blob",
+                Self::CgbC => "CPU CGB C",
+                Self::CgbD => "CPU CGB D",
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct MealybugCase {
+        model: MealybugModel,
+        rom_base: String,
+        expected_crc: u32,
+    }
+
+    fn macro_definition<'a>(source: &'a str, macro_name: &str) -> &'a str {
+        let marker = format!("macro_rules! {macro_name}");
+        let start = source
+            .find(&marker)
+            .unwrap_or_else(|| panic!("{macro_name} macro definition should exist"));
+        let open_brace = source[start..]
+            .find('{')
+            .unwrap_or_else(|| panic!("{macro_name} macro definition should open with a brace"));
+
+        let mut depth = 0_u32;
+        for (offset, ch) in source[start + open_brace..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        let end = start + open_brace + offset;
+                        return &source[start..=end];
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        panic!("{macro_name} macro definition should close its braces");
+    }
+
+    fn parse_mealybug_cases(source: &str) -> Vec<MealybugCase> {
+        let specs = [
+            ("mealybug_dmg_b", MealybugModel::DmgB, false),
+            ("mealybug_cgb_c", MealybugModel::CgbC, false),
+            ("mealybug_cgb_d", MealybugModel::CgbD, false),
+            ("mealybug_ignored_dmg_b", MealybugModel::DmgB, true),
+            ("mealybug_ignored_cgb_c", MealybugModel::CgbC, true),
+            ("mealybug_ignored_cgb_d", MealybugModel::CgbD, true),
+        ];
+        let mut cases = Vec::new();
+
+        for (macro_name, model, ignored) in specs {
+            let needle = format!("{macro_name}!(");
+            let mut search_from = 0;
+
+            while let Some(relative_start) = source[search_from..].find(&needle) {
+                let invocation_start = search_from + relative_start;
+                let args_start = invocation_start + needle.len();
+                let close_paren = find_matching_paren(source, args_start - 1);
+                let args = split_macro_args(&source[args_start..close_paren]);
+                let expected_arg_count = if ignored { 4 } else { 3 };
+                assert_eq!(
+                    args.len(),
+                    expected_arg_count,
+                    "{macro_name} invocation should have {expected_arg_count} arguments: {args:?}"
+                );
+
+                cases.push(MealybugCase {
+                    model,
+                    rom_base: unquote(&args[1]),
+                    expected_crc: parse_crc(&args[expected_arg_count - 1]),
+                });
+
+                search_from = close_paren + 1;
+            }
+        }
+
+        cases
+    }
+
+    fn find_matching_paren(source: &str, open_paren: usize) -> usize {
+        let mut depth = 0_u32;
+        let mut in_string = false;
+
+        for (offset, ch) in source[open_paren..].char_indices() {
+            match ch {
+                '"' => in_string = !in_string,
+                '(' if !in_string => depth += 1,
+                ')' if !in_string => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return open_paren + offset;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        panic!("macro invocation should close its parentheses");
+    }
+
+    fn split_macro_args(args: &str) -> Vec<String> {
+        let mut split = Vec::new();
+        let mut current = String::new();
+        let mut in_string = false;
+
+        for ch in args.chars() {
+            match ch {
+                '"' => {
+                    in_string = !in_string;
+                    current.push(ch);
+                }
+                ',' if !in_string => {
+                    split.push(current.trim().to_owned());
+                    current.clear();
+                }
+                _ => current.push(ch),
+            }
+        }
+
+        if !current.trim().is_empty() {
+            split.push(current.trim().to_owned());
+        }
+
+        split
+    }
+
+    fn unquote(value: &str) -> String {
+        value
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .unwrap_or_else(|| panic!("{value} should be a string literal"))
+            .to_owned()
+    }
+
+    fn parse_crc(value: &str) -> u32 {
+        u32::from_str_radix(
+            value
+                .strip_prefix("0x")
+                .unwrap_or_else(|| panic!("{value} should be a hex CRC literal"))
+                .replace('_', "")
+                .as_str(),
+            16,
+        )
+        .unwrap_or_else(|err| panic!("{value} should parse as a CRC-32 literal: {err}"))
+    }
+
+    fn expected_png_path(case: &MealybugCase) -> PathBuf {
+        Path::new("roms/gb/automated_tests/mealybug-tearoom-tests/expected")
+            .join(case.model.expected_dir())
+            .join(format!("{}.png", case.rom_base))
+    }
+
+    fn expected_png_count(model: MealybugModel) -> usize {
+        std::fs::read_dir(
+            Path::new("roms/gb/automated_tests/mealybug-tearoom-tests/expected")
+                .join(model.expected_dir()),
+        )
+        .unwrap_or_else(|err| panic!("read expected PNG directory for {:?}: {err}", model))
+        .filter(|entry| {
+            entry
+                .as_ref()
+                .ok()
+                .and_then(|entry| entry.path().extension().map(|extension| extension == "png"))
+                .unwrap_or(false)
+        })
+        .count()
+    }
+
+    fn decoded_png_rgb_crc(path: &Path) -> u32 {
+        let file = std::fs::File::open(path)
+            .unwrap_or_else(|err| panic!("open expected PNG {}: {err}", path.display()));
+        let mut decoder = png::Decoder::new(file);
+        decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+
+        let mut reader = decoder
+            .read_info()
+            .unwrap_or_else(|err| panic!("read expected PNG info {}: {err}", path.display()));
+        let mut raw = vec![0; reader.output_buffer_size()];
+        let info = reader
+            .next_frame(&mut raw)
+            .unwrap_or_else(|err| panic!("decode expected PNG {}: {err}", path.display()));
+        let raw = &raw[..info.buffer_size()];
+
+        assert_eq!(
+            (info.width, info.height),
+            (ScreenBuffer::WIDTH, ScreenBuffer::HEIGHT),
+            "{} should have Game Boy screen dimensions",
+            path.display()
+        );
+
+        let rgb = match info.color_type {
+            png::ColorType::Rgb => raw.to_vec(),
+            png::ColorType::Rgba => raw
+                .chunks_exact(4)
+                .flat_map(|pixel| [pixel[0], pixel[1], pixel[2]])
+                .collect(),
+            png::ColorType::Grayscale => raw.iter().flat_map(|value| [*value; 3]).collect(),
+            png::ColorType::GrayscaleAlpha => raw
+                .chunks_exact(2)
+                .flat_map(|pixel| [pixel[0]; 3])
+                .collect(),
+            png::ColorType::Indexed => {
+                panic!("{} should be expanded from indexed to RGB", path.display())
+            }
+        };
+
+        assert_eq!(
+            rgb.len(),
+            (ScreenBuffer::WIDTH * ScreenBuffer::HEIGHT * 3) as usize,
+            "{} should decode to RGB8 screen-buffer bytes",
+            path.display()
+        );
+
+        crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(&rgb)
+    }
+
+    #[test]
+    fn ignored_mealybug_macros_require_expected_crc_assertions() {
+        let source = include_str!("mealybug_tests.rs");
+
+        for macro_name in [
+            "mealybug_ignored_dmg_b",
+            "mealybug_ignored_cgb_c",
+            "mealybug_ignored_cgb_d",
+        ] {
+            let definition = macro_definition(source, macro_name);
+            assert!(
+                definition.contains("$expected_crc:expr"),
+                "{macro_name} should require an expected CRC argument"
+            );
+            assert!(
+                definition.contains("assert_mealybug_crc("),
+                "{macro_name} should assert the breakpoint CRC"
+            );
+        }
+    }
+
+    #[test]
+    fn expected_crc_constants_match_reference_pngs() {
+        let source = include_str!("mealybug_tests.rs");
+        let cases = parse_mealybug_cases(source);
+        assert_eq!(
+            cases.len(),
+            79,
+            "all scoped Mealybug tests should be audited"
+        );
+
+        for (model, expected_count) in [
+            (MealybugModel::DmgB, 24),
+            (MealybugModel::CgbC, 31),
+            (MealybugModel::CgbD, 24),
+        ] {
+            let case_count = cases.iter().filter(|case| case.model == model).count();
+            assert_eq!(
+                case_count,
+                expected_count,
+                "{} test count should match #2427 coverage",
+                model.suffix()
+            );
+            assert_eq!(
+                expected_png_count(model),
+                expected_count,
+                "{} expected PNG count should match #2427 coverage",
+                model.suffix()
+            );
+        }
+
+        let mut paths = HashSet::new();
+        let mut mismatches = Vec::new();
+
+        for case in &cases {
+            let path = expected_png_path(case);
+            assert!(
+                paths.insert(path.clone()),
+                "expected PNG should only be audited once: {}",
+                path.display()
+            );
+
+            let png_crc = decoded_png_rgb_crc(&path);
+            if case.expected_crc != png_crc {
+                mismatches.push(format!(
+                    "{}_{}: code={:#010X}, png={:#010X}",
+                    case.rom_base,
+                    case.model.suffix(),
+                    case.expected_crc,
+                    png_crc
+                ));
+            }
+        }
+
+        assert!(
+            mismatches.is_empty(),
+            "Mealybug expected PNG CRC mismatch(es):\n{}",
+            mismatches.join("\n")
+        );
+    }
 }
 
 // ============================================================================
@@ -226,7 +554,12 @@ mealybug_dmg_b!(
     "m3_scx_low_3_bits",
     0xD49D_F057
 );
-mealybug_ignored_dmg_b!(test_m3_scy_change_dmg_b, "m3_scy_change", "2358");
+mealybug_ignored_dmg_b!(
+    test_m3_scy_change_dmg_b,
+    "m3_scy_change",
+    "2358",
+    0x8179_BF2F
+);
 mealybug_dmg_b!(test_m3_window_timing_dmg_b, "m3_window_timing", 0x92B6_5C2A);
 mealybug_dmg_b!(
     test_m3_window_timing_wx_0_dmg_b,
@@ -324,7 +657,8 @@ mealybug_cgb_c!(
 mealybug_ignored_cgb_c!(
     test_m3_lcdc_win_en_change_multiple_wx_cgb_c,
     "m3_lcdc_win_en_change_multiple_wx",
-    "2579"
+    "2579",
+    0x6581_49F1
 );
 mealybug_cgb_c!(
     test_m3_lcdc_win_map_change_cgb_c,
@@ -352,7 +686,12 @@ mealybug_cgb_c!(
     "m3_scx_low_3_bits",
     0xD49D_F057
 );
-mealybug_ignored_cgb_c!(test_m3_scy_change_cgb_c, "m3_scy_change", "2358");
+mealybug_ignored_cgb_c!(
+    test_m3_scy_change_cgb_c,
+    "m3_scy_change",
+    "2358",
+    0xEEAF_63B5
+);
 mealybug_cgb_c!(test_m3_scy_change2_cgb_c, "m3_scy_change2", 0x6D57_9852);
 mealybug_cgb_c!(test_m3_window_timing_cgb_c, "m3_window_timing", 0x0BE0_3D45);
 mealybug_cgb_c!(
@@ -361,14 +700,29 @@ mealybug_cgb_c!(
     0x1C33_F2FF
 );
 // Same invalid-reference rationale as the CGB-C non-sprite LCDC-WX case above.
-mealybug_ignored_cgb_c!(test_m3_wx_4_change_cgb_c, "m3_wx_4_change", "2579");
+mealybug_ignored_cgb_c!(
+    test_m3_wx_4_change_cgb_c,
+    "m3_wx_4_change",
+    "2579",
+    0x6581_49F1
+);
 mealybug_cgb_c!(
     test_m3_wx_4_change_sprites_cgb_c,
     "m3_wx_4_change_sprites",
     0x2F7D_8812
 );
-mealybug_ignored_cgb_c!(test_m3_wx_5_change_cgb_c, "m3_wx_5_change", "2579");
-mealybug_ignored_cgb_c!(test_m3_wx_6_change_cgb_c, "m3_wx_6_change", "2579");
+mealybug_ignored_cgb_c!(
+    test_m3_wx_5_change_cgb_c,
+    "m3_wx_5_change",
+    "2579",
+    0x6581_49F1
+);
+mealybug_ignored_cgb_c!(
+    test_m3_wx_6_change_cgb_c,
+    "m3_wx_6_change",
+    "2579",
+    0x6581_49F1
+);
 
 // ============================================================================
 // CGB-D tests (reference: expected/CPU CGB D/)
@@ -430,7 +784,8 @@ mealybug_cgb_d!(
 mealybug_ignored_cgb_d!(
     test_m3_lcdc_win_en_change_multiple_wx_cgb_d,
     "m3_lcdc_win_en_change_multiple_wx",
-    "2579"
+    "2579",
+    0x6581_49F1
 );
 mealybug_cgb_d!(
     test_m3_lcdc_win_map_change_cgb_d,
@@ -450,7 +805,12 @@ mealybug_cgb_d!(
     "m3_scx_low_3_bits",
     0xD49D_F057
 );
-mealybug_ignored_cgb_d!(test_m3_scy_change_cgb_d, "m3_scy_change", "2358");
+mealybug_ignored_cgb_d!(
+    test_m3_scy_change_cgb_d,
+    "m3_scy_change",
+    "2358",
+    0x7A71_4C6D
+);
 mealybug_cgb_d!(test_m3_window_timing_cgb_d, "m3_window_timing", 0x92B6_5C2A);
 mealybug_cgb_d!(
     test_m3_window_timing_wx_0_cgb_d,
@@ -458,11 +818,26 @@ mealybug_cgb_d!(
     0x68EF_35FF
 );
 // Same invalid-reference rationale as the CGB-C non-sprite LCDC-WX case above.
-mealybug_ignored_cgb_d!(test_m3_wx_4_change_cgb_d, "m3_wx_4_change", "2579");
+mealybug_ignored_cgb_d!(
+    test_m3_wx_4_change_cgb_d,
+    "m3_wx_4_change",
+    "2579",
+    0x6581_49F1
+);
 mealybug_cgb_d!(
     test_m3_wx_4_change_sprites_cgb_d,
     "m3_wx_4_change_sprites",
     0x2F7D_8812
 );
-mealybug_ignored_cgb_d!(test_m3_wx_5_change_cgb_d, "m3_wx_5_change", "2579");
-mealybug_ignored_cgb_d!(test_m3_wx_6_change_cgb_d, "m3_wx_6_change", "2579");
+mealybug_ignored_cgb_d!(
+    test_m3_wx_5_change_cgb_d,
+    "m3_wx_5_change",
+    "2579",
+    0x6581_49F1
+);
+mealybug_ignored_cgb_d!(
+    test_m3_wx_6_change_cgb_d,
+    "m3_wx_6_change",
+    "2579",
+    0x6581_49F1
+);


### PR DESCRIPTION
## Summary

- Adds expected CRC assertions to ignored Mealybug tests so explicit ignored-test runs fail on CRC mismatches instead of silently passing after the breakpoint.
- Adds the 11 decoded expected-PNG CRC constants for currently ignored Mealybug cases.
- Adds an in-repo audit test that parses all scoped Mealybug macro invocations, decodes expected PNGs to RGB bytes, and verifies every listed CRC against the reference image data.

Related to #2427.

## Validation

- cargo clippy --all-targets --all-features -- -D warnings: passed
- cargo fmt --check: passed
- ./scripts/test-dir.sh src/gb/integration_tests: passed
- wasm-pack test --headless --chrome --no-default-features --features wasm: passed
- Python unittest discovery for scripts, metadata-scraper, and nes-rom-db-scraper: passed
- npm test: passed
- cargo test --no-default-features --lib: failed on unrelated pre-existing latest-main GBA approval mismatch:
  - gba::integration_tests::gba_suite_tests::gba_mgba_suite_passes
  - mgba_timing expected 0xD49CDB49, actual 0xDEEFA167
  - Reproduced on latest main with this branch's changes stashed.

## Notes

- Selectively running ignored test test_m3_scy_change_dmg_b now fails through assert_mealybug_crc with expected PNG CRC 0x8179BF2F, confirming ignored tests no longer silently pass when included explicitly.
