### PR TITLE
feat(config): make audio sample rate configurable (#2708)

### DIFF
--- a/neser.conf.example
+++ b/neser.conf.example
@@ -88,7 +88,7 @@ audio=true
 
 # Target native audio sample rate in Hz.
 # Supported values: 22050, 44100, 48000, 96000, 192000
-# If the requested rate is not supported by the audio device, the device default is used.
+# If no mono f32 stream at the requested rate is available, the device default is used.
 # Default: 44100
 #audio_sample_rate=44100
 

--- a/neser.conf.example
+++ b/neser.conf.example
@@ -86,6 +86,12 @@ audio=true
 # Default: 60
 #audio_buffer_ms=60
 
+# Target native audio sample rate in Hz.
+# Supported values: 22050, 44100, 48000, 96000, 192000
+# If the requested rate is not supported by the audio device, the device default is used.
+# Default: 44100
+#audio_sample_rate=44100
+
 # Individual APU channel toggles.
 # Useful for isolating specific sounds or debugging audio issues.
 nes-pulse1=true

--- a/src/frontends/native/audio.rs
+++ b/src/frontends/native/audio.rs
@@ -82,7 +82,7 @@ impl NativeAudio {
 
         if actual_rate != sample_rate {
             log_info(format!(
-                "Warning: Audio: requested {} Hz but cpal device only supports {} Hz — using device default",
+                "Audio: no mono f32 stream at {} Hz available — falling back to device default at {} Hz",
                 sample_rate, actual_rate
             ));
         }

--- a/src/frontends/native/audio.rs
+++ b/src/frontends/native/audio.rs
@@ -82,7 +82,7 @@ impl NativeAudio {
 
         if actual_rate != sample_rate {
             log_info(format!(
-                "Audio: requested {} Hz, got {} Hz from cpal device",
+                "Warning: Audio: requested {} Hz but cpal device only supports {} Hz — using device default",
                 sample_rate, actual_rate
             ));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,17 +323,21 @@ fn run_native_emulator(
     // record/extend have no guaranteed termination condition.
     let headless = autorun_headless && autorun_mode == platform::autorun::AutorunMode::Playback;
 
-    // Create audio output (request 44.1 kHz) unless disabled or headless.
+    // Create audio output unless disabled or headless.
     let mut audio_sample_rate = None;
-    let (audio_enabled, audio_buffer_ms) = {
+    let (audio_enabled, audio_buffer_ms, configured_sample_rate) = {
         let config = app_context.borrow();
         let frontend = &config.config().frontend;
-        (frontend.audio_enabled, frontend.audio_buffer_ms)
+        (
+            frontend.audio_enabled,
+            frontend.audio_buffer_ms,
+            frontend.audio_sample_rate,
+        )
     };
     let audio = if !audio_enabled || headless {
         None
     } else {
-        let audio = NativeAudio::new(44100, audio_buffer_ms)?;
+        let audio = NativeAudio::new(configured_sample_rate as i32, audio_buffer_ms)?;
         audio_sample_rate = Some(audio.actual_sample_rate() as f32);
         Some(audio)
     };

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -20,6 +20,18 @@ pub(crate) struct CliFlag {
 
 const AUDIO_BUFFER_MIN_MS: u32 = 20;
 const AUDIO_BUFFER_MAX_MS: u32 = 500;
+const ALLOWED_AUDIO_SAMPLE_RATES: [u32; 5] = [22_050, 44_100, 48_000, 96_000, 192_000];
+
+fn validate_audio_sample_rate(rate: u32) -> Result<u32, String> {
+    if ALLOWED_AUDIO_SAMPLE_RATES.contains(&rate) {
+        Ok(rate)
+    } else {
+        Err(format!(
+            "Unsupported audio sample rate '{}'. Supported values are: {:?}",
+            rate, ALLOWED_AUDIO_SAMPLE_RATES
+        ))
+    }
+}
 
 /// RAM initialization mode for power-on/hard reset.
 ///
@@ -59,6 +71,8 @@ pub struct FrontendConfig {
     pub audio_enabled: bool,
     /// Target native audio buffering in milliseconds.
     pub audio_buffer_ms: u32,
+    /// Target native audio sample rate in Hz.
+    pub audio_sample_rate: u32,
     /// Whether VSync is enabled.
     pub vsync_enabled: bool,
     /// Whether gamepad support is enabled.
@@ -126,6 +140,7 @@ pub struct FrontendConfig {
 impl Default for FrontendConfig {
     fn default() -> Self {
         Self {
+            audio_sample_rate: 44_100,
             audio_enabled: true,
             audio_buffer_ms: 60,
             vsync_enabled: true,
@@ -204,6 +219,11 @@ impl FrontendConfig {
 
         if let Some(buffer_ms) = parse_u32_arg(args, "--audio-buffer-ms")? {
             self.audio_buffer_ms = buffer_ms.clamp(AUDIO_BUFFER_MIN_MS, AUDIO_BUFFER_MAX_MS);
+        }
+
+        if let Some(rate) = parse_u32_arg(args, "--audio-sample-rate")? {
+            self.audio_sample_rate = validate_audio_sample_rate(rate)
+                .map_err(|e| format!("--audio-sample-rate: {e}"))?;
         }
 
         // VSync: --vsync true/false, --no-vsync, --disable-vsync
@@ -400,6 +420,17 @@ impl FrontendConfig {
                     self.audio_buffer_ms = ms.clamp(AUDIO_BUFFER_MIN_MS, AUDIO_BUFFER_MAX_MS);
                 }
             }
+            "audio_sample_rate" => match value.parse::<u32>() {
+                Ok(rate) => {
+                    self.audio_sample_rate = validate_audio_sample_rate(rate)?;
+                }
+                Err(_) => {
+                    return Err(format!(
+                        "Invalid value for audio_sample_rate '{}'. Expected a positive integer",
+                        value
+                    ));
+                }
+            },
             "vsync" => {
                 if let Ok(b) = parse_bool(value) {
                     self.vsync_enabled = b;
@@ -710,6 +741,13 @@ pub(crate) const PLATFORM_CLI_FLAGS: &[CliFlag] = &[
     CliFlag {
         flag: "--audio-buffer-ms",
         help: Some("Target native audio buffering in milliseconds (20-500, default: 60)"),
+        has_value: true,
+    },
+    CliFlag {
+        flag: "--audio-sample-rate",
+        help: Some(
+            "Target native audio sample rate in Hz (22050, 44100, 48000, 96000, 192000; default: 44100)",
+        ),
         has_value: true,
     },
     CliFlag {
@@ -1134,6 +1172,8 @@ fn help_section_for_flag(flag: &str) -> &'static str {
         "--audio"
             | "--no-audio"
             | "--disable-audio"
+            | "--audio-buffer-ms"
+            | "--audio-sample-rate"
             | "--nes-pulse1"
             | "--no-nes-pulse1"
             | "--disable-nes-pulse1"
@@ -1472,6 +1512,16 @@ mod tests {
     }
 
     #[test]
+    fn test_help_text_lists_audio_sample_rate_flag() {
+        let help = help_text();
+
+        assert!(help.contains("--audio-sample-rate"));
+        assert!(help.contains("Target native audio sample rate in Hz"));
+        assert!(help.contains("22050, 44100, 48000, 96000, 192000"));
+        assert!(help.contains("default: 44100"));
+    }
+
+    #[test]
     fn test_help_text_oam_dram_decay_shows_default_and_no_negation_aliases() {
         let help = help_text();
 
@@ -1532,6 +1582,66 @@ mod tests {
             .apply_config_value("audio_buffer_ms", "5000")
             .expect("config value should parse");
         assert_eq!(config.audio_buffer_ms, AUDIO_BUFFER_MAX_MS);
+    }
+
+    #[test]
+    fn test_config_audio_sample_rate_default() {
+        let args = vec!["neser".to_string()];
+        let config = parse_config(args);
+        assert_eq!(config.frontend.audio_sample_rate, 44100);
+    }
+
+    #[test]
+    fn test_config_audio_sample_rate_from_cli() {
+        let args = vec![
+            "neser".to_string(),
+            "--audio-sample-rate".to_string(),
+            "48000".to_string(),
+        ];
+        let config = parse_config(args);
+        assert_eq!(config.frontend.audio_sample_rate, 48000);
+    }
+
+    #[test]
+    fn test_config_audio_sample_rate_from_config_value() {
+        let mut config = FrontendConfig::default();
+
+        config
+            .apply_config_value("audio_sample_rate", "96000")
+            .expect("config value should parse");
+        assert_eq!(config.audio_sample_rate, 96000);
+    }
+
+    #[test]
+    fn test_config_audio_sample_rate_rejects_unsupported_rates() {
+        let mut config = FrontendConfig::default();
+
+        assert!(
+            config
+                .apply_config_value("audio_sample_rate", "12345")
+                .is_err()
+        );
+        assert!(config.apply_config_value("audio-sample-rate", "0").is_err());
+        assert!(
+            config
+                .apply_config_value("audio_sample_rate", "-44100")
+                .is_err()
+        );
+        assert!(
+            config
+                .apply_config_value("audio_sample_rate", "not_a_number")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_config_audio_sample_rate_cli_rejects_invalid_values() {
+        let args = vec![
+            "neser".to_string(),
+            "--audio-sample-rate".to_string(),
+            "12345".to_string(),
+        ];
+        assert!(Config::new(&args).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #2708

Makes the native audio output sample rate configurable via CLI flag and config file, replacing the previously hardcoded 44100 Hz.

## Changes

- **`src/platform/config.rs`**: Added `audio_sample_rate: u32` field to `FrontendConfig` (default: 44100), `--audio-sample-rate` CLI flag, `audio_sample_rate` config file key, and `validate_audio_sample_rate` helper. Also fixes a pre-existing bug where `--audio-buffer-ms` was categorised under General instead of Sound in `help_section_for_flag` (this caused `test_help_text_groups_flags_into_readable_sections` to fail on main since #2707).
- **`src/main.rs`**: Reads `frontend.audio_sample_rate` and passes it to `NativeAudio::new` instead of hardcoded 44100.
- **`src/frontends/native/audio.rs`**: Updated device-fallback log message to include explicit warning wording.
- **`neser.conf.example`**: Documents the new `audio_sample_rate` option with supported values and cpal fallback note.

## Supported values

22050, 44100, 48000, 96000, 192000. Other values are rejected with a clear error message at startup.

## Tests

6 new unit tests in `src/platform/config.rs`:
- Default value is 44100
- CLI flag sets the rate
- Config file key sets the rate
- Unsupported rates rejected with error
- CLI invalid value rejected with error
- Help text lists the flag

## Pre-merge checks

- `cargo fmt`: OK
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --no-default-features --lib`: 10746 passed, 0 failed
- Python tests: 197+105+44 passed, all OK
- `npm test`: 363 passed (45 test files)