### PR TITLE
Fix GBA web display, controls, and frame rendering

### DIFF
--- a/src/frontends/web/wasm_gba.rs
+++ b/src/frontends/web/wasm_gba.rs
@@ -14,6 +14,7 @@ pub struct WasmGba {
     rom_loaded: bool,
     pending_toasts: Vec<String>,
     frame_rgba_buffer: Vec<u8>,
+    frame_rgb_buffer: Vec<u8>,
 }
 
 impl Default for WasmGba {
@@ -35,6 +36,19 @@ impl WasmGba {
             for alpha in self.frame_rgba_buffer.iter_mut().skip(3).step_by(4) {
                 *alpha = 0xFF;
             }
+        }
+    }
+
+    fn required_rgb_len() -> usize {
+        (Gba::SCREEN_WIDTH * Gba::SCREEN_HEIGHT * 3) as usize
+    }
+
+    fn fill_black_rgb_frame(&mut self) {
+        let required = Self::required_rgb_len();
+        if self.frame_rgb_buffer.len() != required {
+            self.frame_rgb_buffer.resize(required, 0);
+        } else {
+            self.frame_rgb_buffer.fill(0);
         }
     }
 
@@ -74,6 +88,7 @@ impl WasmGba {
             rom_loaded: false,
             pending_toasts: Vec::new(),
             frame_rgba_buffer: Vec::new(),
+            frame_rgb_buffer: Vec::new(),
         }
     }
 
@@ -133,6 +148,26 @@ impl WasmGba {
             rgba[3] = 0xFF;
         }
         unsafe { js_sys::Uint8Array::view(&self.frame_rgba_buffer) }
+    }
+
+    /// Step the emulator until a full frame is ready and return the native RGB888 pixel buffer.
+    ///
+    /// Returns a `Uint8Array` of `240 × 160 × 3` bytes.
+    /// When no ROM is loaded, returns a black frame.
+    ///
+    /// # Safety
+    ///
+    /// The returned `Uint8Array` is a zero-copy view into WASM linear memory. The caller must
+    /// consume it before invoking another WASM function that could grow linear memory.
+    #[wasm_bindgen]
+    pub fn render_frame_rgb(&mut self) -> js_sys::Uint8Array {
+        if !self.rom_loaded {
+            self.fill_black_rgb_frame();
+            return unsafe { js_sys::Uint8Array::view(&self.frame_rgb_buffer) };
+        }
+
+        self.run_until_frame_ready();
+        unsafe { js_sys::Uint8Array::view(self.gba.framebuffer_rgb()) }
     }
 
     #[wasm_bindgen]

--- a/src/frontends/web/wasm_gba.rs
+++ b/src/frontends/web/wasm_gba.rs
@@ -121,7 +121,7 @@ impl WasmGba {
 
         self.run_until_frame_ready();
         self.ensure_rgba_buffer();
-        let rgb = self.gba.screen_snapshot();
+        let rgb = self.gba.framebuffer_rgb();
         for (rgba, rgb) in self
             .frame_rgba_buffer
             .chunks_exact_mut(4)

--- a/src/frontends/web/wasm_tests.rs
+++ b/src/frontends/web/wasm_tests.rs
@@ -989,6 +989,22 @@ fn wasm_gba_no_rom_renders_opaque_black_frame() {
 }
 
 #[wasm_bindgen_test]
+fn wasm_gba_no_rom_renders_native_rgb_frame() {
+    let mut gba = WasmGba::new();
+    let frame = gba.render_frame_rgb().to_vec();
+    let expected_len = 240 * 160 * 3;
+    assert_eq!(
+        frame.len(),
+        expected_len,
+        "native RGB frame should be {expected_len} bytes"
+    );
+    assert!(
+        frame.iter().all(|&byte| byte == 0x00),
+        "no-ROM native RGB frame should be black"
+    );
+}
+
+#[wasm_bindgen_test]
 fn wasm_gba_load_rom_returns_success_toast() {
     let mut gba = WasmGba::new();
     let rom = minimal_gba_rom();

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -112,6 +112,11 @@ impl Gba {
     /// GBA display height in pixels.
     pub const SCREEN_HEIGHT: u32 = SCREEN_HEIGHT;
 
+    /// Borrow the 240x160 RGB888 framebuffer without cloning it.
+    pub(crate) fn framebuffer_rgb(&self) -> &[u8] {
+        self.bus.ppu.framebuffer()
+    }
+
     /// Create a new GBA emulator instance.
     pub fn new(app_context: impl IntoSharedAppContext) -> Self {
         let app_context = app_context.into_shared();
@@ -544,6 +549,17 @@ mod tests {
         let snapshot = gba.screen_snapshot();
         // 240 × 160 × 3 (RGB888)
         assert_eq!(snapshot.len(), 115200);
+    }
+
+    #[test]
+    fn test_framebuffer_rgb_borrows_full_framebuffer() {
+        let gba = make_gba();
+        let expected_len = (Gba::SCREEN_WIDTH * Gba::SCREEN_HEIGHT * 3) as usize;
+        let snapshot = gba.screen_snapshot();
+        let framebuffer = gba.framebuffer_rgb();
+
+        assert_eq!(framebuffer.len(), expected_len);
+        assert_eq!(framebuffer, snapshot.as_slice());
     }
 
     #[test]

--- a/web/integration/helpers/lifecycle.helpers.ts
+++ b/web/integration/helpers/lifecycle.helpers.ts
@@ -74,9 +74,9 @@ export async function loadRomFromFileInput(page: Page) {
 }
 
 /** Load a minimal GBA ROM via the file input, setting romFromFile = true. */
-export async function loadGbaRomFromFileInput(page: Page) {
+export async function loadGbaRomFromFileInput(page: Page, name = "suite.gba") {
     await page.locator("#rom").setInputFiles({
-        name: "suite.gba",
+        name,
         mimeType: "application/octet-stream",
         buffer: makeMinimalGbaRomBytes()
     });

--- a/web/integration/specs/emulation-lifecycle.integration.spec.ts
+++ b/web/integration/specs/emulation-lifecycle.integration.spec.ts
@@ -78,4 +78,20 @@ test.describe("Phase 1 critical path lifecycle", () => {
         await waitForRunningState(page);
         await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
     });
+
+    test("Given a GBA ROM is loaded, when the canvas is resized, then the GBA aspect ratio is preserved", async ({ page }) => {
+        await openApp(page);
+
+        await loadGbaRomFromFileInput(page);
+        await waitForRunningState(page);
+
+        const canvasSize = await page.locator("#screen").evaluate((canvas) => {
+            if (!(canvas instanceof HTMLCanvasElement)) {
+                throw new Error("Expected #screen to be a canvas");
+            }
+            return { width: canvas.width, height: canvas.height };
+        });
+
+        expect(canvasSize.width / canvasSize.height).toBeCloseTo(240 / 160, 2);
+    });
 });

--- a/web/integration/specs/emulation-lifecycle.integration.spec.ts
+++ b/web/integration/specs/emulation-lifecycle.integration.spec.ts
@@ -79,6 +79,47 @@ test.describe("Phase 1 critical path lifecycle", () => {
         await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
     });
 
+    test("Given a GBA ROM is running, when Reset is clicked, then emulation remains active", async ({ page }) => {
+        const webGlErrors: string[] = [];
+        page.on("console", (msg) => {
+            const text = msg.text();
+            if (text.includes("GL_INVALID_OPERATION")) {
+                webGlErrors.push(text);
+            }
+        });
+        await openApp(page);
+
+        await loadGbaRomFromFileInput(page);
+        await waitForRunningState(page);
+
+        await page.locator(RESET_BUTTON_SELECTOR).click();
+
+        await waitForRunningState(page);
+        await expect(page.locator(PAUSE_BUTTON_SELECTOR)).toHaveText("Pause");
+        await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
+        expect(webGlErrors).toHaveLength(0);
+    });
+
+    test("Given a GBA ROM is running, when another GBA ROM is loaded, then the new session runs without page reload", async ({ page }) => {
+        const webGlErrors: string[] = [];
+        page.on("console", (msg) => {
+            const text = msg.text();
+            if (text.includes("GL_INVALID_OPERATION")) {
+                webGlErrors.push(text);
+            }
+        });
+        await openApp(page);
+
+        await loadGbaRomFromFileInput(page, "first.gba");
+        await waitForRunningState(page);
+
+        await loadGbaRomFromFileInput(page, "second.gba");
+        await waitForRunningState(page);
+
+        await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
+        expect(webGlErrors).toHaveLength(0);
+    });
+
     test("Given a GBA ROM is loaded, when the canvas is resized, then the GBA aspect ratio is preserved", async ({ page }) => {
         await openApp(page);
 

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -748,6 +748,7 @@ function createEmulatorInstance(kind: WebRomConsoleKind): void {
         emulator = { kind: "nes", inst: nes };
     }
     updateNesDisplayDimensions();
+    resizeCanvasForCurrentDisplayMode();
     updateEmulatorKindUI();
 }
 
@@ -2829,6 +2830,16 @@ function updateHandheldCanvasSize() {
         crosshair.updateCanvasSize();
     }
     updateShortcutHelpScale();
+}
+
+function resizeCanvasForCurrentDisplayMode() {
+    if (isInFullscreen() && !isHandheldDevice()) {
+        updateCanvasSizeForFullscreenViewport();
+    } else if (isHandheldDevice()) {
+        updateHandheldCanvasSize();
+    } else {
+        updateCanvasSize(currentHeight);
+    }
 }
 
 function updateShortcutHelpScale() {

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -544,7 +544,7 @@ function setupGbPrograms() {
     return true;
 }
 
-function renderFrameWithCurrentPipeline(frame: Uint8Array): boolean {
+function renderFrameWithCurrentPipeline(frame: Uint8Array, sourceFormat: number): boolean {
     const pipeline = selectRenderPipeline({
         filterType: filters[currentFilter]?.type,
         gbAssetsLoaded,
@@ -559,7 +559,7 @@ function renderFrameWithCurrentPipeline(frame: Uint8Array): boolean {
         return renderGbPass(frame);
     }
 
-    return renderSinglePass(frame);
+    return renderSinglePass(frame, sourceFormat);
 }
 
 function setupFilterPrograms(filterName: string) {
@@ -605,7 +605,7 @@ function initWebGL() {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 
     // Allocate texture storage once (we'll update with texSubImage2D per frame)
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    allocateFrameTextureStorage();
 
     // Create vertex buffers for a full-screen quad
     positionBuffer = gl.createBuffer();
@@ -659,6 +659,16 @@ type ActiveEmulator =
 let emulator: ActiveEmulator | null = null;
 /** Convenience alias for NES-specific code paths. Non-null only when emulator.kind === "nes". */
 let nes: WasmNes | null = null;
+
+function frameTextureFormat(): number {
+    return emulator?.kind === "gba" ? gl.RGB : gl.RGBA;
+}
+
+function allocateFrameTextureStorage() {
+    const textureFormat = frameTextureFormat();
+    gl.texImage2D(gl.TEXTURE_2D, 0, textureFormat, width, height, 0, textureFormat, gl.UNSIGNED_BYTE, null);
+}
+
 let romBytes: Uint8Array | null = null;
 let romMetadata: { name: string; size: number; bytes: Uint8Array } | null = null;
 let saveStateController: { save(): Promise<boolean>; load(): Promise<boolean> } | null = null;
@@ -2133,7 +2143,7 @@ function renderGbPass(frame: Uint8Array): boolean {
     return true;
 }
 
-function renderSinglePass(frame: Uint8Array) {
+function renderSinglePass(frame: Uint8Array, sourceFormat = gl.RGBA) {
     if (!shaderProgram) {
         console.error("Shader program is null, cannot render");
         return false;
@@ -2141,7 +2151,7 @@ function renderSinglePass(frame: Uint8Array) {
 
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, nesTexture);
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, frame);
+    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, sourceFormat, gl.UNSIGNED_BYTE, frame);
 
     gl.useProgram(shaderProgram);
     if (shaderProgram._uTextureSizeLocation) {
@@ -2253,7 +2263,10 @@ function step(timestamp: number) {
         }
 
         const wasmT0 = performance.now();
-        const frame = emulator!.inst.render_frame_rgba(); // RGBA8888
+        const frame = emulator!.kind === "gba"
+            ? emulator!.inst.render_frame_rgb()
+            : emulator!.inst.render_frame_rgba();
+        const sourceFormat = frameTextureFormat();
         const wasmElapsedMs = performance.now() - wasmT0;
 
         // Stop when pure NES autorun playback has consumed all recorded frames
@@ -2266,7 +2279,7 @@ function step(timestamp: number) {
         let rendered = true;
         const renderT0 = performance.now();
         if (shouldRender) {
-            rendered = renderFrameWithCurrentPipeline(frame);
+            rendered = renderFrameWithCurrentPipeline(frame, sourceFormat);
         }
         const renderElapsedMs = performance.now() - renderT0;
 

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -12,6 +12,7 @@ import { applyJoypadButtonIfAllowed, applyMouseMotion, applyMouseButton, isZappe
 import { createSaveStateContext } from "./save-state/save_state_context";
 import { fetchRomList } from "./rom/rom_list";
 import { handleRomSelection } from "./rom/rom_selection";
+import { shouldCreateFreshEmulatorForRomStart } from "./rom/emulator_lifecycle";
 import { supportedRomExtensionsText, webRomConsoleKindForName, webRomExtensionForName, type WebRomConsoleKind } from "./rom/rom_extensions";
 import { createAutorunContext, parseAutorunFile } from "./rom/autorun_context";
 import { createFrameLimiter } from "./audio/frame_limiter";
@@ -544,7 +545,7 @@ function setupGbPrograms() {
     return true;
 }
 
-function renderFrameWithCurrentPipeline(frame: Uint8Array, sourceFormat: number): boolean {
+function renderFrameWithCurrentPipeline(frame: Uint8Array, sourceFormat = gl.RGBA): boolean {
     const pipeline = selectRenderPipeline({
         filterType: filters[currentFilter]?.type,
         gbAssetsLoaded,
@@ -978,7 +979,7 @@ function updateNesDisplayDimensions() {
     // Reallocate the texture with the correct dimensions.
     if (nesTexture) {
         gl.bindTexture(gl.TEXTURE_2D, nesTexture);
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        allocateFrameTextureStorage();
     }
 }
 let lastFrameTime = 0;
@@ -1236,10 +1237,9 @@ async function start() {
             if (!initWebGL()) {
                 throw new Error("Failed to initialize WebGL");
             }
+        }
 
-            createEmulatorInstance(consoleKind);
-        } else if (emulator.kind !== consoleKind) {
-            // Switching emulator kind (NES ↔ GB).
+        if (shouldCreateFreshEmulatorForRomStart(emulator?.kind ?? null, consoleKind)) {
             createEmulatorInstance(consoleKind);
         }
 
@@ -2376,7 +2376,7 @@ if (!pauseBtn || !stopBtn || !resetBtn) {
 pauseBtn.addEventListener("click", pauseResume);
 stopBtn.addEventListener("click", stop);
 resetBtn.addEventListener("click", () => {
-    resetAction();
+    void resetAction();
 });
 
 async function populateRomSelect() {
@@ -2953,18 +2953,67 @@ async function toggleScreenFullscreen() {
     }
 }
 
-function resetAction() {
+async function resetAction() {
     if (!emulator) return;
     cancelActiveRecording();
+    if (emulator.kind === "gba") {
+        await restartGbaSession("Soft reset");
+        return;
+    }
     emulator.inst.reset(true);
     setStatus("Soft reset", false);
 }
 
-function hardResetAction() {
+async function hardResetAction() {
     if (!emulator) return;
     cancelActiveRecording();
+    if (emulator.kind === "gba") {
+        await restartGbaSession("Hard reset");
+        return;
+    }
     emulator.inst.reset(false);
     setStatus("Hard reset", false);
+}
+
+async function restartGbaSession(status: string) {
+    if (!romBytes || !romMetadata) return;
+    const shouldScheduleFrameLoop = !running || paused;
+    try {
+        createEmulatorInstance("gba");
+        emulator!.inst.load_rom(romBytes, romMetadata.name);
+        drainNesToasts(emulator?.inst ?? null, toastOverlay);
+        frameLimiter.setTargetFps(emulator!.inst.frame_rate_hz());
+        await initAudioContext();
+        if (audioContext) nextAudioTime = audioContext.currentTime;
+        emulator!.inst.set_audio_muted(audioMuted);
+        await refreshSaveStateController();
+        running = true;
+        paused = false;
+        lastFrameTime = 0;
+        fpsFrames = 0;
+        fpsLastTime = 0;
+        fpsWasmTimeAccMs = 0;
+        fpsRenderTimeAccMs = 0;
+        frameLimiter.reset();
+        if (isTouchDevice()) document.body.classList.add("touch-running");
+        if (isHandheldDevice()) updateHandheldCanvasSize();
+        const sidebarToggle = document.getElementById("sidebar-toggle") as HTMLInputElement | null;
+        if (sidebarToggle) sidebarToggle.checked = false;
+        setStatus(status, false);
+        updateMouseCursorState();
+        updateAutorunControls();
+        updateEmulationButtons();
+        updateSaveStateButtons();
+        if (shouldScheduleFrameLoop) {
+            requestAnimationFrame(step);
+        }
+    } catch (err) {
+        drainNesToasts(emulator?.inst ?? null, toastOverlay);
+        running = false;
+        paused = false;
+        setStatus(`Failed to reset GBA: ${err}`, true);
+        updateEmulationButtons();
+    }
 }
 
 /** Cancel an active autorun recording (if any), updating UI and showing a toast. */

--- a/web/src/input/keyboard_mapping.test.ts
+++ b/web/src/input/keyboard_mapping.test.ts
@@ -6,28 +6,26 @@ function event(key: string, code = key): Pick<KeyboardEvent, "key" | "code"> {
     return { key, code };
 }
 
-it("maps GBA keyboard face buttons and shoulders", () => {
-    expect(gbaKeyboardButtonForEvent(event("z", "KeyZ"))).toBe(0);
-    expect(gbaKeyboardButtonForEvent(event("x", "KeyX"))).toBe(1);
-    expect(gbaKeyboardButtonForEvent(event("a", "KeyA"))).toBe(8);
-    expect(gbaKeyboardButtonForEvent(event("s", "KeyS"))).toBe(9);
+it("maps GBA keyboard face buttons", () => {
+    expect(gbaKeyboardButtonForEvent(event("g", "KeyG"))).toBe(0);
+    expect(gbaKeyboardButtonForEvent(event("f", "KeyF"))).toBe(1);
 });
 
 it("maps GBA keyboard system buttons", () => {
     expect(gbaKeyboardButtonForEvent(event("5", "Digit5"))).toBe(3);
-    expect(gbaKeyboardButtonForEvent(event("Enter", "Enter"))).toBe(3);
-    expect(gbaKeyboardButtonForEvent(event("Shift", "ShiftLeft"))).toBe(2);
-    expect(gbaKeyboardButtonForEvent(event("Shift", "ShiftRight"))).toBe(2);
-    expect(gbaKeyboardButtonForEvent(event("Backspace", "Backspace"))).toBe(2);
+    expect(gbaKeyboardButtonForEvent(event("4", "Digit4"))).toBe(2);
 });
 
 it("maps GBA keyboard d-pad buttons", () => {
-    expect(gbaKeyboardButtonForEvent(event("ArrowUp", "ArrowUp"))).toBe(4);
-    expect(gbaKeyboardButtonForEvent(event("ArrowDown", "ArrowDown"))).toBe(5);
-    expect(gbaKeyboardButtonForEvent(event("v", "KeyV"))).toBe(6);
-    expect(gbaKeyboardButtonForEvent(event("b", "KeyB"))).toBe(7);
-    expect(gbaKeyboardButtonForEvent(event("ArrowLeft", "ArrowLeft"))).toBe(6);
-    expect(gbaKeyboardButtonForEvent(event("ArrowRight", "ArrowRight"))).toBe(7);
+    expect(gbaKeyboardButtonForEvent(event("w", "KeyW"))).toBe(4);
+    expect(gbaKeyboardButtonForEvent(event("s", "KeyS"))).toBe(5);
+    expect(gbaKeyboardButtonForEvent(event("a", "KeyA"))).toBe(6);
+    expect(gbaKeyboardButtonForEvent(event("d", "KeyD"))).toBe(7);
+});
+
+it("maps GBA keyboard shoulder buttons", () => {
+    expect(gbaKeyboardButtonForEvent(event("v", "KeyV"))).toBe(8);
+    expect(gbaKeyboardButtonForEvent(event("b", "KeyB"))).toBe(9);
 });
 
 it("ignores keys outside the GBA keyboard mapping", () => {

--- a/web/src/input/keyboard_mapping.test.ts
+++ b/web/src/input/keyboard_mapping.test.ts
@@ -14,15 +14,18 @@ it("maps GBA keyboard face buttons and shoulders", () => {
 });
 
 it("maps GBA keyboard system buttons", () => {
+    expect(gbaKeyboardButtonForEvent(event("5", "Digit5"))).toBe(3);
     expect(gbaKeyboardButtonForEvent(event("Enter", "Enter"))).toBe(3);
     expect(gbaKeyboardButtonForEvent(event("Shift", "ShiftLeft"))).toBe(2);
     expect(gbaKeyboardButtonForEvent(event("Shift", "ShiftRight"))).toBe(2);
     expect(gbaKeyboardButtonForEvent(event("Backspace", "Backspace"))).toBe(2);
 });
 
-it("maps GBA keyboard d-pad arrows", () => {
+it("maps GBA keyboard d-pad buttons", () => {
     expect(gbaKeyboardButtonForEvent(event("ArrowUp", "ArrowUp"))).toBe(4);
     expect(gbaKeyboardButtonForEvent(event("ArrowDown", "ArrowDown"))).toBe(5);
+    expect(gbaKeyboardButtonForEvent(event("v", "KeyV"))).toBe(6);
+    expect(gbaKeyboardButtonForEvent(event("b", "KeyB"))).toBe(7);
     expect(gbaKeyboardButtonForEvent(event("ArrowLeft", "ArrowLeft"))).toBe(6);
     expect(gbaKeyboardButtonForEvent(event("ArrowRight", "ArrowRight"))).toBe(7);
 });

--- a/web/src/input/keyboard_mapping.ts
+++ b/web/src/input/keyboard_mapping.ts
@@ -7,14 +7,17 @@ export function gbaKeyboardButtonForEvent(event: Pick<KeyboardEvent, "key" | "co
             return 1;
         case "backspace":
             return 2;
+        case "5":
         case "enter":
             return 3;
         case "arrowup":
             return 4;
         case "arrowdown":
             return 5;
+        case "v":
         case "arrowleft":
             return 6;
+        case "b":
         case "arrowright":
             return 7;
         case "a":

--- a/web/src/input/keyboard_mapping.ts
+++ b/web/src/input/keyboard_mapping.ts
@@ -1,33 +1,27 @@
 export function gbaKeyboardButtonForEvent(event: Pick<KeyboardEvent, "key" | "code">): number | null {
     const key = event.key.toLowerCase();
     switch (key) {
-        case "z":
+        case "g":
             return 0;
-        case "x":
+        case "f":
             return 1;
-        case "backspace":
+        case "4":
             return 2;
         case "5":
-        case "enter":
             return 3;
-        case "arrowup":
+        case "w":
             return 4;
-        case "arrowdown":
-            return 5;
-        case "v":
-        case "arrowleft":
-            return 6;
-        case "b":
-        case "arrowright":
-            return 7;
-        case "a":
-            return 8;
         case "s":
+            return 5;
+        case "a":
+            return 6;
+        case "d":
+            return 7;
+        case "v":
+            return 8;
+        case "b":
             return 9;
         default:
-            if (event.code === "ShiftLeft" || event.code === "ShiftRight") {
-                return 2;
-            }
             return null;
     }
 }

--- a/web/src/rom/emulator_lifecycle.test.ts
+++ b/web/src/rom/emulator_lifecycle.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from "vitest";
+import { shouldCreateFreshEmulatorForRomStart } from "./emulator_lifecycle";
+
+it("creates an emulator when no emulator exists", () => {
+    expect(shouldCreateFreshEmulatorForRomStart(null, "gba")).toBe(true);
+});
+
+it("reuses NES and GB emulators when starting another ROM of the same kind", () => {
+    expect(shouldCreateFreshEmulatorForRomStart("nes", "nes")).toBe(false);
+    expect(shouldCreateFreshEmulatorForRomStart("gb", "gb")).toBe(false);
+});
+
+it("creates a fresh emulator when switching console kind", () => {
+    expect(shouldCreateFreshEmulatorForRomStart("nes", "gba")).toBe(true);
+    expect(shouldCreateFreshEmulatorForRomStart("gba", "nes")).toBe(true);
+});
+
+it("creates a fresh GBA emulator when starting another GBA ROM", () => {
+    // GBA web rendering uses the core's native RGB framebuffer, so a fresh
+    // instance keeps lifecycle restarts away from partially reset core state.
+    expect(shouldCreateFreshEmulatorForRomStart("gba", "gba")).toBe(true);
+});

--- a/web/src/rom/emulator_lifecycle.ts
+++ b/web/src/rom/emulator_lifecycle.ts
@@ -1,0 +1,8 @@
+import type { WebRomConsoleKind } from "./rom_extensions";
+
+export function shouldCreateFreshEmulatorForRomStart(
+    currentKind: WebRomConsoleKind | null,
+    nextKind: WebRomConsoleKind,
+) {
+    return currentKind !== nextKind || nextKind === "gba";
+}

--- a/web/src/shortcuts/shortcut_help.test.ts
+++ b/web/src/shortcuts/shortcut_help.test.ts
@@ -143,12 +143,17 @@ it("buildControllerOverlayText shows only one Game Boy controller with A and B",
 it("buildControllerOverlayText reserves X, Y, and shoulder keys for AGB", () => {
     const text = buildControllerOverlayText(0, "gba");
     expect(text).toMatch(/Controller \(Player 1\)/);
+    expect(text).toMatch(/W\/A\/S\/D: D-Pad/);
     expect(text).toMatch(/R: Y/);
     expect(text).toMatch(/T: X/);
     expect(text).toMatch(/F: B/);
     expect(text).toMatch(/G: A/);
-    expect(text).toMatch(/Q: L/);
-    expect(text).toMatch(/E: R/);
+    expect(text).toMatch(/V: L/);
+    expect(text).toMatch(/B: R/);
+    expect(text).toMatch(/4: Select/);
+    expect(text).toMatch(/5: Start/);
+    expect(text).not.toMatch(/Q: L/);
+    expect(text).not.toMatch(/E: R/);
     expect(text).not.toMatch(/Controller \(Player 2\)/);
 });
 

--- a/web/src/shortcuts/shortcut_help.ts
+++ b/web/src/shortcuts/shortcut_help.ts
@@ -17,7 +17,7 @@ const PLAYER_KEYBOARD_BINDINGS = [
     "I/J/K/L: D-Pad\nO: A\nP: B\n9: Select\n0: Start"
 ];
 
-const AGB_KEYBOARD_BINDINGS = "W/A/S/D: D-Pad\nR: Y\nT: X\nF: B\nG: A\nQ: L\nE: R\n4: Select\n5: Start";
+const AGB_KEYBOARD_BINDINGS = "W/A/S/D: D-Pad\nR: Y\nT: X\nF: B\nG: A\nV: L\nB: R\n4: Select\n5: Start";
 
 export type HelpConsoleKind = "nes" | "gb" | "gba";
 

--- a/web/types/neser-wasm.d.ts
+++ b/web/types/neser-wasm.d.ts
@@ -118,6 +118,7 @@ declare module "*/pkg/neser" {
         is_audio_muted(): boolean;
         load_rom(rom: Uint8Array, rom_name: string): void;
         constructor();
+        render_frame_rgb(): Uint8Array;
         render_frame_rgba(): Uint8Array;
         reset(soft_reset: boolean): void;
         screen_height(): number;


### PR DESCRIPTION
## Summary

- Fixes GBA web canvas sizing so the 240x160 aspect ratio is honored.
- Aligns GBA keyboard mapping and help text with the requested layout.
- Avoids cloning the GBA RGB framebuffer on every web frame before RGBA conversion.
- Adds a native GBA RGB web frame path so the browser uploads 240x160 RGB directly instead of converting/uploading RGBA, reducing per-frame work toward the ~60 FPS target.
- Restarts GBA sessions with a fresh emulator instance for Reset/Hard Reset and GBA-to-GBA ROM reloads, including WebGL texture reallocation with the correct RGB/RGBA format.

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- ./scripts/test-dir.sh src/frontends src/gba --skip-integration
- cargo test --no-default-features --lib
- RUSTC_WRAPPER= wasm-pack test --headless --chrome --no-default-features --features wasm
- npm test
- npx playwright test web/integration/specs/emulation-lifecycle.integration.spec.ts
- npm run build
