### PR TITLE
Add GBA 60 FPS benchmark tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,11 @@ path = "src/bin/frame_bench.rs"
 required-features = ["native"]
 
 [[bin]]
+name = "gba_frame_bench"
+path = "src/bin/gba_frame_bench.rs"
+required-features = ["native"]
+
+[[bin]]
 name = "gamepad_test"
 path = "src/bin/gamepad_test.rs"
 required-features = ["native"]

--- a/src/bin/gba_frame_bench.rs
+++ b/src/bin/gba_frame_bench.rs
@@ -115,9 +115,8 @@ fn print_summary(label: &str, bench_config: &FrameBenchmarkConfig, stats: &Frame
 fn usage() -> &'static str {
     "Usage: gba_frame_bench <rom_path> [--frames N] [--warmup N] [--stability-runs N] [--include-bios-intro] [--continue-stability-runs]\n\
 \n\
-Benchmarks GBA frame execution using the embedded BIOS. By default the GBA BIOS intro is skipped,\n\
-matching the Metroid Zero Mission title/intro benchmark plan. Stability runs reload the ROM by\n\
-default so each run measures the same title/intro window."
+Benchmarks GBA frame execution using the embedded BIOS. By default the GBA BIOS intro is skipped.\n\
+Stability runs reload the ROM by default so each run measures the same title/intro window."
 }
 
 fn config_error_message(err: FrameBenchmarkConfigError) -> String {

--- a/src/bin/gba_frame_bench.rs
+++ b/src/bin/gba_frame_bench.rs
@@ -113,7 +113,7 @@ fn print_summary(label: &str, bench_config: &FrameBenchmarkConfig, stats: &Frame
 }
 
 fn usage() -> &'static str {
-    "Usage: gba_frame_bench <rom_path> [--frames N] [--warmup N] [--stability-runs N] [--include-bios-intro] [--continue-stability-runs]\n\
+    "Usage: gba_frame_bench <rom_path> [--frames N] [--warmup N] [--stability-runs N] [--skip-bios-intro|--include-bios-intro] [--continue-stability-runs]\n\
 \n\
 Benchmarks GBA frame execution using the embedded BIOS. By default the GBA BIOS intro is skipped.\n\
 Stability runs reload the ROM by default so each run measures the same title/intro window."
@@ -146,6 +146,7 @@ mod tests {
         assert!(usage.contains("--frames"));
         assert!(usage.contains("--warmup"));
         assert!(usage.contains("--stability-runs"));
+        assert!(usage.contains("--skip-bios-intro"));
         assert!(usage.contains("--include-bios-intro"));
         assert!(usage.contains("--continue-stability-runs"));
     }

--- a/src/bin/gba_frame_bench.rs
+++ b/src/bin/gba_frame_bench.rs
@@ -1,0 +1,135 @@
+use neser::gba::Gba;
+use neser::platform::app_context::AppContext;
+use neser::platform::config::Config;
+use neser::platform::emulator::Emulator;
+use neser::platform::frame_benchmark::{
+    FrameBenchmarkConfig, FrameBenchmarkConfigError, FrameTimingStats,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+
+fn main() {
+    if let Err(err) = run(std::env::args().collect()) {
+        eprintln!("{err}");
+        eprintln!("{}", usage());
+        std::process::exit(2);
+    }
+}
+
+fn run(args: Vec<String>) -> Result<(), String> {
+    let bench_config = FrameBenchmarkConfig::parse_args(&args).map_err(config_error_message)?;
+    let rom_data = std::fs::read(&bench_config.rom_path)
+        .map_err(|err| format!("failed to read ROM '{}': {err}", bench_config.rom_path))?;
+
+    let mut gba = create_gba(bench_config.skip_gba_bios_intro);
+    gba.load_rom(&rom_data, &bench_config.rom_path)
+        .map_err(|err| format!("failed to load GBA ROM '{}': {err}", bench_config.rom_path))?;
+    gba.set_audio_sample_rate(44_100.0);
+
+    for _ in 0..bench_config.warmup_frames {
+        run_one_frame(&mut gba);
+    }
+
+    let samples = run_measured_frames(&mut gba, bench_config.frames);
+    let stats = FrameTimingStats::from_samples(&samples)
+        .map_err(|err| format!("failed to compute benchmark stats: {err:?}"))?;
+
+    print_summary("Primary run", &bench_config, &stats);
+
+    if bench_config.stability_runs > 0 {
+        println!(
+            "\nStability check ({} run(s) of {} frames):",
+            bench_config.stability_runs, bench_config.frames
+        );
+        for run_index in 1..=bench_config.stability_runs {
+            let samples = run_measured_frames(&mut gba, bench_config.frames);
+            let stats = FrameTimingStats::from_samples(&samples)
+                .map_err(|err| format!("failed to compute benchmark stats: {err:?}"))?;
+            println!(
+                "  Run {run_index}: avg={:.3}ms p95={:.3}ms max={:.3}ms fps={:.1}",
+                stats.average_ms, stats.p95_ms, stats.max_ms, stats.fps
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn create_gba(skip_bios_intro: bool) -> Gba {
+    let mut config = Config::default();
+    config.gba.bios_path = Some("embedded".to_string());
+    config.gba.skip_bios_intro = skip_bios_intro;
+    let app_context = Rc::new(RefCell::new(AppContext::new_with_config(config)));
+    Gba::new(app_context)
+}
+
+fn run_measured_frames(gba: &mut Gba, frames: usize) -> Vec<Duration> {
+    let mut samples = Vec::with_capacity(frames);
+    for _ in 0..frames {
+        let start = Instant::now();
+        run_one_frame(gba);
+        samples.push(start.elapsed());
+    }
+    samples
+}
+
+fn run_one_frame(gba: &mut Gba) {
+    while !gba.is_ready_to_render() {
+        let _cycles = gba.run_tick();
+        while gba.get_stereo_sample().is_some() {}
+    }
+    gba.clear_ready_to_render();
+}
+
+fn print_summary(label: &str, bench_config: &FrameBenchmarkConfig, stats: &FrameTimingStats) {
+    println!("{label}");
+    println!("ROM: {}", bench_config.rom_path);
+    println!("Frames: {}", stats.frames);
+    println!("Warmup frames: {}", bench_config.warmup_frames);
+    println!("Skip GBA BIOS intro: {}", bench_config.skip_gba_bios_intro);
+    println!("Total: {:.1}ms", stats.total.as_secs_f64() * 1000.0);
+    println!("Average: {:.3}ms/frame", stats.average_ms);
+    println!("P50: {:.3}ms/frame", stats.p50_ms);
+    println!("P95: {:.3}ms/frame", stats.p95_ms);
+    println!("Max: {:.3}ms/frame", stats.max_ms);
+    println!("FPS: {:.1}", stats.fps);
+}
+
+fn usage() -> &'static str {
+    "Usage: gba_frame_bench <rom_path> [--frames N] [--warmup N] [--stability-runs N] [--include-bios-intro]\n\
+\n\
+Benchmarks GBA frame execution using the embedded BIOS. By default the GBA BIOS intro is skipped,\n\
+matching the Metroid Zero Mission title/intro benchmark plan."
+}
+
+fn config_error_message(err: FrameBenchmarkConfigError) -> String {
+    match err {
+        FrameBenchmarkConfigError::MissingRomPath => "missing ROM path".to_string(),
+        FrameBenchmarkConfigError::MissingValue { name } => {
+            format!("missing value for --{name}")
+        }
+        FrameBenchmarkConfigError::InvalidNumber { name, value } => {
+            format!("invalid value for --{name}: '{value}'")
+        }
+        FrameBenchmarkConfigError::UnknownArgument(arg) => {
+            format!("unknown argument: {arg}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_documents_primary_gba_benchmark_options() {
+        let usage = usage();
+
+        assert!(usage.contains("Usage: gba_frame_bench <rom_path>"));
+        assert!(usage.contains("--frames"));
+        assert!(usage.contains("--warmup"));
+        assert!(usage.contains("--stability-runs"));
+        assert!(usage.contains("--include-bios-intro"));
+    }
+}

--- a/src/bin/gba_frame_bench.rs
+++ b/src/bin/gba_frame_bench.rs
@@ -22,11 +22,7 @@ fn run(args: Vec<String>) -> Result<(), String> {
     let rom_data = std::fs::read(&bench_config.rom_path)
         .map_err(|err| format!("failed to read ROM '{}': {err}", bench_config.rom_path))?;
 
-    let mut gba = create_gba(bench_config.skip_gba_bios_intro);
-    gba.load_rom(&rom_data, &bench_config.rom_path)
-        .map_err(|err| format!("failed to load GBA ROM '{}': {err}", bench_config.rom_path))?;
-    gba.set_audio_sample_rate(44_100.0);
-
+    let mut gba = create_loaded_gba(&rom_data, &bench_config)?;
     for _ in 0..bench_config.warmup_frames {
         run_one_frame(&mut gba);
     }
@@ -43,7 +39,15 @@ fn run(args: Vec<String>) -> Result<(), String> {
             bench_config.stability_runs, bench_config.frames
         );
         for run_index in 1..=bench_config.stability_runs {
-            let samples = run_measured_frames(&mut gba, bench_config.frames);
+            let samples = if bench_config.reset_stability_runs {
+                let mut stability_gba = create_loaded_gba(&rom_data, &bench_config)?;
+                for _ in 0..bench_config.warmup_frames {
+                    run_one_frame(&mut stability_gba);
+                }
+                run_measured_frames(&mut stability_gba, bench_config.frames)
+            } else {
+                run_measured_frames(&mut gba, bench_config.frames)
+            };
             let stats = FrameTimingStats::from_samples(&samples)
                 .map_err(|err| format!("failed to compute benchmark stats: {err:?}"))?;
             println!(
@@ -54,6 +58,14 @@ fn run(args: Vec<String>) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn create_loaded_gba(rom_data: &[u8], bench_config: &FrameBenchmarkConfig) -> Result<Gba, String> {
+    let mut gba = create_gba(bench_config.skip_gba_bios_intro);
+    gba.load_rom(rom_data, &bench_config.rom_path)
+        .map_err(|err| format!("failed to load GBA ROM '{}': {err}", bench_config.rom_path))?;
+    gba.set_audio_sample_rate(44_100.0);
+    Ok(gba)
 }
 
 fn create_gba(skip_bios_intro: bool) -> Gba {
@@ -88,6 +100,10 @@ fn print_summary(label: &str, bench_config: &FrameBenchmarkConfig, stats: &Frame
     println!("Frames: {}", stats.frames);
     println!("Warmup frames: {}", bench_config.warmup_frames);
     println!("Skip GBA BIOS intro: {}", bench_config.skip_gba_bios_intro);
+    println!(
+        "Reset stability runs: {}",
+        bench_config.reset_stability_runs
+    );
     println!("Total: {:.1}ms", stats.total.as_secs_f64() * 1000.0);
     println!("Average: {:.3}ms/frame", stats.average_ms);
     println!("P50: {:.3}ms/frame", stats.p50_ms);
@@ -97,10 +113,11 @@ fn print_summary(label: &str, bench_config: &FrameBenchmarkConfig, stats: &Frame
 }
 
 fn usage() -> &'static str {
-    "Usage: gba_frame_bench <rom_path> [--frames N] [--warmup N] [--stability-runs N] [--include-bios-intro]\n\
+    "Usage: gba_frame_bench <rom_path> [--frames N] [--warmup N] [--stability-runs N] [--include-bios-intro] [--continue-stability-runs]\n\
 \n\
 Benchmarks GBA frame execution using the embedded BIOS. By default the GBA BIOS intro is skipped,\n\
-matching the Metroid Zero Mission title/intro benchmark plan."
+matching the Metroid Zero Mission title/intro benchmark plan. Stability runs reload the ROM by\n\
+default so each run measures the same title/intro window."
 }
 
 fn config_error_message(err: FrameBenchmarkConfigError) -> String {
@@ -131,5 +148,6 @@ mod tests {
         assert!(usage.contains("--warmup"));
         assert!(usage.contains("--stability-runs"));
         assert!(usage.contains("--include-bios-intro"));
+        assert!(usage.contains("--continue-stability-runs"));
     }
 }

--- a/src/frontends/web/wasm_gba.rs
+++ b/src/frontends/web/wasm_gba.rs
@@ -25,6 +25,22 @@ impl Default for WasmGba {
 
 #[wasm_bindgen]
 impl WasmGba {
+    fn create_with_skip_bios_intro(skip_bios_intro: bool) -> WasmGba {
+        console_error_panic_hook::set_once();
+        let mut config = crate::platform::config::Config::default();
+        config.gba.skip_bios_intro = skip_bios_intro;
+        let app_context: SharedAppContext =
+            Rc::new(RefCell::new(AppContext::new_with_config(config)));
+        WasmGba {
+            gba: Gba::new(app_context),
+            audio_muted: false,
+            rom_loaded: false,
+            pending_toasts: Vec::new(),
+            frame_rgba_buffer: Vec::new(),
+            frame_rgb_buffer: Vec::new(),
+        }
+    }
+
     fn required_rgba_len() -> usize {
         (Gba::SCREEN_WIDTH * Gba::SCREEN_HEIGHT * 4) as usize
     }
@@ -78,18 +94,12 @@ impl WasmGba {
 
     #[wasm_bindgen(constructor)]
     pub fn new() -> WasmGba {
-        console_error_panic_hook::set_once();
-        let app_context: SharedAppContext = Rc::new(RefCell::new(AppContext::new_with_config(
-            Default::default(),
-        )));
-        WasmGba {
-            gba: Gba::new(app_context),
-            audio_muted: false,
-            rom_loaded: false,
-            pending_toasts: Vec::new(),
-            frame_rgba_buffer: Vec::new(),
-            frame_rgb_buffer: Vec::new(),
-        }
+        Self::create_with_skip_bios_intro(false)
+    }
+
+    #[wasm_bindgen]
+    pub fn new_with_skip_bios_intro(skip_bios_intro: bool) -> WasmGba {
+        Self::create_with_skip_bios_intro(skip_bios_intro)
     }
 
     #[wasm_bindgen]

--- a/src/platform/frame_benchmark.rs
+++ b/src/platform/frame_benchmark.rs
@@ -30,6 +30,120 @@ pub enum FrameTimingStatsError {
     ZeroTotal,
 }
 
+/// Command-line configuration for a frame benchmark binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrameBenchmarkConfig {
+    /// ROM path to benchmark.
+    pub rom_path: String,
+    /// Number of frames in each measured run.
+    pub frames: usize,
+    /// Frames to run before measuring.
+    pub warmup_frames: usize,
+    /// Additional measured runs for stability reporting.
+    pub stability_runs: usize,
+    /// Whether the GBA BIOS intro should be skipped before benchmark warmup.
+    pub skip_gba_bios_intro: bool,
+}
+
+/// Errors returned while parsing benchmark command-line options.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FrameBenchmarkConfigError {
+    /// The ROM path argument was omitted.
+    MissingRomPath,
+    /// A flag that requires a value was missing that value.
+    MissingValue { name: &'static str },
+    /// A numeric argument could not be parsed.
+    InvalidNumber { name: &'static str, value: String },
+    /// An unsupported argument was provided.
+    UnknownArgument(String),
+}
+
+impl FrameBenchmarkConfig {
+    /// Parse frame benchmark command-line arguments.
+    pub fn parse_args(args: &[String]) -> Result<Self, FrameBenchmarkConfigError> {
+        let mut args = args.iter();
+        let _program = args.next();
+        let rom_path = args
+            .next()
+            .ok_or(FrameBenchmarkConfigError::MissingRomPath)?
+            .clone();
+
+        let mut config = Self {
+            rom_path,
+            frames: 600,
+            warmup_frames: 60,
+            stability_runs: 5,
+            skip_gba_bios_intro: true,
+        };
+
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--frames" => {
+                    config.frames = parse_positive_usize_arg(&mut args, "frames")?;
+                }
+                "--warmup" => {
+                    config.warmup_frames = parse_usize_arg(&mut args, "warmup")?;
+                }
+                "--stability-runs" => {
+                    config.stability_runs = parse_usize_arg(&mut args, "stability-runs")?;
+                }
+                "--include-bios-intro" => {
+                    config.skip_gba_bios_intro = false;
+                }
+                "--skip-bios-intro" => {
+                    config.skip_gba_bios_intro = true;
+                }
+                _ => return Err(FrameBenchmarkConfigError::UnknownArgument(arg.clone())),
+            }
+        }
+
+        Ok(config)
+    }
+}
+
+fn parse_usize_arg<'a, I>(
+    args: &mut I,
+    name: &'static str,
+) -> Result<usize, FrameBenchmarkConfigError>
+where
+    I: Iterator<Item = &'a String>,
+{
+    let value = args
+        .next()
+        .ok_or(FrameBenchmarkConfigError::MissingValue { name })?;
+    value
+        .parse()
+        .map_err(|_| FrameBenchmarkConfigError::InvalidNumber {
+            name,
+            value: value.clone(),
+        })
+}
+
+fn parse_positive_usize_arg<'a, I>(
+    args: &mut I,
+    name: &'static str,
+) -> Result<usize, FrameBenchmarkConfigError>
+where
+    I: Iterator<Item = &'a String>,
+{
+    let value = args
+        .next()
+        .ok_or(FrameBenchmarkConfigError::MissingValue { name })?;
+    let parsed = value
+        .parse()
+        .map_err(|_| FrameBenchmarkConfigError::InvalidNumber {
+            name,
+            value: value.clone(),
+        })?;
+    if parsed == 0 {
+        return Err(FrameBenchmarkConfigError::InvalidNumber {
+            name,
+            value: value.clone(),
+        });
+    }
+    Ok(parsed)
+}
+
 impl FrameTimingStats {
     /// Compute summary statistics for measured frame durations.
     pub fn from_samples(samples: &[Duration]) -> Result<Self, FrameTimingStatsError> {
@@ -125,5 +239,142 @@ mod tests {
             FrameTimingStats::from_samples(&[Duration::ZERO]),
             Err(FrameTimingStatsError::ZeroTotal)
         );
+    }
+
+    #[test]
+    fn frame_benchmark_config_uses_gba_title_intro_defaults() {
+        let args = vec![
+            "gba_frame_bench".to_string(),
+            "roms/games/metroid-zero-mission.gba".to_string(),
+        ];
+
+        let config = FrameBenchmarkConfig::parse_args(&args).unwrap();
+
+        assert_eq!(config.rom_path, "roms/games/metroid-zero-mission.gba");
+        assert_eq!(config.frames, 600);
+        assert_eq!(config.warmup_frames, 60);
+        assert_eq!(config.stability_runs, 5);
+        assert!(config.skip_gba_bios_intro);
+    }
+
+    #[test]
+    fn frame_benchmark_config_parses_overrides() {
+        let args = vec![
+            "gba_frame_bench".to_string(),
+            "rom.gba".to_string(),
+            "--frames".to_string(),
+            "120".to_string(),
+            "--warmup".to_string(),
+            "30".to_string(),
+            "--stability-runs".to_string(),
+            "2".to_string(),
+            "--include-bios-intro".to_string(),
+        ];
+
+        let config = FrameBenchmarkConfig::parse_args(&args).unwrap();
+
+        assert_eq!(
+            config,
+            FrameBenchmarkConfig {
+                rom_path: "rom.gba".to_string(),
+                frames: 120,
+                warmup_frames: 30,
+                stability_runs: 2,
+                skip_gba_bios_intro: false,
+            }
+        );
+    }
+
+    #[test]
+    fn frame_benchmark_config_rejects_invalid_frame_count() {
+        let args = vec![
+            "gba_frame_bench".to_string(),
+            "rom.gba".to_string(),
+            "--frames".to_string(),
+            "abc".to_string(),
+        ];
+
+        assert_eq!(
+            FrameBenchmarkConfig::parse_args(&args),
+            Err(FrameBenchmarkConfigError::InvalidNumber {
+                name: "frames",
+                value: "abc".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn frame_benchmark_config_rejects_missing_rom_path() {
+        let args = vec!["gba_frame_bench".to_string()];
+
+        assert_eq!(
+            FrameBenchmarkConfig::parse_args(&args),
+            Err(FrameBenchmarkConfigError::MissingRomPath)
+        );
+    }
+
+    #[test]
+    fn frame_benchmark_config_rejects_zero_frame_count() {
+        let args = vec![
+            "gba_frame_bench".to_string(),
+            "rom.gba".to_string(),
+            "--frames".to_string(),
+            "0".to_string(),
+        ];
+
+        assert_eq!(
+            FrameBenchmarkConfig::parse_args(&args),
+            Err(FrameBenchmarkConfigError::InvalidNumber {
+                name: "frames",
+                value: "0".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn frame_benchmark_config_rejects_missing_flag_value() {
+        let args = vec![
+            "gba_frame_bench".to_string(),
+            "rom.gba".to_string(),
+            "--frames".to_string(),
+        ];
+
+        assert_eq!(
+            FrameBenchmarkConfig::parse_args(&args),
+            Err(FrameBenchmarkConfigError::MissingValue { name: "frames" })
+        );
+    }
+
+    #[test]
+    fn frame_benchmark_config_rejects_unknown_argument() {
+        let args = vec![
+            "gba_frame_bench".to_string(),
+            "rom.gba".to_string(),
+            "--frame".to_string(),
+        ];
+
+        assert_eq!(
+            FrameBenchmarkConfig::parse_args(&args),
+            Err(FrameBenchmarkConfigError::UnknownArgument(
+                "--frame".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn frame_benchmark_config_allows_zero_warmup_and_stability_runs() {
+        let args = vec![
+            "gba_frame_bench".to_string(),
+            "rom.gba".to_string(),
+            "--warmup".to_string(),
+            "0".to_string(),
+            "--stability-runs".to_string(),
+            "0".to_string(),
+        ];
+
+        let config = FrameBenchmarkConfig::parse_args(&args).unwrap();
+
+        assert_eq!(config.warmup_frames, 0);
+        assert_eq!(config.stability_runs, 0);
     }
 }

--- a/src/platform/frame_benchmark.rs
+++ b/src/platform/frame_benchmark.rs
@@ -178,8 +178,11 @@ fn duration_ms(duration: Duration) -> f64 {
 }
 
 fn percentile(sorted_samples: &[f64], percentile: f64) -> f64 {
-    let rank = (percentile * sorted_samples.len() as f64).ceil() as usize;
-    sorted_samples[rank.saturating_sub(1).min(sorted_samples.len() - 1)]
+    let index = percentile * (sorted_samples.len() - 1) as f64;
+    let lower = index.floor() as usize;
+    let upper = index.ceil() as usize;
+    let fraction = index - lower as f64;
+    sorted_samples[lower] * (1.0 - fraction) + sorted_samples[upper] * fraction
 }
 
 #[cfg(test)]
@@ -207,7 +210,7 @@ mod tests {
         assert_eq!(stats.total, ms(76));
         assert_close(stats.average_ms, 15.2);
         assert_close(stats.p50_ms, 16.0);
-        assert_close(stats.p95_ms, 20.0);
+        assert_close(stats.p95_ms, 19.6);
         assert_close(stats.max_ms, 20.0);
         assert_close(stats.fps, 65.789);
     }

--- a/src/platform/frame_benchmark.rs
+++ b/src/platform/frame_benchmark.rs
@@ -1,0 +1,129 @@
+//! Shared frame benchmark statistics helpers.
+
+use std::time::Duration;
+
+/// Summary statistics for a frame-timing benchmark run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FrameTimingStats {
+    /// Number of measured frames.
+    pub frames: usize,
+    /// Total measured duration.
+    pub total: Duration,
+    /// Mean frame time in milliseconds.
+    pub average_ms: f64,
+    /// Median frame time in milliseconds.
+    pub p50_ms: f64,
+    /// 95th percentile frame time in milliseconds.
+    pub p95_ms: f64,
+    /// Slowest measured frame in milliseconds.
+    pub max_ms: f64,
+    /// Effective frames per second.
+    pub fps: f64,
+}
+
+/// Errors returned while computing benchmark statistics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameTimingStatsError {
+    /// No frame timing samples were provided.
+    Empty,
+    /// The measured frames completed in zero total time.
+    ZeroTotal,
+}
+
+impl FrameTimingStats {
+    /// Compute summary statistics for measured frame durations.
+    pub fn from_samples(samples: &[Duration]) -> Result<Self, FrameTimingStatsError> {
+        if samples.is_empty() {
+            return Err(FrameTimingStatsError::Empty);
+        }
+
+        let total = samples.iter().copied().sum();
+        if total == Duration::ZERO {
+            return Err(FrameTimingStatsError::ZeroTotal);
+        }
+
+        let frames = samples.len();
+        let total_ms = duration_ms(total);
+        let mut sorted_ms: Vec<f64> = samples.iter().map(|&sample| duration_ms(sample)).collect();
+        sorted_ms.sort_by(f64::total_cmp);
+
+        Ok(Self {
+            frames,
+            total,
+            average_ms: total_ms / frames as f64,
+            p50_ms: percentile(&sorted_ms, 0.50),
+            p95_ms: percentile(&sorted_ms, 0.95),
+            max_ms: sorted_ms[frames - 1],
+            fps: frames as f64 / total.as_secs_f64(),
+        })
+    }
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn percentile(sorted_samples: &[f64], percentile: f64) -> f64 {
+    let rank = (percentile * sorted_samples.len() as f64).ceil() as usize;
+    sorted_samples[rank.saturating_sub(1).min(sorted_samples.len() - 1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ms(value: u64) -> Duration {
+        Duration::from_millis(value)
+    }
+
+    fn assert_close(actual: f64, expected: f64) {
+        assert!(
+            (actual - expected).abs() < 0.001,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn frame_timing_stats_calculate_percentiles_and_fps() {
+        let samples = [ms(12), ms(16), ms(20), ms(10), ms(18)];
+
+        let stats = FrameTimingStats::from_samples(&samples).unwrap();
+
+        assert_eq!(stats.frames, 5);
+        assert_eq!(stats.total, ms(76));
+        assert_close(stats.average_ms, 15.2);
+        assert_close(stats.p50_ms, 16.0);
+        assert_close(stats.p95_ms, 20.0);
+        assert_close(stats.max_ms, 20.0);
+        assert_close(stats.fps, 65.789);
+    }
+
+    #[test]
+    fn frame_timing_stats_handle_single_sample() {
+        let stats = FrameTimingStats::from_samples(&[ms(17)]).unwrap();
+
+        assert_eq!(stats.frames, 1);
+        assert_eq!(stats.total, ms(17));
+        assert_close(stats.average_ms, 17.0);
+        assert_close(stats.p50_ms, 17.0);
+        assert_close(stats.p95_ms, 17.0);
+        assert_close(stats.max_ms, 17.0);
+        assert_close(stats.fps, 58.824);
+    }
+
+    #[test]
+    fn frame_timing_stats_reject_empty_sample_set() {
+        assert_eq!(
+            FrameTimingStats::from_samples(&[]),
+            Err(FrameTimingStatsError::Empty)
+        );
+    }
+
+    #[test]
+    fn frame_timing_stats_reject_zero_total_time() {
+        assert_eq!(
+            FrameTimingStats::from_samples(&[Duration::ZERO]),
+            Err(FrameTimingStatsError::ZeroTotal)
+        );
+    }
+}

--- a/src/platform/frame_benchmark.rs
+++ b/src/platform/frame_benchmark.rs
@@ -43,6 +43,8 @@ pub struct FrameBenchmarkConfig {
     pub stability_runs: usize,
     /// Whether the GBA BIOS intro should be skipped before benchmark warmup.
     pub skip_gba_bios_intro: bool,
+    /// Whether each stability run should reload the ROM before warmup.
+    pub reset_stability_runs: bool,
 }
 
 /// Errors returned while parsing benchmark command-line options.
@@ -74,6 +76,7 @@ impl FrameBenchmarkConfig {
             warmup_frames: 60,
             stability_runs: 5,
             skip_gba_bios_intro: true,
+            reset_stability_runs: true,
         };
 
         while let Some(arg) = args.next() {
@@ -92,6 +95,9 @@ impl FrameBenchmarkConfig {
                 }
                 "--skip-bios-intro" => {
                     config.skip_gba_bios_intro = true;
+                }
+                "--continue-stability-runs" => {
+                    config.reset_stability_runs = false;
                 }
                 _ => return Err(FrameBenchmarkConfigError::UnknownArgument(arg.clone())),
             }
@@ -258,6 +264,7 @@ mod tests {
         assert_eq!(config.warmup_frames, 60);
         assert_eq!(config.stability_runs, 5);
         assert!(config.skip_gba_bios_intro);
+        assert!(config.reset_stability_runs);
     }
 
     #[test]
@@ -284,8 +291,22 @@ mod tests {
                 warmup_frames: 30,
                 stability_runs: 2,
                 skip_gba_bios_intro: false,
+                reset_stability_runs: true,
             }
         );
+    }
+
+    #[test]
+    fn frame_benchmark_config_can_continue_stability_runs_without_resetting() {
+        let args = vec![
+            "gba_frame_bench".to_string(),
+            "rom.gba".to_string(),
+            "--continue-stability-runs".to_string(),
+        ];
+
+        let config = FrameBenchmarkConfig::parse_args(&args).unwrap();
+
+        assert!(!config.reset_stability_runs);
     }
 
     #[test]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod crc32;
 pub mod debugging;
 pub mod emulator;
+pub mod frame_benchmark;
 pub mod frontend_toasts;
 pub mod image_cache;
 pub mod metadata;

--- a/web/README.md
+++ b/web/README.md
@@ -37,15 +37,33 @@ npm test
 npm run test:integration:web
 ```
 
+## GBA performance benchmark
+Build the WASM package, copy a local GBA ROM into `web/roms/`, start the dev
+server, then open the benchmark page:
+
+```bash
+bash scripts/build_web.sh
+cp roms/games/metroid-zero-mission.gba web/roms/
+npm run dev
+# open http://localhost:5173/gba-bench.html?rom=metroid-zero-mission.gba
+```
+
+Optional query parameters:
+- `frames` (default `600`)
+- `warmup` (default `60`)
+- `stabilityRuns` (default `5`)
+
 ## Project structure
 ```
 web/
 ├── index.html              # Entry point
+├── gba-bench.html          # GBA WASM frame benchmark
 ├── styles.css              # Custom styles
 ├── pkg/                    # Generated WASM artifacts (git-ignored)
 ├── src/                    # Application modules
 │   ├── app.js              # Main entry point
 │   ├── audio/              # Audio resampling, frame timing
+│   ├── benchmark/          # Benchmark parsing and frame statistics
 │   ├── debugger/           # Debugger UI components
 │   ├── display/            # Canvas, zoom, cursor management
 │   ├── input/              # Gamepad, mouse, keyboard input

--- a/web/README.md
+++ b/web/README.md
@@ -52,6 +52,7 @@ Optional query parameters:
 - `frames` (default `600`)
 - `warmup` (default `60`)
 - `stabilityRuns` (default `5`)
+- `includeBiosIntro=true` to benchmark from power-on instead of skipping BIOS intro
 - `continueStabilityRuns=true` to keep advancing instead of reloading the ROM
   before each stability run
 

--- a/web/README.md
+++ b/web/README.md
@@ -45,13 +45,15 @@ server, then open the benchmark page:
 bash scripts/build_web.sh
 cp roms/games/metroid-zero-mission.gba web/roms/
 npm run dev
-# open http://localhost:5173/gba-bench.html?rom=metroid-zero-mission.gba
+# open http://localhost:8000/gba-bench.html?rom=metroid-zero-mission.gba
 ```
 
 Optional query parameters:
 - `frames` (default `600`)
 - `warmup` (default `60`)
 - `stabilityRuns` (default `5`)
+- `continueStabilityRuns=true` to keep advancing instead of reloading the ROM
+  before each stability run
 
 ## Project structure
 ```

--- a/web/gba-bench.html
+++ b/web/gba-bench.html
@@ -126,6 +126,18 @@ function formatStats(label, stats) {
     return `${label}: avg=${stats.averageMs.toFixed(3)}ms p50=${stats.p50Ms.toFixed(3)}ms p95=${stats.p95Ms.toFixed(3)}ms max=${stats.maxMs.toFixed(3)}ms fps=${stats.fps.toFixed(1)}`;
 }
 
+function createLoadedGba(romData, config) {
+    const gba = new WasmGba();
+    gba.load_rom(romData, config.romName);
+    return gba;
+}
+
+function warmup(gba, renderer, frames) {
+    for (let i = 0; i < frames; i++) {
+        runFrame(gba, renderer);
+    }
+}
+
 function runFrame(gba, renderer) {
     const frameStart = performance.now();
 
@@ -160,49 +172,60 @@ async function run() {
     if (!resp.ok) throw new Error(`Failed to fetch ROM: ${resp.status}`);
     const romData = new Uint8Array(await resp.arrayBuffer());
 
-    const gba = new WasmGba();
-    gba.load_rom(romData, config.romName);
-    const renderer = createRenderer(
-        document.getElementById("screen"),
-        gba.screen_width(),
-        gba.screen_height()
-    );
+    const gba = createLoadedGba(romData, config);
+    try {
+        const renderer = createRenderer(
+            document.getElementById("screen"),
+            gba.screen_width(),
+            gba.screen_height()
+        );
 
-    log(`ROM loaded. Warmup=${config.warmupFrames}, frames=${config.frames}, stabilityRuns=${config.stabilityRuns}`);
-    for (let i = 0; i < config.warmupFrames; i++) {
-        runFrame(gba, renderer);
-    }
+        log(`ROM loaded. Warmup=${config.warmupFrames}, frames=${config.frames}, stabilityRuns=${config.stabilityRuns}, resetStabilityRuns=${config.resetStabilityRuns}`);
+        warmup(gba, renderer, config.warmupFrames);
 
-    performance.mark("gba-bench-start");
-    const totals = [];
-    let emuTotal = 0;
-    let audioTotal = 0;
-    let glTotal = 0;
-    let audioSamples = 0;
-    for (let i = 0; i < config.frames; i++) {
-        const frame = runFrame(gba, renderer);
-        totals.push(frame.totalMs);
-        emuTotal += frame.emuMs;
-        audioTotal += frame.audioMs;
-        glTotal += frame.glMs;
-        audioSamples += frame.audioSamples;
-    }
-    performance.mark("gba-bench-end");
-    performance.measure("gba-bench", "gba-bench-start", "gba-bench-end");
-
-    const stats = computeFrameStats(totals);
-    log(formatStats("Primary run", stats));
-    log(`Averages: emu=${(emuTotal / config.frames).toFixed(3)}ms audio=${(audioTotal / config.frames).toFixed(3)}ms gl=${(glTotal / config.frames).toFixed(3)}ms audioSamples=${audioSamples}`);
-
-    if (config.stabilityRuns > 0) {
-        log(`\nStability check (${config.stabilityRuns} run(s) of ${config.frames} frames):`);
-        for (let runIndex = 1; runIndex <= config.stabilityRuns; runIndex++) {
-            const runTotals = [];
-            for (let i = 0; i < config.frames; i++) {
-                runTotals.push(runFrame(gba, renderer).totalMs);
-            }
-            log(`  ${formatStats(`Run ${runIndex}`, computeFrameStats(runTotals))}`);
+        performance.mark("gba-bench-start");
+        const totals = [];
+        let emuTotal = 0;
+        let audioTotal = 0;
+        let glTotal = 0;
+        let audioSamples = 0;
+        for (let i = 0; i < config.frames; i++) {
+            const frame = runFrame(gba, renderer);
+            totals.push(frame.totalMs);
+            emuTotal += frame.emuMs;
+            audioTotal += frame.audioMs;
+            glTotal += frame.glMs;
+            audioSamples += frame.audioSamples;
         }
+        performance.mark("gba-bench-end");
+        performance.measure("gba-bench", "gba-bench-start", "gba-bench-end");
+
+        const stats = computeFrameStats(totals);
+        log(formatStats("Primary run", stats));
+        log(`Averages: emu=${(emuTotal / config.frames).toFixed(3)}ms audio=${(audioTotal / config.frames).toFixed(3)}ms gl=${(glTotal / config.frames).toFixed(3)}ms audioSamples=${audioSamples}`);
+
+        if (config.stabilityRuns > 0) {
+            log(`\nStability check (${config.stabilityRuns} run(s) of ${config.frames} frames):`);
+            for (let runIndex = 1; runIndex <= config.stabilityRuns; runIndex++) {
+                const runGba = config.resetStabilityRuns ? createLoadedGba(romData, config) : gba;
+                try {
+                    if (config.resetStabilityRuns) {
+                        warmup(runGba, renderer, config.warmupFrames);
+                    }
+                    const runTotals = [];
+                    for (let i = 0; i < config.frames; i++) {
+                        runTotals.push(runFrame(runGba, renderer).totalMs);
+                    }
+                    log(`  ${formatStats(`Run ${runIndex}`, computeFrameStats(runTotals))}`);
+                } finally {
+                    if (config.resetStabilityRuns) {
+                        runGba.free();
+                    }
+                }
+            }
+        }
+    } finally {
+        gba.free();
     }
 
     log("\nDone. Capture the 'gba-bench' marker in Chrome DevTools for profiler analysis.");

--- a/web/gba-bench.html
+++ b/web/gba-bench.html
@@ -188,21 +188,21 @@ async function run() {
         let emuTotal = 0;
         let audioTotal = 0;
         let glTotal = 0;
-        let audioSamples = 0;
+        let audioSampleValues = 0;
         for (let i = 0; i < config.frames; i++) {
             const frame = runFrame(gba, renderer);
             totals.push(frame.totalMs);
             emuTotal += frame.emuMs;
             audioTotal += frame.audioMs;
             glTotal += frame.glMs;
-            audioSamples += frame.audioSamples;
+            audioSampleValues += frame.audioSamples;
         }
         performance.mark("gba-bench-end");
         performance.measure("gba-bench", "gba-bench-start", "gba-bench-end");
 
         const stats = computeFrameStats(totals);
         log(formatStats("Primary run", stats));
-        log(`Averages: emu=${(emuTotal / config.frames).toFixed(3)}ms audio=${(audioTotal / config.frames).toFixed(3)}ms gl=${(glTotal / config.frames).toFixed(3)}ms audioSamples=${audioSamples}`);
+        log(`Averages: emu=${(emuTotal / config.frames).toFixed(3)}ms audio=${(audioTotal / config.frames).toFixed(3)}ms gl=${(glTotal / config.frames).toFixed(3)}ms audioSampleValues=${audioSampleValues}`);
 
         if (config.stabilityRuns > 0) {
             log(`\nStability check (${config.stabilityRuns} run(s) of ${config.frames} frames):`);

--- a/web/gba-bench.html
+++ b/web/gba-bench.html
@@ -127,7 +127,7 @@ function formatStats(label, stats) {
 }
 
 function createLoadedGba(romData, config) {
-    const gba = new WasmGba();
+    const gba = WasmGba.new_with_skip_bios_intro(config.skipBiosIntro);
     gba.load_rom(romData, config.romName);
     return gba;
 }
@@ -180,7 +180,7 @@ async function run() {
             gba.screen_height()
         );
 
-        log(`ROM loaded. Warmup=${config.warmupFrames}, frames=${config.frames}, stabilityRuns=${config.stabilityRuns}, resetStabilityRuns=${config.resetStabilityRuns}`);
+        log(`ROM loaded. Warmup=${config.warmupFrames}, frames=${config.frames}, stabilityRuns=${config.stabilityRuns}, resetStabilityRuns=${config.resetStabilityRuns}, skipBiosIntro=${config.skipBiosIntro}`);
         warmup(gba, renderer, config.warmupFrames);
 
         performance.mark("gba-bench-start");

--- a/web/gba-bench.html
+++ b/web/gba-bench.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>GBA WASM Frame Benchmark</title>
+    <style>
+        body {
+            background: #111;
+            color: #eee;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        }
+        canvas {
+            image-rendering: pixelated;
+            width: 480px;
+            height: 320px;
+            border: 1px solid #555;
+        }
+    </style>
+</head>
+<body>
+<h2>GBA WASM Frame Benchmark</h2>
+<canvas id="screen" width="240" height="160"></canvas>
+<pre id="out">Loading WASM module...</pre>
+<script type="module">
+import init, { WasmGba } from "./pkg/neser.js";
+import { parseGbaBenchmarkConfig } from "./src/benchmark/gba_benchmark_config.ts";
+import { computeFrameStats } from "./src/benchmark/frame_stats.ts";
+
+const out = document.getElementById("out");
+function log(msg) { out.textContent += "\n" + msg; }
+
+function compileShader(gl, type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const message = gl.getShaderInfoLog(shader);
+        gl.deleteShader(shader);
+        throw new Error(`Shader compile failed: ${message}`);
+    }
+    return shader;
+}
+
+function createProgram(gl) {
+    const vertexShader = compileShader(gl, gl.VERTEX_SHADER, `
+        attribute vec2 a_position;
+        attribute vec2 a_texCoord;
+        varying vec2 v_texCoord;
+        void main() {
+            gl_Position = vec4(a_position, 0.0, 1.0);
+            v_texCoord = a_texCoord;
+        }
+    `);
+    const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, `
+        precision mediump float;
+        uniform sampler2D u_texture;
+        varying vec2 v_texCoord;
+        void main() {
+            gl_FragColor = texture2D(u_texture, v_texCoord);
+        }
+    `);
+    const program = gl.createProgram();
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    gl.deleteShader(vertexShader);
+    gl.deleteShader(fragmentShader);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        const message = gl.getProgramInfoLog(program);
+        gl.deleteProgram(program);
+        throw new Error(`Program link failed: ${message}`);
+    }
+    return program;
+}
+
+function createRenderer(canvas, width, height) {
+    const gl = canvas.getContext("webgl");
+    if (!gl) throw new Error("WebGL is not available");
+
+    const program = createProgram(gl);
+    gl.useProgram(program);
+
+    const positionBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]),
+        gl.STATIC_DRAW
+    );
+    const positionLocation = gl.getAttribLocation(program, "a_position");
+    gl.enableVertexAttribArray(positionLocation);
+    gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+
+    const texCoordBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, texCoordBuffer);
+    gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array([0, 1, 1, 1, 0, 0, 1, 0]),
+        gl.STATIC_DRAW
+    );
+    const texCoordLocation = gl.getAttribLocation(program, "a_texCoord");
+    gl.enableVertexAttribArray(texCoordLocation);
+    gl.vertexAttribPointer(texCoordLocation, 2, gl.FLOAT, false, 0, 0);
+
+    const texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, width, height, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+    gl.viewport(0, 0, canvas.width, canvas.height);
+
+    return {
+        draw(frame) {
+            gl.bindTexture(gl.TEXTURE_2D, texture);
+            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, gl.RGB, gl.UNSIGNED_BYTE, frame);
+            gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+        },
+        finish() {
+            gl.finish();
+        }
+    };
+}
+
+function formatStats(label, stats) {
+    return `${label}: avg=${stats.averageMs.toFixed(3)}ms p50=${stats.p50Ms.toFixed(3)}ms p95=${stats.p95Ms.toFixed(3)}ms max=${stats.maxMs.toFixed(3)}ms fps=${stats.fps.toFixed(1)}`;
+}
+
+function runFrame(gba, renderer) {
+    const frameStart = performance.now();
+
+    const emuStart = performance.now();
+    const frame = gba.render_frame_rgb();
+    const emuMs = performance.now() - emuStart;
+
+    const audioStart = performance.now();
+    const audioSamples = gba.get_audio_samples_stereo();
+    const audioMs = performance.now() - audioStart;
+
+    const glStart = performance.now();
+    renderer.draw(frame);
+    renderer.finish();
+    const glMs = performance.now() - glStart;
+
+    return {
+        totalMs: performance.now() - frameStart,
+        emuMs,
+        audioMs,
+        glMs,
+        audioSamples: audioSamples.length
+    };
+}
+
+async function run() {
+    const config = parseGbaBenchmarkConfig(new URLSearchParams(location.search));
+    await init("./pkg/neser_bg.wasm");
+
+    log(`Fetching ROM: ${config.romName}`);
+    const resp = await fetch(`roms/${encodeURIComponent(config.romName)}`);
+    if (!resp.ok) throw new Error(`Failed to fetch ROM: ${resp.status}`);
+    const romData = new Uint8Array(await resp.arrayBuffer());
+
+    const gba = new WasmGba();
+    gba.load_rom(romData, config.romName);
+    const renderer = createRenderer(
+        document.getElementById("screen"),
+        gba.screen_width(),
+        gba.screen_height()
+    );
+
+    log(`ROM loaded. Warmup=${config.warmupFrames}, frames=${config.frames}, stabilityRuns=${config.stabilityRuns}`);
+    for (let i = 0; i < config.warmupFrames; i++) {
+        runFrame(gba, renderer);
+    }
+
+    performance.mark("gba-bench-start");
+    const totals = [];
+    let emuTotal = 0;
+    let audioTotal = 0;
+    let glTotal = 0;
+    let audioSamples = 0;
+    for (let i = 0; i < config.frames; i++) {
+        const frame = runFrame(gba, renderer);
+        totals.push(frame.totalMs);
+        emuTotal += frame.emuMs;
+        audioTotal += frame.audioMs;
+        glTotal += frame.glMs;
+        audioSamples += frame.audioSamples;
+    }
+    performance.mark("gba-bench-end");
+    performance.measure("gba-bench", "gba-bench-start", "gba-bench-end");
+
+    const stats = computeFrameStats(totals);
+    log(formatStats("Primary run", stats));
+    log(`Averages: emu=${(emuTotal / config.frames).toFixed(3)}ms audio=${(audioTotal / config.frames).toFixed(3)}ms gl=${(glTotal / config.frames).toFixed(3)}ms audioSamples=${audioSamples}`);
+
+    if (config.stabilityRuns > 0) {
+        log(`\nStability check (${config.stabilityRuns} run(s) of ${config.frames} frames):`);
+        for (let runIndex = 1; runIndex <= config.stabilityRuns; runIndex++) {
+            const runTotals = [];
+            for (let i = 0; i < config.frames; i++) {
+                runTotals.push(runFrame(gba, renderer).totalMs);
+            }
+            log(`  ${formatStats(`Run ${runIndex}`, computeFrameStats(runTotals))}`);
+        }
+    }
+
+    log("\nDone. Capture the 'gba-bench' marker in Chrome DevTools for profiler analysis.");
+}
+
+run().catch((err) => log(`ERROR: ${err instanceof Error ? err.message : err}`));
+</script>
+</body>
+</html>

--- a/web/src/benchmark/frame_stats.test.ts
+++ b/web/src/benchmark/frame_stats.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { computeFrameStats } from "./frame_stats";
+
+describe("computeFrameStats", () => {
+    it("calculates frame timing percentiles and effective FPS", () => {
+        expect(computeFrameStats([12, 16, 20, 10, 18])).toEqual({
+            frames: 5,
+            totalMs: 76,
+            averageMs: 15.2,
+            p50Ms: 16,
+            p95Ms: 20,
+            maxMs: 20,
+            fps: 65.78947368421052
+        });
+    });
+
+    it("handles single-sample benchmark runs", () => {
+        expect(computeFrameStats([17])).toEqual({
+            frames: 1,
+            totalMs: 17,
+            averageMs: 17,
+            p50Ms: 17,
+            p95Ms: 17,
+            maxMs: 17,
+            fps: 58.8235294117647
+        });
+    });
+
+    it("rejects empty sample sets", () => {
+        expect(() => computeFrameStats([])).toThrow("frame timing samples must not be empty");
+    });
+
+    it("rejects zero-total sample sets", () => {
+        expect(() => computeFrameStats([0])).toThrow("frame timing total must be greater than zero");
+    });
+
+    it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
+        "rejects invalid sample value %s",
+        (sample) => {
+            expect(() => computeFrameStats([sample])).toThrow(
+                "frame timing samples must be finite non-negative numbers"
+            );
+        }
+    );
+});

--- a/web/src/benchmark/frame_stats.test.ts
+++ b/web/src/benchmark/frame_stats.test.ts
@@ -8,7 +8,7 @@ describe("computeFrameStats", () => {
             totalMs: 76,
             averageMs: 15.2,
             p50Ms: 16,
-            p95Ms: 20,
+            p95Ms: 19.6,
             maxMs: 20,
             fps: 65.78947368421052
         });

--- a/web/src/benchmark/frame_stats.ts
+++ b/web/src/benchmark/frame_stats.ts
@@ -35,6 +35,9 @@ export function computeFrameStats(samplesMs: readonly number[]): FrameStats {
 }
 
 function percentile(sortedSamples: readonly number[], percentileValue: number): number {
-    const rank = Math.ceil(percentileValue * sortedSamples.length);
-    return sortedSamples[Math.min(Math.max(rank - 1, 0), sortedSamples.length - 1)];
+    const index = percentileValue * (sortedSamples.length - 1);
+    const lower = Math.floor(index);
+    const upper = Math.ceil(index);
+    const fraction = index - lower;
+    return sortedSamples[lower] * (1 - fraction) + sortedSamples[upper] * fraction;
 }

--- a/web/src/benchmark/frame_stats.ts
+++ b/web/src/benchmark/frame_stats.ts
@@ -1,0 +1,40 @@
+export interface FrameStats {
+    frames: number;
+    totalMs: number;
+    averageMs: number;
+    p50Ms: number;
+    p95Ms: number;
+    maxMs: number;
+    fps: number;
+}
+
+export function computeFrameStats(samplesMs: readonly number[]): FrameStats {
+    if (samplesMs.length === 0) {
+        throw new Error("frame timing samples must not be empty");
+    }
+    if (samplesMs.some((sample) => !Number.isFinite(sample) || sample < 0)) {
+        throw new Error("frame timing samples must be finite non-negative numbers");
+    }
+
+    const sorted = [...samplesMs].sort((a, b) => a - b);
+    const totalMs = samplesMs.reduce((sum, sample) => sum + sample, 0);
+    if (totalMs === 0) {
+        throw new Error("frame timing total must be greater than zero");
+    }
+    const averageMs = totalMs / samplesMs.length;
+
+    return {
+        frames: samplesMs.length,
+        totalMs,
+        averageMs,
+        p50Ms: percentile(sorted, 0.50),
+        p95Ms: percentile(sorted, 0.95),
+        maxMs: sorted[sorted.length - 1],
+        fps: samplesMs.length * 1000 / totalMs
+    };
+}
+
+function percentile(sortedSamples: readonly number[], percentileValue: number): number {
+    const rank = Math.ceil(percentileValue * sortedSamples.length);
+    return sortedSamples[Math.min(Math.max(rank - 1, 0), sortedSamples.length - 1)];
+}

--- a/web/src/benchmark/gba_benchmark_config.test.ts
+++ b/web/src/benchmark/gba_benchmark_config.test.ts
@@ -10,7 +10,8 @@ describe("parseGbaBenchmarkConfig", () => {
             frames: 600,
             warmupFrames: 60,
             stabilityRuns: 5,
-            resetStabilityRuns: true
+            resetStabilityRuns: true,
+            skipBiosIntro: true
         });
     });
 
@@ -24,7 +25,8 @@ describe("parseGbaBenchmarkConfig", () => {
             frames: 120,
             warmupFrames: 30,
             stabilityRuns: 2,
-            resetStabilityRuns: true
+            resetStabilityRuns: true,
+            skipBiosIntro: true
         });
     });
 
@@ -77,5 +79,13 @@ describe("parseGbaBenchmarkConfig", () => {
         );
 
         expect(config.resetStabilityRuns).toBe(false);
+    });
+
+    it("can include BIOS intro in benchmark runs", () => {
+        const config = parseGbaBenchmarkConfig(
+            new URLSearchParams("rom=test.gba&includeBiosIntro=true")
+        );
+
+        expect(config.skipBiosIntro).toBe(false);
     });
 });

--- a/web/src/benchmark/gba_benchmark_config.test.ts
+++ b/web/src/benchmark/gba_benchmark_config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { parseGbaBenchmarkConfig } from "./gba_benchmark_config";
+
+describe("parseGbaBenchmarkConfig", () => {
+    it("uses Metroid benchmark defaults when only the ROM is provided", () => {
+        const config = parseGbaBenchmarkConfig(new URLSearchParams("rom=metroid-zero-mission.gba"));
+
+        expect(config).toEqual({
+            romName: "metroid-zero-mission.gba",
+            frames: 600,
+            warmupFrames: 60,
+            stabilityRuns: 5
+        });
+    });
+
+    it("parses frame, warmup, and stability overrides", () => {
+        const config = parseGbaBenchmarkConfig(
+            new URLSearchParams("rom=test.gba&frames=120&warmup=30&stabilityRuns=2")
+        );
+
+        expect(config).toEqual({
+            romName: "test.gba",
+            frames: 120,
+            warmupFrames: 30,
+            stabilityRuns: 2
+        });
+    });
+
+    it("rejects missing ROM parameter", () => {
+        expect(() => parseGbaBenchmarkConfig(new URLSearchParams())).toThrow(
+            "Missing ?rom=<file>. Provide a GBA ROM filename in web/roms/."
+        );
+    });
+
+    it("rejects unsafe ROM names", () => {
+        expect(() => parseGbaBenchmarkConfig(new URLSearchParams("rom=../metroid.gba"))).toThrow(
+            "Invalid ROM name. Only letters, numbers, dot, underscore, or dash allowed."
+        );
+    });
+
+    it.each(["0", "-1", "10.5", "abc"])(
+        "rejects invalid positive frame value %s",
+        (frames) => {
+            expect(() =>
+                parseGbaBenchmarkConfig(new URLSearchParams(`rom=test.gba&frames=${frames}`))
+            ).toThrow("Invalid frames value: expected a positive integer.");
+        }
+    );
+
+    it.each([
+        ["warmup", "-1"],
+        ["warmup", "10.5"],
+        ["warmup", "abc"],
+        ["stabilityRuns", "-1"],
+        ["stabilityRuns", "10.5"],
+        ["stabilityRuns", "abc"]
+    ])("rejects invalid non-negative %s value %s", (key, value) => {
+        expect(() =>
+            parseGbaBenchmarkConfig(new URLSearchParams(`rom=test.gba&${key}=${value}`))
+        ).toThrow(`Invalid ${key} value: expected a non-negative integer.`);
+    });
+
+    it("allows zero warmup and stability runs", () => {
+        const config = parseGbaBenchmarkConfig(
+            new URLSearchParams("rom=test.gba&warmup=0&stabilityRuns=0")
+        );
+
+        expect(config.warmupFrames).toBe(0);
+        expect(config.stabilityRuns).toBe(0);
+    });
+});

--- a/web/src/benchmark/gba_benchmark_config.test.ts
+++ b/web/src/benchmark/gba_benchmark_config.test.ts
@@ -9,7 +9,8 @@ describe("parseGbaBenchmarkConfig", () => {
             romName: "metroid-zero-mission.gba",
             frames: 600,
             warmupFrames: 60,
-            stabilityRuns: 5
+            stabilityRuns: 5,
+            resetStabilityRuns: true
         });
     });
 
@@ -22,7 +23,8 @@ describe("parseGbaBenchmarkConfig", () => {
             romName: "test.gba",
             frames: 120,
             warmupFrames: 30,
-            stabilityRuns: 2
+            stabilityRuns: 2,
+            resetStabilityRuns: true
         });
     });
 
@@ -67,5 +69,13 @@ describe("parseGbaBenchmarkConfig", () => {
 
         expect(config.warmupFrames).toBe(0);
         expect(config.stabilityRuns).toBe(0);
+    });
+
+    it("can continue stability runs without resetting", () => {
+        const config = parseGbaBenchmarkConfig(
+            new URLSearchParams("rom=test.gba&continueStabilityRuns=true")
+        );
+
+        expect(config.resetStabilityRuns).toBe(false);
     });
 });

--- a/web/src/benchmark/gba_benchmark_config.ts
+++ b/web/src/benchmark/gba_benchmark_config.ts
@@ -3,6 +3,7 @@ export interface GbaBenchmarkConfig {
     frames: number;
     warmupFrames: number;
     stabilityRuns: number;
+    resetStabilityRuns: boolean;
 }
 
 const SAFE_ROM_BASENAME = /^[A-Za-z0-9._-]+$/;
@@ -20,7 +21,8 @@ export function parseGbaBenchmarkConfig(params: URLSearchParams): GbaBenchmarkCo
         romName,
         frames: parsePositiveInteger(params, "frames", 600),
         warmupFrames: parseNonNegativeInteger(params, "warmup", 60),
-        stabilityRuns: parseNonNegativeInteger(params, "stabilityRuns", 5)
+        stabilityRuns: parseNonNegativeInteger(params, "stabilityRuns", 5),
+        resetStabilityRuns: params.get("continueStabilityRuns") !== "true"
     };
 }
 

--- a/web/src/benchmark/gba_benchmark_config.ts
+++ b/web/src/benchmark/gba_benchmark_config.ts
@@ -4,6 +4,7 @@ export interface GbaBenchmarkConfig {
     warmupFrames: number;
     stabilityRuns: number;
     resetStabilityRuns: boolean;
+    skipBiosIntro: boolean;
 }
 
 const SAFE_ROM_BASENAME = /^[A-Za-z0-9._-]+$/;
@@ -22,7 +23,8 @@ export function parseGbaBenchmarkConfig(params: URLSearchParams): GbaBenchmarkCo
         frames: parsePositiveInteger(params, "frames", 600),
         warmupFrames: parseNonNegativeInteger(params, "warmup", 60),
         stabilityRuns: parseNonNegativeInteger(params, "stabilityRuns", 5),
-        resetStabilityRuns: params.get("continueStabilityRuns") !== "true"
+        resetStabilityRuns: params.get("continueStabilityRuns") !== "true",
+        skipBiosIntro: params.get("includeBiosIntro") !== "true"
     };
 }
 

--- a/web/src/benchmark/gba_benchmark_config.ts
+++ b/web/src/benchmark/gba_benchmark_config.ts
@@ -1,0 +1,53 @@
+export interface GbaBenchmarkConfig {
+    romName: string;
+    frames: number;
+    warmupFrames: number;
+    stabilityRuns: number;
+}
+
+const SAFE_ROM_BASENAME = /^[A-Za-z0-9._-]+$/;
+
+export function parseGbaBenchmarkConfig(params: URLSearchParams): GbaBenchmarkConfig {
+    const romName = params.get("rom");
+    if (!romName) {
+        throw new Error("Missing ?rom=<file>. Provide a GBA ROM filename in web/roms/.");
+    }
+    if (!SAFE_ROM_BASENAME.test(romName)) {
+        throw new Error("Invalid ROM name. Only letters, numbers, dot, underscore, or dash allowed.");
+    }
+
+    return {
+        romName,
+        frames: parsePositiveInteger(params, "frames", 600),
+        warmupFrames: parseNonNegativeInteger(params, "warmup", 60),
+        stabilityRuns: parseNonNegativeInteger(params, "stabilityRuns", 5)
+    };
+}
+
+function parsePositiveInteger(
+    params: URLSearchParams,
+    key: string,
+    defaultValue: number
+): number {
+    const value = params.get(key);
+    if (value === null) return defaultValue;
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`Invalid ${key} value: expected a positive integer.`);
+    }
+    return parsed;
+}
+
+function parseNonNegativeInteger(
+    params: URLSearchParams,
+    key: string,
+    defaultValue: number
+): number {
+    const value = params.get(key);
+    if (value === null) return defaultValue;
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+        throw new Error(`Invalid ${key} value: expected a non-negative integer.`);
+    }
+    return parsed;
+}


### PR DESCRIPTION
## Summary

Closes #2681.

Adds reusable GBA frame benchmark tooling for native and web frontends so GBA 60 FPS performance can be measured repeatably before optimizing.

- Added shared frame timing statistics helpers and option parsing.
- Added native gba_frame_bench binary for GBA ROM frame timing.
- Added web gba-bench.html benchmark with emulator, audio, WebGL, and total frame timing.
- Reset/reload stability runs by default so every stability run measures the same title/intro window, with explicit continue options for diagnostics.
- Documented web benchmark usage in web/README.md.

## Performance results

Primary workload: Metroid Zero Mission from local roms/games, skip BIOS intro, 60 warmup frames, 600 measured frames, 5 stability runs.

Native release benchmark:

- Primary: avg 7.426 ms, p50 7.352 ms, p95 8.248 ms, max 13.982 ms, FPS 134.7.
- Stability: avg 7.041-7.837 ms, p95 7.544-13.161 ms.

Web benchmark in headless Chromium with SwiftShader:

- Latest primary: avg 8.315 ms, p50 9.200 ms, p95 10.500 ms, max 26.200 ms, FPS 120.3.
- Stability: avg 8.136-8.237 ms, p95 10.100-10.200 ms, FPS 121.4-122.9.

No measured hotspot optimization was needed because both native and web baselines exceeded the target of avg under 16.67 ms and p95 under 18 ms for the benchmark workload.

## Validation

- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt
- ./scripts/test-dir.sh src/platform
- cargo test --bin gba_frame_bench
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"
- npm test
