### PR TITLE
Fix #2652: automate Blargg GB timing rows

### DIFF
--- a/src/gb/bus/cgb_bus.rs
+++ b/src/gb/bus/cgb_bus.rs
@@ -1494,7 +1494,7 @@ mod tests {
         // Given/When: a DMG-only cartridge starts on CGB-E with the boot ROM skipped.
         // Then: production CGB post-boot wave RAM is the alternating 00/FF pattern
         // that the CGB boot ROM leaves behind, allowing hardware probes such as
-        // GBEmulatorShootout's acid/which.gb to distinguish CGB-E from generic CGB.
+        // acid/which.gb to distinguish CGB-E from generic CGB.
         for offset in 0..16 {
             let expected = if offset % 2 == 0 { 0x00 } else { 0xFF };
             assert_eq!(
@@ -1538,7 +1538,7 @@ mod tests {
         let mut bus = CgbBus::new(dmg_only_rom_cart(), CgbModel::CgbD, true);
 
         // Given/When: software writes addresses that CGB-C aliases but CGB-D
-        // keeps distinct. GBEmulatorShootout's acid/which.gb uses this
+        // keeps distinct. acid/which.gb uses this
         // hardware difference to distinguish CGB-D from CGB-C.
         bus.write(0xFEA0, 0x12);
         bus.write(0xFEB8, 0x34);

--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -1,4 +1,4 @@
-use super::helpers::load_gb_rom;
+use super::helpers::{load_cgb_rom, load_gb_rom};
 use crate::gb::bus::{DmgBus, GbBus};
 use crate::gb::console::Gb;
 
@@ -118,8 +118,8 @@ fn run_blargg_rom_cart_ram(gb: &mut Gb<DmgBus>) -> String {
 ///
 /// Returns a `String` containing the decoded visible tile map content with
 /// newlines between rows, with trailing whitespace stripped from each row.
-fn vram_tilemap_text(gb: &Gb<DmgBus>) -> String {
-    let tile_map = &gb.cpu.bus.ppu.vram[0x1800..0x1C00];
+fn vram_tilemap_text<B: GbBus>(gb: &Gb<B>) -> String {
+    let tile_map = &gb.cpu.bus.ppu().vram[0x1800..0x1C00];
     let mut result = String::new();
     for row in 0..18usize {
         let start = row * 32;
@@ -147,7 +147,7 @@ fn vram_tilemap_text(gb: &Gb<DmgBus>) -> String {
 ///
 /// Polls the tilemap every 50 000 M-cycles rather than always running to the
 /// full budget, keeping CI runtime predictable.
-fn run_blargg_rom_lcd(gb: &mut Gb<DmgBus>) -> String {
+fn run_blargg_rom_lcd<B: GbBus>(gb: &mut Gb<B>) -> String {
     const POLL_INTERVAL: u64 = 50_000;
     let start = gb.cycles();
     loop {
@@ -308,6 +308,16 @@ fn test_halt_bug() {
 }
 
 #[test]
+fn test_interrupt_time() {
+    let mut gb = load_cgb_rom("roms/gb/automated_tests/blargg/interrupt_time/interrupt_time.gb");
+    let output = run_blargg_rom_lcd(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed in LCD output, got: {output:?}"
+    );
+}
+
+#[test]
 fn test_mem_timing() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/blargg/mem_timing/mem_timing.gb");
     let output = run_blargg_rom(&mut gb);
@@ -318,8 +328,74 @@ fn test_mem_timing() {
 }
 
 #[test]
+fn test_mem_timing_01_read_timing() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/blargg/mem_timing/individual/01-read_timing.gb");
+    let output = run_blargg_rom(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_mem_timing_02_write_timing() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/blargg/mem_timing/individual/02-write_timing.gb");
+    let output = run_blargg_rom(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_mem_timing_03_modify_timing() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/blargg/mem_timing/individual/03-modify_timing.gb");
+    let output = run_blargg_rom(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
 fn test_mem_timing_2() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/blargg/mem_timing-2/mem_timing.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_mem_timing_2_01_read_timing() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/blargg/mem_timing-2/rom_singles/01-read_timing.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_mem_timing_2_02_write_timing() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/blargg/mem_timing-2/rom_singles/02-write_timing.gb");
+    let output = run_blargg_rom_cart_ram(&mut gb);
+    assert!(
+        output.contains("Passed"),
+        "expected Passed, got: {output:?}"
+    );
+}
+
+#[test]
+fn test_mem_timing_2_03_modify_timing() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/blargg/mem_timing-2/rom_singles/03-modify_timing.gb");
     let output = run_blargg_rom_cart_ram(&mut gb);
     assert!(
         output.contains("Passed"),


### PR DESCRIPTION
## Summary

- Automates the remaining Blargg GB timing rows from issue #2652.
- Adds individual `interrupt_time`, `mem_timing`, and `mem_timing-2` integration tests.
- Reuses the LCD harness for the CGB-only interrupt timing ROM by making it generic over `GbBus`.

Fixes #2652

## Validation

- `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/gb --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`
