### PR TITLE
feat(web): enable GBA ROM playback

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -8,7 +8,7 @@ NESER is a cycle-accurate NES (Nintendo Entertainment System) emulator written i
 
 The codebase is roughly 183,000 lines of Rust, with additional JavaScript for the web frontend and Python tooling for ROM management.
 
-As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic `Emulator` trait and a `Console` enum that wraps both the NES and GameBoy implementations. This allows the native frontend and GL backend to dispatch common operations through the trait instead of matching on specific console variants or using NES-specific types directly. The architecture is designed to be extensible for future emulated systems while maintaining a clean separation between hardware-specific logic and shared platform/frontend code.
+As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic `Emulator` trait and a `Console` enum that wraps the NES, Game Boy, and Game Boy Advance implementations. This allows the native frontend and GL backend to dispatch common operations through the trait instead of matching on specific console variants or using NES-specific types directly. The architecture is designed to be extensible for future emulated systems while maintaining a clean separation between hardware-specific logic and shared platform/frontend code.
 
 ## High-Level Architecture
 
@@ -27,7 +27,7 @@ As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic 
 │  │  (src/platform/emulator.rs)                     │  │
 │  │  Hardware-agnostic interface: run_tick, render, │  │
 │  │  audio, input, save/load state, reset           │  │
-│  │  Variants: Console::Nes(Nes), Console::GameBoy  │  │
+│  │  Variants: Nes, GameBoy, GameBoyAdvance         │  │
 │  └──────────────────────┬─────────────────────────-┘  │
 │                         │                             │
 │                         ▼                             │
@@ -68,7 +68,7 @@ As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic 
 
 The emulator is designed around a **multi-layer architecture**:
 
-- **Emulator trait + Console enum** (`src/platform/emulator.rs`): The `Emulator` trait defines the common interface that every emulated system must implement (run, render, audio, input, save/load state, reset — 22 methods total). `Nes` and `GameBoy` implement the trait in their respective modules. The `Console` enum wraps both systems and delegates common methods through `as_core()`/`as_core_mut()` (which return `&dyn Emulator`), keeping a single pair of match arms instead of one per method. System-specific features (NES debugging, PPU viewer, Zapper) are still accessed by matching on `Console::Nes`.
+- **Emulator trait + Console enum** (`src/platform/emulator.rs`): The `Emulator` trait defines the common interface that every emulated system must implement (run, render, audio, input, save/load state, reset — 22 methods total). `Nes`, `GameBoy`, and `Gba` implement the trait in their respective modules. The `Console` enum wraps all three systems and delegates common methods through `as_core()`/`as_core_mut()` (which return `&dyn Emulator`), keeping a single pair of match arms instead of one per method. System-specific features (NES debugging, PPU viewer, Zapper) are still accessed by matching on `Console::Nes`.
 - **NES emulator** (`src/nes/`): All NES-specific hardware lives under this namespace. The `Nes` struct in `src/nes/console/nes.rs` orchestrates the per-cycle stepping of CPU, PPU, APU, and Bus.
 - **Shared platform** (`src/platform/`): `FrontendConfig` (src/platform/config.rs), `AppContext` (src/platform/app_context.rs), audio infrastructure, and system-agnostic toast formatters are shared across all emulated systems.
 - **Bus-centric hardware**: Within the NES, the `Bus` struct routes memory reads and writes between the CPU, PPU registers, APU registers, RAM, OAM DMA, controller ports, and the cartridge mapper.
@@ -338,7 +338,9 @@ All Game Boy Advance hardware lives under `src/gba/`. The module currently provi
 | `src/frontends/tui/launcher.rs` | Launches the SDL emulator for a selected ROM. |
 | `src/frontends/tui/action_menu.rs` | Context menu for ROM actions. |
 | `src/frontends/web/` | WebAssembly frontend. |
-| `src/frontends/web/wasm.rs` | `wasm-bindgen` bindings — exposes `NesEmulator` to JavaScript with methods for frame stepping, input, audio sample retrieval, and save states. |
+| `src/frontends/web/wasm.rs` | `wasm-bindgen` bindings — exposes `WasmNes` to JavaScript with methods for frame stepping, input, audio sample retrieval, save states, autorun, and NES debugger support. |
+| `src/frontends/web/wasm_gb.rs` | `wasm-bindgen` bindings for the Game Boy frontend (`WasmGb`) with ROM loading, frame rendering, audio, reset, and joypad input. |
+| `src/frontends/web/wasm_gba.rs` | `wasm-bindgen` bindings for the Game Boy Advance frontend (`WasmGba`) with ROM loading, 240×160 RGBA frame rendering, audio, reset, toast draining, and 10-button keypad input. |
 | `src/frontends/web/wasm_autorun_state.rs` | Autorun state management for the WASM frontend. |
 | `src/frontends/web/wasm_tests.rs` | WASM-specific integration tests (run via `wasm-pack test`). |
 
@@ -402,11 +404,11 @@ The web frontend is bundled with **Vite** (config at `vite.config.ts`, root: `we
 | `web/index.html` | Entry point — DaisyUI drawer layout with sidebar, top bar, canvas area, footer, and autorun modal dialog. Loads `./src/app.ts` as the main module. |
 | `web/main.css` | Tailwind CSS entry point with DaisyUI plugin config, neon theme overrides, and custom component styles. |
 | `web/debugger.css` | Debugger panel styling (green-on-black terminal aesthetic). |
-| `web/src/app.ts` | Application bootstrapper — initializes the WASM module, sets up the render loop, and coordinates all subsystems. |
+| `web/src/app.ts` | Application bootstrapper — initializes the WASM module, selects `WasmNes` / `WasmGb` / `WasmGba` by ROM extension, sets up the render loop, and coordinates all subsystems. |
 | `web/src/audio/` | Audio resampling (`audio_resampler.ts`), frame timing (`frame_limiter.ts`, `frame_plan.ts`). |
-| `web/src/input/` | Gamepad API (`gamepad.ts`), keyboard/gamepad routing (`input_routing.ts`), mouse input (`mouse_input.ts`), pointer lock (`pointer_lock.ts`). |
-| `web/src/display/` | Canvas sizing (`canvas_size.ts`), zoom controls (`zoom_controls.ts`), cursor visibility, crosshair overlay. |
-| `web/src/rom/` | ROM file listing (`rom_list.ts`), selection UI (`rom_selection.ts`), autorun context. |
+| `web/src/input/` | Gamepad API (`gamepad.ts`), GBA keyboard mapping (`keyboard_mapping.ts`), keyboard/gamepad routing (`input_routing.ts`), mouse input (`mouse_input.ts`), pointer lock (`pointer_lock.ts`). |
+| `web/src/display/` | Canvas sizing (`canvas_size.ts`), zoom controls (`zoom_controls.ts`), cursor visibility, crosshair overlay, and console-specific filter selection (`filters.ts`; GBA is stock-only in the web frontend). |
+| `web/src/rom/` | ROM file listing (`rom_list.ts`), extension-to-console detection (`rom_extensions.ts` for `.nes`, `.gb`, `.gbc`, `.cgb`, `.gba`), selection UI (`rom_selection.ts`), autorun context. |
 | `web/src/save-state/` | Save state persistence using IndexedDB (`save_state_storage.ts`, `save_state_controller.ts`, `save_state_context.ts`). |
 | `web/src/debugger/` | Browser-based debugger panels — disassembly, OAM viewer, watch expressions, PPU viewer layout/scroll. |
 | `web/src/shortcuts/` | Keyboard shortcut actions and help overlay. |

--- a/src/frontends/web/wasm_gba.rs
+++ b/src/frontends/web/wasm_gba.rs
@@ -57,6 +57,11 @@ impl WasmGba {
         while self.gba.get_sample().is_some() {}
     }
 
+    #[cfg(all(test, target_arch = "wasm32"))]
+    pub(crate) fn joypad_button_states_for_test(&self) -> u8 {
+        self.gba.get_joypad_button_states(1)
+    }
+
     #[wasm_bindgen(constructor)]
     pub fn new() -> WasmGba {
         console_error_panic_hook::set_once();
@@ -97,11 +102,21 @@ impl WasmGba {
         self.pending_toasts.drain(..).map(JsValue::from).collect()
     }
 
+    /// Step the emulator until a full frame is ready and return the pixel buffer (RGBA8888).
+    ///
+    /// Returns a `Uint8Array` of `240 × 160 × 4` bytes.
+    /// When no ROM is loaded, returns an opaque black frame.
+    ///
+    /// # Safety
+    ///
+    /// The returned `Uint8Array` is a zero-copy view into `self.frame_rgba_buffer` in WASM
+    /// linear memory. The caller must consume it before invoking another WASM function that could
+    /// grow linear memory.
     #[wasm_bindgen]
-    pub fn render_frame_rgba(&mut self) -> Vec<u8> {
+    pub fn render_frame_rgba(&mut self) -> js_sys::Uint8Array {
         if !self.rom_loaded {
             self.fill_opaque_black_frame();
-            return self.frame_rgba_buffer.clone();
+            return unsafe { js_sys::Uint8Array::view(&self.frame_rgba_buffer) };
         }
 
         self.run_until_frame_ready();
@@ -117,7 +132,7 @@ impl WasmGba {
             rgba[2] = rgb[2];
             rgba[3] = 0xFF;
         }
-        self.frame_rgba_buffer.clone()
+        unsafe { js_sys::Uint8Array::view(&self.frame_rgba_buffer) }
     }
 
     #[wasm_bindgen]
@@ -163,7 +178,9 @@ impl WasmGba {
 
     #[wasm_bindgen]
     pub fn set_button(&mut self, controller: u8, button: u8, pressed: bool) {
-        self.gba.set_button(controller, button, pressed);
+        if controller == 1 {
+            self.gba.set_button(controller, button, pressed);
+        }
     }
 
     #[wasm_bindgen]

--- a/src/frontends/web/wasm_gba.rs
+++ b/src/frontends/web/wasm_gba.rs
@@ -1,0 +1,173 @@
+use crate::gba::Gba;
+use crate::platform::app_context::{AppContext, SharedAppContext};
+use crate::platform::emulator::Emulator;
+use crate::platform::frontend_toasts::cartridge_load_toast_message;
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+
+/// Provides a minimal WASM bridge for running the Game Boy Advance emulator in the browser.
+#[wasm_bindgen]
+pub struct WasmGba {
+    gba: Gba,
+    audio_muted: bool,
+    rom_loaded: bool,
+    pending_toasts: Vec<String>,
+    frame_rgba_buffer: Vec<u8>,
+}
+
+impl Default for WasmGba {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[wasm_bindgen]
+impl WasmGba {
+    fn required_rgba_len() -> usize {
+        (Gba::SCREEN_WIDTH * Gba::SCREEN_HEIGHT * 4) as usize
+    }
+
+    fn ensure_rgba_buffer(&mut self) {
+        let required = Self::required_rgba_len();
+        if self.frame_rgba_buffer.len() != required {
+            self.frame_rgba_buffer.resize(required, 0xFF);
+            for alpha in self.frame_rgba_buffer.iter_mut().skip(3).step_by(4) {
+                *alpha = 0xFF;
+            }
+        }
+    }
+
+    fn fill_opaque_black_frame(&mut self) {
+        self.ensure_rgba_buffer();
+        self.frame_rgba_buffer.fill(0);
+        for alpha in self.frame_rgba_buffer.iter_mut().skip(3).step_by(4) {
+            *alpha = 0xFF;
+        }
+    }
+
+    fn run_until_frame_ready(&mut self) {
+        while !self.gba.is_ready_to_render() {
+            self.gba.run_tick();
+        }
+        self.gba.clear_ready_to_render();
+    }
+
+    fn drain_audio_buffer(&mut self) {
+        while self.gba.get_sample().is_some() {}
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmGba {
+        console_error_panic_hook::set_once();
+        let app_context: SharedAppContext = Rc::new(RefCell::new(AppContext::new_with_config(
+            Default::default(),
+        )));
+        WasmGba {
+            gba: Gba::new(app_context),
+            audio_muted: false,
+            rom_loaded: false,
+            pending_toasts: Vec::new(),
+            frame_rgba_buffer: Vec::new(),
+        }
+    }
+
+    #[wasm_bindgen]
+    pub fn load_rom(&mut self, rom: &[u8], rom_name: &str) -> Result<(), JsValue> {
+        self.rom_loaded = false;
+        match self.gba.load_rom(rom, rom_name) {
+            Ok(()) => {
+                self.rom_loaded = true;
+                self.gba.set_audio_sample_rate(44_100.0);
+                self.pending_toasts
+                    .push(cartridge_load_toast_message(rom_name, true));
+                web_sys::console::log_1(&JsValue::from_str("GBA ROM loaded successfully"));
+                Ok(())
+            }
+            Err(err) => {
+                self.pending_toasts
+                    .push(cartridge_load_toast_message(rom_name, false));
+                Err(JsValue::from_str(&err))
+            }
+        }
+    }
+
+    #[wasm_bindgen]
+    pub fn drain_toasts(&mut self) -> Vec<JsValue> {
+        self.pending_toasts.drain(..).map(JsValue::from).collect()
+    }
+
+    #[wasm_bindgen]
+    pub fn render_frame_rgba(&mut self) -> Vec<u8> {
+        if !self.rom_loaded {
+            self.fill_opaque_black_frame();
+            return self.frame_rgba_buffer.clone();
+        }
+
+        self.run_until_frame_ready();
+        self.ensure_rgba_buffer();
+        let rgb = self.gba.screen_snapshot();
+        for (rgba, rgb) in self
+            .frame_rgba_buffer
+            .chunks_exact_mut(4)
+            .zip(rgb.chunks_exact(3))
+        {
+            rgba[0] = rgb[0];
+            rgba[1] = rgb[1];
+            rgba[2] = rgb[2];
+            rgba[3] = 0xFF;
+        }
+        self.frame_rgba_buffer.clone()
+    }
+
+    #[wasm_bindgen]
+    pub fn screen_width(&self) -> u32 {
+        Gba::SCREEN_WIDTH
+    }
+
+    #[wasm_bindgen]
+    pub fn screen_height(&self) -> u32 {
+        Gba::SCREEN_HEIGHT
+    }
+
+    #[wasm_bindgen]
+    pub fn frame_rate_hz(&self) -> f64 {
+        16_777_216.0 / 280_896.0
+    }
+
+    #[wasm_bindgen]
+    pub fn get_audio_samples(&mut self) -> Vec<f32> {
+        if self.audio_muted {
+            self.drain_audio_buffer();
+            return Vec::new();
+        }
+        let mut samples = Vec::new();
+        while let Some(sample) = self.gba.get_sample() {
+            samples.push(sample);
+        }
+        samples
+    }
+
+    #[wasm_bindgen]
+    pub fn set_audio_muted(&mut self, muted: bool) {
+        self.audio_muted = muted;
+        if muted {
+            self.drain_audio_buffer();
+        }
+    }
+
+    #[wasm_bindgen]
+    pub fn is_audio_muted(&self) -> bool {
+        self.audio_muted
+    }
+
+    #[wasm_bindgen]
+    pub fn set_button(&mut self, controller: u8, button: u8, pressed: bool) {
+        self.gba.set_button(controller, button, pressed);
+    }
+
+    #[wasm_bindgen]
+    pub fn reset(&mut self, soft_reset: bool) {
+        self.gba.reset(soft_reset);
+    }
+}

--- a/src/frontends/web/wasm_tests.rs
+++ b/src/frontends/web/wasm_tests.rs
@@ -5,6 +5,7 @@ use crate::nes::console::SaveState;
 use crate::nes::input::ArkanoidState;
 use crate::wasm::{WasmNes, gamepad_init_toast_message};
 use crate::wasm_gb::WasmGb;
+use crate::wasm_gba::WasmGba;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -925,4 +926,130 @@ fn wasm_gb_load_rom_returns_success_toast() {
         toasts.iter().any(|t| t.contains("test.gb")),
         "expected a toast mentioning 'test.gb', got: {toasts:?}"
     );
+}
+
+// ── WasmGba tests ────────────────────────────────────────────────────────────
+
+fn minimal_gba_rom() -> Vec<u8> {
+    use crate::gba::cartridge::header::{
+        COMPLEMENT_CHECK_OFFSET, FIXED_BYTE_OFFSET, FIXED_BYTE_VALUE, HEADER_SIZE,
+        compute_complement_check,
+    };
+
+    let mut rom = vec![0u8; HEADER_SIZE];
+    rom[FIXED_BYTE_OFFSET] = FIXED_BYTE_VALUE;
+    rom[COMPLEMENT_CHECK_OFFSET] = compute_complement_check(&rom);
+    rom
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_constructs() {
+    let _gba = WasmGba::new();
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_screen_width_is_240() {
+    let gba = WasmGba::new();
+    assert_eq!(gba.screen_width(), 240);
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_screen_height_is_160() {
+    let gba = WasmGba::new();
+    assert_eq!(gba.screen_height(), 160);
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_frame_rate_hz_is_gba_rate() {
+    let gba = WasmGba::new();
+    let hz = gba.frame_rate_hz();
+    assert!(
+        (hz - 59.7275).abs() < 0.01,
+        "expected ~59.7275 Hz but got {hz}"
+    );
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_no_rom_renders_opaque_black_frame() {
+    let mut gba = WasmGba::new();
+    let frame = gba.render_frame_rgba();
+    let expected_len = 240 * 160 * 4;
+    assert_eq!(
+        frame.len(),
+        expected_len,
+        "no-ROM frame should be {expected_len} bytes"
+    );
+    for (i, &byte) in frame.iter().enumerate() {
+        if (i + 1) % 4 == 0 {
+            assert_eq!(byte, 0xFF, "alpha byte at index {i} should be 0xFF");
+        } else {
+            assert_eq!(byte, 0x00, "color byte at index {i} should be 0x00");
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_load_rom_returns_success_toast() {
+    let mut gba = WasmGba::new();
+    let rom = minimal_gba_rom();
+    gba.load_rom(&rom, "suite.gba")
+        .expect("valid GBA ROM should load successfully");
+    let toasts: Vec<String> = gba
+        .drain_toasts()
+        .into_iter()
+        .filter_map(|v| v.as_string())
+        .collect();
+    assert!(
+        toasts.iter().any(|t| t.contains("suite.gba")),
+        "expected a toast mentioning 'suite.gba', got: {toasts:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_load_rom_rejects_invalid_data() {
+    let mut gba = WasmGba::new();
+    let err = gba
+        .load_rom(&[0u8; 8], "broken.gba")
+        .expect_err("invalid GBA ROM should error");
+    assert!(
+        !err.as_string().unwrap_or_default().is_empty(),
+        "invalid GBA ROM should return a message"
+    );
+
+    let toasts: Vec<String> = gba
+        .drain_toasts()
+        .into_iter()
+        .filter_map(|v| v.as_string())
+        .collect();
+    assert!(
+        toasts.iter().any(|t| t.contains("broken.gba")),
+        "expected a failure toast mentioning 'broken.gba', got: {toasts:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_audio_mute_state_is_reported() {
+    let mut gba = WasmGba::new();
+    assert!(!gba.is_audio_muted());
+    gba.set_audio_muted(true);
+    assert!(gba.is_audio_muted());
+    assert!(gba.get_audio_samples().is_empty());
+    gba.set_audio_muted(false);
+    assert!(!gba.is_audio_muted());
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_reset_without_rom_succeeds() {
+    let mut gba = WasmGba::new();
+    gba.reset(true);
+    gba.reset(false);
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_set_button_accepts_all_gba_buttons() {
+    let mut gba = WasmGba::new();
+    for button in 0..=9 {
+        gba.set_button(1, button, true);
+        gba.set_button(1, button, false);
+    }
 }

--- a/src/frontends/web/wasm_tests.rs
+++ b/src/frontends/web/wasm_tests.rs
@@ -972,7 +972,7 @@ fn wasm_gba_frame_rate_hz_is_gba_rate() {
 #[wasm_bindgen_test]
 fn wasm_gba_no_rom_renders_opaque_black_frame() {
     let mut gba = WasmGba::new();
-    let frame = gba.render_frame_rgba();
+    let frame = gba.render_frame_rgba().to_vec();
     let expected_len = 240 * 160 * 4;
     assert_eq!(
         frame.len(),
@@ -1052,4 +1052,13 @@ fn wasm_gba_set_button_accepts_all_gba_buttons() {
         gba.set_button(1, button, true);
         gba.set_button(1, button, false);
     }
+}
+
+#[wasm_bindgen_test]
+fn wasm_gba_set_button_ignores_non_player_one_controllers() {
+    let mut gba = WasmGba::new();
+
+    gba.set_button(2, 0, true);
+
+    assert_eq!(gba.joypad_button_states_for_test(), 0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub mod wasm_autorun;
 #[cfg(feature = "wasm")]
 #[path = "frontends/web/wasm_gb.rs"]
 pub mod wasm_gb;
+#[cfg(feature = "wasm")]
+#[path = "frontends/web/wasm_gba.rs"]
+pub mod wasm_gba;
 #[cfg(all(test, feature = "wasm", target_arch = "wasm32"))]
 #[path = "frontends/web/wasm_tests.rs"]
 mod wasm_tests;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,8 +7,8 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-/** Recursively find all .nes files under a directory, following symlinks safely. */
-function findNesFiles(
+/** Recursively find all supported ROM files under a directory, following symlinks safely. */
+function findRomFiles(
   dir: string,
   base: string,
   visited: Set<string> = new Set(),
@@ -36,8 +36,8 @@ function findNesFiles(
     let stat;
     try { stat = statSync(fullPath); } catch { continue; }
     if (stat.isDirectory()) {
-      results.push(...findNesFiles(fullPath, base, visited, resolvedBase));
-    } else if (entry.name.toLowerCase().endsWith(".nes")) {
+      results.push(...findRomFiles(fullPath, base, visited, resolvedBase));
+    } else if (/\.(nes|gb|gbc|cgb|gba)$/i.test(entry.name)) {
       let resolvedFile: string;
       try { resolvedFile = realpathSync(fullPath); } catch { continue; }
       if (isWithinBase(resolvedFile)) {
@@ -54,7 +54,7 @@ function romManifestPlugin(): Plugin {
   const manifestPath = join(romsDir, "roms.json");
 
   function generate() {
-    const roms = findNesFiles(romsDir, romsDir).sort();
+    const roms = findRomFiles(romsDir, romsDir).sort();
     writeFileSync(manifestPath, JSON.stringify({ roms }, null, 2) + "\n");
     console.log(`[rom-manifest] wrote ${roms.length} entries to web/roms/roms.json`);
   }

--- a/web/index.html
+++ b/web/index.html
@@ -88,7 +88,7 @@
           <!-- ROM controls -->
           <div class="flex flex-col gap-2">
             <label for="rom" class="label text-xs">ROM file</label>
-            <input type="file" id="rom" accept=".nes,.gb,.gbc,.cgb,application/octet-stream" class="file-input file-input-bordered file-input-sm w-full" />
+            <input type="file" id="rom" accept=".nes,.gb,.gbc,.cgb,.gba,application/octet-stream" class="file-input file-input-bordered file-input-sm w-full" />
             <select id="rom-select" class="select select-bordered select-sm w-full" aria-label="Select ROM from server">
               <option value="">Select bundled ROM…</option>
             </select>

--- a/web/integration/helpers/lifecycle.helpers.ts
+++ b/web/integration/helpers/lifecycle.helpers.ts
@@ -47,6 +47,7 @@ async function injectBundledRomOption(page: Page) {
         romSelectId: ROM_SELECT_ID,
         bundledRomName: BUNDLED_ROM_NAME
     });
+    return romDataUrl;
 }
 
 export async function openApp(page: Page) {
@@ -83,19 +84,7 @@ export async function loadGbaRomFromFileInput(page: Page) {
 
 export async function startFromBundledRom(page: Page) {
     await openApp(page);
-    await injectBundledRomOption(page);
-
-    const bundledRomOption = page.locator(`${ROM_SELECT_SELECTOR} option`, {
-        hasText: BUNDLED_ROM_NAME
-    });
-    await expect(bundledRomOption).toHaveCount(1, {
-        timeout: EXPECT_TIMEOUT_MS
-    });
-
-    const romValue = await bundledRomOption.getAttribute("value");
-    if (!romValue) {
-        throw new Error("Expected bundled ROM option to have a value");
-    }
+    const romValue = await injectBundledRomOption(page);
 
     await page.evaluate(({ value, romSelectId }: { value: string; romSelectId: string }) => {
         const romSelect = document.getElementById(romSelectId);

--- a/web/integration/helpers/lifecycle.helpers.ts
+++ b/web/integration/helpers/lifecycle.helpers.ts
@@ -19,6 +19,17 @@ function readMockRomBytes() {
     return readFileSync(path.join(process.cwd(), BUNDLED_ROM_PATH));
 }
 
+function makeMinimalGbaRomBytes() {
+    const rom = Buffer.alloc(0xC0);
+    rom[0xB2] = 0x96;
+    let check = 0;
+    for (let offset = 0xA0; offset <= 0xBC; offset++) {
+        check = (check - rom[offset]) & 0xFF;
+    }
+    rom[0xBD] = (check - 0x19) & 0xFF;
+    return rom;
+}
+
 async function injectBundledRomOption(page: Page) {
     const romDataUrl = `data:application/octet-stream;base64,${readMockRomBytes().toString("base64")}`;
     await page.evaluate(({ value, romSelectId, bundledRomName }: { value: string; romSelectId: string; bundledRomName: string }) => {
@@ -58,6 +69,15 @@ export async function loadRomFromFileInput(page: Page) {
         name: BUNDLED_ROM_NAME,
         mimeType: "application/octet-stream",
         buffer: romBytes
+    });
+}
+
+/** Load a minimal GBA ROM via the file input, setting romFromFile = true. */
+export async function loadGbaRomFromFileInput(page: Page) {
+    await page.locator("#rom").setInputFiles({
+        name: "suite.gba",
+        mimeType: "application/octet-stream",
+        buffer: makeMinimalGbaRomBytes()
     });
 }
 

--- a/web/integration/specs/app-shell.integration.spec.ts
+++ b/web/integration/specs/app-shell.integration.spec.ts
@@ -10,4 +10,10 @@ test.describe("web app shell", () => {
             await expect(page.locator(selector)).toBeVisible();
         }
     });
+
+    test("accepts GBA ROM files in the file picker", async ({ page }) => {
+        await page.goto("/");
+
+        await expect(page.locator("#rom")).toHaveAttribute("accept", /(^|,)\.gba(,|$)/);
+    });
 });

--- a/web/integration/specs/emulation-lifecycle.integration.spec.ts
+++ b/web/integration/specs/emulation-lifecycle.integration.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 import {
+    loadGbaRomFromFileInput,
+    loadRomFromFileInput,
     openApp,
     startFromBundledRom,
     waitForIdleState,
@@ -64,5 +66,16 @@ test.describe("Phase 1 critical path lifecycle", () => {
 
         await expect(page.locator(SAVE_STATE_BUTTON_SELECTOR)).toBeDisabled();
         await expect(page.locator(LOAD_STATE_BUTTON_SELECTOR)).toBeDisabled();
+    });
+
+    test("Given a GBA ROM is loaded, when a NES ROM is loaded afterwards, then both sessions can run without reload", async ({ page }) => {
+        await openApp(page);
+
+        await loadGbaRomFromFileInput(page);
+        await waitForRunningState(page);
+
+        await loadRomFromFileInput(page);
+        await waitForRunningState(page);
+        await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
     });
 });

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1,4 +1,4 @@
-import init, { WasmNes, WasmGb, gamepad_init_toast_message } from "../pkg/neser";
+import init, { WasmNes, WasmGb, WasmGba, gamepad_init_toast_message } from "../pkg/neser";
 import { mapStandardGamepadState, selectGamepads } from "./input/gamepad";
 import {
     createRomSaveKey,
@@ -20,6 +20,7 @@ import { normalizeGbSample, normalizeNesSample } from "./audio/audio_normalizer"
 import { planFrame } from "./audio/frame_plan";
 import { createSineScroller } from "./ui/sine_scroller";
 import { getKeyboardControllerTarget } from "./input/input_routing";
+import { gbaKeyboardButtonForEvent } from "./input/keyboard_mapping";
 import { initTouchControls, isTouchDevice, isHandheldDevice } from "./input/touch_controls";
 import { dispatchWebShortcutAction } from "./shortcuts/shortcut_actions";
 import {
@@ -649,9 +650,12 @@ function cycleFilter() {
     return true;
 }
 
-type ActiveEmulator = { kind: "nes"; inst: WasmNes } | { kind: "gb"; inst: WasmGb };
+type ActiveEmulator =
+    | { kind: "nes"; inst: WasmNes }
+    | { kind: "gb"; inst: WasmGb }
+    | { kind: "gba"; inst: WasmGba };
 
-/** Master emulator state — set to NES or GB depending on the loaded ROM. */
+/** Master emulator state — set by the loaded ROM's console kind. */
 let emulator: ActiveEmulator | null = null;
 /** Convenience alias for NES-specific code paths. Non-null only when emulator.kind === "nes". */
 let nes: WasmNes | null = null;
@@ -726,13 +730,18 @@ function updateEmulationButtons() {
     }
 }
 
-/** Create a fresh NES or GB emulator instance and update kind-dependent UI. */
+/** Create a fresh emulator instance and update kind-dependent UI. */
 function createEmulatorInstance(kind: WebRomConsoleKind): void {
+    resetGamepadState();
     // Free the previous WASM instance to avoid leaking its linear memory.
     emulator?.inst.free();
     if (kind === "gb") {
         const gb = new WasmGb();
         emulator = { kind: "gb", inst: gb };
+        nes = null;
+    } else if (kind === "gba") {
+        const gba = new WasmGba();
+        emulator = { kind: "gba", inst: gba };
         nes = null;
     } else {
         nes = new WasmNes();
@@ -985,7 +994,9 @@ let lastGamepadState1 = {
     up: false,
     down: false,
     left: false,
-    right: false
+    right: false,
+    l: false,
+    r: false
 };
 let lastGamepadState2 = {
     a: false,
@@ -995,7 +1006,9 @@ let lastGamepadState2 = {
     up: false,
     down: false,
     left: false,
-    right: false
+    right: false,
+    l: false,
+    r: false
 };
 
 function setStatus(msg: string, isError = false) {
@@ -1017,7 +1030,7 @@ async function applyRomBytes(bytes: Uint8Array, name: string) {
 }
 
 async function refreshSaveStateController() {
-    // Save states are NES-only (GB save states are not supported in MVP).
+    // Save states are NES-only in the web frontend MVP.
     if (!nes || !romMetadata) {
         saveStateController = null;
         saveStateAvailable = false;
@@ -1139,8 +1152,8 @@ function playAudioSamples(samples: Float32Array) {
     const channelData = buffer.getChannelData(0);
 
     // Normalize and copy samples to the buffer
-    if (emulator?.kind === "gb") {
-        // GB APU outputs bipolar samples in [-1.0, 1.0] — clamp with a safety guard
+    if (emulator?.kind === "gb" || emulator?.kind === "gba") {
+        // Handheld APUs output bipolar samples in [-1.0, 1.0] — clamp with a safety guard.
         for (let i = 0; i < samples.length; i++) {
             channelData[i] = normalizeGbSample(samples[i]);
         }
@@ -2527,6 +2540,15 @@ async function handleKeyDown(event: KeyboardEvent) {
         return;
     }
 
+    if (emulator.kind === "gba") {
+        const button = gbaKeyboardButtonForEvent(event);
+        if (button !== null) {
+            event.preventDefault();
+            emulator.inst.set_button(1, button, true);
+        }
+        return;
+    }
+
     const key = event.key.toLowerCase();
     const targets = getKeyboardControllerTarget(
         connectedGamepads.length,
@@ -2548,6 +2570,15 @@ function handleKeyUp(event: KeyboardEvent) {
 
     // NES-only: block keyboard input while debugger is open.
     if (nes?.is_debugger_open()) {
+        return;
+    }
+
+    if (emulator.kind === "gba") {
+        const button = gbaKeyboardButtonForEvent(event);
+        if (button !== null) {
+            event.preventDefault();
+            emulator.inst.set_button(1, button, false);
+        }
         return;
     }
 
@@ -3015,10 +3046,13 @@ interface GamepadButtonState {
     down: boolean;
     left: boolean;
     right: boolean;
+    l: boolean;
+    r: boolean;
 }
 
 function applyGamepadState(state: GamepadButtonState, controller: number, lastState: GamepadButtonState) {
     if (!emulator) return;
+    if (emulator.kind === "gba" && controller !== 1) return;
     const applyButton = (button: number, pressed: boolean) => {
         if (nes) {
             applyJoypadButtonIfAllowed(nes, controller, button, pressed);
@@ -3034,6 +3068,10 @@ function applyGamepadState(state: GamepadButtonState, controller: number, lastSt
     if (state.down !== lastState.down) applyButton(5, state.down);
     if (state.left !== lastState.left) applyButton(6, state.left);
     if (state.right !== lastState.right) applyButton(7, state.right);
+    if (emulator.kind === "gba") {
+        if (state.l !== lastState.l) applyButton(8, state.l);
+        if (state.r !== lastState.r) applyButton(9, state.r);
+    }
 }
 
 function resetGamepadState() {
@@ -3045,7 +3083,9 @@ function resetGamepadState() {
         up: false,
         down: false,
         left: false,
-        right: false
+        right: false,
+        l: false,
+        r: false
     };
     applyGamepadState(emptyState, 1, lastGamepadState1);
     applyGamepadState(emptyState, 2, lastGamepadState2);

--- a/web/src/display/filters.test.ts
+++ b/web/src/display/filters.test.ts
@@ -51,6 +51,10 @@ describe("filterKeysForConsole", () => {
         const nesKeys = filterKeysForConsole(allKeys, filters, "nes");
         expect(nesKeys).not.toContain("gameboy");
     });
+
+    it("returns only stock for GBA", () => {
+        expect(filterKeysForConsole(allKeys, filters, "gba")).toEqual(["stock"]);
+    });
 });
 
 // ===========================================================================
@@ -77,6 +81,10 @@ describe("cycleFilterKey", () => {
 
     it("GB: cycles from gameboy back to stock", () => {
         expect(cycleFilterKey("gameboy", allKeys, filters, "gb")).toBe("stock");
+    });
+
+    it("GBA: stays on stock", () => {
+        expect(cycleFilterKey("stock", allKeys, filters, "gba")).toBe("stock");
     });
 
     it("returns current filter when no filters available", () => {
@@ -128,6 +136,15 @@ describe("filterOnConsoleSwitch", () => {
     it("keeps gameboy when switching from GB to GB (no-op)", () => {
         expect(filterOnConsoleSwitch("gameboy", allKeys, filters, "gb")).toBe(
             "gameboy",
+        );
+    });
+
+    it("falls back to stock when switching to GBA", () => {
+        expect(filterOnConsoleSwitch("ntsc", allKeys, filters, "gba")).toBe(
+            "stock",
+        );
+        expect(filterOnConsoleSwitch("gameboy", allKeys, filters, "gba")).toBe(
+            "stock",
         );
     });
 });

--- a/web/src/display/filters.ts
+++ b/web/src/display/filters.ts
@@ -15,7 +15,7 @@ export interface FilterDef {
     params?: Record<string, number>;
 }
 
-export type ConsoleKind = "nes" | "gb";
+export type ConsoleKind = "nes" | "gb" | "gba";
 
 /** Return the ordered list of filter keys available for a given console. */
 export function filterKeysForConsole(
@@ -26,9 +26,12 @@ export function filterKeysForConsole(
     return allFilterKeys.filter((key) => {
         const f = filters[key];
         if (!f) return false;
+        if (console === "gba") {
+            return f.type === "single" && key === "stock";
+        }
         if (console === "gb") {
             // GB mode: stock + gb-type filters only
-            return f.type === "single" && key === "stock" || f.type === "gb";
+            return (f.type === "single" && key === "stock") || f.type === "gb";
         }
         // NES mode: everything except gb-type filters
         return f.type !== "gb";
@@ -70,5 +73,11 @@ export function filterOnConsoleSwitch(
 
 /** Return the preferred default filter key for a given console. */
 export function defaultFilterForConsole(console: ConsoleKind): string {
-    return console === "gb" ? "gameboy" : "ntsc";
+    if (console === "gb") {
+        return "gameboy";
+    }
+    if (console === "gba") {
+        return "stock";
+    }
+    return "ntsc";
 }

--- a/web/src/input/gamepad.test.ts
+++ b/web/src/input/gamepad.test.ts
@@ -28,6 +28,20 @@ it("maps standard gamepad buttons to NES inputs", () => {
   expect(state.right).toBe(false);
 });
 
+it("maps standard gamepad shoulder buttons to GBA L and R inputs", () => {
+  const gamepad = {
+    buttons: makeButtons([4, 5]),
+    axes: [0, 0, 0, 0]
+  };
+
+  const state = mapStandardGamepadState(gamepad as unknown as Gamepad);
+
+  expect(state.l).toBe(true);
+  expect(state.r).toBe(true);
+  expect(state.a).toBe(false);
+  expect(state.b).toBe(false);
+});
+
 it("maps left stick axes to NES directions", () => {
   const gamepad = {
     buttons: makeButtons(),

--- a/web/src/input/gamepad.ts
+++ b/web/src/input/gamepad.ts
@@ -19,7 +19,9 @@ export function mapStandardGamepadState(gamepad: Gamepad | null, axisThreshold =
         up,
         down,
         left,
-        right
+        right,
+        l: Boolean(buttons[4]?.pressed),
+        r: Boolean(buttons[5]?.pressed)
     };
 }
 

--- a/web/src/input/keyboard_mapping.test.ts
+++ b/web/src/input/keyboard_mapping.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from "vitest";
+
+import { gbaKeyboardButtonForEvent } from "./keyboard_mapping";
+
+function event(key: string, code = key): Pick<KeyboardEvent, "key" | "code"> {
+    return { key, code };
+}
+
+it("maps GBA keyboard face buttons and shoulders", () => {
+    expect(gbaKeyboardButtonForEvent(event("z", "KeyZ"))).toBe(0);
+    expect(gbaKeyboardButtonForEvent(event("x", "KeyX"))).toBe(1);
+    expect(gbaKeyboardButtonForEvent(event("a", "KeyA"))).toBe(8);
+    expect(gbaKeyboardButtonForEvent(event("s", "KeyS"))).toBe(9);
+});
+
+it("maps GBA keyboard system buttons", () => {
+    expect(gbaKeyboardButtonForEvent(event("Enter", "Enter"))).toBe(3);
+    expect(gbaKeyboardButtonForEvent(event("Shift", "ShiftLeft"))).toBe(2);
+    expect(gbaKeyboardButtonForEvent(event("Shift", "ShiftRight"))).toBe(2);
+    expect(gbaKeyboardButtonForEvent(event("Backspace", "Backspace"))).toBe(2);
+});
+
+it("maps GBA keyboard d-pad arrows", () => {
+    expect(gbaKeyboardButtonForEvent(event("ArrowUp", "ArrowUp"))).toBe(4);
+    expect(gbaKeyboardButtonForEvent(event("ArrowDown", "ArrowDown"))).toBe(5);
+    expect(gbaKeyboardButtonForEvent(event("ArrowLeft", "ArrowLeft"))).toBe(6);
+    expect(gbaKeyboardButtonForEvent(event("ArrowRight", "ArrowRight"))).toBe(7);
+});
+
+it("ignores keys outside the GBA keyboard mapping", () => {
+    expect(gbaKeyboardButtonForEvent(event("q", "KeyQ"))).toBeNull();
+    expect(gbaKeyboardButtonForEvent(event(" ", "Space"))).toBeNull();
+});

--- a/web/src/input/keyboard_mapping.ts
+++ b/web/src/input/keyboard_mapping.ts
@@ -1,0 +1,30 @@
+export function gbaKeyboardButtonForEvent(event: Pick<KeyboardEvent, "key" | "code">): number | null {
+    const key = event.key.toLowerCase();
+    switch (key) {
+        case "z":
+            return 0;
+        case "x":
+            return 1;
+        case "backspace":
+            return 2;
+        case "enter":
+            return 3;
+        case "arrowup":
+            return 4;
+        case "arrowdown":
+            return 5;
+        case "arrowleft":
+            return 6;
+        case "arrowright":
+            return 7;
+        case "a":
+            return 8;
+        case "s":
+            return 9;
+        default:
+            if (event.code === "ShiftLeft" || event.code === "ShiftRight") {
+                return 2;
+            }
+            return null;
+    }
+}

--- a/web/src/rom/rom_extensions.test.ts
+++ b/web/src/rom/rom_extensions.test.ts
@@ -13,9 +13,14 @@ it("classifies DMG and CGB Game Boy ROM extensions as Game Boy", () => {
     expect(webRomConsoleKindForName("POKEMON.CGB")).toBe("gb");
 });
 
+it("classifies Game Boy Advance ROM names as GBA", () => {
+    expect(webRomConsoleKindForName("metroid.gba")).toBe("gba");
+    expect(webRomConsoleKindForName("METROID.GBA")).toBe("gba");
+});
+
 it("rejects unsupported web ROM extensions", () => {
     expect(webRomConsoleKindForName("notes.txt")).toBeNull();
-    expect(webRomConsoleKindForName("advance.gba")).toBeNull();
+    expect(webRomConsoleKindForName("advance.agb")).toBeNull();
 });
 
 it("extracts lower-case extensions for messages", () => {
@@ -25,7 +30,7 @@ it("extracts lower-case extensions for messages", () => {
 });
 
 it("lists all supported web ROM extensions for user-facing messages", () => {
-    expect(supportedRomExtensionsText()).toBe(".nes, .gb, .gbc, .cgb");
+    expect(supportedRomExtensionsText()).toBe(".nes, .gb, .gbc, .cgb, .gba");
 });
 
 it("handles edge case: empty string", () => {

--- a/web/src/rom/rom_extensions.ts
+++ b/web/src/rom/rom_extensions.ts
@@ -1,4 +1,4 @@
-export type WebRomConsoleKind = "nes" | "gb";
+export type WebRomConsoleKind = "nes" | "gb" | "gba";
 
 const GAME_BOY_EXTENSIONS = new Set(["gb", "gbc", "cgb"]);
 
@@ -18,6 +18,9 @@ export function webRomConsoleKindForName(name: string): WebRomConsoleKind | null
     if (GAME_BOY_EXTENSIONS.has(extension)) {
         return "gb";
     }
+    if (extension === "gba") {
+        return "gba";
+    }
     return null;
 }
 
@@ -26,5 +29,5 @@ export function isSupportedWebRomName(name: string): boolean {
 }
 
 export function supportedRomExtensionsText(): string {
-    return ".nes, .gb, .gbc, .cgb";
+    return ".nes, .gb, .gbc, .cgb, .gba";
 }

--- a/web/src/rom/rom_list.test.ts
+++ b/web/src/rom/rom_list.test.ts
@@ -154,6 +154,20 @@ it("parseDirectoryListing includes .gbc and .cgb files", () => {
     expect(roms).toContain("game.gb");
 });
 
+it("parseDirectoryListing includes .gba files", () => {
+    const html = `
+        <html><body>
+            <a href="suite.gba">suite.gba</a>
+            <a href="game.nes">game.nes</a>
+            <a href="notes.txt">notes.txt</a>
+        </body></html>
+    `;
+    const { roms } = parseDirectoryListing(html);
+    expect(roms).toContain("suite.gba");
+    expect(roms).toContain("game.nes");
+    expect(roms).not.toContain("notes.txt");
+});
+
 it("fetchRomList includes .gb entries from directory listing", async () => {
     const base = "https://example.com/roms/";
     const responses = new Map([
@@ -179,6 +193,34 @@ it("fetchRomList includes .gb entries from directory listing", async () => {
     const entries = await fetchRomList(base, fetchFn as any, 4);
     const paths = entries.map((entry: any) => entry.path);
     expect(paths).toContain("gb/tetris.gb");
+    expect(paths).toContain("root.nes");
+});
+
+it("fetchRomList includes .gba entries from directory listing", async () => {
+    const base = "https://example.com/roms/";
+    const responses = new Map([
+        [base, `
+            <a href="../">../</a>
+            <a href="gba/">gba/</a>
+            <a href="root.nes">root.nes</a>
+        `],
+        [`${base}gba/`, `
+            <a href="../">../</a>
+            <a href="suite.gba">suite.gba</a>
+        `]
+    ]);
+
+    const fetchFn = async (url: any) => {
+        const key = url.toString();
+        if (!responses.has(key)) {
+            return { ok: false, status: 404, text: async () => "" };
+        }
+        return { ok: true, text: async () => responses.get(key) };
+    };
+
+    const entries = await fetchRomList(base, fetchFn as any, 4);
+    const paths = entries.map((entry: any) => entry.path);
+    expect(paths).toContain("gba/suite.gba");
     expect(paths).toContain("root.nes");
 });
 
@@ -209,4 +251,32 @@ it("fetchRomList manifest fallback includes .gb entries", async () => {
     expect(paths).toContain("game.nes");
     expect(paths).toContain("color.gbc");
     expect(paths).toContain("camera.cgb");
+});
+
+it("fetchRomList manifest fallback includes .gba entries", async () => {
+    const base = "https://example.com/roms/";
+    const responses = new Map([
+        [base, ""],
+        [`${base}roms.json`, JSON.stringify({
+            roms: ["suite.gba", "game.nes", "notes.txt"]
+        })]
+    ]);
+
+    const fetchFn = async (url: any) => {
+        const key = url.toString();
+        if (!responses.has(key)) {
+            return { ok: false, status: 404, text: async () => "" };
+        }
+        return {
+            ok: true,
+            text: async () => responses.get(key),
+            json: async () => JSON.parse(responses.get(key)!)
+        };
+    };
+
+    const entries = await fetchRomList(base, fetchFn as any, 4);
+    const paths = entries.map((entry: any) => entry.path);
+    expect(paths).toContain("suite.gba");
+    expect(paths).toContain("game.nes");
+    expect(paths).not.toContain("notes.txt");
 });

--- a/web/types/neser-wasm.d.ts
+++ b/web/types/neser-wasm.d.ts
@@ -106,6 +106,26 @@ declare module "*/pkg/neser" {
         set_button(controller: number, button: number, pressed: boolean): void;
     }
 
+    /**
+     * Provides a minimal WASM bridge for running the Game Boy Advance emulator in the browser.
+     */
+    export class WasmGba {
+        free(): void;
+        [Symbol.dispose](): void;
+        drain_toasts(): unknown[];
+        frame_rate_hz(): number;
+        get_audio_samples(): Float32Array;
+        is_audio_muted(): boolean;
+        load_rom(rom: Uint8Array, rom_name: string): void;
+        constructor();
+        render_frame_rgba(): Uint8Array;
+        reset(soft_reset: boolean): void;
+        screen_height(): number;
+        screen_width(): number;
+        set_audio_muted(muted: boolean): void;
+        set_button(controller: number, button: number, pressed: boolean): void;
+    }
+
     export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
     export interface InitOutput {


### PR DESCRIPTION
## Summary

- Adds `WasmGba` for browser GBA ROM loading, 240x160 RGBA rendering, audio, reset, toasts, and 10-button input.
- Enables `.gba` recognition in the web ROM picker, ROM list discovery, Vite ROM manifest generation, and app console switching.
- Adds GBA keyboard/gamepad mappings and stock-only web filter behavior while preserving existing NES/GB paths.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt`
- `./scripts/test-dir.sh src/frontends src/gba --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`
- `npm run test:integration:web -- web/integration/specs/emulation-lifecycle.integration.spec.ts`

Fixes #2674
