### PR TITLE
Fix GBA save-state sticky input

### DIFF
--- a/src/gba/console/save_state.rs
+++ b/src/gba/console/save_state.rs
@@ -187,9 +187,12 @@ impl Gba {
                 found: state.version,
             });
         }
+        let current_input = self.bus().keypad.pressed_mask();
         self.bus_mut()
             .restore_memory_state(&state.bus)
             .map_err(GbaSaveStateError::RestoreFailed)?;
+        let bus = self.bus_mut();
+        bus.keypad.set_pressed_mask(current_input, &mut bus.ic);
         self.restore_cpu_state(&state.cpu);
         Ok(())
     }
@@ -241,6 +244,50 @@ mod tests {
         assert_eq!(loaded.bus.sram.len(), save.bus.sram.len());
         assert_eq!(loaded.bus.ic.ie, save.bus.ic.ie);
         assert_eq!(loaded.cpu.regs.r[15], save.cpu.regs.r[15]);
+    }
+
+    #[test]
+    fn test_load_state_preserves_current_physical_button_state() {
+        let mut gba = make_gba();
+        gba.set_button(0, 0, true);
+        let saved = gba.save_state();
+
+        gba.set_button(0, 0, false);
+        assert_eq!(
+            gba.get_joypad_button_states(0) & 0x01,
+            0,
+            "test setup must release A before restoring"
+        );
+
+        gba.load_state(&saved).expect("restore should succeed");
+
+        assert_eq!(
+            gba.get_joypad_button_states(0) & 0x01,
+            0,
+            "loading a save state must not resurrect a stale physical A press"
+        );
+    }
+
+    #[test]
+    fn test_load_state_preserves_current_physical_shoulder_button_state() {
+        let mut gba = make_gba();
+        gba.set_button(0, 8, true);
+        let saved = gba.save_state();
+
+        gba.set_button(0, 8, false);
+        assert_ne!(
+            gba.bus().keypad.read_keyinput() & (1 << 9),
+            0,
+            "test setup must release L before restoring"
+        );
+
+        gba.load_state(&saved).expect("restore should succeed");
+
+        assert_ne!(
+            gba.bus().keypad.read_keyinput() & (1 << 9),
+            0,
+            "loading a save state must not resurrect a stale physical L press"
+        );
     }
 
     // ── Capture / restore preserves modified memory ────────────────────────

--- a/src/gba/input/keypad.rs
+++ b/src/gba/input/keypad.rs
@@ -131,6 +131,15 @@ impl Keypad {
         actions | (up << 4) | (down << 5) | (left << 6) | (right << 7)
     }
 
+    pub(crate) fn pressed_mask(&self) -> u16 {
+        self.pressed & KEYS_MASK
+    }
+
+    pub(crate) fn set_pressed_mask(&mut self, pressed: u16, ic: &mut InterruptController) {
+        self.pressed = pressed & KEYS_MASK;
+        self.update_irq(ic);
+    }
+
     /// Set the 8 NES-convention buttons in bulk. Preserves the `L`/`R`
     /// shoulder buttons and re-evaluates the keypad IRQ.
     pub fn set_states(&mut self, state: u8, ic: &mut InterruptController) {


### PR DESCRIPTION
## Summary

Fixes GBA save-state loads so stale saved button presses do not override the frontend's current physical controller state.

## Problem

If a GBA state was saved while a button was held, loading that state after releasing the physical button restored the saved pressed bit. The button then stayed logically held until the physical button was pressed and released again.

## Fix

- Preserve the current physical keypad pressed mask before applying the saved bus state.
- Reapply that current input mask after bus restore, while keeping bus-level `restore_memory_state` behavior unchanged for deterministic hardware-state tests.
- Add regression coverage for both A and L button cases.

Fixes #2646

## Validation

- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/gba --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`
