### PR TITLE
Capture and restore GBA CPU state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
         with:
           version: "latest"
       - name: Test WASM frontend
-        run: wasm-pack test --headless --chrome -- --no-default-features --features wasm
+        run: wasm-pack test --headless --chrome --no-default-features --features wasm
 
   web:
     runs-on: ubuntu-latest

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -13,8 +13,8 @@
 use crate::gba::GbaBus;
 use crate::gba::cartridge::load_cartridge;
 use crate::gba::console::config::GBA_FILTER_NAMES;
-use crate::gba::cpu::Arm7tdmi;
 use crate::gba::cpu::bus::Bus;
+use crate::gba::cpu::{Arm7tdmi, Arm7tdmiState};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::gba::debugging::{disasm_arm, disasm_thumb};
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
@@ -189,6 +189,14 @@ impl Gba {
     /// if no ROM is loaded.
     pub fn state_path(&self) -> Option<PathBuf> {
         self.rom_path.as_ref().map(|p| p.with_extension("state"))
+    }
+
+    pub(crate) fn capture_cpu_state(&self) -> Arm7tdmiState {
+        self.cpu.capture_state()
+    }
+
+    pub(crate) fn restore_cpu_state(&mut self, state: &Arm7tdmiState) {
+        self.cpu.restore_state(state);
     }
 
     #[cfg(test)]

--- a/src/gba/console/save_state.rs
+++ b/src/gba/console/save_state.rs
@@ -6,10 +6,10 @@
 //! [`GbaSaveState::from_bytes`].
 //!
 //! This is the initial scaffold for the GBA save-state pipeline.  It
-//! currently captures the bus memory regions (BIOS, EWRAM, IWRAM, PRAM,
-//! VRAM, OAM, SRAM) plus a few simple bus scalars.  Subsystem state for
-//! the CPU, PPU, APU, timers, DMA, interrupt controller and keypad will be
-//! added as those modules are wired into the [`Gba`](super::gba::Gba)
+//! currently captures the CPU plus bus memory regions (BIOS, EWRAM, IWRAM,
+//! PRAM, VRAM, OAM, SRAM) and a few simple bus scalars.  Subsystem state for
+//! the PPU, APU, timers, DMA, interrupt controller and keypad will be added
+//! as those modules are wired into the [`Gba`](super::gba::Gba)
 //! console wrapper.  Because every save-state carries a `version` field,
 //! breaking changes to the captured shape will simply bump
 //! [`GBA_SAVESTATE_VERSION`] and the loader will reject older states with
@@ -17,9 +17,11 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::gba::cpu::Arm7tdmiState;
+
 /// Current save-state format version for Game Boy Advance.
 /// Increment this when making breaking changes to the state format.
-pub const GBA_SAVESTATE_VERSION: u32 = 1;
+pub const GBA_SAVESTATE_VERSION: u32 = 2;
 
 /// Serializable snapshot of the [`GbaBus`](crate::gba::GbaBus) memory
 /// regions and a small number of associated scalar fields.
@@ -60,6 +62,8 @@ pub struct BusMemoryState {
 pub struct GbaSaveState {
     /// Version of the save-state format.
     pub version: u32,
+    /// ARM7TDMI CPU state.
+    pub cpu: Arm7tdmiState,
     /// Bus memory state (RAM regions and a few scalar fields).
     pub bus: BusMemoryState,
 }
@@ -127,6 +131,7 @@ impl Gba {
     pub fn save_state(&self) -> GbaSaveState {
         GbaSaveState {
             version: GBA_SAVESTATE_VERSION,
+            cpu: self.capture_cpu_state(),
             bus: self.bus().capture_memory_state(),
         }
     }
@@ -146,25 +151,38 @@ impl Gba {
         }
         self.bus_mut()
             .restore_memory_state(&state.bus)
-            .map_err(GbaSaveStateError::RestoreFailed)
+            .map_err(GbaSaveStateError::RestoreFailed)?;
+        self.restore_cpu_state(&state.cpu);
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gba::cartridge::header::{
+        COMPLEMENT_CHECK_OFFSET, FIXED_BYTE_OFFSET, FIXED_BYTE_VALUE, compute_complement_check,
+    };
     use crate::gba::console::gba::Gba;
     use crate::platform::app_context::AppContext;
+    use crate::platform::emulator::Emulator;
 
     fn make_gba() -> Gba {
         Gba::new(AppContext::default())
     }
 
+    fn minimal_valid_gba_rom() -> Vec<u8> {
+        let mut rom = vec![0u8; 0xC0];
+        rom[FIXED_BYTE_OFFSET] = FIXED_BYTE_VALUE;
+        rom[COMPLEMENT_CHECK_OFFSET] = compute_complement_check(&rom);
+        rom
+    }
+
     // ── Version checks ─────────────────────────────────────────────────────
 
     #[test]
-    fn test_gba_savestate_version_is_1() {
-        assert_eq!(GBA_SAVESTATE_VERSION, 1);
+    fn test_gba_savestate_version_is_2() {
+        assert_eq!(GBA_SAVESTATE_VERSION, 2);
     }
 
     // ── Round-trip ─────────────────────────────────────────────────────────
@@ -183,6 +201,7 @@ mod tests {
         assert_eq!(loaded.bus.vram.len(), save.bus.vram.len());
         assert_eq!(loaded.bus.oam.len(), save.bus.oam.len());
         assert_eq!(loaded.bus.sram.len(), save.bus.sram.len());
+        assert_eq!(loaded.cpu.regs.r[15], save.cpu.regs.r[15]);
     }
 
     // ── Capture / restore preserves modified memory ────────────────────────
@@ -211,6 +230,23 @@ mod tests {
         assert_eq!(gba.bus_mut().read8(0x0200_0010), 0xAA);
         assert_eq!(gba.bus_mut().read8(0x0300_0020), 0xBB);
         assert_eq!(gba.bus_mut().read8(0x0E00_0030), 0xCC);
+    }
+
+    #[test]
+    fn test_save_state_captures_and_restores_cpu_position() {
+        let mut gba = make_gba();
+        gba.load_rom(&minimal_valid_gba_rom(), "test.gba")
+            .expect("valid GBA ROM");
+
+        let saved = gba.save_state();
+        let saved_pc = gba.cpu_pc();
+
+        gba.run_tick_for_tests();
+        assert_ne!(gba.cpu_pc(), saved_pc, "test must dirty CPU PC after save");
+
+        gba.load_state(&saved).expect("restore should succeed");
+
+        assert_eq!(gba.cpu_pc(), saved_pc);
     }
 
     // ── BIOS exclusion ─────────────────────────────────────────────────────

--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -19,6 +19,7 @@ use super::bus::Bus;
 use super::registers::{CpuMode, FLAG_F, FLAG_I, FLAG_T, Registers};
 use super::thumb;
 use crate::gba::bus::WidthClass;
+use serde::{Deserialize, Serialize};
 
 /// Address of each ARM exception vector in the BIOS region.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,6 +64,21 @@ pub struct Arm7tdmi {
     /// Debug counter: number of times dispatch_irq has been called.
     #[cfg(test)]
     irq_dispatch_count: u64,
+}
+
+/// Serializable ARM7TDMI CPU snapshot for GBA save states.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Arm7tdmiState {
+    pub regs: Registers,
+    pub cycles: u64,
+    pub irq_pending: bool,
+    pub fiq_pending: bool,
+    pub halt_exit_pending: bool,
+    pub prefetch_valid: bool,
+    pub prefetch_arm: [u32; 3],
+    pub prefetch_thumb: [u16; 3],
+    pub halted: bool,
+    pub pending_data_abort_exec_pc: Option<u32>,
 }
 
 impl Default for Arm7tdmi {
@@ -113,6 +129,36 @@ impl Arm7tdmi {
     /// Whether the CPU is currently executing in Thumb state.
     pub fn thumb(&self) -> bool {
         self.regs.thumb()
+    }
+
+    /// Capture CPU state for save-state serialization.
+    pub fn capture_state(&self) -> Arm7tdmiState {
+        Arm7tdmiState {
+            regs: self.regs.clone(),
+            cycles: self.cycles,
+            irq_pending: self.irq_pending,
+            fiq_pending: self.fiq_pending,
+            halt_exit_pending: self.halt_exit_pending,
+            prefetch_valid: self.prefetch_valid,
+            prefetch_arm: self.prefetch_arm,
+            prefetch_thumb: self.prefetch_thumb,
+            halted: self.halted,
+            pending_data_abort_exec_pc: self.pending_data_abort_exec_pc,
+        }
+    }
+
+    /// Restore CPU state from a save-state snapshot.
+    pub fn restore_state(&mut self, state: &Arm7tdmiState) {
+        self.regs = state.regs.clone();
+        self.cycles = state.cycles;
+        self.irq_pending = state.irq_pending;
+        self.fiq_pending = state.fiq_pending;
+        self.halt_exit_pending = state.halt_exit_pending;
+        self.prefetch_valid = state.prefetch_valid;
+        self.prefetch_arm = state.prefetch_arm;
+        self.prefetch_thumb = state.prefetch_thumb;
+        self.halted = state.halted;
+        self.pending_data_abort_exec_pc = state.pending_data_abort_exec_pc;
     }
 
     /// Raise an external IRQ. Will be dispatched on the next `step` if not
@@ -453,6 +499,100 @@ mod tests {
         );
         assert!(!cpu.regs.thumb(), "undefined exception enters ARM state");
         assert_eq!(cpu.regs.r[15], ExceptionVector::Undefined as u32);
+    }
+
+    #[test]
+    fn save_state_restores_register_banks_and_spsr_values() {
+        let mut cpu = Arm7tdmi::new();
+        cpu.regs.switch_mode(CpuMode::User);
+        cpu.regs.r[0] = 0x1111_0000;
+        cpu.regs.r[8] = 0x1111_0008;
+        cpu.regs.r[13] = 0x1111_000D;
+        cpu.regs.r[14] = 0x1111_000E;
+        cpu.regs.r[15] = 0x1111_000F;
+
+        cpu.regs.switch_mode(CpuMode::Fiq);
+        cpu.regs.r[8] = 0xF100_0008;
+        cpu.regs.r[13] = 0xF100_000D;
+        cpu.regs.r[14] = 0xF100_000E;
+        cpu.regs.set_spsr(0xF100_00F0);
+
+        cpu.regs.switch_mode(CpuMode::Irq);
+        cpu.regs.r[13] = 0x1200_000D;
+        cpu.regs.r[14] = 0x1200_000E;
+        cpu.regs.set_spsr(0x1200_00F0);
+
+        let saved = cpu.capture_state();
+
+        cpu = Arm7tdmi::new();
+        cpu.restore_state(&saved);
+
+        cpu.regs.switch_mode(CpuMode::User);
+        assert_eq!(cpu.regs.r[0], 0x1111_0000);
+        assert_eq!(cpu.regs.r[8], 0x1111_0008);
+        assert_eq!(cpu.regs.r[13], 0x1111_000D);
+        assert_eq!(cpu.regs.r[14], 0x1111_000E);
+        assert_eq!(cpu.regs.r[15], 0x1111_000F);
+
+        cpu.regs.switch_mode(CpuMode::Fiq);
+        assert_eq!(cpu.regs.r[8], 0xF100_0008);
+        assert_eq!(cpu.regs.r[13], 0xF100_000D);
+        assert_eq!(cpu.regs.r[14], 0xF100_000E);
+        assert_eq!(cpu.regs.spsr(), 0xF100_00F0);
+
+        cpu.regs.switch_mode(CpuMode::Irq);
+        assert_eq!(cpu.regs.r[13], 0x1200_000D);
+        assert_eq!(cpu.regs.r[14], 0x1200_000E);
+        assert_eq!(cpu.regs.spsr(), 0x1200_00F0);
+    }
+
+    #[test]
+    fn save_state_restores_private_execution_state() {
+        let mut cpu = Arm7tdmi::new();
+        cpu.cycles = 0x1234_5678_9ABC_DEF0;
+        cpu.irq_pending = true;
+        cpu.fiq_pending = true;
+        cpu.halt_exit_pending = true;
+        cpu.prefetch_valid = true;
+        cpu.prefetch_arm = [0x1111_1111, 0x2222_2222, 0x3333_3333];
+        cpu.prefetch_thumb = [0x4444, 0x5555, 0x6666];
+        cpu.halted = true;
+        cpu.pending_data_abort_exec_pc = Some(0x0800_1234);
+
+        let saved = cpu.capture_state();
+
+        cpu = Arm7tdmi::new();
+        cpu.restore_state(&saved);
+
+        assert_eq!(cpu.cycles, 0x1234_5678_9ABC_DEF0);
+        assert!(cpu.irq_pending);
+        assert!(cpu.fiq_pending);
+        assert!(cpu.halt_exit_pending);
+        assert!(cpu.prefetch_valid);
+        assert_eq!(cpu.prefetch_arm, [0x1111_1111, 0x2222_2222, 0x3333_3333]);
+        assert_eq!(cpu.prefetch_thumb, [0x4444, 0x5555, 0x6666]);
+        assert!(cpu.halted);
+        assert_eq!(cpu.pending_data_abort_exec_pc, Some(0x0800_1234));
+    }
+
+    #[test]
+    fn save_state_roundtrips_through_json() {
+        let mut cpu = Arm7tdmi::new();
+        cpu.regs.switch_mode(CpuMode::User);
+        cpu.regs.r[0] = 0xCAFE_BABE;
+        cpu.cycles = 12345;
+        cpu.halted = true;
+
+        let saved = cpu.capture_state();
+        let bytes = serde_json::to_vec(&saved).expect("serialize CPU state");
+        let decoded: Arm7tdmiState = serde_json::from_slice(&bytes).expect("deserialize CPU state");
+
+        let mut restored = Arm7tdmi::new();
+        restored.restore_state(&decoded);
+
+        assert_eq!(restored.regs.r[0], 0xCAFE_BABE);
+        assert_eq!(restored.cycles, 12345);
+        assert!(restored.halted);
     }
 
     #[test]

--- a/src/gba/cpu/mod.rs
+++ b/src/gba/cpu/mod.rs
@@ -27,7 +27,7 @@ pub mod registers;
 pub mod thumb;
 
 #[allow(unused_imports)]
-pub use arm7tdmi::{Arm7tdmi, ExceptionVector};
+pub use arm7tdmi::{Arm7tdmi, Arm7tdmiState, ExceptionVector};
 #[allow(unused_imports)]
 pub use bus::{Bus, RamBus};
 #[allow(unused_imports)]


### PR DESCRIPTION
Closes #2629

Summary:
- Add Arm7tdmiState and CPU capture/restore helpers.
- Include CPU state in GBA save states and bump the GBA save-state version to 2.
- Cover register banking, private execution fields, JSON roundtrip, and console-level CPU PC restore.

Validation:
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- ./scripts/test-dir.sh src/gba src/platform src/nes/console --skip-integration
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- Python unittest suites under scripts
- npm test