### PR TITLE
Fix GBA mGBA BIOS math diagnostics

### DIFF
--- a/src/gba/cpu/arm7tdmi.rs
+++ b/src/gba/cpu/arm7tdmi.rs
@@ -114,6 +114,55 @@ fn cpu_fast_set_source_requires_bios_execution(addr: u32) -> bool {
     !(0x0200_0000..0x1000_0000).contains(&addr)
 }
 
+fn hle_bios_arctan_values(input: i32) -> (i32, i32, i32) {
+    let intermediate = (input.wrapping_mul(input) >> 14).wrapping_neg();
+    let mut coefficient = 0x00A9i32;
+    for addend in [0x0390, 0x091C, 0x0FB6, 0x16AA, 0x2081, 0x3651, 0xA2F9] {
+        coefficient = (coefficient.wrapping_mul(intermediate) >> 14).wrapping_add(addend);
+    }
+    let result = input.wrapping_mul(coefficient) >> 16;
+    (result, intermediate, coefficient)
+}
+
+fn hle_bios_arctan2_values(x: i32, y: i32) -> (i32, i32) {
+    if y == 0 {
+        return (if x >= 0 { 0 } else { 0x8000 }, y);
+    }
+    if x == 0 {
+        return (if y >= 0 { 0x4000 } else { 0xC000 }, y);
+    }
+
+    if y >= 0 {
+        if x >= 0 {
+            if x >= y {
+                let (angle, intermediate, _) =
+                    hle_bios_arctan_values(y.wrapping_shl(14).wrapping_div(x));
+                return (angle, intermediate);
+            }
+        } else if x.wrapping_neg() >= y {
+            let (angle, intermediate, _) =
+                hle_bios_arctan_values(y.wrapping_shl(14).wrapping_div(x));
+            return (angle.wrapping_add(0x8000), intermediate);
+        }
+        let (angle, intermediate, _) = hle_bios_arctan_values(x.wrapping_shl(14).wrapping_div(y));
+        return (0x4000i32.wrapping_sub(angle), intermediate);
+    }
+
+    if x <= 0 {
+        if x.wrapping_neg() > y.wrapping_neg() {
+            let (angle, intermediate, _) =
+                hle_bios_arctan_values(y.wrapping_shl(14).wrapping_div(x));
+            return (angle.wrapping_add(0x8000), intermediate);
+        }
+    } else if x >= y.wrapping_neg() {
+        let (angle, intermediate, _) = hle_bios_arctan_values(y.wrapping_shl(14).wrapping_div(x));
+        return (angle.wrapping_add(0x10000), intermediate);
+    }
+
+    let (angle, intermediate, _) = hle_bios_arctan_values(x.wrapping_shl(14).wrapping_div(y));
+    (0xC000i32.wrapping_sub(angle), intermediate)
+}
+
 impl Default for Arm7tdmi {
     fn default() -> Self {
         Self::new()
@@ -603,6 +652,7 @@ impl Arm7tdmi {
             0x07 => Some(self.hle_bios_div(true)),
             0x08 => Some(self.hle_bios_sqrt()),
             0x09 => Some(self.hle_bios_arctan()),
+            0x0A => Some(self.hle_bios_arctan2()),
             0x0C => self.hle_bios_cpu_fast_set(bus),
             _ => None,
         }?;
@@ -622,14 +672,14 @@ impl Arm7tdmi {
         };
 
         if denominator == 0 {
-            self.regs.r[0] = 0;
-            self.regs.r[1] = 0;
-            self.regs.r[3] = 0;
+            self.regs.r[0] = if numerator < 0 { u32::MAX } else { 1 };
+            self.regs.r[1] = numerator as u32;
+            self.regs.r[3] = 1;
             return 70;
         }
 
-        let quotient = (numerator as i64 / denominator as i64) as i32;
-        let remainder = (numerator as i64 % denominator as i64) as i32;
+        let quotient = numerator.wrapping_div(denominator);
+        let remainder = numerator.wrapping_rem(denominator);
         self.regs.r[0] = quotient as u32;
         self.regs.r[1] = remainder as u32;
         self.regs.r[3] = quotient.unsigned_abs();
@@ -659,17 +709,21 @@ impl Arm7tdmi {
     }
 
     fn hle_bios_arctan(&mut self) -> u32 {
-        let input = self.regs.r[0] as i32;
-        let square = input as i64 * input as i64;
-        let a = -((square >> 14) as i32);
-        self.regs.r[1] = a as u32;
+        let (result, intermediate, coefficient) = hle_bios_arctan_values(self.regs.r[0] as i32);
+        self.regs.r[0] = result as u32;
+        self.regs.r[1] = intermediate as u32;
+        self.regs.r[3] = coefficient as u32;
 
-        let mut b = 0x00A9i32;
-        for coefficient in [0x0390, 0x091C, 0x0FB6, 0x16AA, 0x2081, 0x3651, 0xA2F9] {
-            b = (((b as i64 * a as i64) >> 14) as i32) + coefficient;
-        }
-        self.regs.r[3] = b as u32;
-        self.regs.r[0] = (((input as i64 * b as i64) >> 16) as i32) as u32;
+        99
+    }
+
+    fn hle_bios_arctan2(&mut self) -> u32 {
+        let x = self.regs.r[0] as i32;
+        let y = self.regs.r[1] as i32;
+        let (result, intermediate) = hle_bios_arctan2_values(x, y);
+        self.regs.r[0] = result as u16 as u32;
+        self.regs.r[1] = intermediate as u32;
+        self.regs.r[3] = 0x170;
 
         99
     }

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -45,7 +45,7 @@ armwrestler_page7=0x562A5C65
 # BIOS math, DMA, SIO, misc edge cases, and video.
 # Scores (passing/total, embedded BIOS): Memory 1552/1552, I/O read 130/130, Timing 2020/2020,
 # Timers 936/936, Timer IRQ 90/90, Shifter 140/140, Carry 93/93,
-# Multiply long 72/72, BIOS math 427/615, DMA 1120/1256, SIO read 90/90,
+# Multiply long 72/72, BIOS math 615/615, DMA 1120/1256, SIO read 90/90,
 # SIO timing 0/4, Misc. edge 3/12, Video (sub-menu only).
 mgba_memory=0x61F65500
 mgba_io_read=0x7D320909
@@ -55,8 +55,8 @@ mgba_timer_irq=0xE7796772
 mgba_shifter=0x8B4A12AA
 mgba_carry=0xFD9E45E6
 mgba_multiply_long=0x699655AB
-mgba_bios_math=0x09E82124
-mgba_dma=0x85EE4126
+mgba_bios_math=0x3C1B28DE
+mgba_dma=0x90900973
 mgba_sio_read=0xF5D98687
 mgba_sio_timing=0xD95ACB03
 mgba_misc_edge=0x36ECDBF9

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -731,6 +731,10 @@ fn mgba_dma_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
     mgba_named_sub_suite_diagnostic_from_gba(gba, "DMA tests")
 }
 
+fn mgba_bios_math_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
+    mgba_named_sub_suite_diagnostic_from_gba(gba, "BIOS math tests")
+}
+
 fn mgba_named_sub_suite_diagnostic_from_gba(
     gba: &Gba,
     suite_name: &str,
@@ -771,6 +775,11 @@ pub fn run_mgba_timer_irq_diagnostics() -> MgbaMemoryDiagnosticResult {
 pub fn run_mgba_dma_diagnostics() -> MgbaMemoryDiagnosticResult {
     let (gba, _rom) = boot_mgba_suite();
     run_mgba_sub_suite_diagnostics_from_gba(gba, 9, "DMA diagnostics")
+}
+
+pub fn run_mgba_bios_math_diagnostics() -> MgbaMemoryDiagnosticResult {
+    let (gba, _rom) = boot_mgba_suite();
+    run_mgba_sub_suite_diagnostics_from_gba(gba, 8, "BIOS math diagnostics")
 }
 
 pub fn run_mgba_io_read_diagnostics_after_bios_intro() -> MgbaMemoryDiagnosticResult {
@@ -861,6 +870,7 @@ fn run_mgba_sub_suite_diagnostics_from_gba_with_boot_frames(
         2 => mgba_timing_diagnostic_from_gba(&gba),
         3 => mgba_timers_diagnostic_from_gba(&gba),
         4 => mgba_timer_irq_diagnostic_from_gba(&gba),
+        8 => mgba_bios_math_diagnostic_from_gba(&gba),
         9 => mgba_dma_diagnostic_from_gba(&gba),
         _ => mgba_memory_diagnostic_from_gba(&gba),
     }
@@ -1003,6 +1013,20 @@ fn extract_ascii_segments(bytes: &[u8]) -> Vec<String> {
 }
 
 fn parse_mgba_score(raw_log: &str) -> (Option<u32>, Option<u32>) {
+    if let Some((_, suffix)) = raw_log.rsplit_once("END:") {
+        for token in suffix.split(|ch: char| !(ch.is_ascii_digit() || ch == '/')) {
+            if let Some((passed, total)) = token.split_once('/') {
+                let Ok(passed) = passed.parse::<u32>() else {
+                    continue;
+                };
+                let Ok(total) = total.parse::<u32>() else {
+                    continue;
+                };
+                return (Some(passed), Some(total));
+            }
+        }
+    }
+
     for token in raw_log.split(|ch: char| !(ch.is_ascii_digit() || ch == '/')) {
         if let Some((passed, total)) = token.split_once('/') {
             let Ok(passed) = passed.parse::<u32>() else {
@@ -1598,6 +1622,17 @@ mod tests {
                 detail: "Got 0xFFFF vs 0xDEAD: FAIL".to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn mgba_sub_suite_log_parser_prefers_end_score_over_test_names_with_slashes() {
+        let debug = b"BEGIN: BIOS math testsMath test: Div 00000000/00000000END: 452/615";
+        let sram = b"r0: Got 00000000 vs 00000001: FAIL\0";
+
+        let log = parse_mgba_sub_suite_log(debug, sram, "BIOS math tests");
+
+        assert_eq!(log.passed_count, Some(452));
+        assert_eq!(log.total_count, Some(615));
     }
 
     #[test]

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -1,9 +1,10 @@
 use super::gba_suite_runner::{
     ARMWRESTLER_TEST_PAGE_COUNT, MGBA_SUITE_COUNT, MGBA_SUITE_KEYS, Suite, VIDEO_TEST_NAMES,
-    boot_mgba_suite, run_armwrestler, run_mgba_dma_diagnostics, run_mgba_io_read_diagnostics,
-    run_mgba_io_read_diagnostics_after_bios_intro, run_mgba_memory_diagnostics,
-    run_mgba_memory_diagnostics_with_bios_path, run_mgba_suite, run_mgba_timer_irq_diagnostics,
-    run_mgba_timers_diagnostics, run_mgba_timing_diagnostics, run_mgba_video_tests, run_suite,
+    boot_mgba_suite, run_armwrestler, run_mgba_bios_math_diagnostics, run_mgba_dma_diagnostics,
+    run_mgba_io_read_diagnostics, run_mgba_io_read_diagnostics_after_bios_intro,
+    run_mgba_memory_diagnostics, run_mgba_memory_diagnostics_with_bios_path, run_mgba_suite,
+    run_mgba_timer_irq_diagnostics, run_mgba_timers_diagnostics, run_mgba_timing_diagnostics,
+    run_mgba_video_tests, run_suite,
 };
 use crate::gba::bios::EMBEDDED_BIOS;
 use crate::gba::integration_tests::gba_suite_runner::GBA_CYCLES_PER_FRAME;
@@ -553,6 +554,33 @@ fn gba_mgba_dma_diagnostics_reports_current_score() {
 }
 
 #[test]
+fn gba_mgba_bios_math_diagnostics_passes_every_case() {
+    let result = run_mgba_bios_math_diagnostics();
+
+    assert_eq!(
+        result.total_count,
+        Some(615),
+        "raw mGBA BIOS math log:\n{}",
+        result.raw_log
+    );
+    assert!(
+        result.passed_count.is_some(),
+        "mGBA BIOS math diagnostics should include a parsed pass count"
+    );
+    assert_eq!(
+        result.passed_count, result.total_count,
+        "mGBA BIOS math diagnostics should pass every case with the embedded BIOS.\nfailures: {:?}\nraw log:\n{}",
+        result.failures, result.raw_log
+    );
+    assert!(
+        result.failures.is_empty(),
+        "mGBA BIOS math diagnostics reported failures with the embedded BIOS: {:?}\nraw log:\n{}",
+        result.failures,
+        result.raw_log
+    );
+}
+
+#[test]
 fn gba_mgba_memory_proprietary_diagnostics_skip_without_bios_path() {
     let result = run_mgba_memory_diagnostics_with_bios_path(None).unwrap();
 
@@ -619,8 +647,8 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("mgba_shifter"), Some(&0x8B4A_12AA));
     assert_eq!(approvals.get("mgba_carry"), Some(&0xFD9E_45E6));
     assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
-    assert_eq!(approvals.get("mgba_bios_math"), Some(&0x09E8_2124));
-    assert_eq!(approvals.get("mgba_dma"), Some(&0x85EE_4126));
+    assert_eq!(approvals.get("mgba_bios_math"), Some(&0x3C1B_28DE));
+    assert_eq!(approvals.get("mgba_dma"), Some(&0x9090_0973));
     assert_eq!(approvals.get("mgba_sio_read"), Some(&0xF5D9_8687));
     assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));
     assert_eq!(approvals.get("mgba_misc_edge"), Some(&0x36EC_DBF9));


### PR DESCRIPTION
## Summary

- Fix embedded BIOS HLE math behavior so the mGBA BIOS math diagnostic reaches 615/615.
- Add focused BIOS math diagnostic coverage and fix mGBA score parsing for test names containing slashes.
- Update mGBA suite approvals for the improved BIOS math result and resulting stable DMA framebuffer CRC.

## Validation

- cargo test --no-default-features --lib mgba_sub_suite_log_parser_prefers_end_score_over_test_names_with_slashes -- --nocapture
- cargo test --no-default-features --lib gba_mgba_bios_math_diagnostics_passes_every_case -- --nocapture
- cargo test --no-default-features --lib gba_mgba_timing_diagnostics_passes_bios -- --nocapture
- cargo test --no-default-features --lib gba::bios -- --nocapture
- cargo test --no-default-features --lib approvals_manifest_parses -- --nocapture
- cargo test --no-default-features --lib gba_mgba_suite_passes -- --nocapture
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/test-dir.sh src/gba --skip-integration
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test
