### PR TITLE
Add configurable audio buffering

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -6,6 +6,8 @@
 
 NESER is a cycle-accurate NES (Nintendo Entertainment System) emulator written in Rust, built on an architecture that supports multiple emulated hardware targets. It supports three frontend targets: a native desktop window (winit + OpenGL), a terminal-based TUI ROM launcher, and a WebAssembly-powered browser frontend. The emulator implements the core NES hardware — CPU, PPU, APU, and bus — as well as over 200 cartridge mappers, multiple input device types, debugging tools, save states, and an autorun recording/playback system.
 
+The native frontend now exposes audio buffering in milliseconds through configuration, while the web frontend uses a small profile selector for balanced and low-latency audio scheduling.
+
 The codebase is roughly 183,000 lines of Rust, with additional JavaScript for the web frontend and Python tooling for ROM management.
 
 As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic `Emulator` trait and a `Console` enum that wraps the NES, Game Boy, and Game Boy Advance implementations. This allows the native frontend and GL backend to dispatch common operations through the trait instead of matching on specific console variants or using NES-specific types directly. The architecture is designed to be extensible for future emulated systems while maintaining a clean separation between hardware-specific logic and shared platform/frontend code.

--- a/neser.conf.example
+++ b/neser.conf.example
@@ -79,6 +79,13 @@ nes-hardware=nes-ntsc
 # Enable or disable audio output entirely.
 audio=true
 
+# Target native audio buffering in milliseconds.
+# Lower values reduce latency but increase underrun risk.
+# The native frontend rounds this up to a safe internal sample buffer size.
+# Valid range: 20-500
+# Default: 60
+#audio_buffer_ms=60
+
 # Individual APU channel toggles.
 # Useful for isolating specific sounds or debugging audio issues.
 nes-pulse1=true

--- a/src/frontends/native/audio.rs
+++ b/src/frontends/native/audio.rs
@@ -130,8 +130,10 @@ impl NativeAudio {
     }
 
     fn buffer_samples_for(sample_rate: i32, buffer_ms: u32) -> usize {
-        let sample_rate = sample_rate.max(1) as usize;
-        let requested = ((sample_rate * buffer_ms as usize) + 999) / 1000;
+        let sample_rate = sample_rate.max(1) as u128;
+        let buffer_ms = buffer_ms as u128;
+        let requested = sample_rate.saturating_mul(buffer_ms).saturating_add(999) / 1000;
+        let requested = requested.min(usize::MAX as u128) as usize;
         requested.max(Self::MIN_BUFFER_SAMPLES)
     }
 

--- a/src/frontends/native/audio.rs
+++ b/src/frontends/native/audio.rs
@@ -48,6 +48,8 @@ pub struct NativeAudio {
     stats: Arc<AudioStats>,
     fill_level: Arc<AtomicUsize>,
     actual_sample_rate: i32,
+    buffer_samples: usize,
+    startup_prime_samples: usize,
     paused: Arc<AtomicBool>,
     /// Number of stale ring-buffer samples to discard silently on the next resume.
     ///
@@ -58,18 +60,18 @@ pub struct NativeAudio {
 }
 
 impl NativeAudio {
-    /// Audio buffer size in samples.
-    /// At 44.1kHz, this provides ~0.5 seconds of buffering.
-    const BUFFER_SIZE: usize = 22050;
+    /// Smallest ring buffer we will use, regardless of the configured latency.
+    const MIN_BUFFER_SAMPLES: usize = 2048;
 
     /// Create a new cpal-based audio output handler.
     ///
     /// # Arguments
     /// * `sample_rate` - Target sample rate in Hz (e.g., 44100)
+    /// * `buffer_ms` - Target audio buffering in milliseconds
     ///
     /// # Errors
     /// Returns an error if no audio output device is found or stream creation fails.
-    pub fn new(sample_rate: i32) -> Result<Self, String> {
+    pub fn new(sample_rate: i32, buffer_ms: u32) -> Result<Self, String> {
         let host = cpal::default_host();
         let device = host
             .default_output_device()
@@ -85,7 +87,17 @@ impl NativeAudio {
             ));
         }
 
-        let ring_buffer = HeapRb::<[f32; 2]>::new(Self::BUFFER_SIZE);
+        let buffer_samples = Self::buffer_samples_for(actual_rate, buffer_ms);
+        let startup_prime_samples = Self::startup_prime_samples_for(buffer_samples);
+        log_info(format!(
+            "Audio: using {} ms buffer -> {} samples (~{:.1} ms) at {} Hz",
+            buffer_ms,
+            buffer_samples,
+            buffer_samples as f32 * 1000.0 / actual_rate as f32,
+            actual_rate
+        ));
+
+        let ring_buffer = HeapRb::<[f32; 2]>::new(buffer_samples);
         let (producer, consumer) = ring_buffer.split();
         let shared = StreamSharedState::new();
 
@@ -94,6 +106,7 @@ impl NativeAudio {
             &stream_config,
             channels,
             sample_format,
+            buffer_samples,
             consumer,
             &shared,
         )?;
@@ -109,9 +122,23 @@ impl NativeAudio {
             stats: shared.stats,
             fill_level: shared.fill_level,
             actual_sample_rate: actual_rate,
+            buffer_samples,
+            startup_prime_samples,
             paused: shared.paused,
             drain_stale: shared.drain_stale,
         })
+    }
+
+    fn buffer_samples_for(sample_rate: i32, buffer_ms: u32) -> usize {
+        let sample_rate = sample_rate.max(1) as usize;
+        let requested = ((sample_rate * buffer_ms as usize) + 999) / 1000;
+        requested.max(Self::MIN_BUFFER_SAMPLES)
+    }
+
+    fn startup_prime_samples_for(buffer_samples: usize) -> usize {
+        (buffer_samples / 4)
+            .max(256)
+            .min(buffer_samples.saturating_sub(1))
     }
 
     /// Selects the best available stream config for the device.
@@ -168,19 +195,35 @@ impl NativeAudio {
         config: &StreamConfig,
         channels: u16,
         sample_format: SampleFormat,
+        buffer_samples: usize,
         consumer: AudioConsumer,
         shared: &StreamSharedState,
     ) -> Result<cpal::Stream, String> {
         match sample_format {
-            SampleFormat::F32 => {
-                Self::build_typed_stream::<f32>(device, config, channels, consumer, shared)
-            }
-            SampleFormat::I16 => {
-                Self::build_typed_stream::<i16>(device, config, channels, consumer, shared)
-            }
-            SampleFormat::U16 => {
-                Self::build_typed_stream::<u16>(device, config, channels, consumer, shared)
-            }
+            SampleFormat::F32 => Self::build_typed_stream::<f32>(
+                device,
+                config,
+                channels,
+                buffer_samples,
+                consumer,
+                shared,
+            ),
+            SampleFormat::I16 => Self::build_typed_stream::<i16>(
+                device,
+                config,
+                channels,
+                buffer_samples,
+                consumer,
+                shared,
+            ),
+            SampleFormat::U16 => Self::build_typed_stream::<u16>(
+                device,
+                config,
+                channels,
+                buffer_samples,
+                consumer,
+                shared,
+            ),
             _ => Err(format!(
                 "Unsupported audio sample format: {sample_format:?}"
             )),
@@ -196,6 +239,7 @@ impl NativeAudio {
         device: &cpal::Device,
         config: &StreamConfig,
         channels: u16,
+        buffer_samples: usize,
         mut consumer: AudioConsumer,
         shared: &StreamSharedState,
     ) -> Result<cpal::Stream, String> {
@@ -204,7 +248,7 @@ impl NativeAudio {
         let fill_level = Arc::clone(&shared.fill_level);
         let paused = Arc::clone(&shared.paused);
         let drain_stale = Arc::clone(&shared.drain_stale);
-        let mut resampler = AudioResampler::new(Self::BUFFER_SIZE / 2);
+        let mut resampler = AudioResampler::new(buffer_samples / 2);
 
         device
             .build_output_stream(
@@ -299,6 +343,16 @@ impl NativeAudio {
         self.fill_level.load(Ordering::Relaxed)
     }
 
+    pub fn startup_prime_samples(&self) -> usize {
+        debug_assert!(self.startup_prime_samples <= self.buffer_samples);
+        self.startup_prime_samples
+    }
+
+    #[cfg(test)]
+    pub fn buffer_capacity_samples(&self) -> usize {
+        self.buffer_samples
+    }
+
     /// Returns `true` if audio output is currently paused.
     #[cfg(test)]
     pub fn is_paused(&self) -> bool {
@@ -316,8 +370,10 @@ impl NativeAudio {
     /// Intended for unit tests that exercise pure logic (volume, stats, buffering)
     /// without requiring audio hardware.
     #[cfg(test)]
-    fn new_without_stream(sample_rate: i32) -> Self {
-        let ring_buffer = HeapRb::<[f32; 2]>::new(Self::BUFFER_SIZE);
+    fn new_without_stream(sample_rate: i32, buffer_ms: u32) -> Self {
+        let buffer_samples = Self::buffer_samples_for(sample_rate, buffer_ms);
+        let startup_prime_samples = Self::startup_prime_samples_for(buffer_samples);
+        let ring_buffer = HeapRb::<[f32; 2]>::new(buffer_samples);
         let (producer, _consumer) = ring_buffer.split();
         let shared = StreamSharedState::new();
         Self {
@@ -327,6 +383,8 @@ impl NativeAudio {
             stats: shared.stats,
             fill_level: shared.fill_level,
             actual_sample_rate: sample_rate,
+            buffer_samples,
+            startup_prime_samples,
             paused: shared.paused,
             drain_stale: shared.drain_stale,
         }
@@ -421,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_volume_clamping() {
-        let audio = NativeAudio::new_without_stream(44100);
+        let audio = NativeAudio::new_without_stream(44100, 60);
 
         audio.set_volume(0.5);
         assert_eq!(audio.get_volume(), 0.5);
@@ -435,13 +493,13 @@ mod tests {
 
     #[test]
     fn test_default_volume_is_75_percent() {
-        let audio = NativeAudio::new_without_stream(44100);
+        let audio = NativeAudio::new_without_stream(44100, 60);
         assert_eq!(audio.get_volume(), 0.75);
     }
 
     #[test]
     fn test_stats_reset() {
-        let audio = NativeAudio::new_without_stream(44100);
+        let audio = NativeAudio::new_without_stream(44100, 60);
 
         let (received, dropped, underrun) = audio.take_and_reset_stats();
         assert_eq!(received, 0);
@@ -458,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_prime_startup_and_queue_sample() {
-        let mut audio = NativeAudio::new_without_stream(44100);
+        let mut audio = NativeAudio::new_without_stream(44100, 60);
 
         // Prime buffer (bypasses queue_sample, so works regardless of paused state)
         audio.prime_startup(100);
@@ -473,7 +531,7 @@ mod tests {
 
     #[test]
     fn test_resume_and_pause() {
-        let audio = NativeAudio::new_without_stream(44100);
+        let audio = NativeAudio::new_without_stream(44100, 60);
 
         // Starts paused
         assert!(audio.is_paused());
@@ -487,7 +545,7 @@ mod tests {
 
     #[test]
     fn test_queue_sample_does_not_push_when_paused() {
-        let mut audio = NativeAudio::new_without_stream(44100);
+        let mut audio = NativeAudio::new_without_stream(44100, 60);
         assert!(audio.is_paused(), "starts paused");
 
         for i in 0..5 {
@@ -508,7 +566,7 @@ mod tests {
         // drain_stale (so the cpal callback discards those samples silently)
         // WITHOUT changing the paused state, so emulation audio resumes
         // immediately without an explicit resume() call.
-        let mut audio = NativeAudio::new_without_stream(44100);
+        let mut audio = NativeAudio::new_without_stream(44100, 60);
         audio.resume();
 
         for _ in 0..10 {
@@ -538,7 +596,7 @@ mod tests {
         //
         // pause() must snapshot the current fill_level so the callback knows
         // exactly how many samples to discard silently when it resumes.
-        let mut audio = NativeAudio::new_without_stream(44100);
+        let mut audio = NativeAudio::new_without_stream(44100, 60);
         audio.resume();
 
         for _ in 0..10 {
@@ -559,7 +617,7 @@ mod tests {
     fn test_queue_stereo_sample_increments_buffered_count() {
         // queue_stereo_sample() must push one frame into the ring buffer
         // (stereo pair counts as a single "sample" from fill_level's perspective).
-        let mut audio = NativeAudio::new_without_stream(44100);
+        let mut audio = NativeAudio::new_without_stream(44100, 60);
         audio.resume();
 
         audio.queue_stereo_sample(0.5, -0.3);
@@ -580,7 +638,7 @@ mod tests {
     #[test]
     fn test_queue_stereo_sample_does_not_push_when_paused() {
         // Like queue_sample, queue_stereo_sample must be silent while paused.
-        let mut audio = NativeAudio::new_without_stream(44100);
+        let mut audio = NativeAudio::new_without_stream(44100, 60);
         assert!(audio.is_paused());
 
         audio.queue_stereo_sample(0.5, -0.5);
@@ -596,7 +654,7 @@ mod tests {
     fn test_queue_sample_and_queue_stereo_sample_count_together() {
         // Both queue_sample and queue_stereo_sample contribute to the same
         // fill_level counter, and the counts must be consistent.
-        let mut audio = NativeAudio::new_without_stream(44100);
+        let mut audio = NativeAudio::new_without_stream(44100, 60);
         audio.resume();
 
         audio.queue_sample(0.5);
@@ -608,5 +666,25 @@ mod tests {
             3,
             "3 frames (mix of mono and stereo) must register as 3 buffered samples"
         );
+    }
+
+    #[test]
+    fn test_buffer_samples_are_derived_from_ms_and_floor_to_safe_minimum() {
+        assert_eq!(NativeAudio::buffer_samples_for(44100, 60), 2646);
+        assert_eq!(NativeAudio::buffer_samples_for(44100, 20), 2048);
+    }
+
+    #[test]
+    fn test_startup_prime_samples_scale_with_buffer_size() {
+        assert_eq!(NativeAudio::startup_prime_samples_for(2646), 661);
+        assert_eq!(NativeAudio::startup_prime_samples_for(2048), 512);
+    }
+
+    #[test]
+    fn test_new_without_stream_exposes_buffer_metadata() {
+        let audio = NativeAudio::new_without_stream(44100, 60);
+
+        assert_eq!(audio.buffer_capacity_samples(), 2646);
+        assert_eq!(audio.startup_prime_samples(), 661);
     }
 }

--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -184,7 +184,8 @@ impl NativeEventLoop {
 
     fn initialize_audio(&mut self) {
         if let Some(ref mut audio) = self.audio {
-            audio.prime_startup(2048);
+            let startup_prime_samples = audio.startup_prime_samples();
+            audio.prime_startup(startup_prime_samples);
             audio.resume();
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,11 +325,15 @@ fn run_native_emulator(
 
     // Create audio output (request 44.1 kHz) unless disabled or headless.
     let mut audio_sample_rate = None;
-    let audio_enabled = app_context.borrow().config().frontend.audio_enabled;
+    let (audio_enabled, audio_buffer_ms) = {
+        let config = app_context.borrow();
+        let frontend = &config.config().frontend;
+        (frontend.audio_enabled, frontend.audio_buffer_ms)
+    };
     let audio = if !audio_enabled || headless {
         None
     } else {
-        let audio = NativeAudio::new(44100)?;
+        let audio = NativeAudio::new(44100, audio_buffer_ms)?;
         audio_sample_rate = Some(audio.actual_sample_rate() as f32);
         Some(audio)
     };

--- a/src/nes/console/nes.rs
+++ b/src/nes/console/nes.rs
@@ -1,9 +1,9 @@
 use crate::nes::apu::{Apu, ApuState, SharedApu};
-use crate::nes::console::ApuChannels;
 use crate::nes::bus::{Bus, BusState, MapperState, SharedBus};
 #[cfg(test)]
 use crate::nes::cartridge::TimingMode;
 use crate::nes::cartridge::{Cartridge, RomDb, load_rom_db};
+use crate::nes::console::ApuChannels;
 #[cfg(test)]
 use crate::nes::console::Config;
 #[cfg(test)]

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -18,6 +18,9 @@ pub(crate) struct CliFlag {
     pub has_value: bool,
 }
 
+const AUDIO_BUFFER_MIN_MS: u32 = 20;
+const AUDIO_BUFFER_MAX_MS: u32 = 500;
+
 /// RAM initialization mode for power-on/hard reset.
 ///
 /// Controls how all emulated RAM (CPU, PRG, CHR, PPU nametable, and palette) is
@@ -54,6 +57,8 @@ pub enum RamInitMode {
 pub struct FrontendConfig {
     /// Whether audio is enabled.
     pub audio_enabled: bool,
+    /// Target native audio buffering in milliseconds.
+    pub audio_buffer_ms: u32,
     /// Whether VSync is enabled.
     pub vsync_enabled: bool,
     /// Whether gamepad support is enabled.
@@ -122,6 +127,7 @@ impl Default for FrontendConfig {
     fn default() -> Self {
         Self {
             audio_enabled: true,
+            audio_buffer_ms: 60,
             vsync_enabled: true,
             gamepads_enabled: true,
             fullscreen: false,
@@ -194,6 +200,10 @@ impl FrontendConfig {
         }
         if has_negation_flag(args, &["--no-audio", "--disable-audio"]) {
             self.audio_enabled = false;
+        }
+
+        if let Some(buffer_ms) = parse_u32_arg(args, "--audio-buffer-ms")? {
+            self.audio_buffer_ms = buffer_ms.clamp(AUDIO_BUFFER_MIN_MS, AUDIO_BUFFER_MAX_MS);
         }
 
         // VSync: --vsync true/false, --no-vsync, --disable-vsync
@@ -383,6 +393,11 @@ impl FrontendConfig {
             "audio" => {
                 if let Ok(b) = parse_bool(value) {
                     self.audio_enabled = b;
+                }
+            }
+            "audio_buffer_ms" => {
+                if let Ok(ms) = value.parse::<u32>() {
+                    self.audio_buffer_ms = ms.clamp(AUDIO_BUFFER_MIN_MS, AUDIO_BUFFER_MAX_MS);
                 }
             }
             "vsync" => {
@@ -691,6 +706,11 @@ pub(crate) const PLATFORM_CLI_FLAGS: &[CliFlag] = &[
         flag: "--audio",
         help: Some("Enable audio output (optionally: true/false, default when flag present: true)"),
         has_value: false,
+    },
+    CliFlag {
+        flag: "--audio-buffer-ms",
+        help: Some("Target native audio buffering in milliseconds (20-500, default: 60)"),
+        has_value: true,
     },
     CliFlag {
         flag: "--no-audio",
@@ -1444,6 +1464,14 @@ mod tests {
     }
 
     #[test]
+    fn test_help_text_lists_audio_buffer_ms_flag() {
+        let help = help_text();
+
+        assert!(help.contains("--audio-buffer-ms"));
+        assert!(help.contains("Target native audio buffering in milliseconds"));
+    }
+
+    #[test]
     fn test_help_text_oam_dram_decay_shows_default_and_no_negation_aliases() {
         let help = help_text();
 
@@ -1471,6 +1499,39 @@ mod tests {
         ];
         let config = parse_config(args);
         assert!(!config.frontend.audio_enabled);
+    }
+
+    #[test]
+    fn test_config_audio_buffer_ms_default() {
+        let args = vec!["neser".to_string()];
+        let config = parse_config(args);
+        assert_eq!(config.frontend.audio_buffer_ms, 60);
+    }
+
+    #[test]
+    fn test_config_audio_buffer_ms_from_cli() {
+        let args = vec![
+            "neser".to_string(),
+            "--audio-buffer-ms".to_string(),
+            "75".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(config.frontend.audio_buffer_ms, 75);
+    }
+
+    #[test]
+    fn test_config_audio_buffer_ms_clamps_from_config_value() {
+        let mut config = FrontendConfig::default();
+
+        config
+            .apply_config_value("audio_buffer_ms", "5")
+            .expect("config value should parse");
+        assert_eq!(config.audio_buffer_ms, AUDIO_BUFFER_MIN_MS);
+
+        config
+            .apply_config_value("audio_buffer_ms", "5000")
+            .expect("config value should parse");
+        assert_eq!(config.audio_buffer_ms, AUDIO_BUFFER_MAX_MS);
     }
 
     #[test]

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -17,6 +17,7 @@ import { supportedRomExtensionsText, webRomConsoleKindForName, webRomExtensionFo
 import { createAutorunContext, parseAutorunFile } from "./rom/autorun_context";
 import { createFrameLimiter } from "./audio/frame_limiter";
 import { computePlaybackRate } from "./audio/audio_resampler";
+import { AUDIO_PROFILES, resolveAudioProfileName } from "./audio/audio_profiles.js";
 import { normalizeGbSample, normalizeGbaSample, normalizeNesSample } from "./audio/audio_normalizer";
 import { configureEmulatorAudioSampleRate } from "./audio/audio_output_rate";
 import { getPlaybackAudioSamples } from "./audio/playback_samples";
@@ -996,8 +997,10 @@ let audioContext: AudioContext | null = null;
 let nextAudioTime = 0;
 const AUDIO_SAMPLE_RATE = 44100; // Target output sample rate for Web Audio (NES audio is downsampled to this rate)
 const NES_APU_MAX = 1.177; // Conservative max output from NES APU mixer including expansion audio
-const AUDIO_TARGET_LATENCY = 0.1; // seconds
-const AUDIO_MAX_ADJUST = 0.005; // +/- 0.5% playback rate
+const AUDIO_PROFILE_NAME = resolveAudioProfileName(new URLSearchParams(window.location.search).get("audio-profile"));
+const AUDIO_PROFILE = AUDIO_PROFILES[AUDIO_PROFILE_NAME];
+const AUDIO_TARGET_LATENCY = AUDIO_PROFILE.targetLatencySeconds; // seconds
+const AUDIO_MAX_ADJUST = AUDIO_PROFILE.maxAdjust; // +/- playback rate bound
 const AUDIO_LATENCY_GAIN = 0.1; // scale factor for latency correction
 let audioMuted = false;
 let lastGamepadState1 = {

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -17,7 +17,7 @@ import { supportedRomExtensionsText, webRomConsoleKindForName, webRomExtensionFo
 import { createAutorunContext, parseAutorunFile } from "./rom/autorun_context";
 import { createFrameLimiter } from "./audio/frame_limiter";
 import { computePlaybackRate } from "./audio/audio_resampler";
-import { AUDIO_PROFILES, resolveAudioProfileName } from "./audio/audio_profiles.js";
+import { AUDIO_PROFILES, resolveAudioProfileName } from "./audio/audio_profiles";
 import { normalizeGbSample, normalizeGbaSample, normalizeNesSample } from "./audio/audio_normalizer";
 import { configureEmulatorAudioSampleRate } from "./audio/audio_output_rate";
 import { getPlaybackAudioSamples } from "./audio/playback_samples";

--- a/web/src/audio/audio_profiles.test.ts
+++ b/web/src/audio/audio_profiles.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { AUDIO_PROFILES, resolveAudioProfileName } from "./audio_profiles.js";
+import { AUDIO_PROFILES, resolveAudioProfileName } from "./audio_profiles";
 
 it("resolveAudioProfileName defaults to balanced", () => {
     expect(resolveAudioProfileName(null)).toBe("balanced");

--- a/web/src/audio/audio_profiles.test.ts
+++ b/web/src/audio/audio_profiles.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from "vitest";
+import { AUDIO_PROFILES, resolveAudioProfileName } from "./audio_profiles.js";
+
+it("resolveAudioProfileName defaults to balanced", () => {
+    expect(resolveAudioProfileName(null)).toBe("balanced");
+    expect(resolveAudioProfileName(undefined)).toBe("balanced");
+    expect(resolveAudioProfileName("unknown")).toBe("balanced");
+});
+
+it("resolveAudioProfileName accepts the low-latency profile", () => {
+    expect(resolveAudioProfileName("low-latency")).toBe("low-latency");
+});
+
+it("audio profiles expose the configured latency targets", () => {
+    expect(AUDIO_PROFILES.balanced.targetLatencySeconds).toBe(0.06);
+    expect(AUDIO_PROFILES.balanced.maxAdjust).toBe(0.0075);
+    expect(AUDIO_PROFILES["low-latency"].targetLatencySeconds).toBe(0.04);
+    expect(AUDIO_PROFILES["low-latency"].maxAdjust).toBe(0.01);
+});

--- a/web/src/audio/audio_profiles.ts
+++ b/web/src/audio/audio_profiles.ts
@@ -1,0 +1,21 @@
+export type AudioProfileName = "balanced" | "low-latency";
+
+export type AudioProfile = {
+    targetLatencySeconds: number;
+    maxAdjust: number;
+};
+
+export const AUDIO_PROFILES: Record<AudioProfileName, AudioProfile> = {
+    balanced: {
+        targetLatencySeconds: 0.06,
+        maxAdjust: 0.0075
+    },
+    "low-latency": {
+        targetLatencySeconds: 0.04,
+        maxAdjust: 0.01
+    }
+};
+
+export function resolveAudioProfileName(value: string | null | undefined): AudioProfileName {
+    return value === "low-latency" ? "low-latency" : "balanced";
+}


### PR DESCRIPTION
This PR adds millisecond-based native audio buffering with a default of 60 ms and a clamped 20-500 ms range.

It also replaces the web frontend's hardcoded latency constants with two explicit profiles, `balanced` and `low-latency`, selected via the `audio-profile` query parameter.

Validation:
- cargo test --lib --features native audio_buffer_ms
- cargo test --lib --features native buffer_samples
- cargo test --lib --features native startup_prime_samples
- npm test -- --run web/src/audio/audio_profiles.test.ts