### PR TITLE
Fix #2605: package release resources

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,28 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact: neser
-          - os: macos-latest
+            binary: neser
+            archive_format: tar.gz
+            verify_flags: --require-unix-executable
+            smoke_binary: ./neser
+          - os: macos-13
             target: x86_64-apple-darwin
-            artifact: neser
-          - os: macos-latest
+            binary: neser
+            archive_format: tar.gz
+            verify_flags: --require-unix-executable
+            smoke_binary: ./neser
+          - os: macos-14
             target: aarch64-apple-darwin
-            artifact: neser
+            binary: neser
+            archive_format: tar.gz
+            verify_flags: --require-unix-executable
+            smoke_binary: ./neser
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact: neser.exe
+            binary: neser.exe
+            archive_format: zip
+            verify_flags: ""
+            smoke_binary: ./neser.exe
 
     steps:
       - uses: actions/checkout@v6
@@ -51,20 +63,28 @@ jobs:
       - name: Build
         run: cargo build --release --features native --target ${{ matrix.target }}
 
-      - name: Upload artifact (Unix)
-        if: matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v5
-        with:
-          name: neser-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/neser
+      - name: Package release archive
+        run: >
+          python scripts/package_release.py
+          --binary target/${{ matrix.target }}/release/${{ matrix.binary }}
+          --output-dir dist
+          --target ${{ matrix.target }}
+          --format ${{ matrix.archive_format }}
+          --binary-name ${{ matrix.binary }}
 
-      - name: Upload artifact (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Verify release archive
+        run: >
+          python scripts/verify_release_package.py
+          dist/neser-${{ matrix.target }}.${{ matrix.archive_format }}
+          --binary-name ${{ matrix.binary }}
+          ${{ matrix.verify_flags }}
+          --smoke-command ${{ matrix.smoke_binary }} --version
+
+      - name: Upload release archive
         uses: actions/upload-artifact@v5
         with:
           name: neser-${{ matrix.target }}
-          path: |
-            target/${{ matrix.target }}/release/neser.exe
+          path: dist/neser-${{ matrix.target }}.${{ matrix.archive_format }}
 
   release:
     name: Create GitHub Release
@@ -84,13 +104,6 @@ jobs:
         with:
           path: artifacts
 
-      - name: Prepare release assets
-        run: |
-          mv artifacts/neser-x86_64-unknown-linux-gnu/neser artifacts/neser-linux-x86_64
-          mv artifacts/neser-x86_64-apple-darwin/neser artifacts/neser-macos-x86_64
-          mv artifacts/neser-aarch64-apple-darwin/neser artifacts/neser-macos-aarch64
-          cd artifacts/neser-x86_64-pc-windows-msvc && zip -r ../neser-windows-x86_64.zip . && cd ../..
-
       - name: Install git-cliff
         uses: taiki-e/install-action@v2
         with:
@@ -103,10 +116,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            artifacts/neser-linux-x86_64
-            artifacts/neser-macos-x86_64
-            artifacts/neser-macos-aarch64
-            artifacts/neser-windows-x86_64.zip
+            artifacts/**/*.tar.gz
+            artifacts/**/*.zip
           body_path: RELEASE_NOTES.md
           make_latest: true
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ NESER - NES Emulator in Rust
 
 Download the latest release for your platform from the [GitHub Releases](https://github.com/rmstdope/neser/releases) page.
 
+Release downloads are archives with a top-level `neser/` directory:
+
+| Platform | Archive format | Example asset |
+| -------- | -------------- | ------------- |
+| Linux x86_64 | `.tar.gz` | `neser-x86_64-unknown-linux-gnu.tar.gz` |
+| macOS x86_64 | `.tar.gz` | `neser-x86_64-apple-darwin.tar.gz` |
+| macOS aarch64 | `.tar.gz` | `neser-aarch64-apple-darwin.tar.gz` |
+| Windows x86_64 | `.zip` | `neser-x86_64-pc-windows-msvc.zip` |
+
+After extracting, run NESER from inside the extracted `neser/` directory so the bundled runtime resources are found:
+
+```bash
+cd neser
+./neser --version
+./neser
+```
+
+On Windows, use `neser.exe --version` and `neser.exe` from the extracted `neser\` directory.
+
+Release archives include the emulator binary, `assets/fonts/`, `gamecontrollerdb.txt`, shader presets and only the shader dependencies required by configured presets, `neser.conf.example`, `README.md`, and `LICENSE`. Development scripts are not included in release archives.
+
 ### From source via cargo install
 
 ```bash

--- a/architecture.md
+++ b/architecture.md
@@ -97,6 +97,8 @@ The `src/bin/roms.rs` file is a library binary (accessed via `cargo run --bin ro
 | Tool | Description |
 | ------ | ------------- |
 | `scripts/sort_roms.py` | Sorts ROM files into mapper-numbered subdirectories based on their iNES header. |
+| `scripts/package_release.py` | Builds per-target release archives with a top-level `neser/` directory. Includes the binary, runtime resources, README, LICENSE, config example, fonts, and only shader files reachable from configured shader presets. Excludes development scripts. |
+| `scripts/verify_release_package.py` | Verifies release archive manifests for `.tar.gz` and `.zip`, checks Unix executable permissions when requested, extracts packages to a temporary directory, and can run a smoke command such as `./neser --version` from the package root. |
 | `scripts/disassemble_rom.py` | Disassembles a NES ROM file and prints 6502 assembly output. |
 | `scripts/display_audio_output.py` | Visualizes APU audio output data for debugging audio issues. |
 | `scripts/mappertool/` | A Textual-based TUI application for browsing and managing a ROM database, inspecting mapper assignments, and cross-referencing ROM files with the embedded ROM database. |
@@ -436,7 +438,7 @@ Shader presets using the Slang shading language, loaded via librashader:
 | Workflow | Description |
 | ---------- | ------------- |
 | `ci.yml` | Main CI pipeline. Runs on push to `main` and PRs. Jobs: Rust tests (`cargo test --lib --all-features`), Clippy lint, `cargo fmt` check, WASM build + test (`wasm-pack test`), web JS unit tests (`npm test`), web Playwright integration tests, and Python script tests. Uses path-based change detection to skip unchanged jobs, and runs NES/GBA integration suites selectively (GBA integration also triggers on `roms/gba/automated_tests/gba-tests` asset changes). |
-| `release.yml` | Release pipeline triggered by version tags (`v*.*.*`). Runs full CI, then cross-compiles release binaries for Linux (x86_64), macOS (x86_64 + aarch64), and Windows (x86_64). Windows builds bundle SDL2.dll and SDL2_ttf.dll. Publishes to GitHub Releases with a git-cliff changelog. |
+| `release.yml` | Release pipeline triggered by version tags (`v*.*.*`). Runs full CI, then builds Linux x86_64, macOS x86_64, macOS aarch64, and Windows x86_64 on target-compatible runners. Each build job creates a structured release archive with `scripts/package_release.py`, verifies it with `scripts/verify_release_package.py`, and smoke-runs the packaged binary with `--version` from inside the extracted `neser/` directory. Publishes only verified `.tar.gz` and `.zip` archives to GitHub Releases with a git-cliff changelog. |
 
 #### Agentic Workflows (Copilot-powered)
 

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -2,6 +2,7 @@
 
 import re
 import tarfile
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -33,30 +34,22 @@ def collect_shader_dependencies(repo_root: Path) -> set[Path]:
 def create_release_archive(config: ReleasePackageConfig) -> Path:
     """Create a release archive and return its path."""
 
-    if config.archive_format != "tar.gz":
+    if config.archive_format not in {"tar.gz", "zip"}:
         raise ValueError(f"unsupported archive format: {config.archive_format}")
 
     repo_root = config.repo_root.resolve()
     config.output_dir.mkdir(parents=True, exist_ok=True)
-    archive_path = config.output_dir / f"neser-{config.target}.tar.gz"
+    extension = "tar.gz" if config.archive_format == "tar.gz" else "zip"
+    archive_path = config.output_dir / f"neser-{config.target}.{extension}"
 
-    with tarfile.open(archive_path, "w:gz") as archive:
-        _add_file_to_tar(archive, config.binary_path, Path("neser") / config.binary_name)
-        _add_tree_to_tar(archive, repo_root / "assets/fonts", Path("neser/assets/fonts"))
-        for required_file in (
-            "gamecontrollerdb.txt",
-            "neser.conf.example",
-            "README.md",
-            "LICENSE",
-        ):
-            _add_file_to_tar(archive, repo_root / required_file, Path("neser") / required_file)
-
-        for shader_dependency in sorted(collect_shader_dependencies(repo_root)):
-            _add_file_to_tar(
-                archive,
-                repo_root / shader_dependency,
-                Path("neser") / shader_dependency,
-            )
+    if config.archive_format == "tar.gz":
+        with tarfile.open(archive_path, "w:gz") as archive:
+            for source_path, archive_path_in_package in _package_files(config, repo_root):
+                _add_file_to_tar(archive, source_path, archive_path_in_package)
+    else:
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            for source_path, archive_path_in_package in _package_files(config, repo_root):
+                archive.write(source_path, archive_path_in_package.as_posix())
 
     return archive_path
 
@@ -194,13 +187,32 @@ def _clean_path(path: str) -> str:
     return path
 
 
-def _add_tree_to_tar(archive: tarfile.TarFile, source_dir: Path, archive_dir: Path) -> None:
+def _package_files(config: ReleasePackageConfig, repo_root: Path) -> list[tuple[Path, Path]]:
+    package_files = [(config.binary_path, Path("neser") / config.binary_name)]
+    package_files.extend(_tree_files(repo_root / "assets/fonts", Path("neser/assets/fonts")))
+    for required_file in (
+        "gamecontrollerdb.txt",
+        "neser.conf.example",
+        "README.md",
+        "LICENSE",
+    ):
+        package_files.append((repo_root / required_file, Path("neser") / required_file))
+
+    for shader_dependency in sorted(collect_shader_dependencies(repo_root)):
+        package_files.append((repo_root / shader_dependency, Path("neser") / shader_dependency))
+
+    return package_files
+
+
+def _tree_files(source_dir: Path, archive_dir: Path) -> list[tuple[Path, Path]]:
     if not source_dir.is_dir():
         raise FileNotFoundError(source_dir)
 
-    for path in sorted(source_dir.rglob("*")):
-        if path.is_file():
-            _add_file_to_tar(archive, path, archive_dir / path.relative_to(source_dir))
+    return [
+        (path, archive_dir / path.relative_to(source_dir))
+        for path in sorted(source_dir.rglob("*"))
+        if path.is_file()
+    ]
 
 
 def _add_file_to_tar(archive: tarfile.TarFile, source_path: Path, archive_path: Path) -> None:

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -1,5 +1,6 @@
 """Build verified release archives for neser."""
 
+import argparse
 import re
 import tarfile
 import zipfile
@@ -52,6 +53,31 @@ def create_release_archive(config: ReleasePackageConfig) -> Path:
                 archive.write(source_path, archive_path_in_package.as_posix())
 
     return archive_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the release packager CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--format", choices=("tar.gz", "zip"), required=True)
+    parser.add_argument("--binary-name", default="neser")
+    args = parser.parse_args(argv)
+
+    create_release_archive(
+        ReleasePackageConfig(
+            repo_root=args.repo_root,
+            binary_path=args.binary,
+            output_dir=args.output_dir,
+            target=args.target,
+            archive_format=args.format,
+            binary_name=args.binary_name,
+        )
+    )
+    return 0
 
 
 _PRESET_PATH_RE = re.compile(
@@ -217,3 +243,7 @@ def _tree_files(source_dir: Path, archive_dir: Path) -> list[tuple[Path, Path]]:
 
 def _add_file_to_tar(archive: tarfile.TarFile, source_path: Path, archive_path: Path) -> None:
     archive.add(source_path, arcname=archive_path.as_posix(), recursive=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -28,7 +28,9 @@ def collect_shader_dependencies(repo_root: Path) -> set[Path]:
     dependencies: set[Path] = set()
     processing: set[Path] = set()
     for shader_path in shader_paths:
-        _collect_shader_file(repo_root, repo_root / shader_path, dependencies, processing)
+        _collect_shader_file(
+            repo_root, repo_root / shader_path, dependencies, processing
+        )
     return dependencies
 
 
@@ -45,11 +47,15 @@ def create_release_archive(config: ReleasePackageConfig) -> Path:
 
     if config.archive_format == "tar.gz":
         with tarfile.open(archive_path, "w:gz") as archive:
-            for source_path, archive_path_in_package in _package_files(config, repo_root):
+            for source_path, archive_path_in_package in _package_files(
+                config, repo_root
+            ):
                 _add_file_to_tar(archive, source_path, archive_path_in_package)
     else:
         with zipfile.ZipFile(archive_path, "w") as archive:
-            for source_path, archive_path_in_package in _package_files(config, repo_root):
+            for source_path, archive_path_in_package in _package_files(
+                config, repo_root
+            ):
                 archive.write(source_path, archive_path_in_package.as_posix())
 
     return archive_path
@@ -80,9 +86,7 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-_PRESET_PATH_RE = re.compile(
-    r'\(\s*"[^"]+"\s*,\s*"([^"]+)"\s*,?\s*\)', re.MULTILINE
-)
+_PRESET_PATH_RE = re.compile(r'\(\s*"[^"]+"\s*,\s*"([^"]+)"\s*,?\s*\)', re.MULTILINE)
 _REFERENCE_RE = re.compile(r'^\s*#reference\s+"([^"]+)"')
 _SHADER_RE = re.compile(r"^\s*shader\d+\s*=\s*(.+)$")
 _INCLUDE_RE = re.compile(r'^\s*#include\s+"([^"]+)"')
@@ -213,9 +217,13 @@ def _clean_path(path: str) -> str:
     return path
 
 
-def _package_files(config: ReleasePackageConfig, repo_root: Path) -> list[tuple[Path, Path]]:
+def _package_files(
+    config: ReleasePackageConfig, repo_root: Path
+) -> list[tuple[Path, Path]]:
     package_files = [(config.binary_path, Path("neser") / config.binary_name)]
-    package_files.extend(_tree_files(repo_root / "assets/fonts", Path("neser/assets/fonts")))
+    package_files.extend(
+        _tree_files(repo_root / "assets/fonts", Path("neser/assets/fonts"))
+    )
     for required_file in (
         "gamecontrollerdb.txt",
         "neser.conf.example",
@@ -225,7 +233,9 @@ def _package_files(config: ReleasePackageConfig, repo_root: Path) -> list[tuple[
         package_files.append((repo_root / required_file, Path("neser") / required_file))
 
     for shader_dependency in sorted(collect_shader_dependencies(repo_root)):
-        package_files.append((repo_root / shader_dependency, Path("neser") / shader_dependency))
+        package_files.append(
+            (repo_root / shader_dependency, Path("neser") / shader_dependency)
+        )
 
     return package_files
 
@@ -241,7 +251,9 @@ def _tree_files(source_dir: Path, archive_dir: Path) -> list[tuple[Path, Path]]:
     ]
 
 
-def _add_file_to_tar(archive: tarfile.TarFile, source_path: Path, archive_path: Path) -> None:
+def _add_file_to_tar(
+    archive: tarfile.TarFile, source_path: Path, archive_path: Path
+) -> None:
     archive.add(source_path, arcname=archive_path.as_posix(), recursive=False)
 
 

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -1,0 +1,207 @@
+"""Build verified release archives for neser."""
+
+import re
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ReleasePackageConfig:
+    """Inputs for building one platform release archive."""
+
+    repo_root: Path
+    binary_path: Path
+    output_dir: Path
+    target: str
+    archive_format: str
+    binary_name: str = "neser"
+
+
+def collect_shader_dependencies(repo_root: Path) -> set[Path]:
+    """Return shader files required by configured shader presets."""
+
+    repo_root = repo_root.resolve()
+    shader_paths = _read_shader_preset_paths(repo_root / "src/platform/shaders.rs")
+    dependencies: set[Path] = set()
+    processing: set[Path] = set()
+    for shader_path in shader_paths:
+        _collect_shader_file(repo_root, repo_root / shader_path, dependencies, processing)
+    return dependencies
+
+
+def create_release_archive(config: ReleasePackageConfig) -> Path:
+    """Create a release archive and return its path."""
+
+    if config.archive_format != "tar.gz":
+        raise ValueError(f"unsupported archive format: {config.archive_format}")
+
+    repo_root = config.repo_root.resolve()
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    archive_path = config.output_dir / f"neser-{config.target}.tar.gz"
+
+    with tarfile.open(archive_path, "w:gz") as archive:
+        _add_file_to_tar(archive, config.binary_path, Path("neser") / config.binary_name)
+        _add_tree_to_tar(archive, repo_root / "assets/fonts", Path("neser/assets/fonts"))
+        for required_file in (
+            "gamecontrollerdb.txt",
+            "neser.conf.example",
+            "README.md",
+            "LICENSE",
+        ):
+            _add_file_to_tar(archive, repo_root / required_file, Path("neser") / required_file)
+
+        for shader_dependency in sorted(collect_shader_dependencies(repo_root)):
+            _add_file_to_tar(
+                archive,
+                repo_root / shader_dependency,
+                Path("neser") / shader_dependency,
+            )
+
+    return archive_path
+
+
+_PRESET_PATH_RE = re.compile(
+    r'\(\s*"[^"]+"\s*,\s*"([^"]+)"\s*,?\s*\)', re.MULTILINE
+)
+_REFERENCE_RE = re.compile(r'^\s*#reference\s+"([^"]+)"')
+_SHADER_RE = re.compile(r"^\s*shader\d+\s*=\s*(.+)$")
+_INCLUDE_RE = re.compile(r'^\s*#include\s+"([^"]+)"')
+_LUT_QUOTED_RE = re.compile(r'"([^"]+\.(?:png|jpg|jpeg))"', re.IGNORECASE)
+_LUT_BARE_RE = re.compile(r"=\s*([^\s]+\.(?:png|jpg|jpeg))", re.IGNORECASE)
+
+
+def _read_shader_preset_paths(shaders_rs_path: Path) -> list[Path]:
+    text = shaders_rs_path.read_text(encoding="utf-8")
+    return [Path(match.group(1)) for match in _PRESET_PATH_RE.finditer(text)]
+
+
+def _collect_shader_file(
+    repo_root: Path,
+    path: Path,
+    dependencies: set[Path],
+    processing: set[Path],
+) -> None:
+    path = path.resolve()
+    if path in processing:
+        return
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    relative_path = path.relative_to(repo_root)
+    if relative_path in dependencies:
+        return
+
+    processing.add(path)
+    try:
+        dependencies.add(relative_path)
+
+        suffix = path.suffix.lower()
+        if suffix in {".slangp", ".params"}:
+            _collect_preset_dependencies(repo_root, path, dependencies, processing)
+        elif suffix in {".slang", ".inc", ".h"}:
+            _collect_include_dependencies(repo_root, path, dependencies, processing)
+    finally:
+        processing.remove(path)
+
+
+def _collect_preset_dependencies(
+    repo_root: Path,
+    path: Path,
+    dependencies: set[Path],
+    processing: set[Path],
+) -> None:
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        reference_match = _REFERENCE_RE.match(line)
+        if reference_match:
+            _collect_relative_shader_file(
+                repo_root, path, reference_match.group(1), dependencies, processing
+            )
+            continue
+
+        if path.suffix.lower() == ".slangp":
+            shader_match = _SHADER_RE.match(line)
+            if shader_match:
+                _collect_relative_shader_file(
+                    repo_root,
+                    path,
+                    _clean_path(shader_match.group(1)),
+                    dependencies,
+                    processing,
+                )
+                continue
+
+        for lut_path in _LUT_QUOTED_RE.findall(line):
+            _collect_existing_lut(repo_root, path, lut_path, dependencies, processing)
+        bare_lut_match = _LUT_BARE_RE.search(line)
+        if bare_lut_match:
+            _collect_existing_lut(
+                repo_root,
+                path,
+                bare_lut_match.group(1),
+                dependencies,
+                processing,
+            )
+
+
+def _collect_include_dependencies(
+    repo_root: Path,
+    path: Path,
+    dependencies: set[Path],
+    processing: set[Path],
+) -> None:
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        include_match = _INCLUDE_RE.match(line)
+        if include_match:
+            _collect_relative_shader_file(
+                repo_root, path, include_match.group(1), dependencies, processing
+            )
+
+
+def _collect_relative_shader_file(
+    repo_root: Path,
+    base_file: Path,
+    relative_path: str,
+    dependencies: set[Path],
+    processing: set[Path],
+) -> None:
+    _collect_shader_file(
+        repo_root,
+        base_file.parent / _clean_path(relative_path),
+        dependencies,
+        processing,
+    )
+
+
+def _collect_existing_lut(
+    repo_root: Path,
+    base_file: Path,
+    relative_path: str,
+    dependencies: set[Path],
+    processing: set[Path],
+) -> None:
+    lut_path = base_file.parent / _clean_path(relative_path)
+    if lut_path.exists():
+        _collect_shader_file(repo_root, lut_path, dependencies, processing)
+
+
+def _clean_path(path: str) -> str:
+    path = path.strip()
+    if (path.startswith('"') and path.endswith('"')) or (
+        path.startswith("'") and path.endswith("'")
+    ):
+        return path[1:-1]
+    return path
+
+
+def _add_tree_to_tar(archive: tarfile.TarFile, source_dir: Path, archive_dir: Path) -> None:
+    if not source_dir.is_dir():
+        raise FileNotFoundError(source_dir)
+
+    for path in sorted(source_dir.rglob("*")):
+        if path.is_file():
+            _add_file_to_tar(archive, path, archive_dir / path.relative_to(source_dir))
+
+
+def _add_file_to_tar(archive: tarfile.TarFile, source_path: Path, archive_path: Path) -> None:
+    archive.add(source_path, arcname=archive_path.as_posix(), recursive=False)

--- a/scripts/test_package_release.py
+++ b/scripts/test_package_release.py
@@ -4,6 +4,7 @@ import stat
 import tarfile
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
 from scripts.package_release import (
@@ -131,6 +132,48 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
 
                 binary_info = archive.getmember("neser/neser")
                 self.assertTrue(binary_info.mode & stat.S_IXUSR)
+
+    def test_create_zip_archive_uses_windows_release_layout(self) -> None:
+        """Zip packages contain Windows binary and runtime resources under neser/."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            repo_root = Path(temp_dir_str)
+            output_dir = repo_root / "dist"
+            binary_path = repo_root / "target/release/neser.exe"
+            write_bytes(binary_path, b"MZ")
+            write_bytes(repo_root / "assets/fonts/NunitoSans-Regular.ttf")
+            write_text(repo_root / "gamecontrollerdb.txt", "controller mappings\n")
+            write_text(repo_root / "neser.conf.example", "# config\n")
+            write_text(repo_root / "README.md", "# neser\n")
+            write_text(repo_root / "LICENSE", "license\n")
+            write_text(repo_root / "shaders/stock.slangp", "shader0 = stock.slang\n")
+            write_text(repo_root / "shaders/stock.slang", "void main() {}\n")
+            write_text(
+                repo_root / "src/platform/shaders.rs",
+                'pub const SHADER_PRESETS: &[(&str, &str)] = &[("none", '
+                '"shaders/stock.slangp")];',
+            )
+            write_text(repo_root / "scripts/dev-only.py", "print('dev only')\n")
+
+            archive_path = create_release_archive(
+                ReleasePackageConfig(
+                    repo_root=repo_root,
+                    binary_path=binary_path,
+                    output_dir=output_dir,
+                    target="x86_64-pc-windows-msvc",
+                    archive_format="zip",
+                    binary_name="neser.exe",
+                )
+            )
+
+            self.assertEqual(archive_path.name, "neser-x86_64-pc-windows-msvc.zip")
+            with zipfile.ZipFile(archive_path) as archive:
+                names = set(archive.namelist())
+
+            self.assertIn("neser/neser.exe", names)
+            self.assertIn("neser/gamecontrollerdb.txt", names)
+            self.assertIn("neser/shaders/stock.slangp", names)
+            self.assertFalse(any(name.startswith("neser/scripts/") for name in names))
 
 
 if __name__ == "__main__":

--- a/scripts/test_package_release.py
+++ b/scripts/test_package_release.py
@@ -84,7 +84,9 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
                 },
             )
 
-    def test_create_tar_gz_archive_uses_release_layout_and_excludes_scripts(self) -> None:
+    def test_create_tar_gz_archive_uses_release_layout_and_excludes_scripts(
+        self,
+    ) -> None:
         """Tar packages contain runtime resources under neser/ and omit dev scripts."""
 
         with tempfile.TemporaryDirectory() as temp_dir_str:
@@ -129,7 +131,9 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
                 self.assertIn("neser/LICENSE", names)
                 self.assertIn("neser/shaders/stock.slangp", names)
                 self.assertIn("neser/shaders/stock.slang", names)
-                self.assertFalse(any(name.startswith("neser/scripts/") for name in names))
+                self.assertFalse(
+                    any(name.startswith("neser/scripts/") for name in names)
+                )
 
                 binary_info = archive.getmember("neser/neser")
                 self.assertTrue(binary_info.mode & stat.S_IXUSR)
@@ -214,7 +218,9 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
             )
 
             self.assertEqual(exit_code, 0)
-            self.assertTrue((output_dir / "neser-x86_64-unknown-linux-gnu.tar.gz").exists())
+            self.assertTrue(
+                (output_dir / "neser-x86_64-unknown-linux-gnu.tar.gz").exists()
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test_package_release.py
+++ b/scripts/test_package_release.py
@@ -1,0 +1,137 @@
+"""Unit tests for release package assembly."""
+
+import stat
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.package_release import (
+    ReleasePackageConfig,
+    collect_shader_dependencies,
+    create_release_archive,
+)
+
+
+def write_text(path: Path, text: str) -> None:
+    """Write UTF-8 text, creating parent directories first."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_bytes(path: Path, data: bytes = b"test") -> None:
+    """Write bytes, creating parent directories first."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+class PackageReleaseTests(unittest.TestCase):
+    """Behavior tests for release archive creation."""
+
+    def test_collect_shader_dependencies_resolves_configured_preset_graph(self) -> None:
+        """Configured shader presets include referenced presets, passes, includes, and LUTs."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            repo_root = Path(temp_dir_str)
+            write_text(
+                repo_root / "src/platform/shaders.rs",
+                """
+pub const SHADER_PRESETS: &[(&str, &str)] = &[
+    (
+        "crt",
+        "vendor/slang-shaders/crt/preset.slangp",
+    ),
+];
+""",
+            )
+            write_text(
+                repo_root / "vendor/slang-shaders/crt/preset.slangp",
+                '#reference "../common/base.slangp"\n'
+                "shader0 = pass.slang\n"
+                'textures = "lut.png"\n',
+            )
+            write_text(
+                repo_root / "vendor/slang-shaders/crt/pass.slang",
+                '#include "shared.inc"\n',
+            )
+            write_text(
+                repo_root / "vendor/slang-shaders/crt/shared.inc", "#define TEST 1\n"
+            )
+            write_bytes(repo_root / "vendor/slang-shaders/crt/lut.png")
+            write_text(
+                repo_root / "vendor/slang-shaders/common/base.slangp",
+                "shader0 = base.slang\n",
+            )
+            write_text(
+                repo_root / "vendor/slang-shaders/common/base.slang", "void main() {}\n"
+            )
+
+            dependencies = collect_shader_dependencies(repo_root)
+
+            self.assertEqual(
+                dependencies,
+                {
+                    Path("vendor/slang-shaders/crt/preset.slangp"),
+                    Path("vendor/slang-shaders/crt/pass.slang"),
+                    Path("vendor/slang-shaders/crt/shared.inc"),
+                    Path("vendor/slang-shaders/crt/lut.png"),
+                    Path("vendor/slang-shaders/common/base.slangp"),
+                    Path("vendor/slang-shaders/common/base.slang"),
+                },
+            )
+
+    def test_create_tar_gz_archive_uses_release_layout_and_excludes_scripts(self) -> None:
+        """Tar packages contain runtime resources under neser/ and omit dev scripts."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            repo_root = Path(temp_dir_str)
+            output_dir = repo_root / "dist"
+            binary_path = repo_root / "target/release/neser"
+            write_bytes(binary_path, b"#!/bin/sh\n")
+            binary_path.chmod(0o755)
+            write_bytes(repo_root / "assets/fonts/NunitoSans-Regular.ttf")
+            write_text(repo_root / "gamecontrollerdb.txt", "controller mappings\n")
+            write_text(repo_root / "neser.conf.example", "# config\n")
+            write_text(repo_root / "README.md", "# neser\n")
+            write_text(repo_root / "LICENSE", "license\n")
+            write_text(repo_root / "shaders/stock.slangp", "shader0 = stock.slang\n")
+            write_text(repo_root / "shaders/stock.slang", "void main() {}\n")
+            write_text(
+                repo_root / "src/platform/shaders.rs",
+                'pub const SHADER_PRESETS: &[(&str, &str)] = &[("none", '
+                '"shaders/stock.slangp")];',
+            )
+            write_text(repo_root / "scripts/dev-only.py", "print('dev only')\n")
+
+            archive_path = create_release_archive(
+                ReleasePackageConfig(
+                    repo_root=repo_root,
+                    binary_path=binary_path,
+                    output_dir=output_dir,
+                    target="x86_64-unknown-linux-gnu",
+                    archive_format="tar.gz",
+                )
+            )
+
+            self.assertEqual(archive_path.name, "neser-x86_64-unknown-linux-gnu.tar.gz")
+            with tarfile.open(archive_path, "r:gz") as archive:
+                names = set(archive.getnames())
+
+                self.assertIn("neser/neser", names)
+                self.assertIn("neser/assets/fonts/NunitoSans-Regular.ttf", names)
+                self.assertIn("neser/gamecontrollerdb.txt", names)
+                self.assertIn("neser/neser.conf.example", names)
+                self.assertIn("neser/README.md", names)
+                self.assertIn("neser/LICENSE", names)
+                self.assertIn("neser/shaders/stock.slangp", names)
+                self.assertIn("neser/shaders/stock.slang", names)
+                self.assertFalse(any(name.startswith("neser/scripts/") for name in names))
+
+                binary_info = archive.getmember("neser/neser")
+                self.assertTrue(binary_info.mode & stat.S_IXUSR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_package_release.py
+++ b/scripts/test_package_release.py
@@ -11,6 +11,7 @@ from scripts.package_release import (
     ReleasePackageConfig,
     collect_shader_dependencies,
     create_release_archive,
+    main,
 )
 
 
@@ -174,6 +175,46 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
             self.assertIn("neser/gamecontrollerdb.txt", names)
             self.assertIn("neser/shaders/stock.slangp", names)
             self.assertFalse(any(name.startswith("neser/scripts/") for name in names))
+
+    def test_main_creates_archive_from_cli_arguments(self) -> None:
+        """CLI arguments create the requested release archive."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            repo_root = Path(temp_dir_str)
+            output_dir = repo_root / "dist"
+            binary_path = repo_root / "target/release/neser"
+            write_bytes(binary_path, b"#!/bin/sh\n")
+            binary_path.chmod(0o755)
+            write_bytes(repo_root / "assets/fonts/NunitoSans-Regular.ttf")
+            write_text(repo_root / "gamecontrollerdb.txt", "controller mappings\n")
+            write_text(repo_root / "neser.conf.example", "# config\n")
+            write_text(repo_root / "README.md", "# neser\n")
+            write_text(repo_root / "LICENSE", "license\n")
+            write_text(repo_root / "shaders/stock.slangp", "shader0 = stock.slang\n")
+            write_text(repo_root / "shaders/stock.slang", "void main() {}\n")
+            write_text(
+                repo_root / "src/platform/shaders.rs",
+                'pub const SHADER_PRESETS: &[(&str, &str)] = &[("none", '
+                '"shaders/stock.slangp")];',
+            )
+
+            exit_code = main(
+                [
+                    "--repo-root",
+                    str(repo_root),
+                    "--binary",
+                    str(binary_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--target",
+                    "x86_64-unknown-linux-gnu",
+                    "--format",
+                    "tar.gz",
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue((output_dir / "neser-x86_64-unknown-linux-gnu.tar.gz").exists())
 
 
 if __name__ == "__main__":

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -1,0 +1,33 @@
+"""Regression tests for release workflow packaging steps."""
+
+import unittest
+from pathlib import Path
+
+
+class ReleaseWorkflowTests(unittest.TestCase):
+    """Text-level checks for release archive packaging in GitHub Actions."""
+
+    def test_release_workflow_packages_and_verifies_archives_in_build_matrix(
+        self,
+    ) -> None:
+        """Build jobs package, verify, and upload archives instead of bare binaries."""
+
+        workflow_path = Path(__file__).parents[1] / ".github/workflows/release.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        self.assertIn("python scripts/package_release.py", workflow)
+        self.assertIn("python scripts/verify_release_package.py", workflow)
+        self.assertIn("--smoke-command", workflow)
+        self.assertIn("--version", workflow)
+        self.assertIn(
+            "neser-${{ matrix.target }}.${{ matrix.archive_format }}", workflow
+        )
+        self.assertNotIn("archive_extension", workflow)
+        self.assertIn("*.tar.gz", workflow)
+        self.assertIn("*.zip", workflow)
+        self.assertNotIn("mv artifacts/neser-x86_64-unknown-linux-gnu/neser", workflow)
+        self.assertNotIn("artifacts/neser-linux-x86_64", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verify_release_package.py
+++ b/scripts/test_verify_release_package.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from scripts.verify_release_package import (
     ReleasePackageVerificationError,
     VerificationConfig,
+    main,
     verify_release_package,
 )
 
@@ -110,6 +111,29 @@ class VerifyReleasePackageTests(unittest.TestCase):
                         require_unix_executable=True,
                     )
                 )
+
+    def test_main_verifies_archive_from_cli_arguments(self) -> None:
+        """CLI arguments verify an archive and run the smoke command."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            package_root = create_package_tree(temp_dir / "src")
+            archive_path = temp_dir / "neser-linux-x86_64.tar.gz"
+            create_tar_gz(package_root, archive_path)
+
+            exit_code = main(
+                [
+                    str(archive_path),
+                    "--binary-name",
+                    "neser",
+                    "--require-unix-executable",
+                    "--smoke-command",
+                    "./neser",
+                    "--version",
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
 
 
 if __name__ == "__main__":

--- a/scripts/test_verify_release_package.py
+++ b/scripts/test_verify_release_package.py
@@ -116,6 +116,67 @@ class VerifyReleasePackageTests(unittest.TestCase):
                     )
                 )
 
+    def test_verify_package_requires_default_shader_source(self) -> None:
+        """The verifier requires the shader source referenced by stock.slangp."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            package_root = create_package_tree(temp_dir / "src")
+            (package_root / "shaders/stock.slang").unlink()
+            archive_path = temp_dir / "neser-linux-x86_64.tar.gz"
+            create_tar_gz(package_root, archive_path)
+
+            with self.assertRaisesRegex(
+                ReleasePackageVerificationError, "neser/shaders/stock.slang"
+            ):
+                verify_release_package(
+                    VerificationConfig(
+                        archive_path=archive_path,
+                        binary_name="neser",
+                    )
+                )
+
+    def test_verify_tar_gz_package_rejects_link_members(self) -> None:
+        """Tar packages with symlink members are rejected before extraction."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            package_root = create_package_tree(temp_dir / "src")
+            archive_path = temp_dir / "neser-linux-x86_64.tar.gz"
+            with tarfile.open(archive_path, "w:gz") as archive:
+                archive.add(package_root, arcname="neser")
+                link_info = tarfile.TarInfo("neser/shaders/escape")
+                link_info.type = tarfile.SYMTYPE
+                link_info.linkname = "../../outside"
+                archive.addfile(link_info)
+
+            with self.assertRaisesRegex(
+                ReleasePackageVerificationError, "unsupported tar link"
+            ):
+                verify_release_package(
+                    VerificationConfig(
+                        archive_path=archive_path,
+                        binary_name="neser",
+                    )
+                )
+
+    def test_verify_package_reports_unsupported_single_suffix_archive(self) -> None:
+        """Unsupported archive suffixes fail with a clean verifier error."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            archive_path = Path(temp_dir_str) / "neser-linux-x86_64.tgz"
+            archive_path.write_bytes(b"not an archive")
+
+            with self.assertRaisesRegex(
+                ReleasePackageVerificationError, "unsupported archive format"
+            ):
+                verify_release_package(
+                    VerificationConfig(
+                        archive_path=archive_path,
+                        binary_name="neser",
+                    )
+                )
+
     def test_main_verifies_archive_from_cli_arguments(self) -> None:
         """CLI arguments verify an archive and run the smoke command."""
 

--- a/scripts/test_verify_release_package.py
+++ b/scripts/test_verify_release_package.py
@@ -1,0 +1,116 @@
+"""Unit tests for release package verification."""
+
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from scripts.verify_release_package import (
+    ReleasePackageVerificationError,
+    VerificationConfig,
+    verify_release_package,
+)
+
+
+def write_text(path: Path, text: str) -> None:
+    """Write UTF-8 text, creating parent directories first."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def create_package_tree(root: Path, *, binary_name: str = "neser") -> Path:
+    """Create a minimal extracted release package tree."""
+
+    package_root = root / "neser"
+    write_text(package_root / "assets/fonts/NunitoSans-Regular.ttf", "font\n")
+    write_text(package_root / "gamecontrollerdb.txt", "controller mappings\n")
+    write_text(package_root / "neser.conf.example", "# config\n")
+    write_text(package_root / "README.md", "# neser\n")
+    write_text(package_root / "LICENSE", "license\n")
+    write_text(package_root / "shaders/stock.slangp", "shader0 = stock.slang\n")
+    write_text(package_root / "shaders/stock.slang", "void main() {}\n")
+    binary_path = package_root / binary_name
+    write_text(binary_path, "#!/bin/sh\nprintf 'neser 1.0.0\\n'\n")
+    binary_path.chmod(0o755)
+    return package_root
+
+
+def create_tar_gz(package_root: Path, archive_path: Path) -> None:
+    """Create a tar.gz archive from an extracted package root."""
+
+    with tarfile.open(archive_path, "w:gz") as archive:
+        archive.add(package_root, arcname="neser")
+
+
+def create_zip(package_root: Path, archive_path: Path) -> None:
+    """Create a zip archive from an extracted package root."""
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        for path in sorted(package_root.rglob("*")):
+            if path.is_file():
+                archive.write(path, Path("neser") / path.relative_to(package_root))
+
+
+class VerifyReleasePackageTests(unittest.TestCase):
+    """Behavior tests for release archive verification."""
+
+    def test_verify_tar_gz_package_accepts_required_layout_and_smoke_command(self) -> None:
+        """A complete Unix package passes manifest, permission, and smoke checks."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            package_root = create_package_tree(temp_dir / "src")
+            archive_path = temp_dir / "neser-linux-x86_64.tar.gz"
+            create_tar_gz(package_root, archive_path)
+
+            verify_release_package(
+                VerificationConfig(
+                    archive_path=archive_path,
+                    binary_name="neser",
+                    smoke_command=["./neser", "--version"],
+                    require_unix_executable=True,
+                )
+            )
+
+    def test_verify_zip_package_accepts_required_windows_layout(self) -> None:
+        """A complete Windows zip package passes manifest checks."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            package_root = create_package_tree(temp_dir / "src", binary_name="neser.exe")
+            archive_path = temp_dir / "neser-windows-x86_64.zip"
+            create_zip(package_root, archive_path)
+
+            verify_release_package(
+                VerificationConfig(
+                    archive_path=archive_path,
+                    binary_name="neser.exe",
+                )
+            )
+
+    def test_verify_package_reports_missing_required_resource(self) -> None:
+        """Missing runtime resources fail with the missing archive path."""
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            temp_dir = Path(temp_dir_str)
+            package_root = create_package_tree(temp_dir / "src")
+            (package_root / "gamecontrollerdb.txt").unlink()
+            archive_path = temp_dir / "neser-linux-x86_64.tar.gz"
+            create_tar_gz(package_root, archive_path)
+
+            with self.assertRaisesRegex(
+                ReleasePackageVerificationError, "neser/gamecontrollerdb.txt"
+            ):
+                verify_release_package(
+                    VerificationConfig(
+                        archive_path=archive_path,
+                        binary_name="neser",
+                        require_unix_executable=True,
+                    )
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verify_release_package.py
+++ b/scripts/test_verify_release_package.py
@@ -57,7 +57,9 @@ def create_zip(package_root: Path, archive_path: Path) -> None:
 class VerifyReleasePackageTests(unittest.TestCase):
     """Behavior tests for release archive verification."""
 
-    def test_verify_tar_gz_package_accepts_required_layout_and_smoke_command(self) -> None:
+    def test_verify_tar_gz_package_accepts_required_layout_and_smoke_command(
+        self,
+    ) -> None:
         """A complete Unix package passes manifest, permission, and smoke checks."""
 
         with tempfile.TemporaryDirectory() as temp_dir_str:
@@ -80,7 +82,9 @@ class VerifyReleasePackageTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir_str:
             temp_dir = Path(temp_dir_str)
-            package_root = create_package_tree(temp_dir / "src", binary_name="neser.exe")
+            package_root = create_package_tree(
+                temp_dir / "src", binary_name="neser.exe"
+            )
             archive_path = temp_dir / "neser-windows-x86_64.zip"
             create_zip(package_root, archive_path)
 

--- a/scripts/verify_release_package.py
+++ b/scripts/verify_release_package.py
@@ -1,5 +1,6 @@
 """Verify neser release archive contents and smoke-test packaged binaries."""
 
+import argparse
 import stat
 import subprocess
 import tarfile
@@ -40,6 +41,27 @@ def verify_release_package(config: VerificationConfig) -> None:
 
         if config.smoke_command is not None:
             _run_smoke_command(config.smoke_command, extract_root / "neser")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the release package verifier CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive_path", type=Path)
+    parser.add_argument("--binary-name", required=True)
+    parser.add_argument("--require-unix-executable", action="store_true")
+    parser.add_argument("--smoke-command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    verify_release_package(
+        VerificationConfig(
+            archive_path=args.archive_path,
+            binary_name=args.binary_name,
+            smoke_command=args.smoke_command,
+            require_unix_executable=args.require_unix_executable,
+        )
+    )
+    return 0
 
 
 def _required_paths(binary_name: str) -> set[str]:
@@ -114,3 +136,7 @@ def _run_smoke_command(smoke_command: list[str], cwd: Path) -> None:
         raise ReleasePackageVerificationError(
             f"smoke command failed with exit code {result.returncode}: {output}"
         )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_package.py
+++ b/scripts/verify_release_package.py
@@ -6,6 +6,7 @@ import subprocess
 import tarfile
 import tempfile
 import zipfile
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -73,11 +74,12 @@ def _required_paths(binary_name: str) -> set[str]:
         "neser/README.md",
         "neser/LICENSE",
         "neser/shaders/stock.slangp",
+        "neser/shaders/stock.slang",
     }
 
 
 def _is_tar_gz(path: Path) -> bool:
-    return path.suffixes[-2:] == [".tar", ".gz"]
+    return path.name.endswith(".tar.gz")
 
 
 def _verify_tar_gz(
@@ -95,6 +97,7 @@ def _verify_tar_gz(
                 raise ReleasePackageVerificationError(f"not executable: {binary_path}")
 
         _verify_archive_paths_are_safe(set(members))
+        _verify_tar_members_are_extractable(members.values())
         archive.extractall(extract_root)
 
 
@@ -123,6 +126,14 @@ def _verify_archive_paths_are_safe(names: set[str]) -> None:
         path = Path(name)
         if path.is_absolute() or ".." in path.parts:
             raise ReleasePackageVerificationError(f"unsafe archive path: {name}")
+
+
+def _verify_tar_members_are_extractable(
+    members: Iterable[tarfile.TarInfo],
+) -> None:
+    for member in members:
+        if member.issym() or member.islnk():
+            raise ReleasePackageVerificationError(f"unsupported tar link: {member.name}")
 
 
 def _run_smoke_command(smoke_command: list[str], cwd: Path) -> None:

--- a/scripts/verify_release_package.py
+++ b/scripts/verify_release_package.py
@@ -1,0 +1,116 @@
+"""Verify neser release archive contents and smoke-test packaged binaries."""
+
+import stat
+import subprocess
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class ReleasePackageVerificationError(Exception):
+    """Raised when a release package fails verification."""
+
+
+@dataclass(frozen=True)
+class VerificationConfig:
+    """Inputs for verifying one release archive."""
+
+    archive_path: Path
+    binary_name: str
+    smoke_command: list[str] | None = None
+    require_unix_executable: bool = False
+
+
+def verify_release_package(config: VerificationConfig) -> None:
+    """Verify archive contents and optional smoke command."""
+
+    required_paths = _required_paths(config.binary_name)
+    with tempfile.TemporaryDirectory() as temp_dir_str:
+        extract_root = Path(temp_dir_str)
+        if _is_tar_gz(config.archive_path):
+            _verify_tar_gz(config, required_paths, extract_root)
+        elif config.archive_path.suffix == ".zip":
+            _verify_zip(config, required_paths, extract_root)
+        else:
+            raise ReleasePackageVerificationError(
+                f"unsupported archive format: {config.archive_path}"
+            )
+
+        if config.smoke_command is not None:
+            _run_smoke_command(config.smoke_command, extract_root / "neser")
+
+
+def _required_paths(binary_name: str) -> set[str]:
+    return {
+        f"neser/{binary_name}",
+        "neser/assets/fonts/NunitoSans-Regular.ttf",
+        "neser/gamecontrollerdb.txt",
+        "neser/neser.conf.example",
+        "neser/README.md",
+        "neser/LICENSE",
+        "neser/shaders/stock.slangp",
+    }
+
+
+def _is_tar_gz(path: Path) -> bool:
+    return path.suffixes[-2:] == [".tar", ".gz"]
+
+
+def _verify_tar_gz(
+    config: VerificationConfig,
+    required_paths: set[str],
+    extract_root: Path,
+) -> None:
+    with tarfile.open(config.archive_path, "r:gz") as archive:
+        members = {member.name: member for member in archive.getmembers()}
+        _verify_required_paths(required_paths, set(members))
+
+        if config.require_unix_executable:
+            binary_path = f"neser/{config.binary_name}"
+            if not members[binary_path].mode & stat.S_IXUSR:
+                raise ReleasePackageVerificationError(f"not executable: {binary_path}")
+
+        _verify_archive_paths_are_safe(set(members))
+        archive.extractall(extract_root)
+
+
+def _verify_zip(
+    config: VerificationConfig,
+    required_paths: set[str],
+    extract_root: Path,
+) -> None:
+    with zipfile.ZipFile(config.archive_path) as archive:
+        names = set(archive.namelist())
+        _verify_required_paths(required_paths, names)
+        _verify_archive_paths_are_safe(names)
+        archive.extractall(extract_root)
+
+
+def _verify_required_paths(required_paths: set[str], names: set[str]) -> None:
+    missing_paths = sorted(required_paths - names)
+    if missing_paths:
+        raise ReleasePackageVerificationError(f"missing required path: {missing_paths[0]}")
+
+
+def _verify_archive_paths_are_safe(names: set[str]) -> None:
+    for name in names:
+        path = Path(name)
+        if path.is_absolute() or ".." in path.parts:
+            raise ReleasePackageVerificationError(f"unsafe archive path: {name}")
+
+
+def _run_smoke_command(smoke_command: list[str], cwd: Path) -> None:
+    result = subprocess.run(
+        smoke_command,
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        output = (result.stderr or result.stdout).strip()
+        raise ReleasePackageVerificationError(
+            f"smoke command failed with exit code {result.returncode}: {output}"
+        )

--- a/scripts/verify_release_package.py
+++ b/scripts/verify_release_package.py
@@ -113,7 +113,9 @@ def _verify_zip(
 def _verify_required_paths(required_paths: set[str], names: set[str]) -> None:
     missing_paths = sorted(required_paths - names)
     if missing_paths:
-        raise ReleasePackageVerificationError(f"missing required path: {missing_paths[0]}")
+        raise ReleasePackageVerificationError(
+            f"missing required path: {missing_paths[0]}"
+        )
 
 
 def _verify_archive_paths_are_safe(names: set[str]) -> None:

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Config::print_help();
             return Ok(());
         }
+        ParseResult::Version => {
+            println!("neser {}", env!("CARGO_PKG_VERSION"));
+            return Ok(());
+        }
         ParseResult::Config(c) => *c,
     };
 

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -745,6 +745,7 @@ impl Config {
     ///
     /// # Returns
     /// - `Ok(ParseResult::Help)` if --help or -h was specified
+    /// - `Ok(ParseResult::Version)` if --version was specified
     /// - `Ok(ParseResult::Config(config))` on successful parse
     /// - `Err(message)` on validation error
     #[allow(clippy::new_ret_no_self)]
@@ -752,6 +753,9 @@ impl Config {
         // Check for help first
         if args.iter().any(|a| a == "--help" || a == "-h") {
             return Ok(ParseResult::Help);
+        }
+        if args.iter().any(|a| a == "--version") {
+            return Ok(ParseResult::Version);
         }
 
         // Validate arguments
@@ -1432,6 +1436,7 @@ mod tests {
         match config_new(args).unwrap() {
             ParseResult::Config(c) => *c,
             ParseResult::Help => panic!("Expected Config, got Help"),
+            ParseResult::Version => panic!("Expected Config, got Version"),
         }
     }
 
@@ -5168,6 +5173,7 @@ nes-filter=invalid-shader
                 assert_eq!(config.gb.hardware, Some(crate::gb::model::GbHardware::Dmg));
             }
             ParseResult::Help => panic!("Expected Config, got Help"),
+            ParseResult::Version => panic!("Expected Config, got Version"),
         }
     }
 

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -600,6 +600,8 @@ impl FrontendConfig {
 pub enum ParseResult {
     /// User requested help - print and exit.
     Help,
+    /// User requested version information - print and exit.
+    Version,
     /// Successfully parsed configuration.
     Config(Box<Config>),
 }
@@ -641,6 +643,11 @@ pub(crate) const PLATFORM_CLI_FLAGS: &[CliFlag] = &[
     CliFlag {
         flag: "-h",
         help: None,
+        has_value: false,
+    },
+    CliFlag {
+        flag: "--version",
+        help: Some("Print version information and exit"),
         has_value: false,
     },
     CliFlag {
@@ -1355,6 +1362,7 @@ mod tests {
         match config_new(args).unwrap() {
             ParseResult::Config(c) => *c,
             ParseResult::Help => panic!("Expected Config, got Help"),
+            ParseResult::Version => panic!("Expected Config, got Version"),
         }
     }
 
@@ -1364,6 +1372,7 @@ mod tests {
         let args = vec!["neser".to_string(), "--help".to_string()];
         match config_new(args).unwrap() {
             ParseResult::Help => {}
+            ParseResult::Version => panic!("Expected Help, got Version"),
             ParseResult::Config(_) => panic!("Expected Help"),
         }
     }
@@ -1373,8 +1382,32 @@ mod tests {
         let args = vec!["neser".to_string(), "-h".to_string()];
         match config_new(args).unwrap() {
             ParseResult::Help => {}
+            ParseResult::Version => panic!("Expected Help, got Version"),
             ParseResult::Config(_) => panic!("Expected Help"),
         }
+    }
+
+    #[test]
+    fn test_config_version_flag_returns_version_before_validation() {
+        let args = vec![
+            "neser".to_string(),
+            "--version".to_string(),
+            "--not-a-real-flag".to_string(),
+        ];
+
+        match Config::new(&args).unwrap() {
+            ParseResult::Version => {}
+            ParseResult::Help => panic!("Expected Version, got Help"),
+            ParseResult::Config(_) => panic!("Expected Version, got Config"),
+        }
+    }
+
+    #[test]
+    fn test_help_text_lists_version_flag() {
+        let help = help_text();
+
+        assert!(help.contains("--version"));
+        assert!(help.contains("Print version information and exit"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #2605

Summary
- Adds a native --version flag for release smoke tests.
- Adds checked-in release package and verification scripts for tar.gz and zip archives.
- Updates the release workflow to package required runtime resources, verify archive contents, smoke-test target-compatible artifacts, and publish archives only.
- Documents release archive layout, included resources, and script exclusion in README.md and architecture.md.

Verification
- PASS: cargo fmt
- PASS: cargo clippy --all-targets --all-features -- -D warnings
- PASS: ./scripts/test-dir.sh src/platform src/nes/console --skip-integration (736 passed)
- KNOWN BASE FAILURE: cargo test --no-default-features --lib (10488 passed, 1 failed, 6 ignored). The only failure is gba::integration_tests::gba_suite_tests::gba_mgba_suite_passes with mgba_timing expected=0xD49CDB49 actual=0xDEEFA167. Verified the same isolated test fails identically on current origin/main at 243d5675, so this is pre-existing and unrelated to the release packaging changes.
- PASS: wasm-pack test --headless --chrome --no-default-features --features wasm (54 passed)
- PASS: Python unittest discovery suites (188 passed, 105 passed, 44 passed)
- PASS: npm test (37 files, 298 tests)
