### PR TITLE
Fix daid STOP LCD behavior

### DIFF
--- a/src/gb/bus/bus.rs
+++ b/src/gb/bus/bus.rs
@@ -82,6 +82,13 @@ pub trait GbBus {
         false
     }
 
+    /// Enter normal STOP display behavior after a STOP instruction that did not
+    /// perform a CGB speed switch.
+    fn enter_stop_mode(&mut self) {}
+
+    /// Leave normal STOP display behavior after a joypad wake request.
+    fn exit_stop_mode(&mut self) {}
+
     /// Check if the CPU should be halted for HDMA and consume one halt cycle.
     ///
     /// Returns `true` if the CPU should perform a halt stall (tick subsystems

--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -6,8 +6,8 @@ use crate::gb::cartridge::GbCartridge;
 use crate::gb::compat_palettes;
 use crate::gb::input::joypad::Joypad;
 use crate::gb::model::CgbModel;
-use crate::gb::ppu::Ppu;
 use crate::gb::ppu::timing::PpuMode;
+use crate::gb::ppu::{Ppu, StopDisplayMode};
 use crate::gb::timer::{DIV_APU_BIT_DOUBLE, DIV_APU_BIT_NORMAL, Timer};
 
 // LCD-visible STOP speed-switch pause lengths in PPU dots. daid
@@ -1129,6 +1129,19 @@ impl GbBus for CgbBus {
 
     fn consume_hdma_halt_cycle(&mut self) -> bool {
         CgbBus::consume_hdma_halt_cycle(self)
+    }
+
+    fn enter_stop_mode(&mut self) {
+        let mode = if self.ppu.mode() == PpuMode::PixelTransfer {
+            StopDisplayMode::PreserveCurrent
+        } else {
+            StopDisplayMode::SolidBlack
+        };
+        self.ppu.enter_stop_display_mode(mode);
+    }
+
+    fn exit_stop_mode(&mut self) {
+        self.ppu.exit_stop_display_mode();
     }
 
     fn ppu(&self) -> &Ppu {

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -4,7 +4,7 @@ use crate::gb::bus::GbBus;
 use crate::gb::cartridge::GbCartridge;
 use crate::gb::input::joypad::Joypad;
 use crate::gb::model::{CgbModel, DmgBootVariant, DmgModel};
-use crate::gb::ppu::{Ppu, timing::PpuMode};
+use crate::gb::ppu::{Ppu, StopDisplayMode, timing::PpuMode};
 use crate::gb::timer::Timer;
 
 /// Full DMG memory bus.
@@ -637,6 +637,15 @@ impl GbBus for DmgBus {
             self.tick(1);
             self.write(addr, val);
         }
+    }
+
+    fn enter_stop_mode(&mut self) {
+        self.ppu
+            .enter_stop_display_mode(StopDisplayMode::SolidWhite);
+    }
+
+    fn exit_stop_mode(&mut self) {
+        self.ppu.exit_stop_display_mode();
     }
 
     fn notify_idu_glitch(&mut self, addr: u16) {

--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -151,6 +151,7 @@ impl GbConsole {
             Self::Dmg(gb) => {
                 gb.cpu.restore_state(&state.cpu);
                 gb.cpu.bus.restore_bus_state(&state.bus)?;
+                gb.reconcile_stop_display_after_state_load();
                 gb.cpu.bus.restore_cart_ram(&state.cart_ram);
                 gb.cpu.bus.restore_mbc_state(&state.mbc_state);
                 gb.cpu.bus.joypad.clear_buttons();
@@ -158,6 +159,7 @@ impl GbConsole {
             Self::Cgb(gb) => {
                 gb.cpu.restore_state(&state.cpu);
                 gb.cpu.bus.restore_bus_state(&state.bus)?;
+                gb.reconcile_stop_display_after_state_load();
                 gb.cpu.bus.restore_cart_ram(&state.cart_ram);
                 gb.cpu.bus.restore_mbc_state(&state.mbc_state);
                 gb.cpu.bus.joypad.clear_buttons();

--- a/src/gb/console/gb.rs
+++ b/src/gb/console/gb.rs
@@ -102,6 +102,16 @@ impl<B: GbBus> Gb<B> {
     pub fn clear_frame_ready(&mut self) {
         self.cpu.bus.ppu_mut().clear_frame_ready();
     }
+
+    pub(crate) fn reconcile_stop_display_after_state_load(&mut self) {
+        if self.cpu.stopped
+            && self.cpu.bus.ppu().stop_display_mode() == crate::gb::ppu::StopDisplayMode::Inactive
+        {
+            self.cpu.bus.enter_stop_mode();
+        } else if !self.cpu.stopped {
+            self.cpu.bus.exit_stop_mode();
+        }
+    }
 }
 
 /// Reset support for Gb<DmgBus>.

--- a/src/gb/console/save_state.rs
+++ b/src/gb/console/save_state.rs
@@ -172,6 +172,7 @@ impl Gb<DmgBus> {
     pub fn load_state(&mut self, state: &GbSaveState) -> Result<(), String> {
         self.cpu.restore_state(&state.cpu);
         self.cpu.bus.restore_bus_state(&state.bus)?;
+        self.reconcile_stop_display_after_state_load();
         self.cpu.bus.restore_cart_ram(&state.cart_ram);
         self.cpu.bus.restore_mbc_state(&state.mbc_state);
         Ok(())
@@ -213,6 +214,7 @@ mod tests {
     use crate::gb::cartridge::load_cartridge;
     use crate::gb::console::Gb;
     use crate::gb::model::{CgbModel, DmgModel};
+    use crate::gb::ppu::StopDisplayMode;
 
     fn minimal_rom() -> Vec<u8> {
         let mut rom = vec![0u8; 0x8000];
@@ -375,6 +377,62 @@ mod tests {
             .restore_bus_state(&bus_state)
             .expect("restore should succeed");
         assert_eq!(gb.cpu.bus.read(0xC100), 0x00);
+    }
+
+    #[test]
+    fn test_dmg_load_state_reconciles_stopped_cpu_display_mode() {
+        // Given: an older-style stopped CPU state whose PPU snapshot has no STOP display override.
+        let mut gb = make_dmg();
+        gb.cpu.stopped = true;
+        let save = gb.save_state();
+
+        // When: the state is loaded.
+        let mut restored = make_dmg();
+        restored.load_state(&save).expect("load state");
+
+        // Then: the DMG STOP display is restored to the blank white output.
+        assert_eq!(
+            restored.cpu.bus.ppu().screen_buffer().get_pixel(0, 0),
+            (0xFF, 0xFF, 0xFF)
+        );
+        assert_eq!(
+            restored.cpu.bus.ppu().stop_display_mode(),
+            StopDisplayMode::SolidWhite
+        );
+    }
+
+    #[test]
+    fn test_cgb_load_state_preserves_saved_stop_display_mode() {
+        // Given: a CGB Mode 3 STOP state saved after timing has advanced away from Mode 3.
+        let mut gb = make_cgb();
+        gb.cpu.stopped = true;
+        gb.cpu
+            .bus
+            .ppu_mut()
+            .enter_stop_display_mode(StopDisplayMode::PreserveCurrent);
+        let save = GbSaveState {
+            version: GB_SAVESTATE_VERSION,
+            cpu: gb.cpu.capture_state(),
+            bus: gb.cpu.bus.capture_bus_state(),
+            cart_ram: gb.cpu.bus.cart_ram_snapshot(),
+            mbc_state: gb.cpu.bus.mbc_state_snapshot(),
+        };
+
+        // When: the state is loaded.
+        let mut restored = make_cgb();
+        restored.cpu.restore_state(&save.cpu);
+        restored
+            .cpu
+            .bus
+            .restore_bus_state(&save.bus)
+            .expect("restore bus");
+        restored.reconcile_stop_display_after_state_load();
+
+        // Then: reconciliation trusts the serialized display mode instead of recomputing black.
+        assert_eq!(
+            restored.cpu.bus.ppu().stop_display_mode(),
+            StopDisplayMode::PreserveCurrent
+        );
     }
 
     #[test]

--- a/src/gb/cpu/sm83.rs
+++ b/src/gb/cpu/sm83.rs
@@ -714,6 +714,7 @@ impl<B: GbBus> Sm83<B> {
         if self.stopped {
             if self.bus.read(0xFF0F) & 0x10 != 0 {
                 self.stopped = false;
+                self.bus.exit_stop_mode();
             } else {
                 return;
             }
@@ -1029,6 +1030,7 @@ impl<B: GbBus> Sm83<B> {
                 // If the bus supports CGB speed switching and KEY1 is armed,
                 // perform the speed switch instead of halting.
                 if !self.bus.try_speed_switch() {
+                    self.bus.enter_stop_mode();
                     self.stopped = true;
                 }
             }
@@ -2391,6 +2393,8 @@ mod tests {
         mem: [u8; 0x10000],
         switch_armed: bool,
         speed_switched: bool,
+        stop_mode_entered: bool,
+        stop_mode_exited: bool,
     }
 
     impl SpeedSwitchBus {
@@ -2401,6 +2405,8 @@ mod tests {
                 mem,
                 switch_armed: armed,
                 speed_switched: false,
+                stop_mode_entered: false,
+                stop_mode_exited: false,
             }
         }
     }
@@ -2421,6 +2427,12 @@ mod tests {
                 false
             }
         }
+        fn enter_stop_mode(&mut self) {
+            self.stop_mode_entered = true;
+        }
+        fn exit_stop_mode(&mut self) {
+            self.stop_mode_exited = true;
+        }
     }
 
     #[test]
@@ -2436,6 +2448,10 @@ mod tests {
         assert!(
             cpu.bus.speed_switched,
             "Speed switch should have been triggered"
+        );
+        assert!(
+            !cpu.bus.stop_mode_entered,
+            "speed-switch STOP must not enter normal STOP display mode"
         );
         // And: PC advanced past STOP + operand byte
         assert_eq!(cpu.regs.pc, 2, "PC should advance past STOP instruction");
@@ -2453,6 +2469,10 @@ mod tests {
         assert!(
             !cpu.bus.speed_switched,
             "Speed switch should not have been triggered"
+        );
+        assert!(
+            cpu.bus.stop_mode_entered,
+            "normal STOP should enter STOP display mode"
         );
     }
 
@@ -2490,6 +2510,10 @@ mod tests {
 
         // Then: STOP is cleared and execution resumes at the next opcode
         assert!(!cpu.stopped, "CPU should leave STOP on joypad wake");
+        assert!(
+            cpu.bus.stop_mode_exited,
+            "joypad wake should exit STOP display mode"
+        );
         assert_eq!(cpu.regs.a, 0x42, "instruction after STOP should execute");
     }
 }

--- a/src/gb/integration_tests/daid_tests.rs
+++ b/src/gb/integration_tests/daid_tests.rs
@@ -263,44 +263,39 @@ daid_cgb_case!(
 );
 
 daid_dmg_case!(
-    #[ignore = "known daid mismatch: STOP with LCD on should leave blank DMG reference output (#2613)"]
     test_stop_instr_dmg0_matches_reviewed_crc,
     "stop_instr_dmg0",
     "stop_instr.gb",
     DmgModel::Dmg0,
-    0x7D75_95AD
+    0x811B_B2FB
 );
 daid_dmg_case!(
-    #[ignore = "known daid mismatch: STOP with LCD on should leave blank DMG reference output (#2613)"]
     test_stop_instr_dmga_matches_reviewed_crc,
     "stop_instr_dmga",
     "stop_instr.gb",
     DmgModel::DmgA,
-    0x6763_B6A5
+    0x811B_B2FB
 );
 daid_dmg_case!(
-    #[ignore = "known daid mismatch: STOP with LCD on should leave blank DMG reference output (#2613)"]
     test_stop_instr_dmgb_matches_reviewed_crc,
     "stop_instr_dmgb",
     "stop_instr.gb",
     DmgModel::DmgB,
-    0x6763_B6A5
+    0x811B_B2FB
 );
 daid_dmg_case!(
-    #[ignore = "known daid mismatch: STOP with LCD on should leave blank DMG reference output (#2613)"]
     test_stop_instr_dmgc_matches_reviewed_crc,
     "stop_instr_dmgc",
     "stop_instr.gb",
     DmgModel::DmgC,
-    0x6763_B6A5
+    0x811B_B2FB
 );
 daid_cgb_case!(
-    #[ignore = "known daid mismatch: STOP with LCD on should blank the CGB reference output (#2613)"]
     test_stop_instr_cgbe_matches_reviewed_crc,
     "stop_instr_cgbe",
     "stop_instr.gb",
     CgbModel::CgbE,
-    0x7D75_95AD
+    0x252F_710F
 );
 daid_cgb_case!(
     test_stop_instr_gbc_mode3_cgbe_matches_reviewed_crc,

--- a/src/gb/ppu/mod.rs
+++ b/src/gb/ppu/mod.rs
@@ -14,3 +14,4 @@ mod trace_tests;
 pub mod window;
 
 pub use ppu::Ppu;
+pub(crate) use ppu::StopDisplayMode;

--- a/src/gb/ppu/pixel_fifo.rs
+++ b/src/gb/ppu/pixel_fifo.rs
@@ -1029,6 +1029,7 @@ impl PixelFifoRenderer {
         opri_dmg_mode: bool,
         dmg_compat: bool,
         screen_buffer: &mut ScreenBuffer,
+        suppress_output: bool,
     ) -> Option<u8> {
         if !self.active || self.next_x as u32 >= ScreenBuffer::WIDTH {
             return None;
@@ -1101,32 +1102,34 @@ impl PixelFifoRenderer {
         let x = u32::from(self.next_x);
         self.update_bg_fetch_scx();
         self.update_bg_fetch_scy();
-        if cgb_mode && !dmg_compat {
-            self.render_cgb_pixel(
-                x,
-                vram,
-                vram_bank1,
-                oam,
-                registers,
-                bg_palette_ram,
-                obj_palette_ram,
-                window_line,
-                opri_dmg_mode,
-                screen_buffer,
-            );
-        } else if cgb_mode {
-            self.render_cgb_dmg_compat_pixel(
-                x,
-                vram,
-                oam,
-                registers,
-                bg_palette_ram,
-                obj_palette_ram,
-                window_line,
-                screen_buffer,
-            );
-        } else {
-            self.render_dmg_pixel(x, vram, oam, registers, window_line, screen_buffer);
+        if !suppress_output {
+            if cgb_mode && !dmg_compat {
+                self.render_cgb_pixel(
+                    x,
+                    vram,
+                    vram_bank1,
+                    oam,
+                    registers,
+                    bg_palette_ram,
+                    obj_palette_ram,
+                    window_line,
+                    opri_dmg_mode,
+                    screen_buffer,
+                );
+            } else if cgb_mode {
+                self.render_cgb_dmg_compat_pixel(
+                    x,
+                    vram,
+                    oam,
+                    registers,
+                    bg_palette_ram,
+                    obj_palette_ram,
+                    window_line,
+                    screen_buffer,
+                );
+            } else {
+                self.render_dmg_pixel(x, vram, oam, registers, window_line, screen_buffer);
+            }
         }
         self.clear_consumed_bgp_edge();
         self.clear_consumed_obp_edges();
@@ -4080,6 +4083,7 @@ mod tests {
             false,
             dmg_compat,
             screen_buffer,
+            false,
         );
     }
 
@@ -4113,6 +4117,7 @@ mod tests {
                 false,
                 false,
                 &mut screen_buffer,
+                false,
             ) {
                 activation_count = Some(count);
                 break;
@@ -7061,6 +7066,7 @@ mod tests {
                 false,
                 true,
                 &mut screen_buffer,
+                false,
             );
             dot = dot.saturating_add(1);
             assert!(dot < deadline, "renderer did not reach next_x=8");
@@ -7088,6 +7094,7 @@ mod tests {
                 false,
                 true,
                 &mut screen_buffer,
+                false,
             );
             dot = dot.saturating_add(1);
             assert!(dot < deadline, "renderer did not reach next_x=9");
@@ -7136,6 +7143,7 @@ mod tests {
                 false,
                 true,
                 &mut screen_buffer,
+                false,
             );
             dot = dot.saturating_add(1);
             assert!(dot < deadline, "renderer did not reach next_x=8");
@@ -7160,6 +7168,7 @@ mod tests {
                 false,
                 true,
                 &mut screen_buffer,
+                false,
             );
             dot = dot.saturating_add(1);
             assert!(dot < deadline, "renderer did not reach next_x=9");
@@ -7209,6 +7218,7 @@ mod tests {
                 false,
                 true,
                 &mut screen_buffer,
+                false,
             );
             dot = dot.saturating_add(1);
             assert!(dot < deadline, "renderer did not reach next_x=8");
@@ -7234,6 +7244,7 @@ mod tests {
                 false,
                 true,
                 &mut screen_buffer,
+                false,
             );
             dot = dot.saturating_add(1);
             assert!(dot < deadline, "renderer did not reach next_x=9");

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -351,10 +351,6 @@ impl Ppu {
     }
 
     fn render_pixel_fifo_dot(&mut self) {
-        if self.stop_display_mode != StopDisplayMode::Inactive {
-            return;
-        }
-
         let completed_window_activations = self.pixel_fifo.tick(
             self.timing.dot(),
             &self.vram,
@@ -368,6 +364,7 @@ impl Ppu {
             self.opri,
             self.dmg_compat,
             &mut self.screen_buffer,
+            self.stop_display_mode != StopDisplayMode::Inactive,
         );
         if let Some(window_activations) = completed_window_activations {
             self.window_line = self.window_line.wrapping_add(window_activations);
@@ -1462,6 +1459,23 @@ mod tests {
 
         // Then: frame cadence continues, and normal rendering does not overwrite the blank output.
         assert!(ppu.is_frame_ready());
+        assert_eq!(ppu.screen_buffer.get_pixel(0, 0), (0xFF, 0xFF, 0xFF));
+    }
+
+    #[test]
+    fn test_stop_display_suppresses_pixels_but_keeps_fifo_advancing() {
+        // Given: a STOP display override active before pixel transfer begins.
+        let mut ppu = Ppu::new();
+        ppu.enter_stop_display_mode(StopDisplayMode::SolidWhite);
+        tick_until_pixel_transfer_starts(&mut ppu);
+        assert!(ppu.pixel_fifo.is_active());
+
+        // When: the scanline advances beyond the visible FIFO output period.
+        tick_dots(&mut ppu, 200);
+
+        // Then: the FIFO completed normally, but the STOP blank output was not overwritten.
+        assert_eq!(ppu.timing.mode(), PpuMode::HBlank);
+        assert!(!ppu.pixel_fifo.is_active());
         assert_eq!(ppu.screen_buffer.get_pixel(0, 0), (0xFF, 0xFF, 0xFF));
     }
 

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -9,6 +9,15 @@ use crate::gb::model::CgbModel;
 use crate::platform::debugging::ppu_trace_level;
 use crate::trace_ppu;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum StopDisplayMode {
+    #[default]
+    Inactive,
+    SolidWhite,
+    SolidBlack,
+    PreserveCurrent,
+}
+
 /// Dots per CPU M-cycle — the granularity at which Mode 3 length is observable.
 const DOTS_PER_M_CYCLE: u16 = 4;
 const WINDOW_SETUP_DOTS: u16 = 6;
@@ -33,6 +42,8 @@ pub struct Ppu {
     screen_buffer: ScreenBuffer,
     #[serde(default)]
     pixel_fifo: PixelFifoRenderer,
+    #[serde(default)]
+    stop_display_mode: StopDisplayMode,
     /// Pending interrupt bits for IF register (bit 0 = VBlank, bit 1 = STAT).
     pending_interrupts: u8,
     /// Internal window-line counter (increments each scanline where window is drawn).
@@ -103,6 +114,7 @@ impl Ppu {
             registers: Registers::new(),
             screen_buffer: ScreenBuffer::new(),
             pixel_fifo: PixelFifoRenderer::new(),
+            stop_display_mode: StopDisplayMode::Inactive,
             pending_interrupts: 0,
             window_line: 0,
             prev_stat_irq_line: false,
@@ -166,6 +178,23 @@ impl Ppu {
             self.scy_b_stage_only,
             self.registers.scy,
         );
+    }
+
+    pub(crate) fn enter_stop_display_mode(&mut self, mode: StopDisplayMode) {
+        self.stop_display_mode = mode;
+        match mode {
+            StopDisplayMode::Inactive | StopDisplayMode::PreserveCurrent => {}
+            StopDisplayMode::SolidWhite => self.screen_buffer.fill_rgb(0xFF, 0xFF, 0xFF),
+            StopDisplayMode::SolidBlack => self.screen_buffer.fill_rgb(0x00, 0x00, 0x00),
+        }
+    }
+
+    pub(crate) fn exit_stop_display_mode(&mut self) {
+        self.stop_display_mode = StopDisplayMode::Inactive;
+    }
+
+    pub(crate) fn stop_display_mode(&self) -> StopDisplayMode {
+        self.stop_display_mode
     }
 
     // ── Dot-level tick ────────────────────────────────────────────────────────
@@ -322,6 +351,10 @@ impl Ppu {
     }
 
     fn render_pixel_fifo_dot(&mut self) {
+        if self.stop_display_mode != StopDisplayMode::Inactive {
+            return;
+        }
+
         let completed_window_activations = self.pixel_fifo.tick(
             self.timing.dot(),
             &self.vram,
@@ -1414,6 +1447,38 @@ mod tests {
         assert!(ppu.is_frame_ready());
         ppu.clear_frame_ready();
         assert!(!ppu.is_frame_ready());
+    }
+
+    #[test]
+    fn test_stop_solid_white_display_keeps_frame_timing_running() {
+        // Given: STOP display override has forced the DMG LCD to the blank white reference.
+        let mut ppu = Ppu::new();
+        ppu.screen_buffer.set_pixel(0, 0, 1, 2, 3);
+        ppu.enter_stop_display_mode(StopDisplayMode::SolidWhite);
+        ppu.clear_frame_ready();
+
+        // When: enough PPU dots elapse for one frame while STOP remains active.
+        tick_dots(&mut ppu, FIRST_SCANLINE_DOTS + 456 * 153);
+
+        // Then: frame cadence continues, and normal rendering does not overwrite the blank output.
+        assert!(ppu.is_frame_ready());
+        assert_eq!(ppu.screen_buffer.get_pixel(0, 0), (0xFF, 0xFF, 0xFF));
+    }
+
+    #[test]
+    fn test_stop_preserve_current_display_keeps_existing_framebuffer() {
+        // Given: CGB Mode 3 STOP preserves the visible screen instead of blanking it.
+        let mut ppu = Ppu::new_cgb();
+        ppu.screen_buffer.set_pixel(0, 0, 1, 2, 3);
+        ppu.enter_stop_display_mode(StopDisplayMode::PreserveCurrent);
+        ppu.clear_frame_ready();
+
+        // When: the PPU keeps ticking for a frame.
+        tick_dots(&mut ppu, FIRST_SCANLINE_DOTS + 456 * 153);
+
+        // Then: frame cadence continues, but the framebuffer is not redrawn.
+        assert!(ppu.is_frame_ready());
+        assert_eq!(ppu.screen_buffer.get_pixel(0, 0), (1, 2, 3));
     }
 
     // ── LCD disable/re-enable frame_ready ─────────────────────────────────────

--- a/src/gb/ppu/screen_buffer.rs
+++ b/src/gb/ppu/screen_buffer.rs
@@ -117,11 +117,11 @@ mod tests {
         // When: the buffer is filled
         buf.fill_rgb(0xAA, 0xBB, 0xCC);
 
-        // Then: every sampled pixel has the fill colour
-        assert_eq!(buf.get_pixel(0, 0), (0xAA, 0xBB, 0xCC));
-        assert_eq!(
-            buf.get_pixel(ScreenBuffer::WIDTH - 1, ScreenBuffer::HEIGHT - 1),
-            (0xAA, 0xBB, 0xCC)
+        // Then: every pixel has the fill colour
+        assert!(
+            buf.snapshot()
+                .chunks_exact(ScreenBuffer::BYTES_PER_PIXEL)
+                .all(|pixel| pixel == [0xAA, 0xBB, 0xCC])
         );
     }
 

--- a/src/gb/ppu/screen_buffer.rs
+++ b/src/gb/ppu/screen_buffer.rs
@@ -34,6 +34,14 @@ impl ScreenBuffer {
         self.buffer[offset + 2] = b;
     }
 
+    pub fn fill_rgb(&mut self, r: u8, g: u8, b: u8) {
+        for pixel in self.buffer.chunks_exact_mut(Self::BYTES_PER_PIXEL) {
+            pixel[0] = r;
+            pixel[1] = g;
+            pixel[2] = b;
+        }
+    }
+
     pub fn get_pixel(&self, x: u32, y: u32) -> (u8, u8, u8) {
         let offset = Self::pixel_offset(x, y);
         (
@@ -97,6 +105,24 @@ mod tests {
         assert_eq!(snap[0], 0xAA);
         assert_eq!(snap[1], 0xBB);
         assert_eq!(snap[2], 0xCC);
+    }
+
+    #[test]
+    fn test_fill_rgb_sets_entire_buffer() {
+        // Given: a buffer with different pixels
+        let mut buf = ScreenBuffer::new();
+        buf.set_pixel(0, 0, 1, 2, 3);
+        buf.set_pixel(ScreenBuffer::WIDTH - 1, ScreenBuffer::HEIGHT - 1, 4, 5, 6);
+
+        // When: the buffer is filled
+        buf.fill_rgb(0xAA, 0xBB, 0xCC);
+
+        // Then: every sampled pixel has the fill colour
+        assert_eq!(buf.get_pixel(0, 0), (0xAA, 0xBB, 0xCC));
+        assert_eq!(
+            buf.get_pixel(ScreenBuffer::WIDTH - 1, ScreenBuffer::HEIGHT - 1),
+            (0xAA, 0xBB, 0xCC)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2613.

- Models normal STOP LCD output with a PPU display override:
  - DMG STOP blanks to the white daid reference.
  - CGB non-Mode-3 STOP blanks to the black daid/Pan Docs reference.
  - CGB Mode 3 STOP preserves the current framebuffer.
- Keeps PPU frame cadence running while STOP display output is overridden, so frame-based tests and frontends do not hang.
- Activates the daid `stop_instr` DMG/CGB regression tests and updates them to the upstream reviewed CRCs.
- Reconciles STOP display state after save-state load for older stopped CPU snapshots without overwriting newly serialized CGB Mode 3 preserve state.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `./scripts/test-dir.sh src/gb --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`
- `NESER_CAPTURE_SCREEN=1 cargo test --no-default-features --lib gb::integration_tests::daid_tests::capture_all_daid_screenshots -- --ignored --nocapture`

STOP capture CRCs:

- `stop_instr_dmg0`, `stop_instr_dmga`, `stop_instr_dmgb`, `stop_instr_dmgc`: `0x811BB2FB`
- `stop_instr_cgbe`: `0x252F710F`
- `stop_instr_gbc_mode3_cgbe`: `0x4D1E1139`
