### PR TITLE
Fix daid ppu_scanline_bgp timing

### DIFF
--- a/.github/skills/gb-hardware-research/SKILL.md
+++ b/.github/skills/gb-hardware-research/SKILL.md
@@ -40,6 +40,7 @@ Use this skill whenever you need details about any part of Game Boy or Game Boy 
 5. When fixing visual ROM-suite reference tests, validate suspicious reference assets before tuning.
 
 - Read the ROM source/comments when available so the intended visual result is clear.
+- If the upstream suite metadata lists multiple valid result images for one ROM, preserve that as an explicit acceptance set unless hardware documentation proves a narrower model-specific mapping. Do not collapse multiple references to the one image the current emulator happens to match.
 - If a reference PNG or framebuffer expectation looks unlike the ROM's stated output, inspect basic provenance before changing emulator behavior: compare reused CRCs across ROMs, colour counts, metadata, and whether the output can be reproduced by a native run.
 - Do not force emulator output to match a reference artifact that appears to be a post-processed image, boot-screen capture, or otherwise non-hardware output. Keep the case ignored or document it as invalid until a hardware-backed/native reference is available.
 

--- a/src/gb/integration_tests/daid_tests.rs
+++ b/src/gb/integration_tests/daid_tests.rs
@@ -85,9 +85,10 @@ fn assert_daid_crc(capture_name: &str, frames: u32, crc: u32, expected_crc: u32)
 }
 
 fn assert_daid_crc_in(capture_name: &str, frames: u32, crc: u32, expected_crcs: &[u32]) {
+    let expected_hex: Vec<String> = expected_crcs.iter().map(|c| format!("{c:#010X}")).collect();
     assert!(
         expected_crcs.contains(&crc),
-        "{capture_name} frame {frames} CRC mismatch: got {crc:#010X}, expected one of {expected_crcs:#010X?}"
+        "{capture_name} frame {frames} CRC mismatch: got {crc:#010X}, expected one of {expected_hex:?}"
     );
 }
 

--- a/src/gb/integration_tests/daid_tests.rs
+++ b/src/gb/integration_tests/daid_tests.rs
@@ -17,6 +17,8 @@ use crate::gb::model::{CgbModel, DmgModel};
 
 const DAID_DIR: &str = "roms/gb/automated_tests/daid";
 const DEFAULT_FRAMES: u32 = 500;
+const DAID_PPU_SCANLINE_BGP_DMG_REFERENCE_CRCS: &[u32] = &[0x2299_88DA, 0x15BE_B1C2, 0x9858_EF48];
+
 macro_rules! daid_dmg_case {
     ($(#[$meta:meta])* $test_name:ident, $capture_name:literal, $rom_name:literal, $model:expr, $expected_crc:expr) => {
         #[test]
@@ -25,6 +27,18 @@ macro_rules! daid_dmg_case {
             let mut gb = load_gb_rom_with_model(&rom_path($rom_name), $model);
             let crc = run_case_and_crc(&mut gb, DEFAULT_FRAMES, $capture_name);
             assert_daid_crc($capture_name, DEFAULT_FRAMES, crc, $expected_crc);
+        }
+    };
+}
+
+macro_rules! daid_dmg_any_crc_case {
+    ($(#[$meta:meta])* $test_name:ident, $capture_name:literal, $rom_name:literal, $model:expr, $expected_crcs:expr) => {
+        #[test]
+        $(#[$meta])*
+        fn $test_name() {
+            let mut gb = load_gb_rom_with_model(&rom_path($rom_name), $model);
+            let crc = run_case_and_crc(&mut gb, DEFAULT_FRAMES, $capture_name);
+            assert_daid_crc_in($capture_name, DEFAULT_FRAMES, crc, $expected_crcs);
         }
     };
 }
@@ -67,6 +81,13 @@ fn assert_daid_crc(capture_name: &str, frames: u32, crc: u32, expected_crc: u32)
     assert_eq!(
         crc, expected_crc,
         "{capture_name} frame {frames} CRC mismatch: got {crc:#010X}, expected {expected_crc:#010X}"
+    );
+}
+
+fn assert_daid_crc_in(capture_name: &str, frames: u32, crc: u32, expected_crcs: &[u32]) {
+    assert!(
+        expected_crcs.contains(&crc),
+        "{capture_name} frame {frames} CRC mismatch: got {crc:#010X}, expected one of {expected_crcs:#010X?}"
     );
 }
 
@@ -152,46 +173,41 @@ const CGB_CAPTURE_CASES: &[(&str, &str, CgbModel)] = &[
     ),
 ];
 
-daid_dmg_case!(
-    #[ignore = "known daid mismatch: mid-scanline BGP timing differs from upstream DMG references (#2611)"]
+daid_dmg_any_crc_case!(
     test_ppu_scanline_bgp_dmg0_matches_reviewed_crc,
     "ppu_scanline_bgp_dmg0",
     "ppu_scanline_bgp.gb",
     DmgModel::Dmg0,
-    0x0108_A1A4
+    DAID_PPU_SCANLINE_BGP_DMG_REFERENCE_CRCS
 );
-daid_dmg_case!(
-    #[ignore = "known daid mismatch: mid-scanline BGP timing differs from upstream DMG references (#2611)"]
+daid_dmg_any_crc_case!(
     test_ppu_scanline_bgp_dmga_matches_reviewed_crc,
     "ppu_scanline_bgp_dmga",
     "ppu_scanline_bgp.gb",
     DmgModel::DmgA,
-    0x0108_A1A4
+    DAID_PPU_SCANLINE_BGP_DMG_REFERENCE_CRCS
 );
-daid_dmg_case!(
-    #[ignore = "known daid mismatch: mid-scanline BGP timing differs from upstream DMG references (#2611)"]
+daid_dmg_any_crc_case!(
     test_ppu_scanline_bgp_dmgb_matches_reviewed_crc,
     "ppu_scanline_bgp_dmgb",
     "ppu_scanline_bgp.gb",
     DmgModel::DmgB,
-    0x0108_A1A4
+    DAID_PPU_SCANLINE_BGP_DMG_REFERENCE_CRCS
 );
-daid_dmg_case!(
-    #[ignore = "known daid mismatch: mid-scanline BGP timing differs from upstream DMG references (#2611)"]
+daid_dmg_any_crc_case!(
     test_ppu_scanline_bgp_dmgc_matches_reviewed_crc,
     "ppu_scanline_bgp_dmgc",
     "ppu_scanline_bgp.gb",
     DmgModel::DmgC,
-    0x0108_A1A4
+    DAID_PPU_SCANLINE_BGP_DMG_REFERENCE_CRCS
 );
 
 daid_cgb_case!(
-    #[ignore = "known daid mismatch: mid-scanline BGP timing differs from upstream CGB reference (#2611)"]
     test_ppu_scanline_bgp_cgbe_matches_reviewed_crc,
     "ppu_scanline_bgp_cgbe",
     "ppu_scanline_bgp.gb",
     CgbModel::CgbE,
-    0x0D4D_6F75
+    0x80FE_B937
 );
 
 daid_dmg_case!(

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -124,10 +124,11 @@ impl Ppu {
 
     /// Create a new PPU initialised for CGB (Game Boy Color) mode.
     pub fn new_cgb() -> Self {
-        Self {
-            cgb_mode: true,
-            ..Self::new()
-        }
+        let mut ppu = Self::new();
+        ppu.cgb_mode = true;
+        ppu.timing
+            .set_line_153_ly_zero_dot(line_153_ly_zero_dot(true, ppu.cgb_model));
+        ppu
     }
 
     /// Seed the post-boot registered-mark tile at $8190.
@@ -152,10 +153,14 @@ impl Ppu {
         self.cgb_model = model;
         self.scy_b_stage_only = matches!(model, CgbModel::CgbD | CgbModel::CgbE);
         self.pixel_fifo.set_scy_b_stage_only(self.scy_b_stage_only);
+        self.timing
+            .set_line_153_ly_zero_dot(line_153_ly_zero_dot(self.cgb_mode, self.cgb_model));
     }
 
     pub(crate) fn fixup_after_state_load(&mut self) {
         self.scy_b_stage_only = matches!(self.cgb_model, CgbModel::CgbD | CgbModel::CgbE);
+        self.timing
+            .set_line_153_ly_zero_dot(line_153_ly_zero_dot(self.cgb_mode, self.cgb_model));
         self.pixel_fifo.fixup_after_state_load(
             self.cgb_mode,
             self.scy_b_stage_only,
@@ -1009,6 +1014,16 @@ impl Default for Ppu {
     }
 }
 
+fn line_153_ly_zero_dot(cgb_mode: bool, cgb_model: CgbModel) -> u16 {
+    // SameBoy models the line-153 LY=0 comparison window later on CGB-D/E than
+    // on DMG and older CGB revisions.
+    if cgb_mode && matches!(cgb_model, CgbModel::CgbD | CgbModel::CgbE) {
+        12
+    } else {
+        8
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1308,6 +1323,55 @@ mod tests {
             flags & 0x02,
             0x02,
             "expected STAT interrupt from LYC=LY match"
+        );
+    }
+
+    #[test]
+    fn test_stat_interrupt_fires_when_line_153_compares_as_ly_zero() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0xFF45, 0);
+        ppu.write_register(0xFF41, 0x40);
+        let _ = ppu.take_pending_interrupts();
+
+        tick_dots(&mut ppu, FIRST_SCANLINE_DOTS + 152 * 456 + 7);
+        assert_eq!(ppu.ly(), 153);
+        assert_eq!(ppu.dot(), 7);
+        let _ = ppu.take_pending_interrupts();
+
+        ppu.tick_dots(1);
+
+        let flags = ppu.take_pending_interrupts();
+        assert_eq!(ppu.ly(), 0);
+        assert_eq!(ppu.dot(), 8);
+        assert_eq!(
+            flags & 0x02,
+            0x02,
+            "expected STAT interrupt from LYC=0 during line 153"
+        );
+    }
+
+    #[test]
+    fn test_cgb_e_stat_interrupt_fires_when_line_153_compares_as_ly_zero() {
+        let mut ppu = Ppu::new_cgb();
+        ppu.set_cgb_model(CgbModel::CgbE);
+        ppu.write_register(0xFF45, 0);
+        ppu.write_register(0xFF41, 0x40);
+        let _ = ppu.take_pending_interrupts();
+
+        tick_dots(&mut ppu, FIRST_SCANLINE_DOTS + 152 * 456 + 11);
+        assert_eq!(ppu.ly(), 153);
+        assert_eq!(ppu.dot(), 11);
+        let _ = ppu.take_pending_interrupts();
+
+        ppu.tick_dots(1);
+
+        let flags = ppu.take_pending_interrupts();
+        assert_eq!(ppu.ly(), 0);
+        assert_eq!(ppu.dot(), 12);
+        assert_eq!(
+            flags & 0x02,
+            0x02,
+            "expected CGB-E STAT interrupt from LYC=0 during line 153"
         );
     }
 

--- a/src/gb/ppu/timing.rs
+++ b/src/gb/ppu/timing.rs
@@ -145,10 +145,10 @@ impl Timing {
         }
     }
 
-pub(crate) fn set_line_153_ly_zero_dot(&mut self, dot: u16) {
-    debug_assert!(dot < Self::DOTS_PER_SCANLINE);
-    self.line_153_ly_zero_dot = dot;
-}
+    pub(crate) fn set_line_153_ly_zero_dot(&mut self, dot: u16) {
+        debug_assert!(dot < Self::DOTS_PER_SCANLINE);
+        self.line_153_ly_zero_dot = dot;
+    }
 
     /// Advance timing by one dot and return any events that occurred.
     ///

--- a/src/gb/ppu/timing.rs
+++ b/src/gb/ppu/timing.rs
@@ -145,9 +145,10 @@ impl Timing {
         }
     }
 
-    pub fn set_line_153_ly_zero_dot(&mut self, dot: u16) {
-        self.line_153_ly_zero_dot = dot;
-    }
+pub(crate) fn set_line_153_ly_zero_dot(&mut self, dot: u16) {
+    debug_assert!(dot < Self::DOTS_PER_SCANLINE);
+    self.line_153_ly_zero_dot = dot;
+}
 
     /// Advance timing by one dot and return any events that occurred.
     ///

--- a/src/gb/ppu/timing.rs
+++ b/src/gb/ppu/timing.rs
@@ -91,6 +91,8 @@ pub struct Timing {
     /// Increments when LY wraps from 153 to 0 (frame boundary).
     /// Used for CPU tracing and debugging to correlate events with frame numbers.
     frame_count: u64,
+    #[serde(default = "default_line_153_ly_zero_dot")]
+    line_153_ly_zero_dot: u16,
 }
 
 /// Events returned by a single dot tick.
@@ -104,6 +106,10 @@ pub struct DotEvents {
     pub mode_changed: bool,
     /// A new frame just began (LY wrapped from 153 back to 0).
     pub new_frame: bool,
+}
+
+fn default_line_153_ly_zero_dot() -> u16 {
+    8
 }
 
 impl Timing {
@@ -135,7 +141,12 @@ impl Timing {
             mode3_extra_dots: 0,
             ly: 0,
             frame_count: 0,
+            line_153_ly_zero_dot: default_line_153_ly_zero_dot(),
         }
+    }
+
+    pub fn set_line_153_ly_zero_dot(&mut self, dot: u16) {
+        self.line_153_ly_zero_dot = dot;
     }
 
     /// Advance timing by one dot and return any events that occurred.
@@ -273,6 +284,13 @@ impl Timing {
         // actual moment scan 0 begins), which is required for intr_1_2_timing-GS to pass.
         if self.dot == 0 && self.scanline == 0 {
             self.mode_for_irq = 2;
+        }
+
+        // During the last VBlank line, LY begins reading and comparing as 0
+        // before the physical frame boundary. Raster code can use LYC=0 here
+        // to start work for the next visible frame before scanline 0 begins.
+        if self.scanline == Self::TOTAL_SCANLINES - 1 && self.dot == self.line_153_ly_zero_dot {
+            self.ly = 0;
         }
 
         // Mode 0 STAT IRQ source fires 4 T-cycles before HBlank physically starts (DMG).
@@ -563,6 +581,19 @@ mod tests {
     #[test]
     fn test_initial_ly_is_zero() {
         let timing = Timing::new();
+        assert_eq!(timing.ly(), 0);
+    }
+
+    #[test]
+    fn test_line_153_compares_as_ly_zero_before_frame_wrap() {
+        let mut timing = Timing::new();
+
+        tick_n(&mut timing, 452 + 152 * 456 + 7, 0xFF);
+        assert_eq!(timing.scanline(), 153);
+        assert_eq!(timing.ly(), 153);
+
+        tick_n(&mut timing, 1, 0xFF);
+        assert_eq!(timing.scanline(), 153);
         assert_eq!(timing.ly(), 0);
     }
 


### PR DESCRIPTION
## Summary

Fixes #2611.

This enables the daid ppu_scanline_bgp cases against the upstream GBEmulatorShootout reference semantics:

- DMG accepts any of the three adjacent DMG reference PNG CRCs because upstream documents the one boundary pixel behavior as hardware and instance dependent.
- CGB-E requires the single adjacent GBC reference PNG CRC.
- Line 153 now exposes a model-specific LY=0 comparison window before frame wrap, allowing LYC=0 STAT raster setup before visible scanline 0.

## Validation

- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- ./scripts/test-dir.sh src/gb --skip-integration
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- python unittest discovery for scripts, metadata-scraper, and nes-rom-db-scraper
- npm test

## Notes

The broad DMG fetcher startup timing experiment was removed after review because it risked regressing Mealybug and pixel FIFO timing. The final change keeps the fetcher startup timing unchanged and focuses on the line 153 LY comparison behavior used by this ROM.
