### PR TITLE
Fix Mealybug SCY change timing

### DIFF
--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -557,7 +557,7 @@ mealybug_dmg_b!(
 mealybug_ignored_dmg_b!(
     test_m3_scy_change_dmg_b,
     "m3_scy_change",
-    "2358",
+    "2597",
     0x8179_BF2F
 );
 mealybug_dmg_b!(test_m3_window_timing_dmg_b, "m3_window_timing", 0x92B6_5C2A);
@@ -651,13 +651,13 @@ mealybug_cgb_c!(
     "m3_lcdc_win_en_change_multiple",
     0xC001_01D8
 );
-// The CGB non-sprite WX/LCDC-WX reference PNGs for #2579 are not native emulator
+// The CGB non-sprite WX/LCDC-WX reference PNGs for #2598 are not native emulator
 // captures: they are 171-colour GIMP images and the same image is reused by
 // multiple ROMs.
 mealybug_ignored_cgb_c!(
     test_m3_lcdc_win_en_change_multiple_wx_cgb_c,
     "m3_lcdc_win_en_change_multiple_wx",
-    "2579",
+    "2598",
     0x6581_49F1
 );
 mealybug_cgb_c!(
@@ -689,7 +689,7 @@ mealybug_cgb_c!(
 mealybug_ignored_cgb_c!(
     test_m3_scy_change_cgb_c,
     "m3_scy_change",
-    "2358",
+    "2597",
     0xEEAF_63B5
 );
 mealybug_cgb_c!(test_m3_scy_change2_cgb_c, "m3_scy_change2", 0x6D57_9852);
@@ -703,7 +703,7 @@ mealybug_cgb_c!(
 mealybug_ignored_cgb_c!(
     test_m3_wx_4_change_cgb_c,
     "m3_wx_4_change",
-    "2579",
+    "2598",
     0x6581_49F1
 );
 mealybug_cgb_c!(
@@ -714,13 +714,13 @@ mealybug_cgb_c!(
 mealybug_ignored_cgb_c!(
     test_m3_wx_5_change_cgb_c,
     "m3_wx_5_change",
-    "2579",
+    "2598",
     0x6581_49F1
 );
 mealybug_ignored_cgb_c!(
     test_m3_wx_6_change_cgb_c,
     "m3_wx_6_change",
-    "2579",
+    "2598",
     0x6581_49F1
 );
 
@@ -784,7 +784,7 @@ mealybug_cgb_d!(
 mealybug_ignored_cgb_d!(
     test_m3_lcdc_win_en_change_multiple_wx_cgb_d,
     "m3_lcdc_win_en_change_multiple_wx",
-    "2579",
+    "2598",
     0x6581_49F1
 );
 mealybug_cgb_d!(
@@ -808,7 +808,7 @@ mealybug_cgb_d!(
 mealybug_ignored_cgb_d!(
     test_m3_scy_change_cgb_d,
     "m3_scy_change",
-    "2358",
+    "2597",
     0x7A71_4C6D
 );
 mealybug_cgb_d!(test_m3_window_timing_cgb_d, "m3_window_timing", 0x92B6_5C2A);
@@ -821,7 +821,7 @@ mealybug_cgb_d!(
 mealybug_ignored_cgb_d!(
     test_m3_wx_4_change_cgb_d,
     "m3_wx_4_change",
-    "2579",
+    "2598",
     0x6581_49F1
 );
 mealybug_cgb_d!(
@@ -832,12 +832,12 @@ mealybug_cgb_d!(
 mealybug_ignored_cgb_d!(
     test_m3_wx_5_change_cgb_d,
     "m3_wx_5_change",
-    "2579",
+    "2598",
     0x6581_49F1
 );
 mealybug_ignored_cgb_d!(
     test_m3_wx_6_change_cgb_d,
     "m3_wx_6_change",
-    "2579",
+    "2598",
     0x6581_49F1
 );

--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -104,6 +104,7 @@ macro_rules! mealybug_cgb_d {
 }
 
 /// Generate an ignored DMG-B mealybug test.
+#[allow(unused_macros)]
 macro_rules! mealybug_ignored_dmg_b {
     ($name:ident, $rom_base:literal, $issue:literal, $expected_crc:expr) => {
         #[test]
@@ -554,12 +555,7 @@ mealybug_dmg_b!(
     "m3_scx_low_3_bits",
     0xD49D_F057
 );
-mealybug_ignored_dmg_b!(
-    test_m3_scy_change_dmg_b,
-    "m3_scy_change",
-    "2597",
-    0x8179_BF2F
-);
+mealybug_dmg_b!(test_m3_scy_change_dmg_b, "m3_scy_change", 0x8179_BF2F);
 mealybug_dmg_b!(test_m3_window_timing_dmg_b, "m3_window_timing", 0x92B6_5C2A);
 mealybug_dmg_b!(
     test_m3_window_timing_wx_0_dmg_b,

--- a/src/gb/integration_tests/mealybug_tests.rs
+++ b/src/gb/integration_tests/mealybug_tests.rs
@@ -686,12 +686,7 @@ mealybug_cgb_c!(
     "m3_scx_low_3_bits",
     0xD49D_F057
 );
-mealybug_ignored_cgb_c!(
-    test_m3_scy_change_cgb_c,
-    "m3_scy_change",
-    "2597",
-    0xEEAF_63B5
-);
+mealybug_cgb_c!(test_m3_scy_change_cgb_c, "m3_scy_change", 0xEEAF_63B5);
 mealybug_cgb_c!(test_m3_scy_change2_cgb_c, "m3_scy_change2", 0x6D57_9852);
 mealybug_cgb_c!(test_m3_window_timing_cgb_c, "m3_window_timing", 0x0BE0_3D45);
 mealybug_cgb_c!(
@@ -805,12 +800,7 @@ mealybug_cgb_d!(
     "m3_scx_low_3_bits",
     0xD49D_F057
 );
-mealybug_ignored_cgb_d!(
-    test_m3_scy_change_cgb_d,
-    "m3_scy_change",
-    "2597",
-    0x7A71_4C6D
-);
+mealybug_cgb_d!(test_m3_scy_change_cgb_d, "m3_scy_change", 0x7A71_4C6D);
 mealybug_cgb_d!(test_m3_window_timing_cgb_d, "m3_window_timing", 0x92B6_5C2A);
 mealybug_cgb_d!(
     test_m3_window_timing_wx_0_cgb_d,

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -782,6 +782,8 @@ pub struct PixelFifoRenderer {
     #[serde(default)]
     pending_obj_stall_dots: u16,
     #[serde(default)]
+    pending_obj_bg_fetch_wait_dots: u16,
+    #[serde(default)]
     obj_stall_events: Vec<sprites::ObjPenaltyEvent>,
     #[serde(default)]
     next_obj_stall_event: usize,
@@ -867,6 +869,7 @@ impl PixelFifoRenderer {
             pending_cgb_scy: None,
             scy_b_stage_only: false,
             pending_obj_stall_dots: 0,
+            pending_obj_bg_fetch_wait_dots: 0,
             obj_stall_events: Vec::new(),
             next_obj_stall_event: 0,
             active_obj_stall_x: None,
@@ -944,6 +947,7 @@ impl PixelFifoRenderer {
         self.pending_window_startup_stall_dots = 0;
         self.window_startup_stall_consumed = 0;
         self.pending_obj_stall_dots = 0;
+        self.pending_obj_bg_fetch_wait_dots = 0;
         self.next_obj_stall_event = 0;
         self.active_obj_stall_x = None;
         self.canceled_obj_fetch_ranges.clear();
@@ -1046,9 +1050,16 @@ impl PixelFifoRenderer {
                 self.bg_scx_sampler.tick(elapsed, fetch_scx);
                 self.clear_pending_scx_sample_override(will_sample_scx);
                 self.bg_scy_sampler.tick(elapsed, effective_scy);
+            } else if self.pending_obj_bg_fetch_wait_dots > 0 {
+                // The leading OBJ tile-wait samples SCY timing without
+                // advancing the CGB visible-tile SCX prefetch abstraction.
+                self.bg_scy_sampler.tick(elapsed, effective_scy);
             }
+            self.pending_obj_bg_fetch_wait_dots =
+                self.pending_obj_bg_fetch_wait_dots.saturating_sub(1);
             self.pending_obj_stall_dots -= 1;
             if self.pending_obj_stall_dots == 0 {
+                self.pending_obj_bg_fetch_wait_dots = 0;
                 self.active_obj_stall_x = None;
                 self.active_obj_fetch_lcdc_range = None;
             }
@@ -3770,6 +3781,7 @@ impl PixelFifoRenderer {
                 self.start_obj_fetch_lcdc_range(event.x, lcdc);
             }
             self.pending_obj_stall_dots += event.dots;
+            self.pending_obj_bg_fetch_wait_dots += event.bg_fetch_wait_dots;
             self.next_obj_stall_event += 1;
         }
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -42,7 +42,7 @@ const SCX_LOW_BITS_SAMPLE_DOTS: u16 = 6;
 const DMG_SCY_WRITE_CALLBACK_DELAY_DOTS: u16 = 2;
 const DMG_OBJ_FETCH_EXTRA_SCY_ADVANCE_DOTS: u16 = 1;
 
-fn scy_fetch_start_dots(_cgb_mode: bool) -> u16 {
+fn scy_fetch_start_dots() -> u16 {
     SCX_LOW_BITS_SAMPLE_DOTS + 3
 }
 
@@ -773,8 +773,8 @@ pub struct PixelFifoRenderer {
     effective_scy: u8,
     /// Pending SCY write: `(dot_when_active, new_value)`.
     /// When `elapsed >= dot_when_active`, `effective_scy` is updated to `new_value`.
-    #[serde(default)]
-    pending_cgb_scy: Option<(u16, u8)>,
+    #[serde(default, alias = "pending_cgb_scy")]
+    pending_scy_write: Option<(u16, u8)>,
     /// When `true` (CGB-D and newer), SCY is only sampled at the B (GetTile) stage;
     /// data latches always equal `scy_map` for each tile (no inter-stage mixing).
     #[serde(default)]
@@ -866,7 +866,7 @@ impl PixelFifoRenderer {
             bg_fetch_scy_data_high: 0,
             bg_scy_sampler: BgScySampler::default(),
             effective_scy: 0,
-            pending_cgb_scy: None,
+            pending_scy_write: None,
             scy_b_stage_only: false,
             pending_obj_stall_dots: 0,
             pending_obj_bg_fetch_wait_dots: 0,
@@ -934,12 +934,9 @@ impl PixelFifoRenderer {
             .reset(registers.scx, BgScxSamplerConfig::for_mode(cgb_mode));
         self.pending_scx_sample_override = None;
         self.effective_scy = registers.scy;
-        self.pending_cgb_scy = None;
-        self.bg_scy_sampler.reset(
-            registers.scy,
-            scy_fetch_start_dots(cgb_mode),
-            self.scy_b_stage_only,
-        );
+        self.pending_scy_write = None;
+        self.bg_scy_sampler
+            .reset(registers.scy, scy_fetch_start_dots(), self.scy_b_stage_only);
         self.bg_fetch_scy_map = registers.scy;
         self.bg_fetch_scy_data_low = registers.scy;
         self.bg_fetch_scy_data_high = registers.scy;
@@ -1156,9 +1153,9 @@ impl PixelFifoRenderer {
         self.bg_scx_sampler.config = BgScxSamplerConfig::for_mode(cgb_mode);
         self.scy_b_stage_only = scy_b_stage_only;
         self.bg_scy_sampler.b_stage_only = scy_b_stage_only;
-        self.bg_scy_sampler.fetch_start_dots = scy_fetch_start_dots(cgb_mode);
+        self.bg_scy_sampler.fetch_start_dots = scy_fetch_start_dots();
         self.effective_scy = current_scy;
-        self.pending_cgb_scy = None;
+        self.pending_scy_write = None;
     }
 
     pub(super) fn set_scy_b_stage_only(&mut self, b_stage_only: bool) {
@@ -1196,12 +1193,12 @@ impl PixelFifoRenderer {
             // hardware write propagation delay. Both CGB-C and CGB-D use the same
             // delay since the difference in behavior comes from which stages sample
             // effective_scy (b_stage_only flag), not from write timing.
-            self.pending_cgb_scy = Some((elapsed.saturating_add(4), new_scy));
+            self.pending_scy_write = Some((elapsed.saturating_add(4), new_scy));
         } else {
             // DMG has no hardware propagation delay; the two-dot delay here
             // aligns this tick-before-register-write callback with the PPU's
             // observed fetch-stage sampling point.
-            self.pending_cgb_scy = Some((
+            self.pending_scy_write = Some((
                 elapsed.saturating_add(DMG_SCY_WRITE_CALLBACK_DELAY_DOTS),
                 new_scy,
             ));
@@ -3618,10 +3615,10 @@ impl PixelFifoRenderer {
         self.bg_scy_sampler.consume_pixel();
     }
 
-    /// Apply any matured CGB SCY write to `effective_scy`.
+    /// Apply any matured SCY write to `effective_scy`.
     fn update_effective_scy(&mut self, elapsed: u16) {
-        if matches!(self.pending_cgb_scy, Some((effective_at, _)) if elapsed >= effective_at) {
-            let (_, new_scy) = self.pending_cgb_scy.take().unwrap();
+        if matches!(self.pending_scy_write, Some((effective_at, _)) if elapsed >= effective_at) {
+            let (_, new_scy) = self.pending_scy_write.take().unwrap();
             self.effective_scy = new_scy;
         }
     }
@@ -4155,7 +4152,7 @@ mod tests {
         assert!(renderer.bg_scx_sampler.will_sample_scx(7));
         assert_eq!(
             renderer.bg_scy_sampler.fetch_start_dots,
-            scy_fetch_start_dots(true)
+            scy_fetch_start_dots()
         );
         assert_eq!(renderer.effective_scy, 0x5a);
     }
@@ -4169,7 +4166,7 @@ mod tests {
 
         assert_eq!(
             renderer.bg_scy_sampler.fetch_start_dots,
-            scy_fetch_start_dots(false)
+            scy_fetch_start_dots()
         );
         assert_eq!(renderer.effective_scy, 0x81);
     }

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -39,9 +39,11 @@ const LEFT_EDGE_OBJ_X1_STEADY_WINDOW_MAP_RESTORE_X: u8 = OBJ_PIXELS_PER_FETCH * 
 const SCX_FINE_MASK: u8 = 0x07;
 const SCX_TILE_MASK: u8 = !SCX_FINE_MASK;
 const SCX_LOW_BITS_SAMPLE_DOTS: u16 = 6;
+const DMG_SCY_WRITE_CALLBACK_DELAY_DOTS: u16 = 2;
+const DMG_OBJ_FETCH_EXTRA_SCY_ADVANCE_DOTS: u16 = 1;
 
-fn scy_fetch_start_dots(cgb_mode: bool) -> u16 {
-    SCX_LOW_BITS_SAMPLE_DOTS + if cgb_mode { 3 } else { 1 }
+fn scy_fetch_start_dots(_cgb_mode: bool) -> u16 {
+    SCX_LOW_BITS_SAMPLE_DOTS + 3
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -574,10 +576,9 @@ impl Default for BgScxSamplerConfig {
 /// On CGB-D (and newer), SCY is only read at the **B** stage (`b_stage_only = true`), so
 /// no inter-stage mixing can occur.
 ///
-/// The sampler mirrors the `BgScxSampler` step machine. The `fetch_start_dots` is set to
-/// `SCX_LOW_BITS_SAMPLE_DOTS + 1` for DMG and `SCX_LOW_BITS_SAMPLE_DOTS + 3` for CGB,
-/// placing the first B-stage one or two dots later than the SCX tile-column latch.
-/// This offset was determined empirically to best match mealybug tearoom reference images.
+/// The sampler mirrors the `BgScxSampler` step machine. The `fetch_start_dots`
+/// places the first B-stage three dots later than the SCX tile-column latch,
+/// matching Mealybug's mid-scanline SCY timing on DMG and CGB revisions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct BgScySampler {
     step: BgScxFetchStep,
@@ -766,12 +767,11 @@ pub struct PixelFifoRenderer {
     bg_fetch_scy_data_high: u8,
     #[serde(default)]
     bg_scy_sampler: BgScySampler,
-    /// Effective SCY seen by the PPU tile fetcher. On DMG updated immediately on write;
-    /// on CGB updated after a 4-dot effective delay in this emulator's scheduler
-    /// (2 hardware T-cycles of propagation + 2 dots from tick-before-write ordering).
+    /// Effective SCY seen by the PPU tile fetcher after the write callback has
+    /// reached the model-specific fetch sampling point.
     #[serde(default)]
     effective_scy: u8,
-    /// Pending CGB SCY write: `(dot_when_active, new_value)`.
+    /// Pending SCY write: `(dot_when_active, new_value)`.
     /// When `elapsed >= dot_when_active`, `effective_scy` is updated to `new_value`.
     #[serde(default)]
     pending_cgb_scy: Option<(u16, u8)>,
@@ -965,10 +965,16 @@ impl PixelFifoRenderer {
             .is_some_and(ObjFetchModel::ignores_lcdc_obj_enable);
         if self.obj_fetch_ignores_lcdc || registers.lcdc & LCDC_OBJ_ENABLE != 0 {
             sprites::scan_oam_line_into(scanline, oam, registers.lcdc, &mut self.sprite_indices);
-            sprites::schedule_obj_penalties(
+            let bg_fetch_wait_extra_dots = if cgb_mode {
+                0
+            } else {
+                DMG_OBJ_FETCH_EXTRA_SCY_ADVANCE_DOTS
+            };
+            sprites::schedule_obj_penalties_with_bg_fetch_wait_extra(
                 &self.sprite_indices,
                 oam,
                 registers.scx,
+                bg_fetch_wait_extra_dots,
                 &mut self.obj_stall_events,
             );
             self.leftmost_obj_oam_x = self
@@ -1049,9 +1055,9 @@ impl PixelFifoRenderer {
             if !self.bg_scx_sampler.pauses_on_obj_fetch() {
                 self.bg_scx_sampler.tick(elapsed, fetch_scx);
                 self.clear_pending_scx_sample_override(will_sample_scx);
-                self.bg_scy_sampler.tick(elapsed, effective_scy);
-            } else if self.pending_obj_bg_fetch_wait_dots > 0 {
-                // The leading OBJ tile-wait samples SCY timing without
+            }
+            if self.pending_obj_bg_fetch_wait_dots > 0 {
+                // The leading OBJ tile-wait/fetch setup samples SCY timing without
                 // advancing the CGB visible-tile SCX prefetch abstraction.
                 self.bg_scy_sampler.tick(elapsed, effective_scy);
             }
@@ -1183,8 +1189,8 @@ impl PixelFifoRenderer {
         if !self.active {
             return;
         }
+        let elapsed = dot.saturating_sub(self.mode3_start_dot);
         if cgb_mode {
-            let elapsed = dot.saturating_sub(self.mode3_start_dot);
             // On CGB, SCY writes take effect 4 T-cycles after the write dot.
             // This accounts for the emulator's tick-before-write model plus the CGB
             // hardware write propagation delay. Both CGB-C and CGB-D use the same
@@ -1192,9 +1198,13 @@ impl PixelFifoRenderer {
             // effective_scy (b_stage_only flag), not from write timing.
             self.pending_cgb_scy = Some((elapsed.saturating_add(4), new_scy));
         } else {
-            // DMG: immediate effect.
-            self.pending_cgb_scy = None;
-            self.effective_scy = new_scy;
+            // DMG has no hardware propagation delay; the two-dot delay here
+            // aligns this tick-before-register-write callback with the PPU's
+            // observed fetch-stage sampling point.
+            self.pending_cgb_scy = Some((
+                elapsed.saturating_add(DMG_SCY_WRITE_CALLBACK_DELAY_DOTS),
+                new_scy,
+            ));
         }
     }
 

--- a/src/gb/ppu/sprites.rs
+++ b/src/gb/ppu/sprites.rs
@@ -20,8 +20,8 @@ pub struct SpritePixel {
 pub(super) struct ObjPenaltyEvent {
     pub x: u8,
     pub dots: u16,
-    /// Leading dots where an on-screen OBJ waits for the BG fetcher to reach
-    /// the target tile before the OBJ tile fetch itself starts.
+    /// Leading stall dots where the BG fetcher keeps advancing before the
+    /// visible pixel stream resumes.
     #[serde(default)]
     pub bg_fetch_wait_dots: u16,
 }
@@ -356,6 +356,18 @@ pub(super) fn schedule_obj_penalties(
     scx: u8,
     events: &mut Vec<ObjPenaltyEvent>,
 ) {
+    schedule_obj_penalties_with_bg_fetch_wait_extra(sprite_indices, oam, scx, 0, events);
+}
+
+/// Build OBJ stall events, adding model-specific BG fetcher advance dots to
+/// on-screen sprites without changing the total OBJ penalty.
+pub(super) fn schedule_obj_penalties_with_bg_fetch_wait_extra(
+    sprite_indices: &[usize],
+    oam: &[u8; 0xA0],
+    scx: u8,
+    bg_fetch_wait_extra_dots: u16,
+    events: &mut Vec<ObjPenaltyEvent>,
+) {
     events.clear();
     debug_assert!(
         sprite_indices.len() <= 10,
@@ -391,7 +403,7 @@ pub(super) fn schedule_obj_penalties(
             let tile_wait_dots = tile_wait_penalty(oam_x, bg_x);
             event_dots += tile_wait_dots;
             if oam_x >= FIRST_VISIBLE_OAM_X {
-                bg_fetch_wait_dots = tile_wait_dots;
+                bg_fetch_wait_dots = (tile_wait_dots + bg_fetch_wait_extra_dots).min(event_dots);
             }
             if seen_count < seen_tiles.len() {
                 seen_tiles[seen_count] = tile_id;
@@ -719,6 +731,23 @@ mod tests {
                 x: 0,
                 dots: 11,
                 bg_fetch_wait_dots: 5
+            }]
+        );
+        assert_eq!(calculate_obj_penalty(&indices, &oam, 0), 11);
+    }
+
+    #[test]
+    fn test_obj_penalty_extra_bg_fetch_wait_does_not_change_total_penalty() {
+        let (oam, indices) = penalty_sprites(&[8]);
+        let mut events = Vec::new();
+        schedule_obj_penalties_with_bg_fetch_wait_extra(&indices, &oam, 0, 1, &mut events);
+
+        assert_eq!(
+            events,
+            vec![ObjPenaltyEvent {
+                x: 0,
+                dots: 11,
+                bg_fetch_wait_dots: 6
             }]
         );
         assert_eq!(calculate_obj_penalty(&indices, &oam, 0), 11);

--- a/src/gb/ppu/sprites.rs
+++ b/src/gb/ppu/sprites.rs
@@ -20,13 +20,18 @@ pub struct SpritePixel {
 pub(super) struct ObjPenaltyEvent {
     pub x: u8,
     pub dots: u16,
+    /// Leading dots where an on-screen OBJ waits for the BG fetcher to reach
+    /// the target tile before the OBJ tile fetch itself starts.
+    #[serde(default)]
+    pub bg_fetch_wait_dots: u16,
 }
 
 impl ObjPenaltyEvent {
-    fn new(screen_x: i16, dots: u16) -> Self {
+    fn new(screen_x: i16, dots: u16, bg_fetch_wait_dots: u16) -> Self {
         Self {
             x: screen_x.clamp(0, 159) as u8,
             dots,
+            bg_fetch_wait_dots,
         }
     }
 }
@@ -311,6 +316,9 @@ pub fn fetch_sprite_pixel_cgb(
 /// Flat dot cost per visible sprite (OBJ tile fetch).
 const OBJ_FETCH_DOTS: u16 = 6;
 
+/// OAM X for an OBJ whose leftmost pixel is at visible screen X=0.
+const FIRST_VISIBLE_OAM_X: u8 = 8;
+
 /// BG tile width in pixels.
 const BG_TILE_WIDTH: i16 = 8;
 
@@ -378,15 +386,23 @@ pub(super) fn schedule_obj_penalties(
         let tile_id = bg_x.div_euclid(BG_TILE_WIDTH);
 
         let mut event_dots = OBJ_FETCH_DOTS;
+        let mut bg_fetch_wait_dots = 0;
         if !seen_tiles[..seen_count].contains(&tile_id) {
-            event_dots += tile_wait_penalty(oam_x, bg_x);
+            let tile_wait_dots = tile_wait_penalty(oam_x, bg_x);
+            event_dots += tile_wait_dots;
+            if oam_x >= FIRST_VISIBLE_OAM_X {
+                bg_fetch_wait_dots = tile_wait_dots;
+            }
             if seen_count < seen_tiles.len() {
                 seen_tiles[seen_count] = tile_id;
                 seen_count += 1;
             }
         }
 
-        push_obj_penalty_event(events, ObjPenaltyEvent::new(screen_x, event_dots));
+        push_obj_penalty_event(
+            events,
+            ObjPenaltyEvent::new(screen_x, event_dots, bg_fetch_wait_dots),
+        );
     }
 }
 
@@ -395,6 +411,7 @@ fn push_obj_penalty_event(events: &mut Vec<ObjPenaltyEvent>, event: ObjPenaltyEv
         && last.x == event.x
     {
         last.dots += event.dots;
+        last.bg_fetch_wait_dots += event.bg_fetch_wait_dots;
     } else {
         events.push(event);
     }
@@ -694,6 +711,16 @@ mod tests {
     fn test_obj_penalty_single_sprite_at_x8_is_11_dots() {
         // OAM X=8 → screen_x=0, bg_x=0, pos_in_tile=0, right=7, wait=5, total=5+6=11
         let (oam, indices) = penalty_sprites(&[8]);
+        let mut events = Vec::new();
+        schedule_obj_penalties(&indices, &oam, 0, &mut events);
+        assert_eq!(
+            events,
+            vec![ObjPenaltyEvent {
+                x: 0,
+                dots: 11,
+                bg_fetch_wait_dots: 5
+            }]
+        );
         assert_eq!(calculate_obj_penalty(&indices, &oam, 0), 11);
     }
 
@@ -704,7 +731,14 @@ mod tests {
         let (oam, indices) = penalty_sprites(&[9]);
         let mut events = Vec::new();
         schedule_obj_penalties(&indices, &oam, 0, &mut events);
-        assert_eq!(events, vec![ObjPenaltyEvent { x: 1, dots: 10 }]);
+        assert_eq!(
+            events,
+            vec![ObjPenaltyEvent {
+                x: 1,
+                dots: 10,
+                bg_fetch_wait_dots: 4
+            }]
+        );
         assert_eq!(calculate_obj_penalty(&indices, &oam, 0), 10);
     }
 
@@ -715,7 +749,14 @@ mod tests {
         let (oam, indices) = penalty_sprites(&[5]);
         let mut events = Vec::new();
         schedule_obj_penalties(&indices, &oam, 0, &mut events);
-        assert_eq!(events, vec![ObjPenaltyEvent { x: 0, dots: 6 }]);
+        assert_eq!(
+            events,
+            vec![ObjPenaltyEvent {
+                x: 0,
+                dots: 6,
+                bg_fetch_wait_dots: 0
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enables the Mealybug m3_scy_change tests for DMG-B, CGB-C, and CGB-D.
- Tracks the remaining ignored Mealybug WX/LCDC-WX audit cases under #2598.
- Refines GB PPU SCY sampling around OBJ stalls without changing total OBJ penalty timing.

Closes #2597.

## Validation
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/test-dir.sh src/gb --skip-integration
- cargo test --quiet --no-default-features --lib gb::integration_tests::mealybug_tests:: -- --nocapture
- cargo test --quiet --no-default-features --lib gb::ppu::sprites::tests:: -- --nocapture
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test

## Known baseline failure
- cargo test --no-default-features --lib currently fails on main and on this branch in gba::integration_tests::gba_suite_tests::gba_mgba_suite_passes with mgba_timing expected 0xD49CDB49 actual 0xDEEFA167 on this machine.
