### PR TITLE
feat(snes): implement system bus and console wiring (#2744)

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -316,15 +316,16 @@ All Game Boy Advance hardware lives under `src/gba/`. The module currently provi
 
 #### SNES Emulation (`src/snes/`)
 
-The SNES (Super Nintendo Entertainment System) module contains active 65816 CPU development and verification infrastructure. Platform routing and cartridge loading/header parsing are in place, while bus/PPU/APU/input integration remains incremental.
+The SNES (Super Nintendo Entertainment System) module now includes active 65816 CPU execution wired to a functional `SnesSystemBus`, plus cartridge parsing/mapping for LoROM/HiROM/ExHiROM. PPU/APU/input remain incremental, but the core CPU↔bus bring-up path for cartridge execution is in place.
 
 | Directory/File | Description |
 | ---------------- | ------------- |
 | `src/snes/mod.rs` | SNES module root. Declares all SNES sub-modules (bus, console, cpu, ppu, apu, cartridge, input, integration_tests). |
 | `src/snes/console/mod.rs` | Console module root. Re-exports `Snes` and `SnesConfig`. |
-| `src/snes/console/snes.rs` | `Snes` — platform-facing SNES wrapper implementing the `Emulator` trait. All methods are currently stubbed but return correct dimensions (256×224) and frame timing (~60.098 Hz). Provides `load_rom`, `system_type`, screen dimensions, and frame duration methods. |
+| `src/snes/console/snes.rs` | `Snes` — platform-facing SNES wrapper implementing the `Emulator` trait. Owns `Option<Cpu<SnesSystemBus>>`; `load_rom` parses a `Cartridge`, constructs the system bus, and resets CPU state; `run_tick` executes real CPU steps when a ROM is loaded (returns 0 cycles when not loaded). Screen/audio/input/save-state APIs are still staged for later SNES sub-issues. |
 | `src/snes/console/config.rs` | `SnesConfig` struct for SNES-specific configuration (currently empty, ready for future settings). |
-| `src/snes/bus/mod.rs` | `SnesBus` trait definition and `StubBus` implementation. The trait defines the memory access contract (`read`, `write`, `tick`) mirroring the pattern used in GB and GBA. |
+| `src/snes/bus/mod.rs` | `SnesBus` trait definition plus `StubBus`, `TestBus`, and `SnesSystemBus` exports. The trait defines the memory access contract (`read`, `write`, `tick`) mirroring the pattern used in GB and GBA. |
+| `src/snes/bus/system_bus.rs` | `SnesSystemBus` implementation for #2744 bring-up: WRAM direct/mirror mapping, LoROM/HiROM/ExHiROM ROM decode, SRAM windows with wrap semantics, strict MDR/open-bus reads, and scoped MMIO register support (`$2180-$2183`, mul/div `$4202-$4206`, MEMSEL `$420D`, DMA register latches `$4300-$437F`) including mirrors across system banks. |
 | `src/snes/cpu/mod.rs` | SNES 65816 CPU module root. Re-exports `Cpu` and memory-speed helpers; instruction behavior and timing tests live in `cpu.rs`. |
 | `src/snes/ppu/mod.rs` | PPU module stub (SNES Picture Processing Unit — future implementation). |
 | `src/snes/apu/mod.rs` | APU module stub (SPC700 + DSP — future implementation). |

--- a/src/snes/bus/mod.rs
+++ b/src/snes/bus/mod.rs
@@ -2,7 +2,10 @@
 
 #[allow(clippy::module_inception)]
 mod bus;
+mod system_bus;
 
 #[cfg(test)]
 pub use bus::TestBus;
 pub use bus::{SnesBus, StubBus};
+#[allow(unused_imports)]
+pub use system_bus::SnesSystemBus;

--- a/src/snes/bus/mod.rs
+++ b/src/snes/bus/mod.rs
@@ -6,6 +6,7 @@ mod system_bus;
 
 #[cfg(test)]
 pub use bus::TestBus;
+#[allow(unused_imports)]
 pub use bus::{SnesBus, StubBus};
 #[allow(unused_imports)]
 pub use system_bus::SnesSystemBus;

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -14,6 +14,13 @@ pub struct SnesSystemBus {
     rom: Vec<u8>,
     sram: Vec<u8>,
     wram: Vec<u8>,
+    wmadd: Cell<u32>,
+    wrmpya: u8,
+    wrdiv: u16,
+    rddiv: u16,
+    rdmpy: u16,
+    memsel: u8,
+    dma_regs: [u8; 0x80],
     mdr: Cell<u8>,
     ticks: Cell<u64>,
 }
@@ -29,6 +36,13 @@ impl SnesSystemBus {
             rom,
             sram,
             wram: vec![0; WRAM_SIZE],
+            wmadd: Cell::new(0),
+            wrmpya: 0,
+            wrdiv: 0,
+            rddiv: 0,
+            rdmpy: 0,
+            memsel: 0,
+            dma_regs: [0; 0x80],
             mdr: Cell::new(0),
             ticks: Cell::new(0),
         }
@@ -122,10 +136,118 @@ impl SnesSystemBus {
             }
         }
     }
+
+    fn decode_system_offset(addr: u32) -> Option<u16> {
+        let addr = addr & 0xFF_FFFF;
+        let bank = ((addr >> 16) & 0xFF) as u8;
+        let offset = (addr & 0xFFFF) as u16;
+        if matches!(bank, 0x00..=0x3F | 0x80..=0xBF) {
+            Some(offset)
+        } else {
+            None
+        }
+    }
+
+    fn read_mmio(&self, addr: u32) -> Option<u8> {
+        let offset = Self::decode_system_offset(addr)?;
+        let value = match offset {
+            0x2180 => {
+                let wmadd = self.wmadd.get() & 0x1_FFFF;
+                let value = self.wram[(wmadd as usize) & (WRAM_SIZE - 1)];
+                self.wmadd.set((wmadd + 1) & 0x1_FFFF);
+                value
+            }
+            0x2181 => (self.wmadd.get() & 0xFF) as u8,
+            0x2182 => ((self.wmadd.get() >> 8) & 0xFF) as u8,
+            0x2183 => ((self.wmadd.get() >> 16) & 0x01) as u8,
+            0x4214 => (self.rddiv & 0x00FF) as u8,
+            0x4215 => (self.rddiv >> 8) as u8,
+            0x4216 => (self.rdmpy & 0x00FF) as u8,
+            0x4217 => (self.rdmpy >> 8) as u8,
+            0x420D => self.memsel,
+            0x4300..=0x437F => self.dma_regs[(offset - 0x4300) as usize],
+            _ => return None,
+        };
+        Some(value)
+    }
+
+    fn write_mmio(&mut self, addr: u32, value: u8) -> bool {
+        let Some(offset) = Self::decode_system_offset(addr) else {
+            return false;
+        };
+
+        match offset {
+            0x2180 => {
+                let wmadd = self.wmadd.get() & 0x1_FFFF;
+                let index = (wmadd as usize) & (WRAM_SIZE - 1);
+                self.wram[index] = value;
+                self.wmadd.set((wmadd + 1) & 0x1_FFFF);
+                true
+            }
+            0x2181 => {
+                let wmadd = self.wmadd.get();
+                self.wmadd.set((wmadd & !0x0000_00FF) | value as u32);
+                true
+            }
+            0x2182 => {
+                let wmadd = self.wmadd.get();
+                self.wmadd
+                    .set((wmadd & !0x0000_FF00) | ((value as u32) << 8));
+                true
+            }
+            0x2183 => {
+                let wmadd = self.wmadd.get();
+                self.wmadd
+                    .set((wmadd & !0x0001_0000) | (((value & 0x01) as u32) << 16));
+                true
+            }
+            0x4202 => {
+                self.wrmpya = value;
+                true
+            }
+            0x4203 => {
+                self.rdmpy = (self.wrmpya as u16).wrapping_mul(value as u16);
+                true
+            }
+            0x4204 => {
+                self.wrdiv = (self.wrdiv & 0xFF00) | value as u16;
+                true
+            }
+            0x4205 => {
+                self.wrdiv = (self.wrdiv & 0x00FF) | ((value as u16) << 8);
+                true
+            }
+            0x4206 => {
+                let dividend = self.wrdiv;
+                if value == 0 {
+                    self.rddiv = 0xFFFF;
+                    self.rdmpy = dividend;
+                } else {
+                    self.rddiv = dividend / value as u16;
+                    self.rdmpy = dividend % value as u16;
+                }
+                true
+            }
+            0x420D => {
+                self.memsel = value & 0x01;
+                true
+            }
+            0x4300..=0x437F => {
+                self.dma_regs[(offset - 0x4300) as usize] = value;
+                true
+            }
+            _ => false,
+        }
+    }
 }
 
 impl SnesBus for SnesSystemBus {
     fn read(&self, addr: u32) -> u8 {
+        if let Some(value) = self.read_mmio(addr) {
+            self.mdr.set(value);
+            return value;
+        }
+
         if let Some(index) = Self::decode_wram_index(addr) {
             let value = self.wram[index];
             self.mdr.set(value);
@@ -152,6 +274,10 @@ impl SnesBus for SnesSystemBus {
     }
 
     fn write(&mut self, addr: u32, value: u8) {
+        if self.write_mmio(addr, value) {
+            return;
+        }
+
         if let Some(index) = Self::decode_wram_index(addr) {
             self.wram[index] = value;
         } else if let Some(index) = self.decode_sram_index(addr) {
@@ -306,5 +432,92 @@ mod tests {
         bus.write(0x700000, 0xA1);
         bus.write(0x700800, 0xB2); // +2 KiB -> wraps to same byte
         assert_eq!(bus.read(0x700000), 0xB2);
+    }
+
+    #[test]
+    fn wram_ports_auto_increment_and_write_through() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        // WMADD = 0x000123
+        bus.write(0x002181, 0x23);
+        bus.write(0x002182, 0x01);
+        bus.write(0x002183, 0x00);
+        bus.write(0x002180, 0xAA); // write at 0x0123, increment
+        bus.write(0x002180, 0xBB); // write at 0x0124
+
+        assert_eq!(bus.read(0x7E0123), 0xAA);
+        assert_eq!(bus.read(0x7E0124), 0xBB);
+    }
+
+    #[test]
+    fn multiply_registers_update_rdmpy() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x004202, 6);
+        bus.write(0x004203, 7);
+
+        assert_eq!(bus.read(0x004216), 42);
+        assert_eq!(bus.read(0x004217), 0);
+    }
+
+    #[test]
+    fn divide_registers_update_rddiv_and_remainder() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x004204, 0x34);
+        bus.write(0x004205, 0x12);
+        bus.write(0x004206, 0x10);
+
+        assert_eq!(bus.read(0x004214), 0x23);
+        assert_eq!(bus.read(0x004215), 0x01);
+        assert_eq!(bus.read(0x004216), 0x04);
+        assert_eq!(bus.read(0x004217), 0x00);
+    }
+
+    #[test]
+    fn memsel_register_reads_back_last_written_value() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x00420D, 0x01);
+        assert_eq!(bus.read(0x00420D), 0x01);
+        bus.write(0x80420D, 0x00);
+        assert_eq!(bus.read(0x00420D), 0x00);
+    }
+
+    #[test]
+    fn dma_register_file_latches_and_mirrors_across_system_banks() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x004300, 0xAB);
+        bus.write(0x00430A, 0x55);
+
+        assert_eq!(bus.read(0x004300), 0xAB);
+        assert_eq!(bus.read(0x804300), 0xAB);
+        assert_eq!(bus.read(0x00430A), 0x55);
+    }
+
+    #[test]
+    fn wram_port_reads_auto_increment_address() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x002181, 0x00);
+        bus.write(0x002182, 0x02);
+        bus.write(0x002183, 0x00);
+        bus.write(0x002180, 0xC1);
+        bus.write(0x002180, 0xD2);
+        // Reset WMADD to the first byte and verify consecutive reads advance.
+        bus.write(0x002181, 0x00);
+        bus.write(0x002182, 0x02);
+        bus.write(0x002183, 0x00);
+        assert_eq!(bus.read(0x002180), 0xC1);
+        assert_eq!(bus.read(0x002180), 0xD2);
+    }
+
+    #[test]
+    fn wrdiv_writes_do_not_change_rddiv_until_divide_trigger() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        assert_eq!(bus.read(0x004214), 0x00);
+        assert_eq!(bus.read(0x004215), 0x00);
+        bus.write(0x004204, 0x34);
+        bus.write(0x004205, 0x12);
+        assert_eq!(bus.read(0x004214), 0x00);
+        assert_eq!(bus.read(0x004215), 0x00);
+        bus.write(0x004206, 0x10);
+        assert_eq!(bus.read(0x004214), 0x23);
+        assert_eq!(bus.read(0x004215), 0x01);
     }
 }

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -5,9 +5,15 @@ use std::cell::Cell;
 
 const WRAM_SIZE: usize = 128 * 1024;
 
-/// SNES system bus (placeholder).
+/// SNES system bus.
 ///
-/// Real memory map/MMIO behavior is implemented incrementally in issue #2744.
+/// This bus currently implements:
+/// - WRAM direct and low-RAM mirror windows
+/// - cartridge ROM mapping (LoROM/HiROM/ExHiROM)
+/// - battery SRAM windows
+/// - open-bus/MDR read semantics
+/// - CPU/MMIO registers needed for early bring-up (`$2180-$2183`, `$4202-$4206`,
+///   `$420D`, and `$4300-$437F` register latches)
 pub struct SnesSystemBus {
     _cartridge: Cartridge,
     mapping: Mapping,

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -1,0 +1,109 @@
+use crate::snes::bus::SnesBus;
+use crate::snes::cartridge::Cartridge;
+use std::cell::Cell;
+
+const WRAM_SIZE: usize = 128 * 1024;
+
+/// SNES system bus (placeholder).
+///
+/// Real memory map/MMIO behavior is implemented incrementally in issue #2744.
+pub struct SnesSystemBus {
+    _cartridge: Cartridge,
+    wram: Vec<u8>,
+    mdr: Cell<u8>,
+    ticks: Cell<u64>,
+}
+
+impl SnesSystemBus {
+    pub fn new(cartridge: Cartridge) -> Self {
+        Self {
+            _cartridge: cartridge,
+            wram: vec![0; WRAM_SIZE],
+            mdr: Cell::new(0),
+            ticks: Cell::new(0),
+        }
+    }
+
+    fn decode_wram_index(addr: u32) -> Option<usize> {
+        let addr = addr & 0xFF_FFFF;
+        let bank = ((addr >> 16) & 0xFF) as u8;
+        let offset = (addr & 0xFFFF) as u16;
+
+        if (0x7E..=0x7F).contains(&bank) {
+            return Some((((bank as usize - 0x7E) << 16) | offset as usize) & (WRAM_SIZE - 1));
+        }
+
+        if matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && offset <= 0x1FFF {
+            return Some(offset as usize);
+        }
+
+        None
+    }
+}
+
+impl SnesBus for SnesSystemBus {
+    fn read(&self, addr: u32) -> u8 {
+        if let Some(index) = Self::decode_wram_index(addr) {
+            let value = self.wram[index];
+            self.mdr.set(value);
+            value
+        } else {
+            self.mdr.get()
+        }
+    }
+
+    fn write(&mut self, addr: u32, value: u8) {
+        if let Some(index) = Self::decode_wram_index(addr) {
+            self.wram[index] = value;
+        }
+    }
+
+    fn tick(&mut self) {
+        self.ticks.set(self.ticks.get().wrapping_add(1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lorom_test_cart() -> Cartridge {
+        let mut rom = vec![0u8; 0x10000];
+        let base = 0x7FC0;
+        rom[base..base + 21].copy_from_slice(b"SYSTEM BUS TEST      ");
+        rom[base + 0x3C] = 0x00;
+        rom[base + 0x3D] = 0x80;
+        rom[base + 0xD5] = 0x20;
+        rom[base + 0xD6] = 0x00;
+        rom[base + 0xD7] = 0x07;
+        rom[base + 0xD8] = 0x00;
+        rom[base + 0xDC] = 0x34;
+        rom[base + 0xDD] = 0x12;
+        rom[base + 0xDE] = 0xCB;
+        rom[base + 0xDF] = 0xED;
+        Cartridge::from_bytes(&rom).expect("valid test cartridge")
+    }
+
+    #[test]
+    fn wram_direct_region_round_trips() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x7E0000, 0x5A);
+        assert_eq!(bus.read(0x7E0000), 0x5A);
+    }
+
+    #[test]
+    fn low_ram_mirror_region_maps_to_wram_base() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x000123, 0x3C);
+        assert_eq!(bus.read(0x7E0123), 0x3C);
+        assert_eq!(bus.read(0x800123), 0x3C);
+    }
+
+    #[test]
+    fn unmapped_reads_return_mdr_from_last_successful_read() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x7E0010, 0xA7);
+        assert_eq!(bus.read(0x7E0010), 0xA7);
+        assert_eq!(bus.read(0x002100), 0xA7);
+    }
+}

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -1,5 +1,6 @@
 use crate::snes::bus::SnesBus;
 use crate::snes::cartridge::Cartridge;
+use crate::snes::cartridge::Mapping;
 use std::cell::Cell;
 
 const WRAM_SIZE: usize = 128 * 1024;
@@ -9,6 +10,9 @@ const WRAM_SIZE: usize = 128 * 1024;
 /// Real memory map/MMIO behavior is implemented incrementally in issue #2744.
 pub struct SnesSystemBus {
     _cartridge: Cartridge,
+    mapping: Mapping,
+    rom: Vec<u8>,
+    sram: Vec<u8>,
     wram: Vec<u8>,
     mdr: Cell<u8>,
     ticks: Cell<u64>,
@@ -16,8 +20,14 @@ pub struct SnesSystemBus {
 
 impl SnesSystemBus {
     pub fn new(cartridge: Cartridge) -> Self {
+        let mapping = cartridge.mapping();
+        let rom = cartridge.rom().to_vec();
+        let sram = vec![0; cartridge.sram_size()];
         Self {
             _cartridge: cartridge,
+            mapping,
+            rom,
+            sram,
             wram: vec![0; WRAM_SIZE],
             mdr: Cell::new(0),
             ticks: Cell::new(0),
@@ -39,6 +49,79 @@ impl SnesSystemBus {
 
         None
     }
+
+    fn decode_rom_index(&self, addr: u32) -> Option<usize> {
+        let addr = addr & 0xFF_FFFF;
+        let bank = ((addr >> 16) & 0xFF) as u8;
+        let offset = (addr & 0xFFFF) as u16;
+
+        match self.mapping {
+            Mapping::LoRom => {
+                if (bank <= 0x7D || bank >= 0x80) && offset >= 0x8000 {
+                    let bank_index = (bank & 0x7F) as usize;
+                    Some(bank_index * 0x8000 + (offset as usize - 0x8000))
+                } else {
+                    None
+                }
+            }
+            Mapping::HiRom => {
+                if (0xC0..=0xFF).contains(&bank) {
+                    Some((bank as usize - 0xC0) * 0x10000 + offset as usize)
+                } else if (0x40..=0x7D).contains(&bank) {
+                    Some((bank as usize - 0x40) * 0x10000 + offset as usize)
+                } else if (matches!(bank, 0x00..=0x3F | 0x80..=0xBF)) && offset >= 0x8000 {
+                    Some((bank as usize & 0x3F) * 0x10000 + offset as usize)
+                } else {
+                    None
+                }
+            }
+            Mapping::ExHiRom => {
+                if (0xC0..=0xFF).contains(&bank) {
+                    Some((bank as usize - 0xC0) * 0x10000 + offset as usize)
+                } else if (0x40..=0x7D).contains(&bank) {
+                    Some(0x400000 + (bank as usize - 0x40) * 0x10000 + offset as usize)
+                } else if (matches!(bank, 0x00..=0x3F | 0x80..=0xBF)) && offset >= 0x8000 {
+                    Some((bank as usize & 0x3F) * 0x10000 + offset as usize)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn decode_sram_index(&self, addr: u32) -> Option<usize> {
+        let addr = addr & 0xFF_FFFF;
+        let bank = ((addr >> 16) & 0xFF) as u8;
+        let offset = (addr & 0xFFFF) as u16;
+
+        match self.mapping {
+            Mapping::LoRom => {
+                if (0x70..=0x7D).contains(&bank) && offset <= 0x7FFF {
+                    Some((bank as usize - 0x70) * 0x8000 + offset as usize)
+                } else {
+                    None
+                }
+            }
+            Mapping::HiRom => {
+                if (matches!(bank, 0x20..=0x3F | 0xA0..=0xBF))
+                    && (0x6000..=0x7FFF).contains(&offset)
+                {
+                    Some((bank as usize & 0x1F) * 0x2000 + (offset as usize - 0x6000))
+                } else {
+                    None
+                }
+            }
+            Mapping::ExHiRom => {
+                if (matches!(bank, 0x20..=0x3F | 0xA0..=0xBF))
+                    && (0x6000..=0x7FFF).contains(&offset)
+                {
+                    Some((bank as usize & 0x1F) * 0x2000 + (offset as usize - 0x6000))
+                } else {
+                    None
+                }
+            }
+        }
+    }
 }
 
 impl SnesBus for SnesSystemBus {
@@ -47,6 +130,22 @@ impl SnesBus for SnesSystemBus {
             let value = self.wram[index];
             self.mdr.set(value);
             value
+        } else if let Some(index) = self.decode_rom_index(addr) {
+            if let Some(&value) = self.rom.get(index) {
+                self.mdr.set(value);
+                value
+            } else {
+                self.mdr.get()
+            }
+        } else if let Some(index) = self.decode_sram_index(addr) {
+            if self.sram.is_empty() {
+                self.mdr.get()
+            } else if let Some(&value) = self.sram.get(index % self.sram.len()) {
+                self.mdr.set(value);
+                value
+            } else {
+                self.mdr.get()
+            }
         } else {
             self.mdr.get()
         }
@@ -55,6 +154,14 @@ impl SnesBus for SnesSystemBus {
     fn write(&mut self, addr: u32, value: u8) {
         if let Some(index) = Self::decode_wram_index(addr) {
             self.wram[index] = value;
+        } else if let Some(index) = self.decode_sram_index(addr) {
+            let len = self.sram.len();
+            if len != 0 {
+                let wrapped = index % len;
+                if let Some(slot) = self.sram.get_mut(wrapped) {
+                    *slot = value;
+                }
+            }
         }
     }
 
@@ -67,21 +174,35 @@ impl SnesBus for SnesSystemBus {
 mod tests {
     use super::*;
 
-    fn lorom_test_cart() -> Cartridge {
-        let mut rom = vec![0u8; 0x10000];
-        let base = 0x7FC0;
+    fn build_cart(
+        rom: &mut [u8],
+        header_base: usize,
+        map_mode: u8,
+        ram_size_field: u8,
+    ) -> Cartridge {
+        let base = header_base;
         rom[base..base + 21].copy_from_slice(b"SYSTEM BUS TEST      ");
         rom[base + 0x3C] = 0x00;
         rom[base + 0x3D] = 0x80;
-        rom[base + 0xD5] = 0x20;
+        rom[base + 0xD5] = map_mode;
         rom[base + 0xD6] = 0x00;
         rom[base + 0xD7] = 0x07;
-        rom[base + 0xD8] = 0x00;
+        rom[base + 0xD8] = ram_size_field;
         rom[base + 0xDC] = 0x34;
         rom[base + 0xDD] = 0x12;
         rom[base + 0xDE] = 0xCB;
         rom[base + 0xDF] = 0xED;
-        Cartridge::from_bytes(&rom).expect("valid test cartridge")
+        Cartridge::from_bytes(rom).expect("valid test cartridge")
+    }
+
+    fn lorom_test_cart() -> Cartridge {
+        let mut rom = vec![0u8; 0x10000];
+        build_cart(&mut rom, 0x7FC0, 0x20, 0x00)
+    }
+
+    fn lorom_cart_with_sram() -> Cartridge {
+        let mut rom = vec![0u8; 0x20000];
+        build_cart(&mut rom, 0x7FC0, 0x20, 0x05)
     }
 
     #[test]
@@ -105,5 +226,85 @@ mod tests {
         bus.write(0x7E0010, 0xA7);
         assert_eq!(bus.read(0x7E0010), 0xA7);
         assert_eq!(bus.read(0x002100), 0xA7);
+    }
+
+    #[test]
+    fn lorom_reads_from_upper_32k_windows() {
+        let mut rom = vec![0u8; 0x40000];
+        rom[0x000000] = 0x11; // bank 00, addr 8000
+        rom[0x008000] = 0x22; // bank 01, addr 8000
+        let cart = build_cart(&mut rom, 0x7FC0, 0x20, 0x00);
+        let bus = SnesSystemBus::new(cart);
+
+        assert_eq!(bus.read(0x008000), 0x11);
+        assert_eq!(bus.read(0x018000), 0x22);
+    }
+
+    #[test]
+    fn hirom_reads_from_full_64k_windows() {
+        let mut rom = vec![0u8; 0x30000];
+        rom[0x000000] = 0x33; // C0:0000
+        rom[0x010000] = 0x44; // C1:0000
+        let cart = build_cart(&mut rom, 0xFFC0, 0x21, 0x00);
+        let bus = SnesSystemBus::new(cart);
+
+        assert_eq!(bus.read(0xC00000), 0x33);
+        assert_eq!(bus.read(0xC10000), 0x44);
+    }
+
+    #[test]
+    fn exhirom_maps_c0_ff_to_lower_4mb_and_40_7d_to_upper_4mb() {
+        let mut rom = vec![0u8; 0x800000];
+        rom[0x000000] = 0x55; // C0:0000
+        rom[0x400000] = 0x66; // 40:0000
+        let cart = build_cart(&mut rom, 0x40FFC0, 0x35, 0x00);
+        let bus = SnesSystemBus::new(cart);
+
+        assert_eq!(bus.read(0xC00000), 0x55);
+        assert_eq!(bus.read(0x400000), 0x66);
+    }
+
+    #[test]
+    fn lorom_sram_window_round_trips() {
+        let mut bus = SnesSystemBus::new(lorom_cart_with_sram());
+        bus.write(0x700123, 0x7D);
+        assert_eq!(bus.read(0x700123), 0x7D);
+    }
+
+    #[test]
+    fn hirom_reads_from_40_7d_window() {
+        let mut rom = vec![0u8; 0x20000];
+        rom[0x000000] = 0x77; // 40:0000
+        let cart = build_cart(&mut rom, 0xFFC0, 0x21, 0x00);
+        let bus = SnesSystemBus::new(cart);
+        assert_eq!(bus.read(0x400000), 0x77);
+    }
+
+    #[test]
+    fn exhirom_reads_from_low_bank_upper_window() {
+        let mut rom = vec![0u8; 0x800000];
+        rom[0x008000] = 0x88; // 00:8000
+        let cart = build_cart(&mut rom, 0x40FFC0, 0x35, 0x00);
+        let bus = SnesSystemBus::new(cart);
+        assert_eq!(bus.read(0x008000), 0x88);
+    }
+
+    #[test]
+    fn hirom_sram_window_mirrors_to_a0_bf_banks() {
+        let mut rom = vec![0u8; 0x40000];
+        let cart = build_cart(&mut rom, 0xFFC0, 0x21, 0x05);
+        let mut bus = SnesSystemBus::new(cart);
+        bus.write(0x206123, 0x91);
+        assert_eq!(bus.read(0xA06123), 0x91);
+    }
+
+    #[test]
+    fn sram_window_wraps_for_small_sram_sizes() {
+        let mut rom = vec![0u8; 0x20000];
+        let cart = build_cart(&mut rom, 0x7FC0, 0x20, 0x01); // 2 KiB SRAM
+        let mut bus = SnesSystemBus::new(cart);
+        bus.write(0x700000, 0xA1);
+        bus.write(0x700800, 0xB2); // +2 KiB -> wraps to same byte
+        assert_eq!(bus.read(0x700000), 0xB2);
     }
 }

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -75,6 +75,10 @@ impl Emulator for Snes {
     }
 
     fn run_tick(&mut self) -> u8 {
+        if self.rom_path.is_none() {
+            return 0;
+        }
+
         // TODO: Implement CPU execution
         // Stub: signal a frame ready after every tick so the platform loop doesn't stall
         self.ready_to_render = true;
@@ -224,13 +228,22 @@ mod tests {
     #[test]
     fn run_tick_returns_nonzero_cycles() {
         let mut snes = make_snes();
+        snes.load_rom(&[], "test.sfc").unwrap();
         let cycles = snes.run_tick();
         assert!(cycles > 0);
     }
 
     #[test]
+    fn run_tick_returns_zero_when_no_rom_loaded() {
+        let mut snes = make_snes();
+        let cycles = snes.run_tick();
+        assert_eq!(cycles, 0);
+    }
+
+    #[test]
     fn run_tick_sets_ready_to_render() {
         let mut snes = make_snes();
+        snes.load_rom(&[], "test.sfc").unwrap();
         assert!(!snes.is_ready_to_render());
         snes.run_tick();
         assert!(snes.is_ready_to_render());
@@ -239,6 +252,7 @@ mod tests {
     #[test]
     fn clear_ready_to_render_clears_flag() {
         let mut snes = make_snes();
+        snes.load_rom(&[], "test.sfc").unwrap();
         snes.run_tick();
         assert!(snes.is_ready_to_render());
         snes.clear_ready_to_render();

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -8,7 +8,9 @@
 
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
 use crate::platform::emulator::{Emulator, SystemType};
-use crate::snes::bus::StubBus;
+use crate::snes::bus::SnesSystemBus;
+use crate::snes::cartridge::Cartridge;
+use crate::snes::cpu::Cpu;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -27,7 +29,7 @@ const FRAME_DURATION_NANOS: u64 = 16_639_000;
 /// implementation for platform integration.
 pub struct Snes {
     app_context: SharedAppContext,
-    _bus: StubBus,
+    cpu: Option<Cpu<SnesSystemBus>>,
     rom_path: Option<PathBuf>,
     ready_to_render: bool,
 }
@@ -42,7 +44,7 @@ impl Snes {
     pub fn new(app_context: impl IntoSharedAppContext) -> Self {
         Self {
             app_context: app_context.into_shared(),
-            _bus: StubBus,
+            cpu: None,
             rom_path: None,
             ready_to_render: false,
         }
@@ -68,21 +70,25 @@ impl Emulator for Snes {
         &[]
     }
 
-    fn load_rom(&mut self, _bytes: &[u8], name: &str) -> Result<(), String> {
-        // TODO: Implement ROM loading
+    fn load_rom(&mut self, bytes: &[u8], name: &str) -> Result<(), String> {
+        let cartridge = Cartridge::from_bytes(bytes).map_err(|e| format!("{e:?}"))?;
+        let bus = SnesSystemBus::new(cartridge);
+        let mut cpu = Cpu::new(bus);
+        cpu.do_reset();
+        self.cpu = Some(cpu);
         self.rom_path = Some(PathBuf::from(name));
+        self.ready_to_render = false;
         Ok(())
     }
 
     fn run_tick(&mut self) -> u8 {
-        if self.rom_path.is_none() {
+        let Some(cpu) = self.cpu.as_mut() else {
             return 0;
-        }
+        };
 
-        // TODO: Implement CPU execution
-        // Stub: signal a frame ready after every tick so the platform loop doesn't stall
+        let cycles = cpu.step();
         self.ready_to_render = true;
-        1
+        cycles
     }
 
     fn is_ready_to_render(&self) -> bool {
@@ -155,7 +161,10 @@ impl Emulator for Snes {
     }
 
     fn reset(&mut self, _soft_reset: bool) {
-        // TODO: Implement reset
+        if let Some(cpu) = self.cpu.as_mut() {
+            cpu.do_reset();
+        }
+        self.ready_to_render = false;
     }
 
     fn save_ram(&self) -> Result<(), String> {
@@ -177,6 +186,24 @@ mod tests {
     use super::*;
     use crate::platform::app_context::AppContext;
     use crate::platform::config::Config;
+
+    fn valid_lorom_nop_rom() -> Vec<u8> {
+        let mut rom = vec![0u8; 0x10000];
+        let header = 0x7FC0;
+        rom[header..header + 21].copy_from_slice(b"SNES TEST ROM        ");
+        rom[header + 0x3C] = 0x00;
+        rom[header + 0x3D] = 0x80;
+        rom[header + 0xD5] = 0x20;
+        rom[header + 0xD6] = 0x00;
+        rom[header + 0xD7] = 0x07;
+        rom[header + 0xD8] = 0x00;
+        rom[header + 0xDC] = 0x34;
+        rom[header + 0xDD] = 0x12;
+        rom[header + 0xDE] = 0xCB;
+        rom[header + 0xDF] = 0xED;
+        rom[0x0000] = 0xEA; // NOP at $00:8000
+        rom
+    }
 
     fn make_snes() -> Snes {
         let app_context = AppContext::new_with_config(Config::default());
@@ -219,7 +246,7 @@ mod tests {
     #[test]
     fn state_path_returns_path_after_rom_loaded() {
         let mut snes = make_snes();
-        snes.load_rom(&[], "test.sfc").unwrap();
+        snes.load_rom(&valid_lorom_nop_rom(), "test.sfc").unwrap();
         let state_path = snes.state_path();
         assert!(state_path.is_some());
         assert_eq!(state_path.unwrap().to_string_lossy(), "test.state");
@@ -228,7 +255,7 @@ mod tests {
     #[test]
     fn run_tick_returns_nonzero_cycles() {
         let mut snes = make_snes();
-        snes.load_rom(&[], "test.sfc").unwrap();
+        snes.load_rom(&valid_lorom_nop_rom(), "test.sfc").unwrap();
         let cycles = snes.run_tick();
         assert!(cycles > 0);
     }
@@ -243,7 +270,7 @@ mod tests {
     #[test]
     fn run_tick_sets_ready_to_render() {
         let mut snes = make_snes();
-        snes.load_rom(&[], "test.sfc").unwrap();
+        snes.load_rom(&valid_lorom_nop_rom(), "test.sfc").unwrap();
         assert!(!snes.is_ready_to_render());
         snes.run_tick();
         assert!(snes.is_ready_to_render());
@@ -252,10 +279,46 @@ mod tests {
     #[test]
     fn clear_ready_to_render_clears_flag() {
         let mut snes = make_snes();
-        snes.load_rom(&[], "test.sfc").unwrap();
+        snes.load_rom(&valid_lorom_nop_rom(), "test.sfc").unwrap();
         snes.run_tick();
         assert!(snes.is_ready_to_render());
         snes.clear_ready_to_render();
+        assert!(!snes.is_ready_to_render());
+    }
+
+    #[test]
+    fn load_rom_rejects_invalid_snes_bytes() {
+        let mut snes = make_snes();
+        let result = snes.load_rom(&[0x00, 0x01, 0x02], "bad.sfc");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn run_tick_after_rom_load_uses_cpu_step_cycles() {
+        let mut snes = make_snes();
+        snes.load_rom(&valid_lorom_nop_rom(), "test.sfc").unwrap();
+        let cycles = snes.run_tick();
+        assert_ne!(cycles, 1);
+    }
+
+    #[test]
+    fn load_rom_clears_ready_to_render_flag() {
+        let mut snes = make_snes();
+        let rom = valid_lorom_nop_rom();
+        snes.load_rom(&rom, "test.sfc").unwrap();
+        snes.run_tick();
+        assert!(snes.is_ready_to_render());
+        snes.load_rom(&rom, "test.sfc").unwrap();
+        assert!(!snes.is_ready_to_render());
+    }
+
+    #[test]
+    fn reset_clears_ready_to_render_flag() {
+        let mut snes = make_snes();
+        snes.load_rom(&valid_lorom_nop_rom(), "test.sfc").unwrap();
+        snes.run_tick();
+        assert!(snes.is_ready_to_render());
+        snes.reset(false);
         assert!(!snes.is_ready_to_render());
     }
 


### PR DESCRIPTION
## Summary
- implement `SnesSystemBus` with WRAM direct/mirror mapping, LoROM/HiROM/ExHiROM ROM decode, SRAM windows, and MDR/open-bus semantics
- add scoped system MMIO support for `$2180-$2183`, mul/div (`$4202-$4206` with `$4214-$4217` readback), MEMSEL (`$420D`), and `$43x0-$43xB` DMA register latches with system-bank mirrors
- wire SNES console to `Option<Cpu<SnesSystemBus>>` so ROM load builds/reset CPU on real bus and `run_tick()` executes CPU steps (returns 0 when no ROM loaded)
- update SNES architecture documentation to reflect non-stub bus/console behavior landed in #2744

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/snes --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`

Closes #2744
