### PR TITLE
Fix mGBA timing suite approval

### DIFF
--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -49,9 +49,7 @@ armwrestler_page7=0x562A5C65
 # SIO timing 0/4, Misc. edge 3/12, Video (sub-menu only).
 mgba_memory=0x179DE4D1
 mgba_io_read=0x5B5C9186
-mgba_timing=0xD49CDB49
-# Linux CI renders a different timing summary after the LDM/POP PC waitstate fix.
-mgba_timing_linux=0xDEEFA167
+mgba_timing=0xDEEFA167
 mgba_timers=0xCFAB2DCC
 mgba_timer_irq=0xD1FFFC47
 mgba_shifter=0x8B4A12AA

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -85,14 +85,6 @@ fn approved_crc_for_suite_key(key: &str) -> u32 {
     })
 }
 
-fn mgba_suite_approval_key(key: &str) -> &str {
-    if cfg!(target_os = "linux") && key == "mgba_timing" {
-        "mgba_timing_linux"
-    } else {
-        key
-    }
-}
-
 fn assert_suite_passes_with_crc(suite: Suite) {
     let suite_label = suite.label();
     let expected_crc32 = approved_crc_for_suite(suite);
@@ -241,7 +233,7 @@ fn gba_mgba_suite_passes() {
     );
     let mut mismatches = Vec::new();
     for (i, &crc) in result.suite_crcs.iter().enumerate() {
-        let key = mgba_suite_approval_key(MGBA_SUITE_KEYS[i]);
+        let key = MGBA_SUITE_KEYS[i];
         match approvals.get(key) {
             Some(&expected) if crc == expected => {}
             Some(&expected) => mismatches.push(format!(
@@ -343,8 +335,7 @@ fn approvals_manifest_parses() {
     // mgba-emu/suite keys
     assert_eq!(approvals.get("mgba_memory"), Some(&0x179D_E4D1));
     assert_eq!(approvals.get("mgba_io_read"), Some(&0x5B5C_9186));
-    assert_eq!(approvals.get("mgba_timing"), Some(&0xD49C_DB49));
-    assert_eq!(approvals.get("mgba_timing_linux"), Some(&0xDEEF_A167));
+    assert_eq!(approvals.get("mgba_timing"), Some(&0xDEEF_A167));
     assert_eq!(approvals.get("mgba_timers"), Some(&0xCFAB_2DCC));
     assert_eq!(approvals.get("mgba_timer_irq"), Some(&0xD1FF_FC47));
     assert_eq!(approvals.get("mgba_shifter"), Some(&0x8B4A_12AA));


### PR DESCRIPTION
## Summary

- Fixes `gba::integration_tests::gba_suite_tests::gba_mgba_suite_passes` by making the current mGBA Timing framebuffer CRC (`0xDEEFA167`) the single approval for all platforms.
- Removes the stale `mgba_timing_linux` approval indirection now that local output matches that reviewed CRC.
- Updates the approval-manifest parser test to assert the new single timing approval.

## Validation

- `cargo test --no-default-features --lib gba::integration_tests::gba_suite_tests::gba_mgba_suite_passes -- --exact --test-threads=1`
- `cargo test --no-default-features --lib gba::integration_tests::gba_suite_tests -- --test-threads=1`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt`
- `git diff --check`
- `./scripts/test-dir.sh src/gba`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`
