### PR TITLE
Fix GBA SIO timing diagnostics

### DIFF
--- a/src/gba/bus/cpu_bus.rs
+++ b/src/gba/bus/cpu_bus.rs
@@ -308,7 +308,7 @@ impl Bus for GbaBus {
                     }
                     // SIOCNT is at 0x0400_0128 (low halfword of a 32-bit write).
                     if aligned == 0x0400_0128 {
-                        self.sio.write_siocnt(value as u16);
+                        self.write_siocnt(value as u16);
                     }
                     // RCNT is at 0x0400_0134 (low halfword of a 32-bit write).
                     if aligned == 0x0400_0134 {
@@ -386,7 +386,7 @@ impl Bus for GbaBus {
                         self.waitstates.recalculate(value);
                     }
                     if aligned == 0x0400_0128 {
-                        self.sio.write_siocnt(value);
+                        self.write_siocnt(value);
                     }
                     if aligned == 0x0400_0134 {
                         self.sio.write_rcnt(value);
@@ -472,7 +472,7 @@ impl Bus for GbaBus {
                     // Merge the written byte into the current register value.
                     if aligned == 0x0400_0128 {
                         let merged = self.io.backing_u16(0x0400_0128);
-                        self.sio.write_siocnt(merged);
+                        self.write_siocnt(merged);
                     }
                     if aligned == 0x0400_0134 {
                         let merged = self.io.backing_u16(0x0400_0134);

--- a/src/gba/bus/dma.rs
+++ b/src/gba/bus/dma.rs
@@ -516,6 +516,7 @@ impl DmaController {
     }
 
     /// Perform one read-with-latch / write / address-step unit for channel `idx`.
+    #[allow(clippy::too_many_arguments)]
     fn execute_transfer_unit<B: DmaBus>(
         &mut self,
         idx: usize,
@@ -636,7 +637,16 @@ impl DmaController {
             let dst = fifo_dst.unwrap_or(self.channels[idx].cur_dst);
             self.cpu_stall += dma_unit_cycles(bus, src, dst, active_word, first_unit);
             first_unit = false;
-            self.execute_transfer_unit(idx, src, dst, active_word, src_ctrl, dst_step, fifo_dst, bus);
+            self.execute_transfer_unit(
+                idx,
+                src,
+                dst,
+                active_word,
+                src_ctrl,
+                dst_step,
+                fifo_dst,
+                bus,
+            );
             count -= 1;
         }
 
@@ -675,7 +685,16 @@ impl DmaController {
             let dst = fifo_dst.unwrap_or(self.channels[idx].cur_dst);
             self.cpu_stall += dma_unit_cycles(bus, src, dst, active_word, first_unit);
             first_unit = false;
-            self.execute_transfer_unit(idx, src, dst, active_word, src_ctrl, dst_step, fifo_dst, bus);
+            self.execute_transfer_unit(
+                idx,
+                src,
+                dst,
+                active_word,
+                src_ctrl,
+                dst_step,
+                fifo_dst,
+                bus,
+            );
             count -= 1;
         }
         self.finish_burst(idx, special, irq, repeat, bus);

--- a/src/gba/bus/gba_bus.rs
+++ b/src/gba/bus/gba_bus.rs
@@ -41,6 +41,10 @@ fn timer_start_delay_cycles() -> u32 {
     2
 }
 
+fn sio_start_delay_cycles() -> u32 {
+    29
+}
+
 /// GBA memory bus.
 pub struct GbaBus {
     /// 16 KB BIOS ROM at `0x0000_0000`.
@@ -118,6 +122,9 @@ pub struct GbaBus {
     /// Set when a CPU-visible write enables a timer. The instruction that
     /// performs the enable write completes before the timer starts ticking.
     pub(super) timer_start_delay_pending: bool,
+    /// Remaining CPU cycles before a newly started SIO transfer begins
+    /// shifting bits on the serial clock.
+    pub(super) sio_start_delay_cycles: u32,
     /// Remaining CPU cycles before a newly enabled immediate DMA can seize the
     /// bus. GBATek documents a 2-cycle delay after the DMA enable edge.
     pub(super) dma_start_delay_cycles: u32,
@@ -212,6 +219,7 @@ impl GbaBus {
             undoc_0x410: 0,
             halt_requested: false,
             timer_start_delay_pending: false,
+            sio_start_delay_cycles: 0,
             dma_start_delay_cycles: 0,
             timer_global_cycles: 0,
             irq_line_delay_cycles: 0,
@@ -383,7 +391,7 @@ impl GbaBus {
         self.timer_start_delay_pending = false;
         let overflow_mask = self.timers.step(cycles, &mut self.ic);
         self.handle_timer_overflow_fifo(overflow_mask);
-        self.sio.step(cycles, &mut self.ic);
+        self.step_sio(cycles);
         self.apu.tick(cycles);
         let events = self.ppu.step(
             cycles,
@@ -417,7 +425,7 @@ impl GbaBus {
         };
         let overflow_mask = self.timers.step(timer_cycles, &mut self.ic);
         self.handle_timer_overflow_fifo(overflow_mask);
-        self.sio.step(cycles, &mut self.ic);
+        self.step_sio(cycles);
         self.apu.tick(cycles);
         let events = self.ppu.step(
             cycles,
@@ -527,6 +535,27 @@ impl GbaBus {
         }
         self.run_pending_dma();
         self.step_dma_stalls();
+    }
+
+    pub(super) fn step_sio(&mut self, cycles: u32) {
+        let cycles = if self.sio_start_delay_cycles > 0 {
+            if cycles <= self.sio_start_delay_cycles {
+                self.sio_start_delay_cycles -= cycles;
+                return;
+            }
+            let remaining_cycles = cycles - self.sio_start_delay_cycles;
+            self.sio_start_delay_cycles = 0;
+            remaining_cycles
+        } else {
+            cycles
+        };
+        self.sio.step(cycles, &mut self.ic);
+    }
+
+    pub(super) fn write_siocnt(&mut self, value: u16) {
+        if self.sio.write_siocnt(value) {
+            self.sio_start_delay_cycles = sio_start_delay_cycles();
+        }
     }
 
     pub(super) fn mark_timer_start_delay_for_write16(&mut self, addr: u32, value: u16) {
@@ -733,6 +762,7 @@ impl GbaBus {
             undoc_0x410: self.undoc_0x410,
             halt_requested: self.halt_requested,
             timer_global_cycles: self.timer_global_cycles,
+            sio_start_delay_cycles: self.sio_start_delay_cycles,
             irq_line_delay_cycles: self.irq_line_delay_cycles,
             irq_sources_were_asserted: self.irq_sources_were_asserted,
         }
@@ -786,6 +816,7 @@ impl GbaBus {
         self.undoc_0x410 = state.undoc_0x410;
         self.halt_requested = state.halt_requested;
         self.timer_global_cycles = state.timer_global_cycles;
+        self.sio_start_delay_cycles = state.sio_start_delay_cycles;
         self.irq_line_delay_cycles = state.irq_line_delay_cycles;
         self.irq_sources_were_asserted = state.irq_sources_were_asserted;
         self.timer_start_delay_pending = false;
@@ -1323,7 +1354,7 @@ mod tests {
         let mut bus = GbaBus::new();
         bus.write16(0x0400_0200, irq_bits::SERIAL);
         bus.write16(0x0400_0128, 0x4082);
-        bus.step(63);
+        bus.step(92);
 
         let saved = bus.capture_memory_state();
 
@@ -1527,6 +1558,26 @@ mod tests {
         assert_eq!(bus.read16(0x0400_0100), 1);
         bus.step_after_cpu_instruction(1);
         assert_eq!(bus.read16(0x0400_0100), 2);
+    }
+
+    #[test]
+    fn sio_transfer_does_not_tick_during_starting_cpu_instruction() {
+        let mut bus = GbaBus::new();
+        bus.ic.ie = irq_bits::SERIAL;
+        bus.ic.ime = true;
+
+        bus.begin_cpu_instruction();
+        bus.write16(0x0400_0128, 0x4081);
+        bus.end_cpu_instruction();
+        bus.step_after_cpu_instruction(29);
+
+        assert_ne!(bus.read16(0x0400_0128) & 0x0080, 0);
+        bus.step(511);
+        assert_ne!(bus.read16(0x0400_0128) & 0x0080, 0);
+        bus.step(1);
+
+        assert_eq!(bus.read16(0x0400_0128) & 0x0080, 0);
+        assert_ne!(bus.ic.if_flags & irq_bits::SERIAL, 0);
     }
 
     #[test]

--- a/src/gba/bus/sio.rs
+++ b/src/gba/bus/sio.rs
@@ -57,29 +57,48 @@ impl Sio {
     /// Read SIOCNT (0x0400_0128). Bit 7 reflects live transfer state.
     /// Applies the mode-dependent read mask (UART: 0x7FAF, others: 0x7F8F).
     pub fn read_siocnt(&self) -> u16 {
-        let mask = if self.mode() == SioMode::Uart {
+        let mode = self.mode();
+        let mask = if mode == SioMode::Uart {
             0x7FAF
         } else {
             0x7F8F
         };
-        let val = if self.transfer_active {
-            self.siocnt | 0x0080
-        } else {
-            self.siocnt & !0x0080
+        let val = match mode {
+            SioMode::Normal8 | SioMode::Normal32 | SioMode::Multi => {
+                if self.transfer_active {
+                    self.siocnt | 0x0080
+                } else {
+                    self.siocnt & !0x0080
+                }
+            }
+            SioMode::Uart | SioMode::Gpio => self.siocnt,
         };
         val & mask
     }
 
     /// Write SIOCNT (0x0400_0128). A rising edge on bit 7 starts a transfer.
-    pub fn write_siocnt(&mut self, value: u16) {
+    pub fn write_siocnt(&mut self, value: u16) -> bool {
+        let old_mode = self.mode();
+        self.siocnt = value;
+        if self.mode() != old_mode {
+            self.transfer_active = false;
+            self.remaining_cycles = 0;
+        }
+        let mode = self.mode();
+        if matches!(mode, SioMode::Normal8 | SioMode::Normal32 | SioMode::Multi) {
+            self.siocnt &= !0x0080;
+        }
         let was_busy = self.transfer_active;
-        // Store the register value (without bit 7 — that's managed by state)
-        self.siocnt = value & !0x0080;
+        let mut started = false;
 
         // Rising edge on bit 7 starts a transfer
-        if !was_busy && value & 0x0080 != 0 {
+        if !was_busy
+            && value & 0x0080 != 0
+            && matches!(mode, SioMode::Normal8 | SioMode::Normal32 | SioMode::Multi)
+        {
             self.transfer_active = true;
-            match self.mode() {
+            started = true;
+            match mode {
                 SioMode::Normal8 | SioMode::Normal32 => {
                     self.remaining_cycles = self.normal_transfer_cycles();
                 }
@@ -87,12 +106,10 @@ impl Sio {
                     // No slaves connected — transfer never completes
                     self.remaining_cycles = u32::MAX;
                 }
-                _ => {
-                    // UART / GPIO: not implemented, don't start
-                    self.transfer_active = false;
-                }
+                SioMode::Uart | SioMode::Gpio => unreachable!(),
             }
         }
+        started
     }
 
     /// Advance the SIO state by `cycles` CPU cycles.
@@ -237,6 +254,20 @@ mod tests {
         assert_ne!(sio.read_siocnt() & 0x0080, 0);
     }
 
+    #[test]
+    fn switching_from_busy_multi_to_normal_allows_new_normal_transfer() {
+        let mut sio = make_sio();
+
+        sio.write_siocnt(0x6080);
+        assert!(sio.transfer_active);
+
+        sio.write_siocnt(0x4001);
+        sio.write_siocnt(0x4081);
+
+        assert!(sio.transfer_active);
+        assert_eq!(sio.remaining_cycles, 512);
+    }
+
     // --- Transfer completion tests ---
 
     #[test]
@@ -325,5 +356,26 @@ mod tests {
         let val = sio.read_siocnt();
         assert_ne!(val & 0x4000, 0, "bit 14 (IRQ enable) should be preserved");
         assert_ne!(val & 0x0002, 0, "bit 1 (clock) should be preserved");
+    }
+
+    #[test]
+    fn read_siocnt_preserves_written_bit7_in_uart_mode() {
+        let mut sio = make_sio();
+
+        sio.write_siocnt(0xF080);
+
+        assert_ne!(sio.read_siocnt() & 0x0080, 0);
+        assert!(!sio.transfer_active);
+    }
+
+    #[test]
+    fn read_siocnt_preserves_written_bit7_in_gpio_mode() {
+        let mut sio = make_sio();
+        sio.write_rcnt(0x8000);
+
+        sio.write_siocnt(0xC080);
+
+        assert_ne!(sio.read_siocnt() & 0x0080, 0);
+        assert!(!sio.transfer_active);
     }
 }

--- a/src/gba/bus/sio.rs
+++ b/src/gba/bus/sio.rs
@@ -54,7 +54,8 @@ impl Sio {
         }
     }
 
-    /// Read SIOCNT (0x0400_0128). Bit 7 reflects live transfer state.
+    /// Read SIOCNT (0x0400_0128). In Normal/Multi modes, bit 7 reflects
+    /// live transfer state; in UART/GPIO modes, it reflects the written value.
     /// Applies the mode-dependent read mask (UART: 0x7FAF, others: 0x7F8F).
     pub fn read_siocnt(&self) -> u16 {
         let mode = self.mode();
@@ -76,7 +77,8 @@ impl Sio {
         val & mask
     }
 
-    /// Write SIOCNT (0x0400_0128). A rising edge on bit 7 starts a transfer.
+    /// Write SIOCNT (0x0400_0128). In Normal/Multi modes, a rising edge on
+    /// bit 7 starts a transfer; in UART/GPIO modes, bit 7 is preserved only.
     pub fn write_siocnt(&mut self, value: u16) -> bool {
         let old_mode = self.mode();
         self.siocnt = value;
@@ -91,7 +93,7 @@ impl Sio {
         let was_busy = self.transfer_active;
         let mut started = false;
 
-        // Rising edge on bit 7 starts a transfer
+        // Rising edge on bit 7 starts a transfer in Normal/Multi modes.
         if !was_busy
             && value & 0x0080 != 0
             && matches!(mode, SioMode::Normal8 | SioMode::Normal32 | SioMode::Multi)

--- a/src/gba/console/save_state.rs
+++ b/src/gba/console/save_state.rs
@@ -96,6 +96,9 @@ pub struct BusMemoryState {
     /// Global timer cycle phase used when newly enabling prescaled timers.
     #[serde(default)]
     pub timer_global_cycles: u32,
+    /// Remaining cycles before a newly started SIO transfer begins shifting.
+    #[serde(default)]
+    pub sio_start_delay_cycles: u32,
     /// Remaining cycles before a newly asserted IRQ line reaches the CPU.
     #[serde(default)]
     pub irq_line_delay_cycles: u32,

--- a/src/gba/integration_tests/gba_suite_crc_approvals.txt
+++ b/src/gba/integration_tests/gba_suite_crc_approvals.txt
@@ -46,7 +46,7 @@ armwrestler_page7=0x562A5C65
 # Scores (passing/total, embedded BIOS): Memory 1552/1552, I/O read 130/130, Timing 2020/2020,
 # Timers 936/936, Timer IRQ 90/90, Shifter 140/140, Carry 93/93,
 # Multiply long 72/72, BIOS math 615/615, DMA 1256/1256, SIO read 90/90,
-# SIO timing 0/4, Misc. edge 3/12, Video (sub-menu only).
+# SIO timing 4/4, Misc. edge 3/12, Video (sub-menu only).
 mgba_memory=0x61F65500
 mgba_io_read=0x7D320909
 mgba_timing=0xEABA32BC
@@ -58,6 +58,6 @@ mgba_multiply_long=0x699655AB
 mgba_bios_math=0x3C1B28DE
 mgba_dma=0x06A624A4
 mgba_sio_read=0xF5D98687
-mgba_sio_timing=0xD95ACB03
+mgba_sio_timing=0x81BB7F79
 mgba_misc_edge=0x36ECDBF9
 mgba_video=0xAB7EC249

--- a/src/gba/integration_tests/gba_suite_runner.rs
+++ b/src/gba/integration_tests/gba_suite_runner.rs
@@ -731,6 +731,14 @@ fn mgba_dma_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
     mgba_named_sub_suite_diagnostic_from_gba(gba, "DMA tests")
 }
 
+fn mgba_sio_read_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
+    mgba_named_sub_suite_diagnostic_from_gba(gba, "SIO register R/W tests")
+}
+
+fn mgba_sio_timing_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
+    mgba_named_sub_suite_diagnostic_from_gba(gba, "SIO timing tests")
+}
+
 fn mgba_bios_math_diagnostic_from_gba(gba: &Gba) -> MgbaMemoryDiagnosticResult {
     mgba_named_sub_suite_diagnostic_from_gba(gba, "BIOS math tests")
 }
@@ -775,6 +783,16 @@ pub fn run_mgba_timer_irq_diagnostics() -> MgbaMemoryDiagnosticResult {
 pub fn run_mgba_dma_diagnostics() -> MgbaMemoryDiagnosticResult {
     let (gba, _rom) = boot_mgba_suite();
     run_mgba_sub_suite_diagnostics_from_gba(gba, 9, "DMA diagnostics")
+}
+
+pub fn run_mgba_sio_read_diagnostics() -> MgbaMemoryDiagnosticResult {
+    let (gba, _rom) = boot_mgba_suite();
+    run_mgba_sub_suite_diagnostics_from_gba(gba, 10, "SIO read diagnostics")
+}
+
+pub fn run_mgba_sio_timing_diagnostics() -> MgbaMemoryDiagnosticResult {
+    let (gba, _rom) = boot_mgba_suite();
+    run_mgba_sub_suite_diagnostics_from_gba(gba, 11, "SIO timing diagnostics")
 }
 
 pub fn run_mgba_bios_math_diagnostics() -> MgbaMemoryDiagnosticResult {
@@ -872,6 +890,8 @@ fn run_mgba_sub_suite_diagnostics_from_gba_with_boot_frames(
         4 => mgba_timer_irq_diagnostic_from_gba(&gba),
         8 => mgba_bios_math_diagnostic_from_gba(&gba),
         9 => mgba_dma_diagnostic_from_gba(&gba),
+        10 => mgba_sio_read_diagnostic_from_gba(&gba),
+        11 => mgba_sio_timing_diagnostic_from_gba(&gba),
         _ => mgba_memory_diagnostic_from_gba(&gba),
     }
 }

--- a/src/gba/integration_tests/gba_suite_tests.rs
+++ b/src/gba/integration_tests/gba_suite_tests.rs
@@ -2,7 +2,8 @@ use super::gba_suite_runner::{
     ARMWRESTLER_TEST_PAGE_COUNT, MGBA_SUITE_COUNT, MGBA_SUITE_KEYS, Suite, VIDEO_TEST_NAMES,
     boot_mgba_suite, run_armwrestler, run_mgba_bios_math_diagnostics, run_mgba_dma_diagnostics,
     run_mgba_io_read_diagnostics, run_mgba_io_read_diagnostics_after_bios_intro,
-    run_mgba_memory_diagnostics, run_mgba_memory_diagnostics_with_bios_path, run_mgba_suite,
+    run_mgba_memory_diagnostics, run_mgba_memory_diagnostics_with_bios_path,
+    run_mgba_sio_read_diagnostics, run_mgba_sio_timing_diagnostics, run_mgba_suite,
     run_mgba_timer_irq_diagnostics, run_mgba_timers_diagnostics, run_mgba_timing_diagnostics,
     run_mgba_video_tests, run_suite,
 };
@@ -559,6 +560,56 @@ fn gba_mgba_dma_diagnostics_passes_every_case() {
 }
 
 #[test]
+fn gba_mgba_sio_timing_diagnostics_passes_every_counted_case() {
+    let result = run_mgba_sio_timing_diagnostics();
+
+    assert_eq!(
+        result.total_count,
+        Some(4),
+        "raw mGBA SIO timing log:\n{}",
+        result.raw_log
+    );
+    assert!(
+        result.passed_count.is_some(),
+        "mGBA SIO timing diagnostics should include a parsed pass count"
+    );
+    assert_eq!(
+        result.passed_count, result.total_count,
+        "mGBA SIO timing diagnostics should pass every counted case with the embedded BIOS.\nfailures: {:?}\nraw log:\n{}",
+        result.failures, result.raw_log
+    );
+    assert!(
+        result.failures.is_empty(),
+        "mGBA SIO timing diagnostics reported failures with the embedded BIOS: {:?}\nraw log:\n{}",
+        result.failures,
+        result.raw_log
+    );
+}
+
+#[test]
+fn gba_mgba_sio_read_diagnostics_still_passes_every_case() {
+    let result = run_mgba_sio_read_diagnostics();
+
+    assert_eq!(
+        result.total_count,
+        Some(90),
+        "raw mGBA SIO read log:\n{}",
+        result.raw_log
+    );
+    assert_eq!(
+        result.passed_count, result.total_count,
+        "mGBA SIO read diagnostics should still pass every case with the embedded BIOS.\nfailures: {:?}\nraw log:\n{}",
+        result.failures, result.raw_log
+    );
+    assert!(
+        result.failures.is_empty(),
+        "mGBA SIO read diagnostics reported failures with the embedded BIOS: {:?}\nraw log:\n{}",
+        result.failures,
+        result.raw_log
+    );
+}
+
+#[test]
 fn gba_mgba_bios_math_diagnostics_passes_every_case() {
     let result = run_mgba_bios_math_diagnostics();
 
@@ -655,7 +706,7 @@ fn approvals_manifest_parses() {
     assert_eq!(approvals.get("mgba_bios_math"), Some(&0x3C1B_28DE));
     assert_eq!(approvals.get("mgba_dma"), Some(&0x06A6_24A4));
     assert_eq!(approvals.get("mgba_sio_read"), Some(&0xF5D9_8687));
-    assert_eq!(approvals.get("mgba_sio_timing"), Some(&0xD95A_CB03));
+    assert_eq!(approvals.get("mgba_sio_timing"), Some(&0x81BB_7F79));
     assert_eq!(approvals.get("mgba_misc_edge"), Some(&0x36EC_DBF9));
     assert_eq!(approvals.get("mgba_video"), Some(&0xAB7E_C249));
 }


### PR DESCRIPTION
## Summary

- Add focused mGBA SIO read and SIO timing diagnostics.
- Make SIO timing pass all counted Normal-mode cases (`4/4`).
- Clear stale active transfer state when changing SIO modes.
- Add bus-level SIO start delay so transfer timing aligns with mGBA expectations.
- Preserve SIOCNT bit 7 read/write semantics in non-transfer modes so SIO read remains `90/90`.
- Update the mGBA approval manifest for the improved SIO timing CRC.

## Validation

- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/gba --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`

## Notes

- mGBA SIO timing now reports `4/4`.
- mGBA SIO read remains `90/90`.
