### PR TITLE
fix(ci): authenticate release changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v6
@@ -110,7 +111,9 @@ jobs:
           tool: git-cliff
 
       - name: Generate changelog
-        run: git-cliff -l --strip header --github-repo rmstdope/neser --output RELEASE_NOTES.md
+        run: git-cliff -l --strip header --github-repo "${{ github.repository }}" --output RELEASE_NOTES.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Create release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Pass GITHUB_TOKEN to git-cliff during release changelog generation.
- Grant the release job pull-requests: read so git-cliff can fetch PR metadata.
- Use github.repository instead of hard-coding the owner/repo.

## Validation
- gh api repos/rmstdope/neser/pulls?per_page=100&page=13\&state=closed --jq length
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"

## Release note
After this lands on main, recreate or move the v1.1.1 tag to a commit that contains this workflow change, then push the tag again. The failed run used the workflow from the tagged commit, so rerunning the old tag will still use the old workflow.
