### PR TITLE
fix(web): tailor help overlay by emulator

### DIFF
--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -771,6 +771,7 @@ function updateEmulatorKindUI() {
     }
     filterToggleBtn.disabled = false;
     updateFilterToggleButtonLabel();
+    updateShortcutHelpOverlayText();
 }
 
 /** Update the recording overlay (REC : MM:SS) on the canvas. */
@@ -2441,7 +2442,10 @@ const webShortcutActions = {
 
 function updateShortcutHelpOverlayText() {
     if (shortcutHelpOverlay) {
-        shortcutHelpOverlay.textContent = buildFullHelpOverlayText(connectedGamepads.length);
+        shortcutHelpOverlay.textContent = buildFullHelpOverlayText(
+            connectedGamepads.length,
+            emulator?.kind ?? "nes"
+        );
     }
 }
 

--- a/web/src/shortcuts/shortcut_help.test.ts
+++ b/web/src/shortcuts/shortcut_help.test.ts
@@ -5,6 +5,7 @@ import {
     buildShortcutOverlayText,
     buildShortcutReferenceText,
     buildControllerOverlayText,
+    buildFullHelpOverlayText,
     computeShortcutHelpFontSizePx,
     toggleShortcutHelpVisibility
 } from "./shortcut_help";
@@ -101,16 +102,18 @@ it("toggleShortcutHelpVisibility hides visible overlay", () => {
 });
 
 // Tests for buildControllerOverlayText
-it("buildControllerOverlayText shows keyboard keys for both players when no gamepads", () => {
-    const text = buildControllerOverlayText(0);
+it("buildControllerOverlayText shows NES keyboard keys for both players when no gamepads", () => {
+    const text = buildControllerOverlayText(0, "nes");
     expect(text).toMatch(/Controller \(Player 1\)/);
     expect(text).toMatch(/W\/A\/S\/D: D-Pad/);
-    expect(text).toMatch(/R: Y/);
-    expect(text).toMatch(/T: X/);
-    expect(text).toMatch(/F: B/);
-    expect(text).toMatch(/G: A/);
-    expect(text).toMatch(/Q: L/);
-    expect(text).toMatch(/E: R/);
+    expect(text).toMatch(/R: A/);
+    expect(text).toMatch(/T: B/);
+    expect(text).not.toMatch(/F: B/);
+    expect(text).not.toMatch(/G: A/);
+    expect(text).not.toMatch(/Q: L/);
+    expect(text).not.toMatch(/E: R/);
+    expect(text).not.toMatch(/X/);
+    expect(text).not.toMatch(/Y/);
     expect(text).toMatch(/4: Select/);
     expect(text).toMatch(/5: Start/);
     expect(text).toMatch(/Controller \(Player 2\)/);
@@ -121,8 +124,36 @@ it("buildControllerOverlayText shows keyboard keys for both players when no game
     expect(text).toMatch(/0: Start/);
 });
 
+it("buildControllerOverlayText shows only one Game Boy controller with A and B", () => {
+    const text = buildControllerOverlayText(0, "gb");
+    expect(text).toMatch(/Controller \(Player 1\)/);
+    expect(text).toMatch(/W\/A\/S\/D: D-Pad/);
+    expect(text).toMatch(/R: A/);
+    expect(text).toMatch(/T: B/);
+    expect(text).toMatch(/4: Select/);
+    expect(text).toMatch(/5: Start/);
+    expect(text).not.toMatch(/Controller \(Player 2\)/);
+    expect(text).not.toMatch(/I\/J\/K\/L/);
+    expect(text).not.toMatch(/X/);
+    expect(text).not.toMatch(/Y/);
+    expect(text).not.toMatch(/Q: L/);
+    expect(text).not.toMatch(/E: R/);
+});
+
+it("buildControllerOverlayText reserves X, Y, and shoulder keys for AGB", () => {
+    const text = buildControllerOverlayText(0, "gba");
+    expect(text).toMatch(/Controller \(Player 1\)/);
+    expect(text).toMatch(/R: Y/);
+    expect(text).toMatch(/T: X/);
+    expect(text).toMatch(/F: B/);
+    expect(text).toMatch(/G: A/);
+    expect(text).toMatch(/Q: L/);
+    expect(text).toMatch(/E: R/);
+    expect(text).not.toMatch(/Controller \(Player 2\)/);
+});
+
 it("buildControllerOverlayText shows Gamepad for player 1 and keyboard for player 2 when one gamepad connected", () => {
-    const text = buildControllerOverlayText(1);
+    const text = buildControllerOverlayText(1, "nes");
     expect(text).toMatch(/Controller \(Player 1\)/);
     expect(text).toMatch(/Gamepad/);
     expect(text).not.toMatch(/W\/A\/S\/D/);
@@ -131,11 +162,18 @@ it("buildControllerOverlayText shows Gamepad for player 1 and keyboard for playe
 });
 
 it("buildControllerOverlayText shows Gamepad for both players when two gamepads connected", () => {
-    const text = buildControllerOverlayText(2);
+    const text = buildControllerOverlayText(2, "nes");
     expect(text).toMatch(/Controller \(Player 1\)/);
     expect(text).toMatch(/Controller \(Player 2\)/);
     expect(text).not.toMatch(/W\/A\/S\/D/);
     expect(text).not.toMatch(/I\/J\/K\/L/);
     const gamepadMatches = [...text.matchAll(/Gamepad/g)];
     expect(gamepadMatches.length).toBe(2);
+});
+
+it("buildFullHelpOverlayText uses the selected emulator controller help", () => {
+    const text = buildFullHelpOverlayText(0, "gb");
+    expect(text).toMatch(/^Shortcuts/m);
+    expect(text).toMatch(/Controller \(Player 1\)/);
+    expect(text).not.toMatch(/Controller \(Player 2\)/);
 });

--- a/web/src/shortcuts/shortcut_help.ts
+++ b/web/src/shortcuts/shortcut_help.ts
@@ -13,23 +13,35 @@ export const WEB_SHORTCUT_REFERENCE = [
 ];
 
 const PLAYER_KEYBOARD_BINDINGS = [
-    "W/A/S/D: D-Pad\nR: Y\nT: X\nF: B\nG: A\nQ: L\nE: R\n4: Select\n5: Start",
+    "W/A/S/D: D-Pad\nR: A\nT: B\n4: Select\n5: Start",
     "I/J/K/L: D-Pad\nO: A\nP: B\n9: Select\n0: Start"
 ];
+
+const AGB_KEYBOARD_BINDINGS = "W/A/S/D: D-Pad\nR: Y\nT: X\nF: B\nG: A\nQ: L\nE: R\n4: Select\n5: Start";
+
+export type HelpConsoleKind = "nes" | "gb" | "gba";
 
 function buildPlayerSection(playerNumber: number, hasGamepad: boolean, keyBindings: string) {
     const controls = hasGamepad ? "Gamepad" : keyBindings;
     return `Controller (Player ${playerNumber})\n${controls}`;
 }
 
-export function buildControllerOverlayText(gamepadCount = 0) {
+export function buildControllerOverlayText(gamepadCount = 0, consoleKind: HelpConsoleKind = "nes") {
+    if (consoleKind === "gb") {
+        return buildPlayerSection(1, gamepadCount >= 1, PLAYER_KEYBOARD_BINDINGS[0]);
+    }
+
+    if (consoleKind === "gba") {
+        return buildPlayerSection(1, gamepadCount >= 1, AGB_KEYBOARD_BINDINGS);
+    }
+
     const player1 = buildPlayerSection(1, gamepadCount >= 1, PLAYER_KEYBOARD_BINDINGS[0]);
     const player2 = buildPlayerSection(2, gamepadCount >= 2, PLAYER_KEYBOARD_BINDINGS[1]);
     return `${player1}\n\n${player2}`;
 }
 
-export function buildFullHelpOverlayText(gamepadCount = 0) {
-    return buildShortcutOverlayText() + "\n\n" + buildControllerOverlayText(gamepadCount);
+export function buildFullHelpOverlayText(gamepadCount = 0, consoleKind: HelpConsoleKind = "nes") {
+    return buildShortcutOverlayText() + "\n\n" + buildControllerOverlayText(gamepadCount, consoleKind);
 }
 
 export function buildShortcutReferenceText(shortcuts = WEB_SHORTCUT_REFERENCE) {


### PR DESCRIPTION
## Summary
- makes the web help overlay render controller keys for the active emulator
- shows NES with two controllers and only D-pad/A/B/Select/Start keyboard bindings
- shows GB with one controller and only D-pad/A/B/Select/Start keyboard bindings
- keeps X/Y/L/R shoulder help reserved for AGB/GBA help text

## Validation
- `npx vitest run web/src/shortcuts/shortcut_help.test.ts`
- `npm test`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt`
- `./scripts/test-dir.sh src/frontends/web`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`

Note: `cargo clean` was run locally to clear generated build artifacts after the first clippy attempt hit disk-space exhaustion.
