### PR TITLE
fix(nes): apply APU channel flags and triangle halt output

### DIFF
--- a/src/nes/apu/apu.rs
+++ b/src/nes/apu/apu.rs
@@ -1204,7 +1204,7 @@ mod tests {
         assert_eq!(apu.frame_counter().get_cycle_counter(), 0);
         assert_eq!(apu.pulse1().output(), 0);
         assert_eq!(apu.pulse2().output(), 0);
-        assert_eq!(apu.triangle().output(), 0); // Triangle is muted with zero counters
+        assert_eq!(apu.triangle().output(), 0); // Triangle DAC starts at 0
         assert_eq!(apu.noise().output(), 0); // Noise is muted with zero length counter
     }
 
@@ -1809,6 +1809,7 @@ mod tests {
         triangle_only.triangle_mut().write_linear_counter(0x7F);
         triangle_only.triangle_mut().trigger_linear_counter_reload();
         write_triangle_length(&mut triangle_only, 0b00001_000);
+        triangle_only.triangle_mut().clock_timer();
 
         let baseline = triangle_only.mix();
         assert!(baseline > 0.0, "Expected non-zero triangle-only mix output");
@@ -1828,6 +1829,7 @@ mod tests {
             .triangle_mut()
             .trigger_linear_counter_reload();
         write_triangle_length(&mut loud_but_muted, 0b00001_000);
+        loud_but_muted.triangle_mut().clock_timer();
 
         // Pulse channels (would be non-zero if enabled)
         loud_but_muted.pulse1_mut().write_control(0b1111_1111);

--- a/src/nes/apu/audio_analysis_triangle_test.rs
+++ b/src/nes/apu/audio_analysis_triangle_test.rs
@@ -161,6 +161,12 @@ mod tests {
         samples.iter().any(|&value| value > 0.0)
     }
 
+    fn all_samples_equal_to(samples: &[f32], expected: f32) -> bool {
+        samples
+            .iter()
+            .all(|&value| value.to_bits() == expected.to_bits())
+    }
+
     fn read_status(device: &mut ApuDevice) -> u8 {
         device.read(0x4015, 0, false).unwrap_or(0)
     }
@@ -188,9 +194,11 @@ mod tests {
         );
 
         let mode = mode_run_length(&runs);
-        let zero_run = runs.iter().find(|(value, _)| *value == 0);
+        let has_double_zero_run = runs
+            .iter()
+            .any(|(value, length)| *value == 0 && *length >= 2 * mode);
         assert!(
-            zero_run.is_some_and(|(_, length)| *length >= 2 * mode),
+            has_double_zero_run,
             "expected double-length run for 0 in 32-step sequence"
         );
     }
@@ -251,6 +259,9 @@ mod tests {
             has_nonzero_output(&initial_outputs),
             "expected audible triangle output before length expires"
         );
+        let held_output = *initial_outputs
+            .last()
+            .expect("expected active triangle samples before halt");
 
         for _ in 0..3 {
             clock_immediate_quarter_and_half(&apu, &mut device);
@@ -258,8 +269,8 @@ mod tests {
 
         let halted_outputs = collect_samples(&apu, 64);
         assert!(
-            halted_outputs.iter().all(|&value| value == 0.0),
-            "expected length counter to gate triangle output"
+            all_samples_equal_to(&halted_outputs, held_output),
+            "expected length counter to halt triangle on its last DAC output"
         );
     }
 
@@ -282,12 +293,15 @@ mod tests {
         clock_immediate_quarter_and_half(&apu, &mut device);
         let outputs = collect_samples(&apu, 32);
         assert!(has_nonzero_output(&outputs), "expected output at counter=1");
+        let held_output = *outputs
+            .last()
+            .expect("expected active triangle samples before linear halt");
 
         clock_immediate_quarter_and_half(&apu, &mut device);
         let outputs = collect_samples(&apu, 32);
         assert!(
-            outputs.iter().all(|&value| value == 0.0),
-            "expected output muted when linear counter reaches 0"
+            all_samples_equal_to(&outputs, held_output),
+            "expected output held when linear counter reaches 0"
         );
     }
 
@@ -357,9 +371,10 @@ mod tests {
         write_triangle_timer_and_length(&mut device, 0x0002, 0x1F);
         clock_immediate_quarter_and_half(&apu, &mut device);
         let outputs = collect_samples(&apu, 32);
+        let held_output = *outputs.first().expect("expected held samples");
         assert!(
-            outputs.iter().all(|&value| value == 0.0),
-            "expected output muted with reload=0"
+            all_samples_equal_to(&outputs, held_output),
+            "expected output held with reload=0"
         );
 
         write_register(&mut device, 0x4008, 0x80 | 0x07); // control on, reload 7
@@ -381,8 +396,8 @@ mod tests {
         let sample_before = collect_samples(&apu, 1)[0];
 
         write_register(&mut device, 0x4015, 0x00);
-        let muted = collect_samples(&apu, 16);
-        assert!(muted.iter().all(|&value| value == 0.0));
+        let halted_outputs = collect_samples(&apu, 16);
+        assert!(all_samples_equal_to(&halted_outputs, sample_before));
 
         write_register(&mut device, 0x4015, 0x04);
         write_triangle_timer_and_length(&mut device, timer, 1);
@@ -407,7 +422,7 @@ mod tests {
         let outputs = collect_samples(&apu, 16);
         assert!(
             outputs.iter().all(|&value| value == 0.0),
-            "expected output muted when linear counter is zero"
+            "expected initial DAC output held at zero when linear counter is zero"
         );
 
         write_register(&mut device, 0x4008, 0x04);
@@ -419,12 +434,15 @@ mod tests {
             has_nonzero_output(&outputs),
             "expected output when both counters are non-zero"
         );
+        let held_output = *outputs
+            .last()
+            .expect("expected active triangle samples before halt");
 
         write_register(&mut device, 0x4015, 0x00);
         let outputs = collect_samples(&apu, 16);
         assert!(
-            outputs.iter().all(|&value| value == 0.0),
-            "expected output muted when length counter is zero"
+            all_samples_equal_to(&outputs, held_output),
+            "expected triangle DAC to hold its last output when length counter is zero"
         );
     }
 
@@ -438,14 +456,17 @@ mod tests {
 
         write_register(&mut device, 0x4015, 0x00);
         assert_eq!(read_status(&mut device) & 0x04, 0);
-        let muted = collect_samples(&apu, 16);
-        assert!(muted.iter().all(|&value| value == 0.0));
+        let held_output = *initial
+            .last()
+            .expect("expected active triangle samples before disable");
+        let halted = collect_samples(&apu, 16);
+        assert!(all_samples_equal_to(&halted, held_output));
 
         write_register(&mut device, 0x4015, 0x04);
-        let still_muted = collect_samples(&apu, 16);
+        let still_halted = collect_samples(&apu, 16);
         assert!(
-            still_muted.iter().all(|&value| value == 0.0),
-            "expected triangle to remain muted until $400B reload"
+            all_samples_equal_to(&still_halted, held_output),
+            "expected triangle to remain halted until $400B reload"
         );
 
         write_triangle_timer_and_length(&mut device, 0x0004, 1);
@@ -497,10 +518,13 @@ mod tests {
             let outputs = collect_samples(&apu, 16);
             assert!(has_nonzero_output(&outputs));
         }
+        let held_output = *collect_samples(&apu, 1)
+            .last()
+            .expect("expected active triangle sample before duration expiry");
 
         clock_immediate_quarter_and_half(&apu, &mut device);
         let outputs = collect_samples(&apu, 16);
-        assert!(outputs.iter().all(|&value| value == 0.0));
+        assert!(all_samples_equal_to(&outputs, held_output));
     }
 
     #[test]

--- a/src/nes/apu/triangle.rs
+++ b/src/nes/apu/triangle.rs
@@ -20,6 +20,8 @@ pub struct TriangleState {
     pub linear_counter_reload_flag: bool,
     pub control_flag: bool,
     pub sequence_position: u8,
+    #[serde(default)]
+    pub output: u8,
 }
 
 pub struct Triangle {
@@ -29,6 +31,7 @@ pub struct Triangle {
 
     // Sequencer fields (32-step triangle wave)
     sequence_position: u8,
+    output: u8,
 
     // Linear counter fields
     linear_counter: u8,
@@ -63,6 +66,7 @@ impl Triangle {
             timer_period: 0,
             timer_counter: 0,
             sequence_position: 0,
+            output: 0,
             linear_counter: 0,
             linear_counter_reload_value: 0,
             linear_counter_reload_flag: false,
@@ -98,6 +102,7 @@ impl Triangle {
     /// Clock the sequencer (advances through triangle wave)
     fn clock_sequencer(&mut self) {
         self.sequence_position = (self.sequence_position + 1) % TRIANGLE_SEQUENCE_LENGTH;
+        self.output = TRIANGLE_SEQUENCE[self.sequence_position as usize];
     }
 
     /// Expose the current sequencer position for integration tests.
@@ -108,11 +113,7 @@ impl Triangle {
 
     /// Get the current output sample from the triangle channel
     pub fn output(&self) -> u8 {
-        // Triangle is muted when either linear counter or length counter is zero
-        if self.linear_counter == 0 || self.length_counter.value() == 0 {
-            return 0;
-        }
-        TRIANGLE_SEQUENCE[self.sequence_position as usize]
+        self.output
     }
 
     /// Write to $4008 register (linear counter control and reload value)
@@ -261,6 +262,7 @@ impl Triangle {
             linear_counter_reload_flag: self.linear_counter_reload_flag,
             control_flag: self.control_flag,
             sequence_position: self.sequence_position,
+            output: self.output,
         }
     }
 
@@ -285,6 +287,7 @@ impl Triangle {
         self.linear_counter_reload_flag = state.linear_counter_reload_flag;
         self.control_flag = state.control_flag;
         self.sequence_position = state.sequence_position;
+        self.output = state.output;
     }
 }
 
@@ -318,6 +321,7 @@ mod tests {
         assert_eq!(triangle.timer_period, 0);
         assert_eq!(triangle.timer_counter, 0);
         assert_eq!(triangle.sequence_position, 0);
+        assert_eq!(triangle.output(), 0);
         assert_eq!(triangle.linear_counter, 0);
         assert_eq!(triangle.get_length_counter(), 0);
     }
@@ -332,14 +336,16 @@ mod tests {
         triangle.set_length_counter_enabled(true);
         load_length(&mut triangle, 0); // 10
 
-        // The triangle wave should produce values 0-15 ascending, then 15-0 descending
-        // Creating a 32-step sequence: 15,14,13,...,1,0,0,1,2,...,14,15
+        // The DAC output starts at 0 and updates only when the sequencer clocks.
+        // The timer advances the sequence before latching the next DAC value.
         let expected_sequence = vec![
-            15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // Descending
+            14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, // Descending
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, // Ascending
+            15, // Wrapped to sequence position 0
         ];
 
         for expected_value in expected_sequence {
+            triangle.clock_timer();
             assert_eq!(
                 triangle.output(),
                 expected_value,
@@ -347,7 +353,6 @@ mod tests {
                 expected_value,
                 triangle.sequence_position
             );
-            triangle.clock_timer();
         }
 
         // After 32 steps, should wrap back to start
@@ -518,7 +523,7 @@ mod tests {
     }
 
     #[test]
-    fn test_length_counter_zero_mutes_output_but_linear_counter_still_clocks() {
+    fn test_length_counter_zero_holds_output_but_linear_counter_still_clocks() {
         let mut triangle = Triangle::new();
 
         // Set length to a small value: table index 3 => length 2.
@@ -533,20 +538,22 @@ mod tests {
         triangle.clock_linear_counter_with_reload();
         assert_eq!(triangle.get_linear_counter(), 3);
 
-        // Output is audible while both counters are non-zero.
+        // Output is audible after the timer clocks while both counters are non-zero.
+        triangle.clock_timer();
         assert_ne!(triangle.output(), 0);
+        let held_output = triangle.output();
 
         // Length counter decrements on half-frame clocks.
         triangle.clock_length_counter();
         assert_eq!(triangle.get_length_counter(), 1);
-        assert_ne!(triangle.output(), 0);
+        assert_eq!(triangle.output(), held_output);
 
-        // Output stops exactly when length reaches zero.
+        // Output holds when length reaches zero; only sequencer advancement stops.
         triangle.clock_length_counter();
         assert_eq!(triangle.get_length_counter(), 0);
-        assert_eq!(triangle.output(), 0);
+        assert_eq!(triangle.output(), held_output);
 
-        // Linear counter still behaves internally even while output is muted by length=0.
+        // Linear counter still behaves internally while length=0 halts the sequencer.
         triangle.clock_linear_counter_with_reload();
         assert_eq!(triangle.get_linear_counter(), 2);
         triangle.clock_linear_counter_with_reload();
@@ -558,7 +565,7 @@ mod tests {
         triangle.set_linear_counter_reload_flag();
         triangle.clock_linear_counter_with_reload();
         assert_eq!(triangle.get_linear_counter(), 3);
-        assert_eq!(triangle.output(), 0);
+        assert_eq!(triangle.output(), held_output);
     }
 
     #[test]
@@ -652,65 +659,71 @@ mod tests {
     }
 
     #[test]
-    fn test_output_muted_when_counters_zero() {
+    fn test_output_holds_last_value_when_counters_zero() {
         let mut triangle = Triangle::new();
         triangle.timer_period = 0;
         triangle.set_length_counter_enabled(true);
 
-        // Triangle should be muted when linear counter is 0
+        // With no prior DAC output, halted triangle output remains 0.
         triangle.set_linear_counter_reload(0);
         triangle.trigger_linear_counter_reload();
         load_length(&mut triangle, 1); // Length counter = 254
-        assert_eq!(triangle.output(), 0); // Muted
+        assert_eq!(triangle.output(), 0);
 
-        // Triangle should be muted when length counter is 0
+        // With no prior DAC output, length-gated triangle output remains 0.
         triangle.set_linear_counter_reload(10);
         triangle.trigger_linear_counter_reload();
         triangle.clear_length_counter();
-        assert_eq!(triangle.output(), 0); // Muted
+        assert_eq!(triangle.output(), 0);
 
-        // Triangle should output when both counters are non-zero
+        // Triangle latches a non-zero DAC value once both counters are non-zero
+        // and the timer clocks the sequencer.
         triangle.linear_counter = 5;
         load_length(&mut triangle, 1); // Length counter = 254
-        assert_eq!(triangle.output(), 15); // Not muted, returns sequence value
+        triangle.clock_timer();
+        assert_ne!(triangle.output(), 0);
     }
 
     #[test]
-    fn test_output_mutes_immediately_when_linear_counter_zero_and_recovers() {
+    fn test_output_holds_immediately_when_linear_counter_zero_and_recovers() {
         let mut triangle = Triangle::new();
         triangle.set_length_counter_enabled(true);
         load_length(&mut triangle, 1); // Non-zero length
 
         // Start audible.
         triangle.linear_counter = 5;
+        triangle.clock_timer();
         assert_ne!(triangle.output(), 0);
+        let held_output = triangle.output();
 
-        // Force linear counter to zero: output must go silent immediately.
+        // Force linear counter to zero: output holds its last DAC value.
         triangle.linear_counter = 0;
-        assert_eq!(triangle.output(), 0);
+        assert_eq!(triangle.output(), held_output);
 
         // Recover by restoring linear counter to non-zero.
         triangle.linear_counter = 5;
-        assert_ne!(triangle.output(), 0);
+        assert_eq!(triangle.output(), held_output);
     }
 
     #[test]
-    fn test_output_mutes_immediately_when_length_counter_zero_and_recovers() {
+    fn test_output_holds_immediately_when_length_counter_zero_and_recovers() {
         let mut triangle = Triangle::new();
         triangle.set_length_counter_enabled(true);
 
         // Start audible.
         triangle.linear_counter = 5;
         load_length(&mut triangle, 3); // index 3 => length 2
+        triangle.clock_timer();
         assert_ne!(triangle.output(), 0);
+        let held_output = triangle.output();
 
-        // Force length counter to zero: output must go silent immediately.
+        // Force length counter to zero: output holds its last DAC value.
         triangle.clear_length_counter();
-        assert_eq!(triangle.output(), 0);
+        assert_eq!(triangle.output(), held_output);
 
         // Recover by reloading length to a non-zero value.
         load_length(&mut triangle, 3);
-        assert_ne!(triangle.output(), 0);
+        assert_eq!(triangle.output(), held_output);
     }
 
     #[test]

--- a/src/nes/console/nes.rs
+++ b/src/nes/console/nes.rs
@@ -146,6 +146,15 @@ impl Nes {
             config.nes.hardware_mode == crate::nes::console::HardwareMode::Famicom,
         );
         let apu = Rc::new(RefCell::new(Apu::new_with_tv_system(tv_system)));
+        {
+            let channels = config.nes.apu_channels;
+            let mut apu = apu.borrow_mut();
+            apu.set_pulse1_enabled(channels.contains(crate::nes::console::ApuChannels::PULSE1));
+            apu.set_pulse2_enabled(channels.contains(crate::nes::console::ApuChannels::PULSE2));
+            apu.set_triangle_enabled(channels.contains(crate::nes::console::ApuChannels::TRIANGLE));
+            apu.set_noise_enabled(channels.contains(crate::nes::console::ApuChannels::NOISE));
+            apu.set_dmc_enabled(channels.contains(crate::nes::console::ApuChannels::DMC));
+        }
         let memory = Rc::new(RefCell::new(Bus::new(
             ppu.clone(),
             apu.clone(),
@@ -1407,6 +1416,24 @@ pub use savestate_error::SaveStateError;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::config::ParseResult;
+
+    fn parse_cli_config(mut args: Vec<String>) -> Config {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"").unwrap();
+
+        args.push("--config".to_string());
+        args.push(file.path().to_string_lossy().to_string());
+
+        match Config::new(&args).unwrap() {
+            ParseResult::Config(config) => *config,
+            ParseResult::Help => panic!("Expected Config, got Help"),
+            ParseResult::Version => panic!("Expected Config, got Version"),
+        }
+    }
 
     fn load_test_cartridge(rom_data: &[u8]) -> Cartridge {
         Cartridge::load_from_file(rom_data, "nes-test-rom.nes", None)
@@ -1459,6 +1486,38 @@ mod tests {
             (fps - 50.00698).abs() < 0.01,
             "PAL frame rate should be ~50.00698 Hz, got {fps}"
         );
+    }
+
+    #[test]
+    fn test_nes_new_applies_cli_disabled_apu_channels() {
+        let config = parse_cli_config(vec![
+            "neser".to_string(),
+            "--disable-nes-pulse1".to_string(),
+            "--disable-nes-pulse2".to_string(),
+            "--disable-nes-triangle".to_string(),
+            "--disable-nes-noise".to_string(),
+            "--disable-nes-dmc".to_string(),
+        ]);
+
+        let mut nes = Nes::new(crate::platform::app_context::AppContext::new_with_config(
+            config,
+        ));
+        nes.insert_cartridge(load_test_cartridge(&create_minimal_rom()));
+
+        assert_all_apu_channels_disabled(&nes);
+        nes.reset(true);
+        assert_all_apu_channels_disabled(&nes);
+        nes.reset(false);
+        assert_all_apu_channels_disabled(&nes);
+    }
+
+    fn assert_all_apu_channels_disabled(nes: &Nes) {
+        let apu_state = nes.apu.borrow().capture_state();
+        assert!(!apu_state.pulse1_enabled);
+        assert!(!apu_state.pulse2_enabled);
+        assert!(!apu_state.triangle_enabled);
+        assert!(!apu_state.noise_enabled);
+        assert!(!apu_state.dmc_enabled);
     }
 
     #[test]

--- a/src/nes/integration_tests/apu_audio_tests.rs
+++ b/src/nes/integration_tests/apu_audio_tests.rs
@@ -419,6 +419,22 @@ mod tests {
         rms
     }
 
+    /// Compute AC-coupled RMS values over sliding windows.
+    fn ac_rms_windows(samples: &[f32], window_size: usize, hop_size: usize) -> Vec<f32> {
+        if window_size == 0 || hop_size == 0 || samples.len() < window_size {
+            return Vec::new();
+        }
+
+        let mut rms = Vec::new();
+        let mut start = 0usize;
+        while start + window_size <= samples.len() {
+            rms.push(ac_coupled_rms(&samples[start..start + window_size]));
+            start += hop_size;
+        }
+
+        rms
+    }
+
     /// Count how many distinct period plateaus appear, based on a tolerance.
     fn count_period_segments(periods: &[f32], tolerance: f32) -> usize {
         if periods.is_empty() {
@@ -1542,12 +1558,12 @@ mod tests {
     #[test]
     fn test_tri_lin_ctr() {
         // The ROM tests the triangle linear counter in three phases:
-        //   1. Silence – various linear-counter manipulations that should produce no sound
+        //   1. No waveform – linear-counter manipulations halt the triangle sequencer
         //   2. Noise marker – a brief noise burst separating the phases
         //   3. Continuous triangle – linear counter reloaded and sustained
         //
         // Strategy: two captures (triangle-only + noise-only) to locate the noise
-        // marker via RMS, then verify silence before it and sustained activity after.
+        // marker via RMS, then verify no AC waveform before it and sustained activity after.
 
         let rom_path = "roms/nes/automated_tests/test_tri_lin_ctr/lin_ctr.nes";
 
@@ -1584,7 +1600,7 @@ mod tests {
         let window_samples = (SAMPLE_RATE_HZ * 0.20) as usize;
         let hop_samples = window_samples;
 
-        let tri_rms = rms_windows(tri_samples, window_samples, hop_samples);
+        let tri_rms = ac_rms_windows(tri_samples, window_samples, hop_samples);
         let noise_rms = rms_windows(noise_samples, window_samples, hop_samples);
         assert!(
             !tri_rms.is_empty(),
@@ -1602,25 +1618,28 @@ mod tests {
         let tri_max = tri_rms.iter().copied().fold(0.0f32, f32::max);
         assert!(tri_max > 0.0, "no triangle audio captured");
         let silence_threshold = tri_max * 0.05;
+        let click_threshold = tri_max * 0.50;
 
-        // Phase 1 – Silence: all triangle windows before the noise marker must be silent.
+        // Phase 1 – no sustained triangle waveform. The ROM documentation allows
+        // a few slight pops/clicks before the noise marker, so permit a short
+        // transient but reject full-strength triangle output.
         for (index, &rms) in tri_rms.iter().enumerate().take(noise_start) {
             assert!(
-                rms <= silence_threshold,
-                "expected silence in window {} before noise marker (rms={}, threshold={})",
+                rms <= click_threshold,
+                "expected at most triangle click/transient before noise marker at window {} (ac_rms={}, threshold={})",
                 index,
                 rms,
-                silence_threshold
+                click_threshold
             );
         }
 
-        // Phase 2 – During the noise marker, triangle should also be silent.
+        // Phase 2 – During the noise marker, triangle should also have no AC waveform.
         let noise_window_end = noise_end.min(tri_rms.len());
         for (offset, &rms) in tri_rms[noise_start..noise_window_end].iter().enumerate() {
             let window = noise_start + offset;
             assert!(
                 rms <= silence_threshold,
-                "expected triangle silence during noise marker window {} (rms={})",
+                "expected no triangle waveform during noise marker window {} (ac_rms={})",
                 window,
                 rms
             );


### PR DESCRIPTION
## Summary
- Apply configured NES APU channel mask to the live APU during Nes construction.
- Add regression coverage for CLI disable flags and reset persistence.
- Model NES triangle output as a latched DAC value that holds when the length or linear counter halts the sequencer.
- Update triangle APU and integration tests to assert held output/no sustained waveform instead of forcing halted output to zero.

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- ./scripts/test-dir.sh src/nes/apu
- cargo test --no-default-features --lib
