### PR TITLE
Fix v1.1.0 release shader packaging

### DIFF
--- a/scripts/test_package_release.py
+++ b/scripts/test_package_release.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from scripts.package_release import (
     ReleasePackageConfig,
+    _read_shader_preset_paths,
     collect_shader_dependencies,
     create_release_archive,
     main,
@@ -29,8 +30,45 @@ def write_bytes(path: Path, data: bytes = b"test") -> None:
     path.write_bytes(data)
 
 
+def path_exists_with_exact_case(repo_root: Path, relative_path: Path) -> bool:
+    """Return whether each path segment matches the directory entry casing exactly."""
+
+    current = repo_root
+    for part in relative_path.parts:
+        if not current.is_dir():
+            return False
+        entries = {entry.name for entry in current.iterdir()}
+        if part not in entries:
+            return False
+        current = current / part
+    return current.exists()
+
+
 class PackageReleaseTests(unittest.TestCase):
     """Behavior tests for release archive creation."""
+
+    def test_repository_shader_dependencies_are_collectable(self) -> None:
+        """Release packaging can collect every shader preset configured by the repository."""
+
+        repo_root = Path(__file__).resolve().parents[1]
+
+        dependencies = collect_shader_dependencies(repo_root)
+
+        self.assertIn(Path("shaders/stock.slangp"), dependencies)
+
+    def test_repository_shader_preset_paths_match_exact_vendor_casing(self) -> None:
+        """Configured shader preset paths match vendored filenames on case-sensitive runners."""
+
+        repo_root = Path(__file__).resolve().parents[1]
+        preset_paths = _read_shader_preset_paths(repo_root / "src/platform/shaders.rs")
+
+        mismatches = [
+            path
+            for path in preset_paths
+            if not path_exists_with_exact_case(repo_root, path)
+        ]
+
+        self.assertEqual(mismatches, [])
 
     def test_collect_shader_dependencies_resolves_configured_preset_graph(self) -> None:
         """Configured shader presets include referenced presets, passes, includes, and LUTs."""

--- a/src/frontends/native/shader_manager.rs
+++ b/src/frontends/native/shader_manager.rs
@@ -459,7 +459,7 @@ mod tests {
             ),
             (
                 "sp101-color",
-                "vendor/slang-shaders/handheld/color-mod/SP101-color.slangp",
+                "vendor/slang-shaders/handheld/color-mod/sp101-color.slangp",
             ),
             ("none", "shaders/stock.slangp"),
             (
@@ -476,7 +476,7 @@ mod tests {
             PathBuf::from("shaders/gba-lcd.slangp"),
             PathBuf::from("vendor/slang-shaders/handheld/agb001.slangp"),
             PathBuf::from("vendor/slang-shaders/handheld/color-mod/NSO-gba-color.slangp"),
-            PathBuf::from("vendor/slang-shaders/handheld/color-mod/SP101-color.slangp"),
+            PathBuf::from("vendor/slang-shaders/handheld/color-mod/sp101-color.slangp"),
             PathBuf::from("vendor/slang-shaders/handheld/console-border/gba-lcd-grid-v2.slangp"),
         ];
 

--- a/src/nes/console/config.rs
+++ b/src/nes/console/config.rs
@@ -5403,7 +5403,7 @@ nes-filter=invalid-shader
         let config = parse_config(args);
         assert_eq!(
             config.frontend.shader_path,
-            Some("vendor/slang-shaders/handheld/color-mod/SP101-color.slangp".to_string())
+            Some("vendor/slang-shaders/handheld/color-mod/sp101-color.slangp".to_string())
         );
     }
 
@@ -5467,7 +5467,7 @@ nes-filter=invalid-shader
             .unwrap();
         assert_eq!(
             config.frontend.shader_path,
-            Some("vendor/slang-shaders/handheld/color-mod/SP101-color.slangp".to_string())
+            Some("vendor/slang-shaders/handheld/color-mod/sp101-color.slangp".to_string())
         );
     }
 

--- a/src/platform/shaders.rs
+++ b/src/platform/shaders.rs
@@ -30,7 +30,7 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
     ),
     (
         "sp101-color",
-        "vendor/slang-shaders/handheld/color-mod/SP101-color.slangp",
+        "vendor/slang-shaders/handheld/color-mod/sp101-color.slangp",
     ),
     (
         "gba-lcd-grid",
@@ -72,7 +72,7 @@ mod tests {
     fn test_gba_preset_sp101_color_maps_to_expected_path() {
         assert_preset_path(
             "sp101-color",
-            "vendor/slang-shaders/handheld/color-mod/SP101-color.slangp",
+            "vendor/slang-shaders/handheld/color-mod/sp101-color.slangp",
         );
     }
 


### PR DESCRIPTION
## Summary

- Fix the release-packaging shader path from `SP101-color.slangp` to the vendored `sp101-color.slangp` exact casing.
- Add release packaging regression coverage that verifies configured shader preset paths match vendored filename casing even on case-insensitive filesystems.

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --no-default-features --lib sp101
- source .venv/bin/activate && python -m unittest scripts.test_package_release scripts.test_verify_release_package
- git --no-pager diff --check

## Release note

After this merges to main, the existing failed `v1.1.0` tag should be recreated on the fixed main commit so the Release workflow rebuilds from the corrected shader path.
