### PR TITLE
Fix GBA mGBA timer IRQ timing

### DIFF
--- a/src/gba/bus/cpu_bus.rs
+++ b/src/gba/bus/cpu_bus.rs
@@ -286,6 +286,7 @@ impl Bus for GbaBus {
                     }
                     let high = (value >> 16) as u16;
                     let timer_enable_phase = self.timer_enable_phase_for_write16(aligned + 2, high);
+                    self.defer_active_timer_reload_write_cycle(aligned);
                     self.prestep_timer_disable_for_write16(aligned + 2, high);
                     self.mark_timer_start_delay_for_write16(aligned + 2, high);
                     self.mark_dma_start_delay_for_write16(aligned + 2, (value >> 16) as u16);
@@ -364,6 +365,7 @@ impl Bus for GbaBus {
                         }
                     }
                     let timer_enable_phase = self.timer_enable_phase_for_write16(aligned, value);
+                    self.defer_active_timer_reload_write_cycle(aligned);
                     self.prestep_timer_disable_for_write16(aligned, value);
                     self.mark_timer_start_delay_for_write16(aligned, value);
                     self.mark_dma_start_delay_for_write16(aligned, value);

--- a/src/gba/bus/gba_bus.rs
+++ b/src/gba/bus/gba_bus.rs
@@ -132,6 +132,9 @@ pub struct GbaBus {
     pub(super) cpu_instruction_active: bool,
     /// Timer cycles already advanced inside the current CPU instruction.
     pub(super) timer_cycles_prestepped_this_instruction: u32,
+    /// Timers whose next IRQ follows an immediate FFFF overflow reload-write
+    /// timing path and needs one cycle of CPU-visible IRQ compensation.
+    pub(super) immediate_overflow_irq_compensation_pending: [bool; 4],
 }
 
 impl Default for GbaBus {
@@ -215,6 +218,7 @@ impl GbaBus {
             irq_sources_were_asserted: 0,
             cpu_instruction_active: false,
             timer_cycles_prestepped_this_instruction: 0,
+            immediate_overflow_irq_compensation_pending: [false; 4],
         }
     }
 
@@ -391,6 +395,7 @@ impl GbaBus {
         self.handle_ppu_events(events);
         self.run_pending_dma_after_start_delay(cycles);
         self.latch_cpu_irq_line();
+        self.clear_immediate_overflow_compensation_for_overflows(overflow_mask);
     }
 
     /// Step peripherals after one CPU instruction. If that instruction enabled
@@ -424,6 +429,7 @@ impl GbaBus {
         self.handle_ppu_events(events);
         self.run_pending_dma_after_start_delay(cycles);
         self.latch_cpu_irq_line();
+        self.clear_immediate_overflow_compensation_for_overflows(overflow_mask);
     }
 
     pub(super) fn advance_cpu_irq_line_delay(&mut self, cycles: u32) {
@@ -437,11 +443,41 @@ impl GbaBus {
         let newly_asserted = active_sources & !self.irq_sources_were_asserted;
         let cycles_late = self.ic.take_irq_cycles_late();
         if newly_asserted & DELAYED_IRQ_SOURCES != 0 {
-            self.irq_line_delay_cycles = irq_line_assert_delay_cycles().saturating_sub(cycles_late);
+            let compensation =
+                u32::from(self.take_immediate_overflow_irq_compensation(newly_asserted));
+            self.irq_line_delay_cycles =
+                irq_line_assert_delay_cycles().saturating_sub(cycles_late + compensation);
         } else if active_sources & DELAYED_IRQ_SOURCES == 0 {
             self.irq_line_delay_cycles = 0;
         }
         self.irq_sources_were_asserted = active_sources;
+    }
+
+    fn take_immediate_overflow_irq_compensation(&mut self, newly_asserted: u16) -> bool {
+        const TIMER_IRQ_BITS: [u16; 4] = [
+            irq_bits::TIMER0,
+            irq_bits::TIMER1,
+            irq_bits::TIMER2,
+            irq_bits::TIMER3,
+        ];
+
+        let mut compensate = false;
+        for (timer, bit) in TIMER_IRQ_BITS.iter().enumerate() {
+            if newly_asserted & bit != 0 && self.immediate_overflow_irq_compensation_pending[timer]
+            {
+                compensate = true;
+                self.immediate_overflow_irq_compensation_pending[timer] = false;
+            }
+        }
+        compensate
+    }
+
+    fn clear_immediate_overflow_compensation_for_overflows(&mut self, overflow_mask: [u32; 4]) {
+        for (timer, overflows) in overflow_mask.iter().enumerate() {
+            if *overflows > 0 {
+                self.immediate_overflow_irq_compensation_pending[timer] = false;
+            }
+        }
     }
 
     pub(super) fn prestep_timers_before_cpu_sample(&mut self, cycles: u32) {
@@ -453,6 +489,7 @@ impl GbaBus {
         let overflow_mask = self.timers.step(cycles, &mut self.ic);
         self.handle_timer_overflow_fifo(overflow_mask);
         self.latch_cpu_irq_line();
+        self.clear_immediate_overflow_compensation_for_overflows(overflow_mask);
         self.timer_cycles_prestepped_this_instruction = self
             .timer_cycles_prestepped_this_instruction
             .saturating_add(cycles);
@@ -466,6 +503,7 @@ impl GbaBus {
             }
             let overflow_mask = self.timers.step(cycles, &mut self.ic);
             self.handle_timer_overflow_fifo(overflow_mask);
+            self.clear_immediate_overflow_compensation_for_overflows(overflow_mask);
             self.apu.tick(cycles);
             let events = self.ppu.step(
                 cycles,
@@ -534,6 +572,21 @@ impl GbaBus {
         };
         if self.timers.channels[timer].enabled() && value & 0x0080 == 0 {
             self.prestep_timers_before_cpu_sample(1);
+            self.immediate_overflow_irq_compensation_pending[timer] = false;
+        }
+    }
+
+    pub(super) fn defer_active_timer_reload_write_cycle(&mut self, addr: u32) {
+        let is_timer_reload = matches!(addr, 0x0400_0100 | 0x0400_0104 | 0x0400_0108 | 0x0400_010C);
+        if !is_timer_reload || !self.cpu_instruction_active {
+            return;
+        }
+        let timer = ((addr - 0x0400_0100) / 4) as usize;
+        if self.timers.channels[timer].enabled() && self.timers.channels[timer].counter == 0xFFFF {
+            self.timer_cycles_prestepped_this_instruction = self
+                .timer_cycles_prestepped_this_instruction
+                .saturating_add(1);
+            self.immediate_overflow_irq_compensation_pending[timer] = true;
         }
     }
 
@@ -739,6 +792,7 @@ impl GbaBus {
         self.dma_start_delay_cycles = 0;
         self.cpu_instruction_active = false;
         self.timer_cycles_prestepped_this_instruction = 0;
+        self.immediate_overflow_irq_compensation_pending = [false; 4];
         Ok(())
     }
 
@@ -1064,7 +1118,9 @@ mod tests {
         clear_gba_bus_trace_lines_for_tests, take_gba_bus_trace_lines_for_tests,
     };
     use crate::gba::bios::EMBEDDED_BIOS;
-    use crate::gba::bus::{REG_IE, REG_IF, REG_IME, WidthClass, irq_bits};
+    use crate::gba::bus::WidthClass;
+    use crate::gba::bus::interrupt::bits as irq_bits;
+    use crate::gba::bus::io::{REG_IE, REG_IF, REG_IME};
     use crate::gba::cartridge::{Flash, SaveBackend};
     use crate::gba::console::config::GbaTraceConfig;
     use crate::gba::cpu::bus::Bus;
@@ -1471,6 +1527,49 @@ mod tests {
         assert_eq!(bus.read16(0x0400_0100), 1);
         bus.step_after_cpu_instruction(1);
         assert_eq!(bus.read16(0x0400_0100), 2);
+    }
+
+    #[test]
+    fn active_timer_reload_from_ffff_defers_current_instruction_tick() {
+        let mut bus = GbaBus::new();
+        bus.write16(0x0400_0100, 0xFFFF);
+        bus.write16(0x0400_0102, 0x00C0 | 0x0080);
+
+        bus.begin_cpu_instruction();
+        bus.write16(0x0400_0100, 0);
+        bus.end_cpu_instruction();
+        bus.step_after_cpu_instruction(1);
+
+        assert_eq!(
+            bus.read16(0x0400_0100),
+            0xFFFF,
+            "the active reload write cycle should not immediately tick TM0 from FFFF"
+        );
+        assert_eq!(bus.ic.if_flags & irq_bits::TIMER0, 0);
+    }
+
+    #[test]
+    fn immediate_ffff_overflow_irq_line_uses_compensated_delay() {
+        let mut bus = GbaBus::new();
+        bus.write16(REG_IE, irq_bits::TIMER0);
+        bus.write16(REG_IME, 1);
+        bus.write16(0x0400_0100, 0xFFFF);
+        bus.write16(0x0400_0102, 0x00C0 | 0x0080);
+
+        bus.begin_cpu_instruction();
+        bus.write16(0x0400_0100, 0);
+        bus.end_cpu_instruction();
+        bus.step_after_cpu_instruction(1);
+        bus.step_after_cpu_instruction(1);
+
+        assert_ne!(bus.ic.if_flags & irq_bits::TIMER0, 0);
+        assert!(!bus.cpu_irq_line());
+        bus.step_after_cpu_instruction(4);
+        assert!(
+            bus.cpu_irq_line(),
+            "immediate FFFF overflow should reach the CPU after the compensated timer IRQ delay"
+        );
+        assert!(!bus.immediate_overflow_irq_compensation_pending[0]);
     }
 
     #[test]

--- a/src/gba/bus/mod.rs
+++ b/src/gba/bus/mod.rs
@@ -22,9 +22,9 @@ pub mod sio;
 pub mod timer;
 mod waitstates;
 
-pub use dma::{DmaBus, DmaChannel, DmaController};
+pub use dma::DmaController;
 pub use gba_bus::GbaBus;
-pub use interrupt::{InterruptController, bits as irq_bits};
-pub use io::{IoRegisters, REG_IE, REG_IF, REG_IME};
-pub use timer::{Timer, Timers};
+pub use interrupt::InterruptController;
+pub use io::IoRegisters;
+pub use timer::Timers;
 pub use waitstates::{Waitstates, WidthClass};

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -44,19 +44,19 @@ armwrestler_page7=0x562A5C65
 # 14 sub-suites exercising memory, I/O, timing, shifter, carry, multiply,
 # BIOS math, DMA, SIO, misc edge cases, and video.
 # Scores (passing/total, embedded BIOS): Memory 1552/1552, I/O read 130/130, Timing 2020/2020,
-# Timers 936/936, Timer IRQ 80/90, Shifter 140/140, Carry 93/93,
-# Multiply long 72/72, BIOS math 427/615, DMA 1116/1256, SIO read 90/90,
+# Timers 936/936, Timer IRQ 90/90, Shifter 140/140, Carry 93/93,
+# Multiply long 72/72, BIOS math 427/615, DMA 1120/1256, SIO read 90/90,
 # SIO timing 0/4, Misc. edge 3/12, Video (sub-menu only).
 mgba_memory=0x61F65500
 mgba_io_read=0x7D320909
 mgba_timing=0xEABA32BC
 mgba_timers=0xBAEFCA7B
-mgba_timer_irq=0xDA4110EF
+mgba_timer_irq=0xE7796772
 mgba_shifter=0x8B4A12AA
 mgba_carry=0xFD9E45E6
 mgba_multiply_long=0x699655AB
 mgba_bios_math=0x09E82124
-mgba_dma=0xADABAAA9
+mgba_dma=0x85EE4126
 mgba_sio_read=0xF5D98687
 mgba_sio_timing=0xD95ACB03
 mgba_misc_edge=0x36ECDBF9

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -723,6 +723,14 @@ fn mgba_timers_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
     mgba_named_sub_suite_diagnostic_from_gba(gba, "Timer count-up tests")
 }
 
+fn mgba_timer_irq_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
+    mgba_named_sub_suite_diagnostic_from_gba(gba, "Timer IRQ tests")
+}
+
+fn mgba_dma_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
+    mgba_named_sub_suite_diagnostic_from_gba(gba, "DMA tests")
+}
+
 fn mgba_named_sub_suite_diagnostic_from_gba(
     gba: &Gba,
     suite_name: &str,
@@ -753,6 +761,16 @@ pub fn run_mgba_timing_diagnostics() -> MgbaMemoryDiagnosticResult {
 pub fn run_mgba_timers_diagnostics() -> MgbaMemoryDiagnosticResult {
     let (gba, _rom) = boot_mgba_suite();
     run_mgba_sub_suite_diagnostics_from_gba(gba, 3, "Timers diagnostics")
+}
+
+pub fn run_mgba_timer_irq_diagnostics() -> MgbaMemoryDiagnosticResult {
+    let (gba, _rom) = boot_mgba_suite();
+    run_mgba_sub_suite_diagnostics_from_gba(gba, 4, "Timer IRQ diagnostics")
+}
+
+pub fn run_mgba_dma_diagnostics() -> MgbaMemoryDiagnosticResult {
+    let (gba, _rom) = boot_mgba_suite();
+    run_mgba_sub_suite_diagnostics_from_gba(gba, 9, "DMA diagnostics")
 }
 
 pub fn run_mgba_io_read_diagnostics_after_bios_intro() -> MgbaMemoryDiagnosticResult {
@@ -842,6 +860,8 @@ fn run_mgba_sub_suite_diagnostics_from_gba_with_boot_frames(
         1 => mgba_io_read_diagnostic_from_gba(&gba),
         2 => mgba_timing_diagnostic_from_gba(&gba),
         3 => mgba_timers_diagnostic_from_gba(&gba),
+        4 => mgba_timer_irq_diagnostic_from_gba(&gba),
+        9 => mgba_dma_diagnostic_from_gba(&gba),
         _ => mgba_memory_diagnostic_from_gba(&gba),
     }
 }

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -1,9 +1,9 @@
 use super::gba_suite_runner::{
     ARMWRESTLER_TEST_PAGE_COUNT, MGBA_SUITE_COUNT, MGBA_SUITE_KEYS, Suite, VIDEO_TEST_NAMES,
-    boot_mgba_suite, run_armwrestler, run_mgba_io_read_diagnostics,
+    boot_mgba_suite, run_armwrestler, run_mgba_dma_diagnostics, run_mgba_io_read_diagnostics,
     run_mgba_io_read_diagnostics_after_bios_intro, run_mgba_memory_diagnostics,
-    run_mgba_memory_diagnostics_with_bios_path, run_mgba_suite, run_mgba_timers_diagnostics,
-    run_mgba_timing_diagnostics, run_mgba_video_tests, run_suite,
+    run_mgba_memory_diagnostics_with_bios_path, run_mgba_suite, run_mgba_timer_irq_diagnostics,
+    run_mgba_timers_diagnostics, run_mgba_timing_diagnostics, run_mgba_video_tests, run_suite,
 };
 use crate::gba::bios::EMBEDDED_BIOS;
 use crate::gba::integration_tests::gba_suite_runner::GBA_CYCLES_PER_FRAME;
@@ -508,6 +508,51 @@ fn gba_mgba_timers_diagnostics_passes_every_count_up_case() {
 }
 
 #[test]
+fn gba_mgba_timer_irq_diagnostics_passes_every_irq_case() {
+    let result = run_mgba_timer_irq_diagnostics();
+
+    assert_eq!(
+        result.total_count,
+        Some(90),
+        "raw mGBA Timer IRQ log:\n{}",
+        result.raw_log
+    );
+    assert!(
+        result.passed_count.is_some(),
+        "mGBA Timer IRQ diagnostics should include a parsed pass count"
+    );
+    assert_eq!(
+        result.passed_count, result.total_count,
+        "mGBA Timer IRQ diagnostics should pass every case with the embedded BIOS.\nfailures: {:?}\nraw log:\n{}",
+        result.failures, result.raw_log
+    );
+    assert!(
+        result.failures.is_empty(),
+        "mGBA Timer IRQ diagnostics reported failures with the embedded BIOS: {:?}\nraw log:\n{}",
+        result.failures,
+        result.raw_log
+    );
+}
+
+#[test]
+fn gba_mgba_dma_diagnostics_reports_current_score() {
+    let result = run_mgba_dma_diagnostics();
+
+    assert_eq!(
+        result.total_count,
+        Some(1256),
+        "raw mGBA DMA log:\n{}",
+        result.raw_log
+    );
+    assert_eq!(
+        result.passed_count,
+        Some(1120),
+        "raw mGBA DMA log:\n{}",
+        result.raw_log
+    );
+}
+
+#[test]
 fn gba_mgba_memory_proprietary_diagnostics_skip_without_bios_path() {
     let result = run_mgba_memory_diagnostics_with_bios_path(None).unwrap();
 
@@ -570,12 +615,12 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("mgba_io_read"), Some(&0x7D32_0909));
     assert_eq!(approvals.get("mgba_timing"), Some(&0xEABA_32BC));
     assert_eq!(approvals.get("mgba_timers"), Some(&0xBAEF_CA7B));
-    assert_eq!(approvals.get("mgba_timer_irq"), Some(&0xDA41_10EF));
+    assert_eq!(approvals.get("mgba_timer_irq"), Some(&0xE779_6772));
     assert_eq!(approvals.get("mgba_shifter"), Some(&0x8B4A_12AA));
     assert_eq!(approvals.get("mgba_carry"), Some(&0xFD9E_45E6));
     assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
     assert_eq!(approvals.get("mgba_bios_math"), Some(&0x09E8_2124));
-    assert_eq!(approvals.get("mgba_dma"), Some(&0xADAB_AAA9));
+    assert_eq!(approvals.get("mgba_dma"), Some(&0x85EE_4126));
     assert_eq!(approvals.get("mgba_sio_read"), Some(&0xF5D9_8687));
     assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));
     assert_eq!(approvals.get("mgba_misc_edge"), Some(&0x36EC_DBF9));


### PR DESCRIPTION
## Summary

- Fix GBA timer IRQ timing for active reload writes when an enabled timer counter is at 0xFFFF.
- Add focused mGBA Timer IRQ diagnostics and unit coverage for the FFFF reload/IRQ timing path.
- Update mGBA suite approvals for Timer IRQ 90/90 and the related DMA score improvement to 1120/1256.

## Validation

- cargo test --no-default-features --lib gba_mgba_timer_irq_diagnostics_passes_every_irq_case -- --nocapture
- cargo test --no-default-features --lib gba_mgba_dma_diagnostics_reports_current_score -- --nocapture
- cargo test --no-default-features --lib approvals_manifest_parses -- --nocapture
- cargo test --no-default-features --lib gba_mgba_suite_passes -- --nocapture
- cargo test --no-default-features --lib gba::bus::gba_bus -- --nocapture
- cargo test --no-default-features --lib gba::bus::timer -- --nocapture
- ./scripts/test-dir.sh src/gba --skip-integration
- cargo test --no-default-features --lib
- cargo clippy --all-targets --all-features -- -D warnings
