### PR TITLE
Add GBA save-state integration coverage

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -270,6 +270,7 @@ All Game Boy Advance hardware lives under `src/gba/`. The module currently provi
 | `src/gba/integration_tests/mod.rs` | GBA integration test module root. Includes gba-suite runner and test definitions. |
 | `src/gba/integration_tests/gba_suite_runner.rs` | Headless harness for jsmolka `gba-tests` ARM/Thumb/Memory ROMs. Loads ROM assets from `roms/gba/automated_tests/gba-tests`, injects a synthetic stub BIOS and HLE SWI for CI-safe execution, runs until idle-loop detection/timeout, and reports pass/fail from suite registers (ARM `R12`, Thumb `R7`, Memory `R12`). |
 | `src/gba/integration_tests/gba_suite_tests.rs` | Three ROM-level integration tests (`arm.gba`, `thumb.gba`, `memory.gba`) with failure diagnostics (index/register/PC/cycles/exit reason). |
+| `src/gba/integration_tests/save_state_tests.rs` | End-to-end GBA save-state integration tests that save, dirty CPU/bus/PPU state, restore, and verify screen CRC plus state markers return to the saved point. |
 | `src/gba/cpu/mod.rs` | Module root for the ARM7TDMI core. Re-exports `Arm7tdmi`, `Bus`, `RamBus`, `Registers`, `CpuMode`, etc. |
 | `src/gba/cpu/registers.rs` | `Registers` — ARM7TDMI register file with R0–R15, CPSR, and per-mode banked SPSR/SP/LR (and FIQ-banked R8–R12). Includes `CpuMode` (USR/FIQ/IRQ/SVC/ABT/UND/SYS) and `condition_met` for the 16 ARM condition codes. |
 | `src/gba/cpu/bus.rs` | `Bus` trait used by the CPU for byte/halfword/word reads and writes, plus a flat little-endian `RamBus` implementation used by tests and boot stubs. |

--- a/src/gba/integration_tests/mod.rs
+++ b/src/gba/integration_tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod gba_suite_runner;
 pub mod gba_suite_tests;
+pub mod save_state_tests;

--- a/src/gba/integration_tests/save_state_tests.rs
+++ b/src/gba/integration_tests/save_state_tests.rs
@@ -1,0 +1,82 @@
+use crate::gba::cartridge::header::{
+    COMPLEMENT_CHECK_OFFSET, FIXED_BYTE_OFFSET, FIXED_BYTE_VALUE, compute_complement_check,
+};
+use crate::gba::console::save_state::{GBA_SAVESTATE_VERSION, GbaSaveStateError};
+use crate::gba::cpu::bus::Bus;
+use crate::gba::ppu;
+use crate::gba::ppu::{CYCLES_PER_SCANLINE, SCANLINES_PER_FRAME};
+use crate::platform::app_context::AppContext;
+use crate::platform::config::Config;
+use crate::platform::emulator::Emulator;
+
+fn make_gba() -> crate::gba::Gba {
+    let mut config = Config::default();
+    config.gba.bios_path = Some("embedded".to_string());
+    crate::gba::Gba::new(AppContext::new_with_config(config))
+}
+
+fn minimal_valid_gba_rom() -> Vec<u8> {
+    let mut rom = vec![0u8; 0xC0];
+    rom[FIXED_BYTE_OFFSET] = FIXED_BYTE_VALUE;
+    rom[COMPLEMENT_CHECK_OFFSET] = compute_complement_check(&rom);
+    rom
+}
+
+fn render_mode3_frame(gba: &mut crate::gba::Gba, color: u16) {
+    let bus = gba.bus_mut();
+    bus.write16(ppu::REG_DISPCNT, 3 | ppu::dispcnt::BG2_ENABLE);
+    bus.write16(ppu::REG_BG2PA, 0x0100);
+    bus.write16(ppu::REG_BG2PD, 0x0100);
+    bus.write16(0x0600_0000, color);
+    bus.step(CYCLES_PER_SCANLINE * SCANLINES_PER_FRAME);
+}
+
+#[test]
+fn gba_save_state_restore_returns_screen_and_state_to_saved_point() {
+    let mut gba = make_gba();
+    let rom = minimal_valid_gba_rom();
+    gba.load_rom(&rom, "synthetic.gba").expect("valid GBA ROM");
+
+    render_mode3_frame(&mut gba, 0x001F);
+    gba.bus_mut().write32(0x0200_0100, 0x1234_5678);
+    gba.bus_mut().write16(0x0400_0200, 0x0001);
+    let saved_pc = gba.cpu_pc();
+    let saved_crc = gba.screen_crc32();
+    let saved = gba.save_state();
+
+    render_mode3_frame(&mut gba, 0x7C00);
+    gba.bus_mut().write32(0x0200_0100, 0xDEAD_BEEF);
+    gba.bus_mut().write16(0x0400_0200, 0x0040);
+    for _ in 0..16 {
+        gba.run_tick_for_tests();
+    }
+
+    assert_ne!(
+        gba.screen_crc32(),
+        saved_crc,
+        "test must dirty screen output"
+    );
+    assert_ne!(gba.cpu_pc(), saved_pc, "test must dirty CPU state");
+    assert_eq!(gba.bus_mut().read32(0x0200_0100), 0xDEAD_BEEF);
+
+    gba.load_state(&saved).expect("restore succeeds");
+
+    assert_eq!(gba.screen_crc32(), saved_crc);
+    assert_eq!(gba.cpu_pc(), saved_pc);
+    assert_eq!(gba.bus_mut().read32(0x0200_0100), 0x1234_5678);
+    assert_eq!(gba.bus_mut().read16(0x0400_0200), 0x0001);
+}
+
+#[test]
+fn gba_save_state_rejects_incompatible_version_without_crashing() {
+    let mut gba = make_gba();
+    let mut saved = gba.save_state();
+    saved.version = GBA_SAVESTATE_VERSION + 1;
+
+    let result = gba.load_state(&saved);
+
+    assert!(matches!(
+        result,
+        Err(GbaSaveStateError::IncompatibleVersion { .. })
+    ));
+}


### PR DESCRIPTION
## Summary
- Add deterministic GBA save-state integration tests using a synthetic valid ROM.
- Verify save → dirty CPU/bus/PPU state → restore returns screen CRC, CPU PC, EWRAM, and interrupt state to the saved point.
- Cover incompatible GBA save-state version rejection without crashing.
- Document the new integration test module in architecture.md.

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- ./scripts/test-dir.sh src/gba --skip-integration
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test

Closes #2634
