### PR TITLE
feat(snes): general-purpose DMA with cycle accounting (#2745)

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -316,7 +316,7 @@ All Game Boy Advance hardware lives under `src/gba/`. The module currently provi
 
 #### SNES Emulation (`src/snes/`)
 
-The SNES (Super Nintendo Entertainment System) module now includes active 65816 CPU execution wired to a functional `SnesSystemBus`, plus cartridge parsing/mapping for LoROM/HiROM/ExHiROM. PPU/APU/input remain incremental, but the core CPU↔bus bring-up path for cartridge execution is in place.
+The SNES (Super Nintendo Entertainment System) module now includes active 65816 CPU execution wired to a functional `SnesSystemBus`, cartridge parsing/mapping for LoROM/HiROM/ExHiROM, and initial general-purpose DMA channel execution. PPU/APU/input and HDMA remain incremental, but the core CPU↔bus bring-up path for cartridge execution and DMA-backed B-bus transfer plumbing are in place.
 
 | Directory/File | Description |
 | ---------------- | ------------- |
@@ -325,7 +325,8 @@ The SNES (Super Nintendo Entertainment System) module now includes active 65816 
 | `src/snes/console/snes.rs` | `Snes` — platform-facing SNES wrapper implementing the `Emulator` trait. Owns `Option<Cpu<SnesSystemBus>>`; `load_rom` parses a `Cartridge`, constructs the system bus, and resets CPU state; `run_tick` executes real CPU steps when a ROM is loaded (returns 0 cycles when not loaded). Screen/audio/input/save-state APIs are still staged for later SNES sub-issues. |
 | `src/snes/console/config.rs` | `SnesConfig` struct for SNES-specific configuration (currently empty, ready for future settings). |
 | `src/snes/bus/mod.rs` | `SnesBus` trait definition plus `StubBus`, `TestBus`, and `SnesSystemBus` exports. The trait defines the memory access contract (`read`, `write`, `tick`) mirroring the pattern used in GB and GBA. |
-| `src/snes/bus/system_bus.rs` | `SnesSystemBus` implementation for #2744 bring-up: WRAM direct/mirror mapping, LoROM/HiROM/ExHiROM ROM decode, SRAM windows with wrap semantics, strict MDR/open-bus reads, and scoped MMIO register support (`$2180-$2183`, mul/div `$4202-$4206`, MEMSEL `$420D`, DMA register latches `$4300-$437F`) including mirrors across system banks. |
+| `src/snes/bus/system_bus.rs` | `SnesSystemBus` implementation: WRAM direct/mirror mapping, LoROM/HiROM/ExHiROM ROM decode, SRAM windows with wrap semantics, strict MDR/open-bus reads, scoped MMIO support (`$2180-$2183`, mul/div `$4202-$4206`, MEMSEL `$420D`), and MDMAEN (`$420B`) dispatch into the DMA controller. |
+| `src/snes/bus/dma.rs` | `DmaController` for #2745: `$43x0-$43xB` channel register file, synchronous general-purpose DMA execution for channels 0..7, transfer modes (including aliases 5/6/7 -> 1/2/3), A-bus inc/dec/fixed stepping, per-transfer cycle accounting (8/byte + per-channel/global overhead), and deterministic B-bus stub storage for pre-PPU/APU validation. |
 | `src/snes/cpu/mod.rs` | SNES 65816 CPU module root. Re-exports `Cpu` and memory-speed helpers; instruction behavior and timing tests live in `cpu.rs`. |
 | `src/snes/ppu/mod.rs` | PPU module stub (SNES Picture Processing Unit — future implementation). |
 | `src/snes/apu/mod.rs` | APU module stub (SPC700 + DSP — future implementation). |

--- a/src/snes/bus/dma.rs
+++ b/src/snes/bus/dma.rs
@@ -35,9 +35,14 @@ impl DmaController {
         true
     }
 
-    pub fn start_dma<B: DmaABus>(&mut self, mdmaen: u8, abus: &mut B, seed_open_bus: u8) -> u64 {
+    pub fn start_dma<B: DmaABus>(
+        &mut self,
+        mdmaen: u8,
+        abus: &mut B,
+        seed_open_bus: u8,
+    ) -> (u64, u8) {
         if mdmaen == 0 {
-            return 0;
+            return (0, seed_open_bus);
         }
 
         let mut ticks = 16u64;
@@ -52,7 +57,7 @@ impl DmaController {
             ticks += self.run_channel(channel, abus, &mut open_bus);
         }
 
-        ticks
+        (ticks, open_bus)
     }
 
     fn run_channel<B: DmaABus>(&mut self, channel: u8, abus: &mut B, open_bus: &mut u8) -> u64 {

--- a/src/snes/bus/dma.rs
+++ b/src/snes/bus/dma.rs
@@ -1,0 +1,154 @@
+const DMA_REG_BYTES: usize = 0x80;
+const B_BUS_PORT_BYTES: usize = 0x100;
+
+pub trait DmaABus {
+    fn dma_read_a_bus(&mut self, addr: u32, open_bus: u8) -> u8;
+    fn dma_write_a_bus(&mut self, addr: u32, value: u8);
+}
+
+#[derive(Clone)]
+pub struct DmaController {
+    regs: [u8; DMA_REG_BYTES],
+    bbus_ports: [u8; B_BUS_PORT_BYTES],
+}
+
+impl DmaController {
+    pub fn new() -> Self {
+        Self {
+            regs: [0; DMA_REG_BYTES],
+            bbus_ports: [0; B_BUS_PORT_BYTES],
+        }
+    }
+
+    pub fn read_register(&self, offset: u16) -> Option<u8> {
+        if !(0x4300..=0x437F).contains(&offset) {
+            return None;
+        }
+        Some(self.regs[(offset - 0x4300) as usize])
+    }
+
+    pub fn write_register(&mut self, offset: u16, value: u8) -> bool {
+        if !(0x4300..=0x437F).contains(&offset) {
+            return false;
+        }
+        self.regs[(offset - 0x4300) as usize] = value;
+        true
+    }
+
+    pub fn start_dma<B: DmaABus>(&mut self, mdmaen: u8, abus: &mut B, seed_open_bus: u8) -> u64 {
+        if mdmaen == 0 {
+            return 0;
+        }
+
+        let mut ticks = 16u64;
+        let mut open_bus = seed_open_bus;
+
+        for channel in 0u8..8 {
+            if (mdmaen & (1 << channel)) == 0 {
+                continue;
+            }
+
+            ticks += 8;
+            ticks += self.run_channel(channel, abus, &mut open_bus);
+        }
+
+        ticks
+    }
+
+    fn run_channel<B: DmaABus>(&mut self, channel: u8, abus: &mut B, open_bus: &mut u8) -> u64 {
+        let dmap = self.get_reg(channel, 0x0);
+        let bbad = self.get_reg(channel, 0x1);
+        let mut a_low = self.get_reg(channel, 0x2);
+        let mut a_high = self.get_reg(channel, 0x3);
+        let bank = self.get_reg(channel, 0x4);
+        let das_low = self.get_reg(channel, 0x5);
+        let das_high = self.get_reg(channel, 0x6);
+
+        let mode = Self::canonical_mode(dmap & 0x07);
+        let pattern = Self::transfer_offsets(mode);
+        let direction_b_to_a = (dmap & 0x80) != 0;
+        let step = (dmap >> 3) & 0x03;
+
+        let mut count = u16::from_le_bytes([das_low, das_high]);
+        let transfer_bytes: usize = if count == 0 { 0x1_0000 } else { count as usize };
+        let mut ticks = 0u64;
+
+        for i in 0..transfer_bytes {
+            let a_addr = ((bank as u32) << 16) | ((a_high as u32) << 8) | (a_low as u32);
+            let b_addr = bbad.wrapping_add(pattern[i % pattern.len()]);
+
+            if direction_b_to_a {
+                let value = self.read_b_bus(b_addr);
+                *open_bus = value;
+                abus.dma_write_a_bus(a_addr, value);
+            } else {
+                let value = abus.dma_read_a_bus(a_addr, *open_bus);
+                *open_bus = value;
+                self.write_b_bus(b_addr, value);
+            }
+
+            ticks += 8;
+            count = count.wrapping_sub(1);
+            (a_low, a_high) = Self::advance_a_address(a_low, a_high, step);
+        }
+
+        self.set_reg(channel, 0x2, a_low);
+        self.set_reg(channel, 0x3, a_high);
+        self.set_reg(channel, 0x5, (count & 0x00FF) as u8);
+        self.set_reg(channel, 0x6, (count >> 8) as u8);
+        ticks
+    }
+
+    fn canonical_mode(mode: u8) -> u8 {
+        match mode {
+            0x5 => 0x1,
+            0x6 => 0x2,
+            0x7 => 0x3,
+            _ => mode,
+        }
+    }
+
+    fn transfer_offsets(mode: u8) -> &'static [u8] {
+        match mode {
+            0x0 => &[0],
+            0x1 => &[0, 1],
+            0x2 => &[0, 0],
+            0x3 => &[0, 0, 1, 1],
+            0x4 => &[0, 1, 2, 3],
+            _ => &[0],
+        }
+    }
+
+    fn advance_a_address(low: u8, high: u8, step: u8) -> (u8, u8) {
+        let mut addr = u16::from_le_bytes([low, high]);
+        match step {
+            0x0 => addr = addr.wrapping_add(1),
+            0x2 => addr = addr.wrapping_sub(1),
+            _ => {}
+        }
+        let [next_low, next_high] = addr.to_le_bytes();
+        (next_low, next_high)
+    }
+
+    fn read_b_bus(&self, addr: u8) -> u8 {
+        self.bbus_ports[addr as usize]
+    }
+
+    fn write_b_bus(&mut self, addr: u8, value: u8) {
+        self.bbus_ports[addr as usize] = value;
+    }
+
+    fn get_reg(&self, channel: u8, reg: usize) -> u8 {
+        self.regs[(channel as usize) * 0x10 + reg]
+    }
+
+    fn set_reg(&mut self, channel: u8, reg: usize, value: u8) {
+        self.regs[(channel as usize) * 0x10 + reg] = value;
+    }
+}
+
+impl Default for DmaController {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/snes/bus/mod.rs
+++ b/src/snes/bus/mod.rs
@@ -2,6 +2,7 @@
 
 #[allow(clippy::module_inception)]
 mod bus;
+mod dma;
 mod system_bus;
 
 #[cfg(test)]

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -1,4 +1,5 @@
 use crate::snes::bus::SnesBus;
+use crate::snes::bus::dma::{DmaABus, DmaController};
 use crate::snes::cartridge::Cartridge;
 use crate::snes::cartridge::Mapping;
 use std::cell::Cell;
@@ -26,7 +27,7 @@ pub struct SnesSystemBus {
     rddiv: u16,
     rdmpy: u16,
     memsel: u8,
-    dma_regs: [u8; 0x80],
+    dma: DmaController,
     mdr: Cell<u8>,
     ticks: Cell<u64>,
 }
@@ -48,7 +49,7 @@ impl SnesSystemBus {
             rddiv: 0,
             rdmpy: 0,
             memsel: 0,
-            dma_regs: [0; 0x80],
+            dma: DmaController::new(),
             mdr: Cell::new(0),
             ticks: Cell::new(0),
         }
@@ -154,6 +155,62 @@ impl SnesSystemBus {
         }
     }
 
+    fn is_system_bank(bank: u8) -> bool {
+        matches!(bank, 0x00..=0x3F | 0x80..=0xBF)
+    }
+
+    fn is_dma_a_bus_mmio(addr: u32) -> bool {
+        let bank = ((addr >> 16) & 0xFF) as u8;
+        let offset = (addr & 0xFFFF) as u16;
+        Self::is_system_bank(bank)
+            && (matches!(offset, 0x2100..=0x21FF | 0x4000..=0x41FF | 0x4200..=0x421F)
+                || (0x4300..=0x437F).contains(&offset))
+    }
+
+    fn dma_read_a_bus_impl(&self, addr: u32, open_bus: u8) -> u8 {
+        if Self::is_dma_a_bus_mmio(addr) {
+            return open_bus;
+        }
+
+        if let Some(index) = Self::decode_wram_index(addr) {
+            self.wram[index]
+        } else if let Some(index) = self.decode_rom_index(addr) {
+            self.rom.get(index).copied().unwrap_or(open_bus)
+        } else if let Some(index) = self.decode_sram_index(addr) {
+            if self.sram.is_empty() {
+                open_bus
+            } else {
+                self.sram[index % self.sram.len()]
+            }
+        } else {
+            open_bus
+        }
+    }
+
+    fn dma_write_a_bus_impl(&mut self, addr: u32, value: u8) {
+        if Self::is_dma_a_bus_mmio(addr) {
+            return;
+        }
+
+        if let Some(index) = Self::decode_wram_index(addr) {
+            self.wram[index] = value;
+        } else if let Some(index) = self.decode_sram_index(addr) {
+            let len = self.sram.len();
+            if len != 0 {
+                self.sram[index % len] = value;
+            }
+        }
+    }
+
+    fn start_dma_transfer(&mut self, mdmaen: u8) {
+        let mut dma = std::mem::take(&mut self.dma);
+        let consumed_ticks = dma.start_dma(mdmaen, self, self.mdr.get());
+
+        self.ticks
+            .set(self.ticks.get().wrapping_add(consumed_ticks));
+        self.dma = dma;
+    }
+
     fn read_mmio(&self, addr: u32) -> Option<u8> {
         let offset = Self::decode_system_offset(addr)?;
         let value = match offset {
@@ -171,7 +228,7 @@ impl SnesSystemBus {
             0x4216 => (self.rdmpy & 0x00FF) as u8,
             0x4217 => (self.rdmpy >> 8) as u8,
             0x420D => self.memsel,
-            0x4300..=0x437F => self.dma_regs[(offset - 0x4300) as usize],
+            0x4300..=0x437F => self.dma.read_register(offset)?,
             _ => return None,
         };
         Some(value)
@@ -238,12 +295,23 @@ impl SnesSystemBus {
                 self.memsel = value & 0x01;
                 true
             }
-            0x4300..=0x437F => {
-                self.dma_regs[(offset - 0x4300) as usize] = value;
+            0x420B => {
+                self.start_dma_transfer(value);
                 true
             }
+            0x4300..=0x437F => self.dma.write_register(offset, value),
             _ => false,
         }
+    }
+}
+
+impl DmaABus for SnesSystemBus {
+    fn dma_read_a_bus(&mut self, addr: u32, open_bus: u8) -> u8 {
+        self.dma_read_a_bus_impl(addr, open_bus)
+    }
+
+    fn dma_write_a_bus(&mut self, addr: u32, value: u8) {
+        self.dma_write_a_bus_impl(addr, value);
     }
 }
 
@@ -335,6 +403,24 @@ mod tests {
     fn lorom_cart_with_sram() -> Cartridge {
         let mut rom = vec![0u8; 0x20000];
         build_cart(&mut rom, 0x7FC0, 0x20, 0x05)
+    }
+
+    fn write_dma_channel(
+        bus: &mut SnesSystemBus,
+        channel: u8,
+        dmap: u8,
+        bbad: u8,
+        a_addr: u32,
+        count: u16,
+    ) {
+        let base = 0x004300u32 + (channel as u32) * 0x10;
+        bus.write(base, dmap);
+        bus.write(base + 0x1, bbad);
+        bus.write(base + 0x2, (a_addr & 0xFF) as u8);
+        bus.write(base + 0x3, ((a_addr >> 8) & 0xFF) as u8);
+        bus.write(base + 0x4, ((a_addr >> 16) & 0xFF) as u8);
+        bus.write(base + 0x5, (count & 0xFF) as u8);
+        bus.write(base + 0x6, (count >> 8) as u8);
     }
 
     #[test]
@@ -498,6 +584,27 @@ mod tests {
     }
 
     #[test]
+    fn dma_channel_register_blocks_do_not_alias() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+
+        for channel in 0u32..8 {
+            for reg in 0u32..=0x0B {
+                let addr = 0x004300 + channel * 0x10 + reg;
+                let value = (channel as u8).wrapping_mul(0x10).wrapping_add(reg as u8);
+                bus.write(addr, value);
+            }
+        }
+
+        for channel in 0u32..8 {
+            for reg in 0u32..=0x0B {
+                let addr = 0x004300 + channel * 0x10 + reg;
+                let expected = (channel as u8).wrapping_mul(0x10).wrapping_add(reg as u8);
+                assert_eq!(bus.read(addr), expected);
+            }
+        }
+    }
+
+    #[test]
     fn wram_port_reads_auto_increment_address() {
         let mut bus = SnesSystemBus::new(lorom_test_cart());
         bus.write(0x002181, 0x00);
@@ -525,5 +632,116 @@ mod tests {
         bus.write(0x004206, 0x10);
         assert_eq!(bus.read(0x004214), 0x23);
         assert_eq!(bus.read(0x004215), 0x01);
+    }
+
+    #[test]
+    fn mdmaen_runs_dma_synchronously_and_updates_channel_registers() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x7E0100, 0x3A);
+        write_dma_channel(&mut bus, 0, 0x00, 0x00, 0x7E0100, 1);
+        bus.write(0x00420B, 0x01);
+
+        // Read back from B-bus via reverse DMA to verify data landed at $2100.
+        write_dma_channel(&mut bus, 0, 0x80, 0x00, 0x7E0200, 1);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E0200), 0x3A);
+
+        // DAS reaches zero and A1T advances by transfer byte count.
+        assert_eq!(bus.read(0x004305), 0x00);
+        assert_eq!(bus.read(0x004306), 0x00);
+        assert_eq!(bus.read(0x004302), 0x01);
+        assert_eq!(bus.read(0x004303), 0x02);
+    }
+
+    #[test]
+    fn mdmaen_executes_channels_in_priority_order_and_accounts_cycles() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x7E0100, 0x11);
+        bus.write(0x7E0200, 0x22);
+        write_dma_channel(&mut bus, 0, 0x00, 0x10, 0x7E0100, 1);
+        write_dma_channel(&mut bus, 1, 0x00, 0x10, 0x7E0200, 1);
+
+        let ticks_before = bus.ticks.get();
+        bus.write(0x00420B, 0x03);
+        let ticks_after = bus.ticks.get();
+
+        // Channel 1 must run after channel 0, so final B-bus value is from channel 1.
+        write_dma_channel(&mut bus, 0, 0x80, 0x10, 0x7E0300, 1);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E0300), 0x22);
+
+        // 8/byte + 8/channel + fixed 16 global transfer overhead.
+        assert_eq!(ticks_after - ticks_before, 16 + 2 * 8 + 2 * 8);
+    }
+
+    #[test]
+    fn dma_modes_5_6_7_alias_modes_1_2_3() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+
+        // mode 5 should alias mode 1 (p, p+1)
+        bus.write(0x7E1000, 0xA1);
+        bus.write(0x7E1001, 0xB2);
+        write_dma_channel(&mut bus, 0, 0x05, 0x20, 0x7E1000, 2);
+        bus.write(0x00420B, 0x01);
+        write_dma_channel(&mut bus, 0, 0x81, 0x20, 0x7E1100, 2);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E1100), 0xA1);
+        assert_eq!(bus.read(0x7E1101), 0xB2);
+
+        // mode 6 should alias mode 2 (p, p)
+        bus.write(0x7E1200, 0xC3);
+        bus.write(0x7E1201, 0xD4);
+        write_dma_channel(&mut bus, 0, 0x06, 0x24, 0x7E1200, 2);
+        bus.write(0x00420B, 0x01);
+        write_dma_channel(&mut bus, 0, 0x82, 0x24, 0x7E1300, 2);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E1300), 0xD4);
+        assert_eq!(bus.read(0x7E1301), 0xD4);
+
+        // mode 7 should alias mode 3 (p, p, p+1, p+1)
+        bus.write(0x7E1400, 0x10);
+        bus.write(0x7E1401, 0x20);
+        bus.write(0x7E1402, 0x30);
+        bus.write(0x7E1403, 0x40);
+        write_dma_channel(&mut bus, 0, 0x07, 0x28, 0x7E1400, 4);
+        bus.write(0x00420B, 0x01);
+        write_dma_channel(&mut bus, 0, 0x83, 0x28, 0x7E1500, 4);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E1500), 0x20);
+        assert_eq!(bus.read(0x7E1501), 0x20);
+        assert_eq!(bus.read(0x7E1502), 0x40);
+        assert_eq!(bus.read(0x7E1503), 0x40);
+    }
+
+    #[test]
+    fn dma_a_bus_mmio_regions_are_treated_as_open_bus() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+
+        // Prime MDR with a value that differs from DMA register file contents.
+        bus.write(0x7E0010, 0x9A);
+        assert_eq!(bus.read(0x7E0010), 0x9A);
+        bus.write(0x004300, 0x55);
+
+        // A-bus source points to excluded MMIO space ($4300); DMA must read open bus (MDR=0x9A).
+        write_dma_channel(&mut bus, 0, 0x00, 0x30, 0x004300, 1);
+        bus.write(0x00420B, 0x01);
+        write_dma_channel(&mut bus, 0, 0x80, 0x30, 0x7E1600, 1);
+        bus.write(0x00420B, 0x01);
+
+        assert_eq!(bus.read(0x7E1600), 0x9A);
+    }
+
+    #[test]
+    fn dma_byte_count_zero_means_65536_bytes() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x7E1700, 0x6E);
+        write_dma_channel(&mut bus, 0, 0x08, 0x38, 0x7E1700, 0x0000); // fixed A-bus step
+        bus.write(0x00420B, 0x01);
+
+        assert_eq!(bus.read(0x004305), 0x00);
+        assert_eq!(bus.read(0x004306), 0x00);
+        // Fixed addressing keeps A1T unchanged after a 65536-byte transfer.
+        assert_eq!(bus.read(0x004302), 0x00);
+        assert_eq!(bus.read(0x004303), 0x17);
     }
 }

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -204,10 +204,11 @@ impl SnesSystemBus {
 
     fn start_dma_transfer(&mut self, mdmaen: u8) {
         let mut dma = std::mem::take(&mut self.dma);
-        let consumed_ticks = dma.start_dma(mdmaen, self, self.mdr.get());
+        let (consumed_ticks, dma_open_bus) = dma.start_dma(mdmaen, self, self.mdr.get());
 
         self.ticks
             .set(self.ticks.get().wrapping_add(consumed_ticks));
+        self.mdr.set(dma_open_bus);
         self.dma = dma;
     }
 
@@ -743,5 +744,16 @@ mod tests {
         // Fixed addressing keeps A1T unchanged after a 65536-byte transfer.
         assert_eq!(bus.read(0x004302), 0x00);
         assert_eq!(bus.read(0x004303), 0x17);
+    }
+
+    #[test]
+    fn dma_updates_mdr_with_last_transferred_byte() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x7E1800, 0x5C);
+        write_dma_channel(&mut bus, 0, 0x00, 0x40, 0x7E1800, 1);
+        bus.write(0x00420B, 0x01);
+
+        // Unmapped read returns MDR; after DMA it should be the last transferred byte.
+        assert_eq!(bus.read(0x002200), 0x5C);
     }
 }


### PR DESCRIPTION
## Summary
- add `src/snes/bus/dma.rs` with a dedicated `DmaController` and channel register model (`$43x0-$43xB`)
- implement synchronous MDMAEN (`$420B`) execution in `SnesSystemBus` for channels 0..7 in priority order
- implement transfer modes 0..4 plus canonical alias mapping for 5/6/7 -> 1/2/3
- implement DMA A-bus address stepping (increment/decrement/fixed), 16-bit wrap semantics, and `DAS=$0000 => 65536 bytes`
- enforce DMA-specific A-bus MMIO exclusion/open-bus behavior for `$2100-$21FF`, `$4000-$41FF`, `$4200-$421F`, `$4300-$437F`
- wire deterministic cycle accounting: `8 cycles/byte + 8/channel + 16 global`
- add/extend SNES bus tests for synchronous DMA behavior, multi-channel ordering, mode alias behavior, MMIO exclusion, count-zero behavior, and register-block non-aliasing
- update `architecture.md` SNES section with DMA module/status details

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/snes --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`

Closes #2745
