### PR TITLE
Fix GBA mGBA DMA diagnostics

### DIFF
--- a/src/gba/bus/dma.rs
+++ b/src/gba/bus/dma.rs
@@ -134,6 +134,10 @@ pub struct DmaChannel {
     /// Whether the channel is currently running (used so that a
     /// higher-priority channel can preempt mid-transfer).
     active: bool,
+    /// Per-channel DMA transfer latch. Reads from invalid/locked source
+    /// regions reuse this value instead of updating it from the bus.
+    #[serde(default)]
+    latch: u32,
 }
 
 impl DmaChannel {
@@ -438,6 +442,26 @@ fn dma_unit_cycles<B: DmaBus>(bus: &B, src: u32, dst: u32, word: bool, first_uni
     src_cycles + dst_cycles
 }
 
+fn dma_source_updates_latch(src: u32) -> bool {
+    src >= 0x0200_0000
+}
+
+fn dma_source_forces_increment(src: u32) -> bool {
+    matches!((src >> 24) & 0xF, 0x8..=0xD)
+}
+
+fn dma_source_step(src: u32, src_ctrl: AddrControl, unit: u32) -> i64 {
+    if dma_source_forces_increment(src) {
+        return unit as i64;
+    }
+
+    match src_ctrl {
+        AddrControl::Increment => unit as i64,
+        AddrControl::Decrement => -(unit as i64),
+        _ => 0,
+    }
+}
+
 impl DmaController {
     /// Run any pending Immediate-mode transfers, draining the highest-
     /// priority channel first. Higher-priority channels that become
@@ -505,11 +529,6 @@ impl DmaController {
             )
         };
         let unit = if is_word { 4u32 } else { 2u32 };
-        let src_step: i64 = match src_ctrl {
-            AddrControl::Increment => unit as i64,
-            AddrControl::Decrement => -(unit as i64),
-            _ => 0,
-        };
         let dst_step: i64 = match dst_ctrl {
             AddrControl::Increment | AddrControl::IncrementReload => unit as i64,
             AddrControl::Decrement => -(unit as i64),
@@ -536,14 +555,6 @@ impl DmaController {
 
         let active_word = is_word || force_word;
         let active_unit = if active_word { 4u32 } else { 2u32 };
-        let active_src_step = if src_step == 0 {
-            0
-        } else if src_step > 0 {
-            active_unit as i64
-        } else {
-            -(active_unit as i64)
-        };
-
         self.channels[idx].active = true;
         let mut first_unit = true;
         self.cpu_stall += 2;
@@ -570,7 +581,7 @@ impl DmaController {
                         idx,
                         count,
                         active_word,
-                        active_src_step,
+                        src_ctrl,
                         dst_step,
                         special,
                         irq,
@@ -586,12 +597,27 @@ impl DmaController {
             self.cpu_stall += dma_unit_cycles(bus, src, dst, active_word, first_unit);
             first_unit = false;
             if active_word {
-                let v = bus.dma_read32(src & !0x3);
+                let v = if dma_source_updates_latch(src) {
+                    let v = bus.dma_read32(src & !0x3);
+                    self.channels[idx].latch = v;
+                    v
+                } else {
+                    self.channels[idx].latch
+                };
                 bus.dma_write32(dst & !0x3, v);
             } else {
-                let v = bus.dma_read16(src & !0x1);
+                let v = if dma_source_updates_latch(src) {
+                    let v = bus.dma_read16(src & !0x1);
+                    self.channels[idx].latch = u32::from(v) | (u32::from(v) << 16);
+                    v
+                } else if dst & 0x2 == 0 {
+                    self.channels[idx].latch as u16
+                } else {
+                    (self.channels[idx].latch >> 16) as u16
+                };
                 bus.dma_write16(dst & !0x1, v);
             }
+            let active_src_step = dma_source_step(src, src_ctrl, active_unit);
             self.channels[idx].cur_src = (src as i64).wrapping_add(active_src_step) as u32;
             if fifo_dst.is_none() {
                 self.channels[idx].cur_dst = (dst as i64).wrapping_add(dst_step) as u32;
@@ -608,7 +634,7 @@ impl DmaController {
         idx: usize,
         mut count: u32,
         active_word: bool,
-        src_step: i64,
+        src_ctrl: AddrControl,
         dst_step: i64,
         special: bool,
         irq: bool,
@@ -635,12 +661,27 @@ impl DmaController {
             self.cpu_stall += dma_unit_cycles(bus, src, dst, active_word, first_unit);
             first_unit = false;
             if active_word {
-                let v = bus.dma_read32(src & !0x3);
+                let v = if dma_source_updates_latch(src) {
+                    let v = bus.dma_read32(src & !0x3);
+                    self.channels[idx].latch = v;
+                    v
+                } else {
+                    self.channels[idx].latch
+                };
                 bus.dma_write32(dst & !0x3, v);
             } else {
-                let v = bus.dma_read16(src & !0x1);
+                let v = if dma_source_updates_latch(src) {
+                    let v = bus.dma_read16(src & !0x1);
+                    self.channels[idx].latch = u32::from(v) | (u32::from(v) << 16);
+                    v
+                } else if dst & 0x2 == 0 {
+                    self.channels[idx].latch as u16
+                } else {
+                    (self.channels[idx].latch >> 16) as u16
+                };
                 bus.dma_write16(dst & !0x1, v);
             }
+            let src_step = dma_source_step(src, src_ctrl, if active_word { 4u32 } else { 2u32 });
             self.channels[idx].cur_src = (src as i64).wrapping_add(src_step) as u32;
             if fifo_dst.is_none() {
                 self.channels[idx].cur_dst = (dst as i64).wrapping_add(dst_step) as u32;
@@ -835,6 +876,11 @@ mod tests {
         count: u16,
         cnt: u16,
     ) {
+        let sad = if (0x1000..0x8000).contains(&sad) {
+            0x0200_0000 | sad
+        } else {
+            sad
+        };
         let base = 0x0400_00B0 + (chan as u32) * 12;
         d.write16(base, sad as u16);
         d.write16(base + 2, (sad >> 16) as u16);
@@ -916,6 +962,122 @@ mod tests {
         d.run_pending(&mut bus);
         // Last value wins at 0x2000.
         assert_eq!(bus.read32_at(0x2000), 0xAA02);
+    }
+
+    #[test]
+    fn game_pak_source_addresses_increment_even_when_source_control_is_fixed() {
+        let mut bus = TestBus::new();
+        for i in 0..4 {
+            bus.write32_at(0x0800_0000 + i * 4, 0xDEAD_BEEF + i);
+        }
+
+        let mut d = DmaController::new();
+        write_dma_setup(
+            &mut d,
+            1,
+            0x0800_0000,
+            0x2000,
+            4,
+            cnt_h(true, false, 0, true, false, 2, 0),
+        );
+
+        d.run_pending(&mut bus);
+
+        assert_eq!(bus.read32_at(0x2000), 0xDEAD_BEEF);
+        assert_eq!(bus.read32_at(0x2004), 0xDEAD_BEF0);
+        assert_eq!(bus.read32_at(0x2008), 0xDEAD_BEF1);
+        assert_eq!(bus.read32_at(0x200C), 0xDEAD_BEF2);
+    }
+
+    #[test]
+    fn invalid_source_addresses_reuse_each_channels_dma_latch() {
+        let mut bus = TestBus::new();
+        bus.write32_at(0x0200_0000, 0x1111_1111);
+        bus.write32_at(0x0200_0100, 0x2222_2222);
+
+        let mut d = DmaController::new();
+        write_dma_setup(
+            &mut d,
+            0,
+            0x0200_0000,
+            0x3000,
+            1,
+            cnt_h(true, false, 0, true, false, 0, 0),
+        );
+        d.run_pending(&mut bus);
+
+        write_dma_setup(
+            &mut d,
+            1,
+            0x0200_0100,
+            0x3004,
+            1,
+            cnt_h(true, false, 0, true, false, 0, 0),
+        );
+        d.run_pending(&mut bus);
+
+        write_dma_setup(
+            &mut d,
+            0,
+            0x0000_0010,
+            0x3010,
+            1,
+            cnt_h(true, false, 0, true, false, 0, 0),
+        );
+        d.run_pending(&mut bus);
+
+        write_dma_setup(
+            &mut d,
+            1,
+            0x0000_0010,
+            0x3014,
+            1,
+            cnt_h(true, false, 0, true, false, 0, 0),
+        );
+        d.run_pending(&mut bus);
+
+        assert_eq!(bus.read32_at(0x3010), 0x1111_1111);
+        assert_eq!(bus.read32_at(0x3014), 0x2222_2222);
+    }
+
+    #[test]
+    fn invalid_halfword_source_uses_latch_half_selected_by_destination_alignment() {
+        let mut bus = TestBus::new();
+        bus.write32_at(0x0200_0000, 0xAAAA_BBBB);
+
+        let mut d = DmaController::new();
+        write_dma_setup(
+            &mut d,
+            1,
+            0x0200_0000,
+            0x3000,
+            1,
+            cnt_h(true, false, 0, true, false, 0, 0),
+        );
+        d.run_pending(&mut bus);
+
+        write_dma_setup(
+            &mut d,
+            1,
+            0x0000_0010,
+            0x3010,
+            1,
+            cnt_h(true, false, 0, false, false, 0, 0),
+        );
+        d.run_pending(&mut bus);
+
+        write_dma_setup(
+            &mut d,
+            1,
+            0x0000_0010,
+            0x3012,
+            1,
+            cnt_h(true, false, 0, false, false, 0, 0),
+        );
+        d.run_pending(&mut bus);
+
+        assert_eq!(bus.read16_at(0x3010), 0xBBBB);
+        assert_eq!(bus.read16_at(0x3012), 0xAAAA);
     }
 
     #[test]

--- a/src/gba/bus/gba_bus.rs
+++ b/src/gba/bus/gba_bus.rs
@@ -1868,7 +1868,7 @@ mod tests {
     }
 
     #[test]
-    fn dma0_source_masks_game_pak_rom_to_internal_memory() {
+    fn dma0_game_pak_rom_source_uses_initial_dma_latch_after_internal_mask() {
         let mut bus = GbaBus::new();
         bus.load_bios(&0x1122_3344u32.to_le_bytes());
         bus.load_rom(&0xAABB_CCDDu32.to_le_bytes());
@@ -1877,7 +1877,9 @@ mod tests {
         write_dma_registers(&mut bus, 0, 0x0800_0000, 0x0200_0000, 1, 0x8000 | 0x0400);
         step_past_immediate_dma_start_delay(&mut bus);
 
-        assert_eq!(bus.read32(0x0200_0000), 0x1122_3344);
+        // DMA0 masks Game Pak source addresses into the internal-memory range,
+        // but DMA reads below EWRAM reuse the channel's transfer latch.
+        assert_eq!(bus.read32(0x0200_0000), 0);
     }
 
     #[test]

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -45,7 +45,7 @@ armwrestler_page7=0x562A5C65
 # BIOS math, DMA, SIO, misc edge cases, and video.
 # Scores (passing/total, embedded BIOS): Memory 1552/1552, I/O read 130/130, Timing 2020/2020,
 # Timers 936/936, Timer IRQ 90/90, Shifter 140/140, Carry 93/93,
-# Multiply long 72/72, BIOS math 615/615, DMA 1120/1256, SIO read 90/90,
+# Multiply long 72/72, BIOS math 615/615, DMA 1256/1256, SIO read 90/90,
 # SIO timing 0/4, Misc. edge 3/12, Video (sub-menu only).
 mgba_memory=0x61F65500
 mgba_io_read=0x7D320909
@@ -56,7 +56,7 @@ mgba_shifter=0x8B4A12AA
 mgba_carry=0xFD9E45E6
 mgba_multiply_long=0x699655AB
 mgba_bios_math=0x3C1B28DE
-mgba_dma=0x90900973
+mgba_dma=0x06A624A4
 mgba_sio_read=0xF5D98687
 mgba_sio_timing=0xD95ACB03
 mgba_misc_edge=0x36ECDBF9

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -536,7 +536,7 @@ fn gba_mgba_timer_irq_diagnostics_passes_every_irq_case() {
 }
 
 #[test]
-fn gba_mgba_dma_diagnostics_reports_current_score() {
+fn gba_mgba_dma_diagnostics_passes_every_case() {
     let result = run_mgba_dma_diagnostics();
 
     assert_eq!(
@@ -546,9 +546,14 @@ fn gba_mgba_dma_diagnostics_reports_current_score() {
         result.raw_log
     );
     assert_eq!(
-        result.passed_count,
-        Some(1120),
-        "raw mGBA DMA log:\n{}",
+        result.passed_count, result.total_count,
+        "mGBA DMA diagnostics should pass every case with the embedded BIOS.\nfailures: {:?}\nraw log:\n{}",
+        result.failures, result.raw_log
+    );
+    assert!(
+        result.failures.is_empty(),
+        "mGBA DMA diagnostics reported failures with the embedded BIOS: {:?}\nraw log:\n{}",
+        result.failures,
         result.raw_log
     );
 }
@@ -648,7 +653,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("mgba_carry"), Some(&0xFD9E_45E6));
     assert_eq!(approvals.get("mgba_multiply_long"), Some(&0x6996_55AB));
     assert_eq!(approvals.get("mgba_bios_math"), Some(&0x3C1B_28DE));
-    assert_eq!(approvals.get("mgba_dma"), Some(&0x9090_0973));
+    assert_eq!(approvals.get("mgba_dma"), Some(&0x06A6_24A4));
     assert_eq!(approvals.get("mgba_sio_read"), Some(&0xF5D9_8687));
     assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));
     assert_eq!(approvals.get("mgba_misc_edge"), Some(&0x36EC_DBF9));


### PR DESCRIPTION
## Summary

- Fix GBA DMA behavior so the focused mGBA DMA diagnostic reaches 1256/1256.
- Model per-channel DMA transfer latches for invalid/locked source reads.
- Force Game Pak ROM source addresses to increment regardless of source address-control mode.
- Add focused DMA regressions and update the mGBA DMA approval CRC.

## Validation

- cargo test --no-default-features --lib gba_mgba_dma_diagnostics_passes_every_case -- --nocapture
- cargo test --no-default-features --lib gba::bus::dma -- --nocapture
- cargo test --no-default-features --lib gba_mgba_suite_passes -- --nocapture
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/test-dir.sh src/gba --skip-integration
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test

Note: initial full pre-PR run hit local disk exhaustion while compiling; target artifacts were cleaned with cargo clean and the required checks were rerun successfully.
