### PR TITLE
fix(web): support CGB ROM extensions

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -88,7 +88,7 @@
           <!-- ROM controls -->
           <div class="flex flex-col gap-2">
             <label for="rom" class="label text-xs">ROM file</label>
-            <input type="file" id="rom" accept=".nes,.gb,application/octet-stream" class="file-input file-input-bordered file-input-sm w-full" />
+            <input type="file" id="rom" accept=".nes,.gb,.gbc,.cgb,application/octet-stream" class="file-input file-input-bordered file-input-sm w-full" />
             <select id="rom-select" class="select select-bordered select-sm w-full" aria-label="Select ROM from server">
               <option value="">Select bundled ROM…</option>
             </select>

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -12,6 +12,7 @@ import { applyJoypadButtonIfAllowed, applyMouseMotion, applyMouseButton, isZappe
 import { createSaveStateContext } from "./save-state/save_state_context";
 import { fetchRomList } from "./rom/rom_list";
 import { handleRomSelection } from "./rom/rom_selection";
+import { supportedRomExtensionsText, webRomConsoleKindForName, webRomExtensionForName, type WebRomConsoleKind } from "./rom/rom_extensions";
 import { createAutorunContext, parseAutorunFile } from "./rom/autorun_context";
 import { createFrameLimiter } from "./audio/frame_limiter";
 import { computePlaybackRate } from "./audio/audio_resampler";
@@ -726,10 +727,10 @@ function updateEmulationButtons() {
 }
 
 /** Create a fresh NES or GB emulator instance and update kind-dependent UI. */
-function createEmulatorInstance(ext: string): void {
+function createEmulatorInstance(kind: WebRomConsoleKind): void {
     // Free the previous WASM instance to avoid leaking its linear memory.
     emulator?.inst.free();
-    if (ext === "gb") {
+    if (kind === "gb") {
         const gb = new WasmGb();
         emulator = { kind: "gb", inst: gb };
         nes = null;
@@ -1189,11 +1190,12 @@ async function start() {
         return;
     }
     const romName = romMetadata?.name ?? "selected-rom.nes";
-    const ext = romName.toLowerCase().split(".").pop() ?? "";
+    const consoleKind = webRomConsoleKindForName(romName);
 
     // Reject unsupported file types before any async work.
-    if (ext !== "nes" && ext !== "gb") {
-        toastOverlay.show(`Unsupported file type .${ext} — only .nes and .gb are supported`);
+    if (!consoleKind) {
+        const ext = webRomExtensionForName(romName);
+        toastOverlay.show(`Unsupported file type .${ext} — only ${supportedRomExtensionsText()} are supported`);
         setStatus(`Unsupported file type .${ext}`, true);
         updateEmulationButtons();
         return;
@@ -1210,10 +1212,10 @@ async function start() {
                 throw new Error("Failed to initialize WebGL");
             }
 
-            createEmulatorInstance(ext);
-        } else if (emulator.kind !== ext) {
+            createEmulatorInstance(consoleKind);
+        } else if (emulator.kind !== consoleKind) {
             // Switching emulator kind (NES ↔ GB).
-            createEmulatorInstance(ext);
+            createEmulatorInstance(consoleKind);
         }
 
         // ── NES-only: Autorun setup (configure before loading ROM) ──────────

--- a/web/src/rom/rom_extensions.test.ts
+++ b/web/src/rom/rom_extensions.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from "vitest";
+import { supportedRomExtensionsText, webRomConsoleKindForName, webRomExtensionForName } from "./rom_extensions";
+
+it("classifies NES ROM names as NES", () => {
+    expect(webRomConsoleKindForName("mario.nes")).toBe("nes");
+    expect(webRomConsoleKindForName("MARIO.NES")).toBe("nes");
+});
+
+it("classifies DMG and CGB Game Boy ROM extensions as Game Boy", () => {
+    expect(webRomConsoleKindForName("tetris.gb")).toBe("gb");
+    expect(webRomConsoleKindForName("zelda.gbc")).toBe("gb");
+    expect(webRomConsoleKindForName("pocket-camera.cgb")).toBe("gb");
+    expect(webRomConsoleKindForName("POKEMON.CGB")).toBe("gb");
+});
+
+it("rejects unsupported web ROM extensions", () => {
+    expect(webRomConsoleKindForName("notes.txt")).toBeNull();
+    expect(webRomConsoleKindForName("advance.gba")).toBeNull();
+});
+
+it("extracts lower-case extensions for messages", () => {
+    expect(webRomExtensionForName("POKEMON.CGB")).toBe("cgb");
+    expect(webRomExtensionForName("README")).toBe("");
+    expect(webRomExtensionForName("game.")).toBe("");
+});
+
+it("lists all supported web ROM extensions for user-facing messages", () => {
+    expect(supportedRomExtensionsText()).toBe(".nes, .gb, .gbc, .cgb");
+});
+
+it("handles edge case: empty string", () => {
+    expect(webRomConsoleKindForName("")).toBeNull();
+});
+
+it("handles edge case: no extension", () => {
+    expect(webRomConsoleKindForName("file")).toBeNull();
+});
+
+it("handles edge case: multiple dots", () => {
+    expect(webRomConsoleKindForName("my.game.nes")).toBe("nes");
+});
+
+it("handles edge case: dots at end with no extension name", () => {
+    expect(webRomConsoleKindForName("file.")).toBeNull();
+});
+
+it("handles edge case: hidden file .nes", () => {
+    expect(webRomConsoleKindForName(".nes")).toBe("nes");
+});
+
+it("handles edge case: path with slashes", () => {
+    expect(webRomConsoleKindForName("/path/to/game.gb")).toBe("gb");
+});
+
+it("handles edge case: Windows path", () => {
+    expect(webRomConsoleKindForName("C:\\games\\pokemon.gbc")).toBe("gb");
+});

--- a/web/src/rom/rom_extensions.ts
+++ b/web/src/rom/rom_extensions.ts
@@ -1,0 +1,30 @@
+export type WebRomConsoleKind = "nes" | "gb";
+
+const GAME_BOY_EXTENSIONS = new Set(["gb", "gbc", "cgb"]);
+
+export function webRomExtensionForName(name: string): string {
+    const dotIndex = name.lastIndexOf(".");
+    if (dotIndex < 0 || dotIndex === name.length - 1) {
+        return "";
+    }
+    return name.slice(dotIndex + 1).toLowerCase();
+}
+
+export function webRomConsoleKindForName(name: string): WebRomConsoleKind | null {
+    const extension = webRomExtensionForName(name);
+    if (extension === "nes") {
+        return "nes";
+    }
+    if (GAME_BOY_EXTENSIONS.has(extension)) {
+        return "gb";
+    }
+    return null;
+}
+
+export function isSupportedWebRomName(name: string): boolean {
+    return webRomConsoleKindForName(name) !== null;
+}
+
+export function supportedRomExtensionsText(): string {
+    return ".nes, .gb, .gbc, .cgb";
+}

--- a/web/src/rom/rom_list.test.ts
+++ b/web/src/rom/rom_list.test.ts
@@ -140,15 +140,17 @@ it("parseDirectoryListing includes .gb files alongside .nes", () => {
     expect(roms).toContain("game.nes");
 });
 
-it("parseDirectoryListing excludes .gbc files", () => {
+it("parseDirectoryListing includes .gbc and .cgb files", () => {
     const html = `
         <html><body>
             <a href="game.gbc">game.gbc</a>
+            <a href="camera.cgb">camera.cgb</a>
             <a href="game.gb">game.gb</a>
         </body></html>
     `;
     const { roms } = parseDirectoryListing(html);
-    expect(roms).not.toContain("game.gbc");
+    expect(roms).toContain("game.gbc");
+    expect(roms).toContain("camera.cgb");
     expect(roms).toContain("game.gb");
 });
 
@@ -185,7 +187,7 @@ it("fetchRomList manifest fallback includes .gb entries", async () => {
     const responses = new Map([
         [base, ""],
         [`${base}roms.json`, JSON.stringify({
-            roms: ["tetris.gb", "game.nes", "color.gbc"]
+            roms: ["tetris.gb", "game.nes", "color.gbc", "camera.cgb"]
         })]
     ]);
 
@@ -205,5 +207,6 @@ it("fetchRomList manifest fallback includes .gb entries", async () => {
     const paths = entries.map((entry: any) => entry.path);
     expect(paths).toContain("tetris.gb");
     expect(paths).toContain("game.nes");
-    expect(paths).not.toContain("color.gbc");
+    expect(paths).toContain("color.gbc");
+    expect(paths).toContain("camera.cgb");
 });

--- a/web/src/rom/rom_list.ts
+++ b/web/src/rom/rom_list.ts
@@ -1,3 +1,5 @@
+import { isSupportedWebRomName } from "./rom_extensions";
+
 export function parseDirectoryListing(html: string) {
     const dirs = [];
     const roms = [];
@@ -8,7 +10,7 @@ export function parseDirectoryListing(html: string) {
         if (!href || href === "../") continue;
         if (href.endsWith("/")) {
             dirs.push(href);
-        } else if (href.toLowerCase().endsWith(".nes") || href.toLowerCase().endsWith(".gb")) {
+        } else if (isSupportedWebRomName(href)) {
             roms.push(href);
         }
     }
@@ -94,7 +96,7 @@ export async function fetchRomList(baseUrl: string, fetchFn: typeof fetch = fetc
     const manifest = await manifestResponse.json();
     const roms = Array.isArray(manifest?.roms) ? manifest.roms : [];
     return roms
-        .filter((rom: string) => typeof rom === "string" && (rom.toLowerCase().endsWith(".nes") || rom.toLowerCase().endsWith(".gb")))
+        .filter((rom: string) => typeof rom === "string" && isSupportedWebRomName(rom))
         .map((rom: string) => ({
             path: rom.replace(/^\//, ""),
             url: new URL(rom.replace(/^\//, ""), baseRoot).toString()


### PR DESCRIPTION
## Summary
- accepts `.cgb` and `.gbc` ROM files in the web file picker
- routes `.gb`, `.gbc`, and `.cgb` through the existing Game Boy WASM frontend
- includes `.cgb` and `.gbc` in bundled ROM directory/manifest discovery
- adds shared web ROM extension classification tests

## Validation
- `npx vitest run web/src/rom/rom_extensions.test.ts web/src/rom/rom_list.test.ts`
- `npm test`
- `cargo fmt`
- `./scripts/test-dir.sh src/frontends/web`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`

## Known pre-existing main failure
`cargo clippy --all-targets --all-features -- -D warnings` fails on both this branch and `main` due to unrelated unused GBA re-exports in `src/gba/bus/mod.rs` (`DmaBus`, `DmaChannel`, `irq_bits`, `REG_IE`, `REG_IF`, `REG_IME`, `Timer`). This branch only changes web TypeScript/HTML.
