### PR TITLE
feat(snes): Add SNES module scaffolding and platform integration (#2717)

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -10,7 +10,7 @@ The native frontend now exposes audio buffering in milliseconds through configur
 
 The codebase is roughly 183,000 lines of Rust, with additional JavaScript for the web frontend and Python tooling for ROM management.
 
-As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic `Emulator` trait and a `Console` enum that wraps the NES, Game Boy, and Game Boy Advance implementations. This allows the native frontend and GL backend to dispatch common operations through the trait instead of matching on specific console variants or using NES-specific types directly. The architecture is designed to be extensible for future emulated systems while maintaining a clean separation between hardware-specific logic and shared platform/frontend code.
+As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic `Emulator` trait and a `Console` enum that wraps the NES, Game Boy, Game Boy Advance, and SNES (stub) implementations. This allows the native frontend and GL backend to dispatch common operations through the trait instead of matching on specific console variants or using NES-specific types directly. The architecture is designed to be extensible for future emulated systems while maintaining a clean separation between hardware-specific logic and shared platform/frontend code.
 
 ## High-Level Architecture
 
@@ -29,7 +29,7 @@ As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic 
 │  │  (src/platform/emulator.rs)                     │  │
 │  │  Hardware-agnostic interface: run_tick, render, │  │
 │  │  audio, input, save/load state, reset           │  │
-│  │  Variants: Nes, GameBoy, GameBoyAdvance         │  │
+│  │  Variants: Nes, GameBoy, GameBoyAdvance, Snes   │  │
 │  └──────────────────────┬─────────────────────────-┘  │
 │                         │                             │
 │                         ▼                             │
@@ -70,7 +70,7 @@ As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic 
 
 The emulator is designed around a **multi-layer architecture**:
 
-- **Emulator trait + Console enum** (`src/platform/emulator.rs`): The `Emulator` trait defines the common interface that every emulated system must implement (run, render, audio, input, save/load state, reset — 22 methods total). `Nes`, `GameBoy`, and `Gba` implement the trait in their respective modules. The `Console` enum wraps all three systems and delegates common methods through `as_core()`/`as_core_mut()` (which return `&dyn Emulator`), keeping a single pair of match arms instead of one per method. System-specific features (NES debugging, PPU viewer, Zapper) are still accessed by matching on `Console::Nes`.
+- **Emulator trait + Console enum** (`src/platform/emulator.rs`): The `Emulator` trait defines the common interface that every emulated system must implement (run, render, audio, input, save/load state, reset — 22 methods total). `Nes`, `GameBoy`, `Gba`, and `Snes` (stub) implement the trait in their respective modules. The `Console` enum wraps all four systems and delegates common methods through `as_core()`/`as_core_mut()` (which return `&dyn Emulator`), keeping a single pair of match arms instead of one per method. System-specific features (NES debugging, PPU viewer, Zapper) are still accessed by matching on `Console::Nes`.
 - **NES emulator** (`src/nes/`): All NES-specific hardware lives under this namespace. The `Nes` struct in `src/nes/console/nes.rs` orchestrates the per-cycle stepping of CPU, PPU, APU, and Bus.
 - **Shared platform** (`src/platform/`): `FrontendConfig` (src/platform/config.rs), `AppContext` (src/platform/app_context.rs), audio infrastructure, and system-agnostic toast formatters are shared across all emulated systems.
 - **Bus-centric hardware**: Within the NES, the `Bus` struct routes memory reads and writes between the CPU, PPU registers, APU registers, RAM, OAM DMA, controller ports, and the cartridge mapper.
@@ -312,6 +312,30 @@ All Game Boy Advance hardware lives under `src/gba/`. The module currently provi
 | `src/gba/debugging/breakpoints.rs` | `Breakpoints` — `BTreeSet<u32>` wrapper supporting insert/remove/contains/clear and ordered iteration over breakpoint addresses. |
 | `src/gba/debugging/trace.rs` | `CpuTrace` ring buffer of recently retired instructions (`TraceEntry` carrying PC, raw word, Thumb flag, mnemonic, R0–R15 snapshot, CPSR and cumulative cycle count); configurable capacity, default 1024, with enable/disable toggle. |
 | `src/gba/debugging/controller.rs` | `GbaDebuggerController` — glues the breakpoint set, trace ring buffer, optional file logger, and disassembler to `Arm7tdmi`. Provides `step`, `run_until_breakpoint` and trace-to-file hooks. |
+
+#### SNES Emulation (`src/snes/`)
+
+The SNES (Super Nintendo Entertainment System) module provides scaffolding for future SNES emulation. Currently, it contains only stub implementations that allow SNES ROMs (`.sfc`/`.smc` files) to be recognized and dispatched through the platform layer.
+
+| Directory/File | Description |
+| ---------------- | ------------- |
+| `src/snes/mod.rs` | SNES module root. Declares all SNES sub-modules (bus, console, cpu, ppu, apu, cartridge, input, integration_tests). |
+| `src/snes/console/mod.rs` | Console module root. Re-exports `Snes` and `SnesConfig`. |
+| `src/snes/console/snes.rs` | `Snes` — platform-facing SNES wrapper implementing the `Emulator` trait. All methods are currently stubbed but return correct dimensions (256×224) and frame timing (~60.098 Hz). Provides `load_rom`, `system_type`, screen dimensions, and frame duration methods. |
+| `src/snes/console/config.rs` | `SnesConfig` struct for SNES-specific configuration (currently empty, ready for future settings). |
+| `src/snes/bus/mod.rs` | `SnesBus` trait definition and `StubBus` implementation. The trait defines the memory access contract (`read`, `write`, `tick`) mirroring the pattern used in GB and GBA. |
+| `src/snes/cpu/mod.rs` | CPU module stub (65816 processor — future implementation). |
+| `src/snes/ppu/mod.rs` | PPU module stub (SNES Picture Processing Unit — future implementation). |
+| `src/snes/apu/mod.rs` | APU module stub (SPC700 + DSP — future implementation). |
+| `src/snes/cartridge/mod.rs` | Cartridge module stub (SNES ROM parsing and LoROM/HiROM mapping — future implementation). |
+| `src/snes/input/mod.rs` | Input module stub (SNES controller protocol — future implementation). |
+| `src/snes/integration_tests/mod.rs` | Integration tests module stub (SNES validation ROMs — future implementation). |
+
+**Hardware Constants** (defined in `src/snes/console/snes.rs`):
+- Screen resolution: 256×224 pixels (NTSC mode, most common)
+- Pixel aspect ratio: 8:7 (matching NES NTSC)
+- Frame rate: ~60.098 Hz (21.477272 MHz master clock ÷ 357366 cycles per frame)
+- Frame duration: 16.639 ms
 
 #### Frontends
 

--- a/src/frontends/native/app_state.rs
+++ b/src/frontends/native/app_state.rs
@@ -250,7 +250,9 @@ impl NativeAppState {
                         nes.active_controller_port_type(2) == ControllerType::PowerPad,
                     )
                 }
-                Console::GameBoy(_) | Console::GameBoyAdvance(_) => (false, false),
+                Console::GameBoy(_) | Console::GameBoyAdvance(_) | Console::Snes(_) => {
+                    (false, false)
+                }
             };
             return Some(help_overlay_text(
                 console,
@@ -309,6 +311,10 @@ F6/F7: Save/Load state";
 
     if matches!(console, Console::GameBoy(_)) {
         return format!("{hotkeys}{}", gameboy_keyboard_section(gamepad_count));
+    }
+
+    if matches!(console, Console::Snes(_)) {
+        return format!("{hotkeys}{}", snes_keyboard_section(gamepad_count));
     }
 
     for port in 1..=max_ports {
@@ -404,6 +410,27 @@ Q: L\n\
 E: R\n\
 R: B\n\
 T: A\n\
+4: Select\n\
+5: Start"
+    )
+}
+
+fn snes_keyboard_section(gamepad_count: usize) -> String {
+    let controller = if gamepad_count == 0 {
+        "Keyboard".to_string()
+    } else {
+        "Gamepad + Keyboard shoulders/aliases".to_string()
+    };
+    format!(
+        "\n\nSNES: {controller}\n\
+W/A/S/D: D-Pad\n\
+Arrow keys: D-Pad\n\
+Q: L\n\
+E: R\n\
+R: B\n\
+T: A\n\
+Y: Y\n\
+U: X\n\
 4: Select\n\
 5: Start"
     )

--- a/src/frontends/native/app_state.rs
+++ b/src/frontends/native/app_state.rs
@@ -422,7 +422,7 @@ fn snes_keyboard_section(gamepad_count: usize) -> String {
         "Gamepad + Keyboard shoulders/aliases".to_string()
     };
     format!(
-        "\n\nSNES: {controller}\n\
+        "\n\nSNES: {controller} (controller input not yet implemented)\n\
 W/A/S/D: D-Pad\n\
 Arrow keys: D-Pad\n\
 Q: L\n\

--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -194,7 +194,7 @@ impl NativeEventLoop {
         let debugger_paused = match &self.console {
             Console::Nes(_) => self.debugger_controller.is_paused(),
             Console::GameBoy(_) => self.gb_debugger_controller.is_paused(),
-            Console::GameBoyAdvance(_) => false, // GBA debugger not yet implemented
+            Console::GameBoyAdvance(_) | Console::Snes(_) => false, // GBA and SNES debuggers not yet implemented
         };
         if self.state.paused && !debugger_paused {
             // Manually paused (not debugger) — skip frame
@@ -247,6 +247,19 @@ impl NativeEventLoop {
                     }
                 }
             }
+            Console::Snes(snes) => {
+                // SNES: run frame without debugger support
+                while !snes.is_ready_to_render() {
+                    let _ = snes.run_tick();
+                    if let Some(ref mut audio) = *audio_cell.borrow_mut() {
+                        while snes.sample_ready() {
+                            if let Some(sample) = snes.get_sample() {
+                                audio.queue_sample(sample);
+                            }
+                        }
+                    }
+                }
+            }
         }
         self.audio = audio_cell.into_inner();
         self.sync_from_controller();
@@ -289,7 +302,7 @@ impl NativeEventLoop {
         let debugger_open = match &self.console {
             Console::Nes(_) => self.debugger_controller.is_debugger_open(),
             Console::GameBoy(_) => self.gb_debugger_controller.is_debugger_open(),
-            Console::GameBoyAdvance(_) => false, // GBA debugger not yet implemented
+            Console::GameBoyAdvance(_) | Console::Snes(_) => false, // GBA and SNES debuggers not yet implemented
         };
 
         if debugger_open {
@@ -782,8 +795,8 @@ impl ApplicationHandler for NativeEventLoop {
                                         &mut self.gb_debugger_controller,
                                     );
                                 }
-                                Console::GameBoyAdvance(_) => {
-                                    // GBA debugger not yet implemented
+                                Console::GameBoyAdvance(_) | Console::Snes(_) => {
+                                    // GBA and SNES debuggers not yet implemented
                                 }
                             }
                             self.sync_from_controller();
@@ -796,8 +809,8 @@ impl ApplicationHandler for NativeEventLoop {
                                 Console::GameBoy(gb) => {
                                     gb.step_over_with_controller(&mut self.gb_debugger_controller);
                                 }
-                                Console::GameBoyAdvance(_) => {
-                                    // GBA debugger not yet implemented
+                                Console::GameBoyAdvance(_) | Console::Snes(_) => {
+                                    // GBA and SNES debuggers not yet implemented
                                 }
                             }
                             self.sync_from_controller();
@@ -810,8 +823,8 @@ impl ApplicationHandler for NativeEventLoop {
                                 Console::GameBoy(gb) => {
                                     gb.step_into_with_controller(&mut self.gb_debugger_controller);
                                 }
-                                Console::GameBoyAdvance(_) => {
-                                    // GBA debugger not yet implemented
+                                Console::GameBoyAdvance(_) | Console::Snes(_) => {
+                                    // GBA and SNES debuggers not yet implemented
                                 }
                             }
                             self.sync_from_controller();
@@ -1012,8 +1025,8 @@ impl ApplicationHandler for NativeEventLoop {
                         Console::GameBoy(_) => {
                             gl.update_gb_breakpoints(self.gb_debugger_controller.breakpoints());
                         }
-                        Console::GameBoyAdvance(_) => {
-                            // GBA debugger breakpoints not yet implemented
+                        Console::GameBoyAdvance(_) | Console::Snes(_) => {
+                            // GBA and SNES debugger breakpoints not yet implemented
                         }
                     }
                     let crosshair =
@@ -1048,8 +1061,8 @@ impl ApplicationHandler for NativeEventLoop {
                             );
                         }
                     }
-                    Console::GameBoyAdvance(_) => {
-                        // GBA debugger UI not yet implemented
+                    Console::GameBoyAdvance(_) | Console::Snes(_) => {
+                        // GBA and SNES debugger UI not yet implemented
                     }
                 }
                 self.sync_from_controller();

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -65,10 +65,7 @@ pub fn handle_key_pressed(
         }
         Console::GameBoy(_) => handle_gameboy_key_pressed(console, key_code, app_state, audio),
         Console::GameBoyAdvance(_) => handle_gba_key_pressed(console, key_code, app_state, audio),
-        Console::Snes(_) => {
-            // SNES: basic input handling (no debugger yet)
-            KeyOutcome::Continue
-        }
+        Console::Snes(_) => handle_snes_key_pressed(console, key_code, app_state, audio),
     }
 }
 
@@ -243,6 +240,17 @@ fn handle_gba_key_pressed(
     audio: Option<&dyn EmulatorAudio>,
 ) -> KeyOutcome {
     handle_single_joypad_key_pressed(console, key_code, app_state, audio, gba_key_to_button_id)
+}
+
+fn handle_snes_key_pressed(
+    console: &mut Console,
+    key_code: KeyCode,
+    app_state: &mut NativeAppState,
+    audio: Option<&dyn EmulatorAudio>,
+) -> KeyOutcome {
+    // SNES controller input mapping not yet implemented; route common hotkeys
+    // (quit, pause, reset, fullscreen, volume, etc.) so the app remains operable.
+    handle_single_joypad_key_pressed(console, key_code, app_state, audio, |_| None)
 }
 
 fn handle_single_joypad_key_pressed(

--- a/src/frontends/native/keyboard.rs
+++ b/src/frontends/native/keyboard.rs
@@ -65,6 +65,10 @@ pub fn handle_key_pressed(
         }
         Console::GameBoy(_) => handle_gameboy_key_pressed(console, key_code, app_state, audio),
         Console::GameBoyAdvance(_) => handle_gba_key_pressed(console, key_code, app_state, audio),
+        Console::Snes(_) => {
+            // SNES: basic input handling (no debugger yet)
+            KeyOutcome::Continue
+        }
     }
 }
 
@@ -96,6 +100,9 @@ pub fn handle_key_released(
             if let Some(btn_id) = gba_key_to_button_id(key_code) {
                 console.set_button(0, btn_id, false);
             }
+        }
+        Console::Snes(_) => {
+            // SNES: input handling not yet implemented
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod gb;
 pub mod gba;
 pub mod nes;
 pub mod platform;
+pub mod snes;
 
 #[cfg(feature = "wasm")]
 #[path = "frontends/web/wasm.rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,12 @@
 // by the library or test code, producing dead_code warnings in the binary crate.
 #![allow(dead_code)]
 
-mod nes;
-
 mod frontends;
 mod gb;
 mod gba;
+mod nes;
 mod platform;
+mod snes;
 
 use nes::console::{
     CartridgeCatalogOptions, Config, Nes, ParseResult, default_catalog_csv_path,
@@ -415,6 +415,19 @@ fn run_native_emulator(
                 .add_toast(cartridge_load_toast_message(rom_path, true));
             console
         }
+        platform::emulator::SystemType::Snes => {
+            let mut console = platform::emulator::Console::new_snes(app_context.clone());
+            if let Err(err) = console.load_rom(&rom_bytes, rom_path) {
+                app_context
+                    .borrow_mut()
+                    .add_toast(cartridge_load_toast_message(rom_path, false));
+                return Err(err.into());
+            }
+            app_context
+                .borrow_mut()
+                .add_toast(cartridge_load_toast_message(rom_path, true));
+            console
+        }
     };
     let mut console = console;
 
@@ -473,6 +486,8 @@ fn detect_system_type(path: &str) -> platform::emulator::SystemType {
         platform::emulator::SystemType::GameBoy
     } else if ext.eq_ignore_ascii_case("gba") {
         platform::emulator::SystemType::Gba
+    } else if ext.eq_ignore_ascii_case("sfc") || ext.eq_ignore_ascii_case("smc") {
+        platform::emulator::SystemType::Snes
     } else {
         platform::emulator::SystemType::Nes
     }
@@ -513,6 +528,26 @@ mod tests {
     #[test]
     fn detect_system_type_gba_extension_returns_gba() {
         assert_eq!(detect_system_type("zelda.gba"), SystemType::Gba);
+    }
+
+    #[test]
+    fn detect_system_type_sfc_extension_returns_snes() {
+        assert_eq!(detect_system_type("game.sfc"), SystemType::Snes);
+    }
+
+    #[test]
+    fn detect_system_type_smc_extension_returns_snes() {
+        assert_eq!(detect_system_type("game.smc"), SystemType::Snes);
+    }
+
+    #[test]
+    fn detect_system_type_uppercase_sfc_returns_snes() {
+        assert_eq!(detect_system_type("GAME.SFC"), SystemType::Snes);
+    }
+
+    #[test]
+    fn detect_system_type_uppercase_smc_returns_snes() {
+        assert_eq!(detect_system_type("GAME.SMC"), SystemType::Snes);
     }
 
     #[test]

--- a/src/platform/config.rs
+++ b/src/platform/config.rs
@@ -184,7 +184,8 @@ impl Default for FrontendConfig {
 /// Composed of [`FrontendConfig`] (generic frontend settings),
 /// [`NesConfig`](crate::nes::console::NesConfig) (NES hardware-specific settings),
 /// [`GbConfig`](crate::gb::console::config::GbConfig) (Game Boy-specific settings),
-/// and [`GbaConfig`](crate::gba::console::config::GbaConfig) (GBA-specific settings).
+/// [`GbaConfig`](crate::gba::console::config::GbaConfig) (GBA-specific settings),
+/// and [`SnesConfig`](crate::snes::console::config::SnesConfig) (SNES-specific settings).
 /// Parsing from CLI arguments and config files populates all sub-configs.
 #[derive(Debug, Clone, Default)]
 pub struct Config {
@@ -196,6 +197,8 @@ pub struct Config {
     pub gb: crate::gb::console::config::GbConfig,
     /// GBA-specific hardware configuration.
     pub gba: crate::gba::console::config::GbaConfig,
+    /// SNES-specific hardware configuration.
+    pub snes: crate::snes::console::config::SnesConfig,
 }
 
 impl FrontendConfig {

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -16,6 +16,7 @@ use crate::gb::GameBoy;
 use crate::gba::Gba;
 use crate::nes::console::Nes;
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
+use crate::snes::console::Snes;
 
 /// Common operations that every emulated system must support.
 ///
@@ -67,6 +68,7 @@ pub enum SystemType {
     Nes,
     GameBoy,
     Gba,
+    Snes,
 }
 
 /// Hardware-agnostic wrapper around system-specific emulators.
@@ -84,6 +86,7 @@ pub enum Console {
     Nes(Box<Nes>),
     GameBoy(Box<GameBoy>),
     GameBoyAdvance(Box<Gba>),
+    Snes(Box<Snes>),
 }
 
 impl Console {
@@ -102,12 +105,18 @@ impl Console {
         Console::GameBoyAdvance(Box::new(Gba::new(app_context)))
     }
 
+    /// Create a new SNES emulator instance.
+    pub fn new_snes(app_context: impl IntoSharedAppContext) -> Self {
+        Console::Snes(Box::new(Snes::new(app_context)))
+    }
+
     /// Access the common emulator interface (immutable).
     pub fn as_core(&self) -> &dyn Emulator {
         match self {
             Console::Nes(nes) => nes.as_ref(),
             Console::GameBoy(gb) => gb.as_ref(),
             Console::GameBoyAdvance(gba) => gba.as_ref(),
+            Console::Snes(snes) => snes.as_ref(),
         }
     }
 
@@ -117,6 +126,7 @@ impl Console {
             Console::Nes(nes) => nes.as_mut(),
             Console::GameBoy(gb) => gb.as_mut(),
             Console::GameBoyAdvance(gba) => gba.as_mut(),
+            Console::Snes(snes) => snes.as_mut(),
         }
     }
 
@@ -255,6 +265,7 @@ impl Console {
             Console::Nes(nes) => nes.state_path(),
             Console::GameBoy(gb) => gb.state_path(),
             Console::GameBoyAdvance(gba) => gba.state_path(),
+            Console::Snes(snes) => snes.state_path(),
         }
     }
 
@@ -284,7 +295,7 @@ impl Console {
     /// Horizontal and vertical overscan in pixels for the current system.
     ///
     /// For NES, values are read from the emulator configuration.
-    /// For Game Boy, overscan is always `(0, 0)` — the GB has no overscan.
+    /// For Game Boy, GBA, and SNES, overscan is always `(0, 0)`.
     pub fn overscan(&self) -> (u32, u32) {
         match self {
             Console::Nes(nes) => {
@@ -295,7 +306,7 @@ impl Console {
                     cfg.nes.vertical_overscan as u32,
                 )
             }
-            Console::GameBoy(_) | Console::GameBoyAdvance(_) => (0, 0),
+            Console::GameBoy(_) | Console::GameBoyAdvance(_) | Console::Snes(_) => (0, 0),
         }
     }
 
@@ -311,8 +322,8 @@ impl Console {
     /// precondition used by the NES cropped snapshot path instead of silently
     /// clamping invalid values.
     ///
-    /// For Game Boy, overscan parameters are ignored and the native 160×144
-    /// resolution is always returned.
+    /// For Game Boy, GBA, and SNES, overscan parameters are ignored and the
+    /// native resolution is always returned.
     pub fn cropped_dims(&self, h_overscan: u32, v_overscan: u32) -> (u32, u32) {
         match self {
             Console::Nes(_) => {
@@ -341,7 +352,7 @@ impl Console {
                     screen_height - 2 * v_overscan,
                 )
             }
-            Console::GameBoy(_) | Console::GameBoyAdvance(_) => {
+            Console::GameBoy(_) | Console::GameBoyAdvance(_) | Console::Snes(_) => {
                 (self.screen_width(), self.screen_height())
             }
         }
@@ -349,12 +360,13 @@ impl Console {
 
     /// Pixel aspect ratio correction factor for the current system.
     ///
-    /// NES pixels are not square: the NTSC hardware maps 256 pixels across the
-    /// same horizontal extent as approximately 280 square pixels (8:7 ratio).
-    /// Game Boy and GBA pixels are square, so the correction factor is 1.0.
+    /// NES and SNES pixels are not square: the NTSC hardware maps 256 pixels
+    /// across the same horizontal extent as approximately 280 square pixels
+    /// (8:7 ratio). Game Boy and GBA pixels are square, so the correction
+    /// factor is 1.0.
     pub fn pixel_aspect(&self) -> f32 {
         match self {
-            Console::Nes(_) => 8.0 / 7.0,
+            Console::Nes(_) | Console::Snes(_) => 8.0 / 7.0,
             Console::GameBoy(_) | Console::GameBoyAdvance(_) => 1.0,
         }
     }
@@ -373,9 +385,9 @@ impl Console {
 impl SystemType {
     /// Computes windowed-mode dimensions that preserve the system's correct aspect ratio.
     ///
-    /// For NES, overscan is read from `app_context` and the NTSC 8:7 pixel aspect
-    /// ratio is applied.  For Game Boy and GBA, square pixels (1:1) are assumed
-    /// and there is no overscan.
+    /// For NES and SNES, overscan is read from `app_context` (NES only) and the
+    /// NTSC 8:7 pixel aspect ratio is applied. For Game Boy and GBA, square pixels
+    /// (1:1) are assumed and there is no overscan.
     pub fn windowed_dimensions(&self, height: u32, app_context: &SharedAppContext) -> (u32, u32) {
         let clamped_height = height.max(1);
         match self {
@@ -398,6 +410,12 @@ impl SystemType {
             SystemType::Gba => {
                 // GBA: 240×160 with square pixels (1:1)
                 let aspect = Gba::SCREEN_WIDTH as f32 / Gba::SCREEN_HEIGHT as f32;
+                let width = (clamped_height as f32 * aspect).round() as u32;
+                (width.max(1), clamped_height)
+            }
+            SystemType::Snes => {
+                // SNES: 256×224 with 8:7 pixel aspect (NTSC)
+                let aspect = (Snes::SCREEN_WIDTH as f32 / Snes::SCREEN_HEIGHT as f32) * (8.0 / 7.0);
                 let width = (clamped_height as f32 * aspect).round() as u32;
                 (width.max(1), clamped_height)
             }
@@ -1033,6 +1051,24 @@ mod tests_console_abstraction {
         let (w, h) = SystemType::Gba.windowed_dimensions(640, &app);
         assert_eq!(h, 640);
         assert_eq!(w, 960);
+    }
+
+    #[test]
+    fn test_snes_windowed_dimensions_height_224() {
+        let app = make_app_context_with_overscan(0, 0);
+        let (w, h) = SystemType::Snes.windowed_dimensions(224, &app);
+        assert_eq!(h, 224);
+        // 256 × (8/7) = ~293
+        assert_eq!(w, 293);
+    }
+
+    #[test]
+    fn test_snes_windowed_dimensions_height_448() {
+        // 2× scale: 448 × (256/224) × (8/7) = ~586
+        let app = make_app_context_with_overscan(0, 0);
+        let (w, h) = SystemType::Snes.windowed_dimensions(448, &app);
+        assert_eq!(h, 448);
+        assert_eq!(w, 585); // (448 * 256 / 224 * 8 / 7).round() = 585
     }
 
     // --- Console::target_frame_duration() ---

--- a/src/snes/apu/mod.rs
+++ b/src/snes/apu/mod.rs
@@ -1,0 +1,3 @@
+//! SNES APU (Audio Processing Unit) emulation.
+//!
+//! Implementation will be added in future issues.

--- a/src/snes/bus/mod.rs
+++ b/src/snes/bus/mod.rs
@@ -1,0 +1,62 @@
+//! SNES bus architecture and memory access.
+
+/// SNES bus interface for memory reads, writes, and cycle advancement.
+///
+/// This trait defines the contract for all SNES bus implementations,
+/// mirroring the pattern used in `GbBus` and `GbaBus`.
+pub trait SnesBus {
+    /// Read a byte from the given address.
+    fn read(&self, addr: u32) -> u8;
+
+    /// Write a byte to the given address.
+    fn write(&mut self, addr: u32, value: u8);
+
+    /// Advance the bus state by one master clock cycle.
+    fn tick(&mut self);
+}
+
+/// Stub bus implementation for unit tests.
+///
+/// Returns 0xFF for all reads and ignores all writes.
+#[derive(Debug)]
+pub struct StubBus;
+
+impl SnesBus for StubBus {
+    fn read(&self, _addr: u32) -> u8 {
+        0xFF
+    }
+
+    fn write(&mut self, _addr: u32, _value: u8) {
+        // No-op
+    }
+
+    fn tick(&mut self) {
+        // No-op
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stub_bus_read_returns_0xff() {
+        let bus = StubBus;
+        assert_eq!(bus.read(0x0000), 0xFF);
+        assert_eq!(bus.read(0x7FFF), 0xFF);
+        assert_eq!(bus.read(0xFFFF), 0xFF);
+    }
+
+    #[test]
+    fn stub_bus_write_does_not_panic() {
+        let mut bus = StubBus;
+        bus.write(0x0000, 0x42);
+        bus.write(0x7FFF, 0x00);
+    }
+
+    #[test]
+    fn stub_bus_tick_does_not_panic() {
+        let mut bus = StubBus;
+        bus.tick();
+    }
+}

--- a/src/snes/cartridge/mod.rs
+++ b/src/snes/cartridge/mod.rs
@@ -1,0 +1,3 @@
+//! SNES cartridge and ROM loading.
+//!
+//! Implementation will be added in future issues.

--- a/src/snes/console/config.rs
+++ b/src/snes/console/config.rs
@@ -1,0 +1,7 @@
+//! SNES-specific configuration.
+
+/// Configuration options for SNES emulation.
+#[derive(Debug, Clone, Default)]
+pub struct SnesConfig {
+    // Configuration fields will be added as needed
+}

--- a/src/snes/console/mod.rs
+++ b/src/snes/console/mod.rs
@@ -1,0 +1,6 @@
+//! SNES console and platform integration.
+
+pub mod config;
+pub mod snes;
+
+pub use snes::Snes;

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -1,0 +1,235 @@
+//! Platform-facing SNES wrapper for the `Console` enum.
+//!
+//! `Snes` provides the platform interface for SNES emulation, implementing the
+//! [`Emulator`] trait so frontends can drive it through [`Console`].
+//!
+//! [`Emulator`]: crate::platform::emulator::Emulator
+//! [`Console`]: crate::platform::emulator::Console
+
+use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
+use crate::platform::emulator::{Emulator, SystemType};
+use crate::snes::bus::StubBus;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// SNES display width in pixels (standard NTSC mode).
+const SCREEN_WIDTH: u32 = 256;
+/// SNES display height in pixels (standard NTSC mode).
+const SCREEN_HEIGHT: u32 = 224;
+
+/// SNES frame duration (~60.098 Hz refresh rate).
+/// Master clock: 21.477272 MHz, 357366 cycles per frame → 16.639 ms per frame.
+const FRAME_DURATION_NANOS: u64 = 16_639_000;
+
+/// Super Nintendo Entertainment System emulator wrapper.
+///
+/// This struct wraps the SNES emulation core and provides the [`Emulator`] trait
+/// implementation for platform integration.
+pub struct Snes {
+    app_context: SharedAppContext,
+    _bus: StubBus,
+    rom_path: Option<PathBuf>,
+}
+
+impl Snes {
+    /// SNES display width in pixels.
+    pub const SCREEN_WIDTH: u32 = SCREEN_WIDTH;
+    /// SNES display height in pixels.
+    pub const SCREEN_HEIGHT: u32 = SCREEN_HEIGHT;
+
+    /// Create a new SNES emulator instance.
+    pub fn new(app_context: impl IntoSharedAppContext) -> Self {
+        Self {
+            app_context: app_context.into_shared(),
+            _bus: StubBus,
+            rom_path: None,
+        }
+    }
+
+    /// Returns the file path where save-state data should be stored.
+    pub fn state_path(&self) -> Option<PathBuf> {
+        self.rom_path.as_ref().map(|path| {
+            let mut state_path = path.clone();
+            state_path.set_extension("state");
+            state_path
+        })
+    }
+}
+
+impl Emulator for Snes {
+    fn system_type(&self) -> SystemType {
+        SystemType::Snes
+    }
+
+    fn allowed_shaders(&self) -> &'static [&'static str] {
+        // TODO: Define SNES-specific shader presets
+        &[]
+    }
+
+    fn load_rom(&mut self, _bytes: &[u8], name: &str) -> Result<(), String> {
+        // TODO: Implement ROM loading
+        self.rom_path = Some(PathBuf::from(name));
+        Ok(())
+    }
+
+    fn run_tick(&mut self) -> u8 {
+        // TODO: Implement CPU execution
+        // Stub: return 1 cycle
+        1
+    }
+
+    fn is_ready_to_render(&self) -> bool {
+        // TODO: Implement frame ready detection
+        false
+    }
+
+    fn clear_ready_to_render(&mut self) {
+        // TODO: Implement frame ready flag clearing
+    }
+
+    fn screen_width(&self) -> u32 {
+        SCREEN_WIDTH
+    }
+
+    fn screen_height(&self) -> u32 {
+        SCREEN_HEIGHT
+    }
+
+    fn screen_snapshot(&self) -> Vec<u8> {
+        // TODO: Implement screen capture
+        // Return black screen for now
+        vec![0; (SCREEN_WIDTH * SCREEN_HEIGHT * 3) as usize]
+    }
+
+    fn cropped_screen_snapshot(&self, _h_overscan: u32, _v_overscan: u32) -> Vec<u8> {
+        // SNES has no overscan, return full screen
+        self.screen_snapshot()
+    }
+
+    fn screen_crc32(&self) -> u32 {
+        // TODO: Implement screen CRC32
+        0
+    }
+
+    fn sample_ready(&self) -> bool {
+        // TODO: Implement audio sample ready detection
+        false
+    }
+
+    fn get_sample(&mut self) -> Option<f32> {
+        // TODO: Implement audio sample retrieval
+        None
+    }
+
+    fn set_audio_sample_rate(&mut self, _rate: f32) {
+        // TODO: Implement audio sample rate configuration
+    }
+
+    fn set_button(&mut self, _port: u8, _button_id: u8, _pressed: bool) {
+        // TODO: Implement button state setting
+    }
+
+    fn set_joypad_button_states(&mut self, _port: u8, _state: u8) {
+        // TODO: Implement joypad state setting
+    }
+
+    fn get_joypad_button_states(&self, _port: u8) -> u8 {
+        // TODO: Implement joypad state retrieval
+        0
+    }
+
+    fn save_state_bytes(&self) -> Result<Vec<u8>, String> {
+        // TODO: Implement save state serialization
+        Err("Save states not yet implemented for SNES".to_string())
+    }
+
+    fn load_state_bytes(&mut self, _data: &[u8]) -> Result<(), String> {
+        // TODO: Implement save state deserialization
+        Err("Save states not yet implemented for SNES".to_string())
+    }
+
+    fn reset(&mut self, _soft_reset: bool) {
+        // TODO: Implement reset
+    }
+
+    fn save_ram(&self) -> Result<(), String> {
+        // TODO: Implement battery-backed RAM saving
+        Ok(())
+    }
+
+    fn app_context(&self) -> &SharedAppContext {
+        &self.app_context
+    }
+
+    fn target_frame_duration(&self) -> Duration {
+        Duration::from_nanos(FRAME_DURATION_NANOS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::app_context::AppContext;
+    use crate::platform::config::Config;
+
+    fn make_snes() -> Snes {
+        let app_context = AppContext::new_with_config(Config::default());
+        Snes::new(app_context)
+    }
+
+    #[test]
+    fn new_snes_constructs_successfully() {
+        let _snes = make_snes();
+    }
+
+    #[test]
+    fn system_type_returns_snes() {
+        let snes = make_snes();
+        assert_eq!(snes.system_type(), SystemType::Snes);
+    }
+
+    #[test]
+    fn screen_dimensions_are_256x224() {
+        let snes = make_snes();
+        assert_eq!(snes.screen_width(), 256);
+        assert_eq!(snes.screen_height(), 224);
+    }
+
+    #[test]
+    fn target_frame_duration_is_approximately_60hz() {
+        let snes = make_snes();
+        let duration = snes.target_frame_duration();
+        // ~60.098 Hz = ~16.639 ms per frame
+        let expected_nanos = 16_639_000u64;
+        assert_eq!(duration.as_nanos(), expected_nanos as u128);
+    }
+
+    #[test]
+    fn state_path_returns_none_when_no_rom_loaded() {
+        let snes = make_snes();
+        assert_eq!(snes.state_path(), None);
+    }
+
+    #[test]
+    fn state_path_returns_path_after_rom_loaded() {
+        let mut snes = make_snes();
+        snes.load_rom(&[], "test.sfc").unwrap();
+        let state_path = snes.state_path();
+        assert!(state_path.is_some());
+        assert_eq!(state_path.unwrap().to_string_lossy(), "test.state");
+    }
+
+    #[test]
+    fn run_tick_returns_nonzero_cycles() {
+        let mut snes = make_snes();
+        let cycles = snes.run_tick();
+        assert!(cycles > 0);
+    }
+
+    #[test]
+    fn screen_snapshot_returns_correct_size_buffer() {
+        let snes = make_snes();
+        let snapshot = snes.screen_snapshot();
+        assert_eq!(snapshot.len(), (256 * 224 * 3) as usize);
+    }
+}

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -29,6 +29,7 @@ pub struct Snes {
     app_context: SharedAppContext,
     _bus: StubBus,
     rom_path: Option<PathBuf>,
+    ready_to_render: bool,
 }
 
 impl Snes {
@@ -43,6 +44,7 @@ impl Snes {
             app_context: app_context.into_shared(),
             _bus: StubBus,
             rom_path: None,
+            ready_to_render: false,
         }
     }
 
@@ -74,17 +76,17 @@ impl Emulator for Snes {
 
     fn run_tick(&mut self) -> u8 {
         // TODO: Implement CPU execution
-        // Stub: return 1 cycle
+        // Stub: signal a frame ready after every tick so the platform loop doesn't stall
+        self.ready_to_render = true;
         1
     }
 
     fn is_ready_to_render(&self) -> bool {
-        // TODO: Implement frame ready detection
-        false
+        self.ready_to_render
     }
 
     fn clear_ready_to_render(&mut self) {
-        // TODO: Implement frame ready flag clearing
+        self.ready_to_render = false;
     }
 
     fn screen_width(&self) -> u32 {
@@ -107,8 +109,8 @@ impl Emulator for Snes {
     }
 
     fn screen_crc32(&self) -> u32 {
-        // TODO: Implement screen CRC32
-        0
+        let pixels = self.screen_snapshot();
+        crate::platform::crc32::crc32(&[&pixels])
     }
 
     fn sample_ready(&self) -> bool {
@@ -224,6 +226,31 @@ mod tests {
         let mut snes = make_snes();
         let cycles = snes.run_tick();
         assert!(cycles > 0);
+    }
+
+    #[test]
+    fn run_tick_sets_ready_to_render() {
+        let mut snes = make_snes();
+        assert!(!snes.is_ready_to_render());
+        snes.run_tick();
+        assert!(snes.is_ready_to_render());
+    }
+
+    #[test]
+    fn clear_ready_to_render_clears_flag() {
+        let mut snes = make_snes();
+        snes.run_tick();
+        assert!(snes.is_ready_to_render());
+        snes.clear_ready_to_render();
+        assert!(!snes.is_ready_to_render());
+    }
+
+    #[test]
+    fn screen_crc32_matches_snapshot_crc() {
+        let snes = make_snes();
+        let pixels = snes.screen_snapshot();
+        let expected = crate::platform::crc32::crc32(&[&pixels]);
+        assert_eq!(snes.screen_crc32(), expected);
     }
 
     #[test]

--- a/src/snes/cpu/mod.rs
+++ b/src/snes/cpu/mod.rs
@@ -1,0 +1,3 @@
+//! SNES CPU (65816) emulation.
+//!
+//! Implementation will be added in future issues.

--- a/src/snes/input/mod.rs
+++ b/src/snes/input/mod.rs
@@ -1,0 +1,3 @@
+//! SNES input (controller) handling.
+//!
+//! Implementation will be added in future issues.

--- a/src/snes/integration_tests/mod.rs
+++ b/src/snes/integration_tests/mod.rs
@@ -1,0 +1,3 @@
+//! SNES integration tests.
+//!
+//! Tests will be added as subsystems are implemented.

--- a/src/snes/mod.rs
+++ b/src/snes/mod.rs
@@ -1,0 +1,15 @@
+//! Super Nintendo Entertainment System (SNES) emulation.
+//!
+//! This module provides SNES hardware emulation including CPU (65816), PPU,
+//! APU (SPC700 + DSP), bus architecture, cartridge support, and input handling.
+
+pub mod apu;
+pub mod bus;
+pub mod cartridge;
+pub mod console;
+pub mod cpu;
+pub mod input;
+pub mod ppu;
+
+#[cfg(test)]
+mod integration_tests;

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -1,0 +1,3 @@
+//! SNES PPU (Picture Processing Unit) emulation.
+//!
+//! Implementation will be added in future issues.


### PR DESCRIPTION
## Summary

This PR creates the SNES (Super Nintendo Entertainment System) module skeleton and integrates it into the hardware-agnostic platform layer, establishing the foundation for future SNES emulation.

## Changes

### SNES Module Structure
- ✅ Added complete `src/snes/` module with subsystem stubs
- ✅ Created stub modules for cpu, ppu, apu, bus, cartridge, input, integration_tests
- ✅ Follows established patterns from GB/GBA implementations

### Bus Abstraction  
- ✅ Defined `SnesBus` trait with read/write/tick contract
- ✅ Implemented `StubBus` for unit testing

### Platform Integration
- ✅ Created `Snes` struct implementing all 22 `Emulator` trait methods
- ✅ Added `SystemType::Snes` and `Console::Snes` variants
- ✅ Added `.sfc/.smc` file extension routing
- ✅ Added `SnesConfig` to platform `Config` struct

### Frontend Updates
- ✅ Fixed 11 non-exhaustive pattern matches across frontend code
- ✅ Added SNES-specific help overlay with controller mappings
- ✅ Updated event loop, keyboard, and app_state

### Hardware Constants
- Screen: 256×224 pixels (NTSC mode)
- Pixel aspect: 8:7 (matching NES NTSC)
- Frame rate: ~60.098 Hz
- Frame duration: 16.639 ms

## Testing

All tests pass:
- ✅ 11 new SNES unit tests
- ✅ 10,784 lib tests pass
- ✅ 66 WASM tests pass
- ✅ 346 Python tests pass
- ✅ 364 npm tests pass
- ✅ Clippy with `-D warnings`
- ✅ cargo fmt

## Documentation

- ✅ Updated `architecture.md` with SNES module section

## Future Work

All actual emulation logic (CPU, PPU, APU, cartridge handling) will be implemented in future sub-issues. This PR provides only the scaffolding and platform integration layer.

Closes #2717
