### PR TITLE
Sub-issue (2719): implement SNES HDMA per-scanline transfers (#2746)

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -316,7 +316,7 @@ All Game Boy Advance hardware lives under `src/gba/`. The module currently provi
 
 #### SNES Emulation (`src/snes/`)
 
-The SNES (Super Nintendo Entertainment System) module now includes active 65816 CPU execution wired to a functional `SnesSystemBus`, cartridge parsing/mapping for LoROM/HiROM/ExHiROM, and initial general-purpose DMA channel execution. PPU/APU/input and HDMA remain incremental, but the core CPU↔bus bring-up path for cartridge execution and DMA-backed B-bus transfer plumbing are in place.
+The SNES (Super Nintendo Entertainment System) module now includes active 65816 CPU execution wired to a functional `SnesSystemBus`, cartridge parsing/mapping for LoROM/HiROM/ExHiROM, and both general-purpose DMA and explicit HDMA execution hooks. PPU/APU/input remain incremental; HDMA scanline scheduling is intentionally exposed as bus APIs (`hdma_init` / `hdma_do_line`) until PPU timing wiring lands.
 
 | Directory/File | Description |
 | ---------------- | ------------- |
@@ -325,8 +325,8 @@ The SNES (Super Nintendo Entertainment System) module now includes active 65816 
 | `src/snes/console/snes.rs` | `Snes` — platform-facing SNES wrapper implementing the `Emulator` trait. Owns `Option<Cpu<SnesSystemBus>>`; `load_rom` parses a `Cartridge`, constructs the system bus, and resets CPU state; `run_tick` executes real CPU steps when a ROM is loaded (returns 0 cycles when not loaded). Screen/audio/input/save-state APIs are still staged for later SNES sub-issues. |
 | `src/snes/console/config.rs` | `SnesConfig` struct for SNES-specific configuration (currently empty, ready for future settings). |
 | `src/snes/bus/mod.rs` | `SnesBus` trait definition plus `StubBus`, `TestBus`, and `SnesSystemBus` exports. The trait defines the memory access contract (`read`, `write`, `tick`) mirroring the pattern used in GB and GBA. |
-| `src/snes/bus/system_bus.rs` | `SnesSystemBus` implementation: WRAM direct/mirror mapping, LoROM/HiROM/ExHiROM ROM decode, SRAM windows with wrap semantics, strict MDR/open-bus reads, scoped MMIO support (`$2180-$2183`, mul/div `$4202-$4206`, MEMSEL `$420D`), and MDMAEN (`$420B`) dispatch into the DMA controller. |
-| `src/snes/bus/dma.rs` | `DmaController` for #2745: `$43x0-$43xB` channel register file, synchronous general-purpose DMA execution for channels 0..7, transfer modes (including aliases 5/6/7 -> 1/2/3), A-bus inc/dec/fixed stepping, per-transfer cycle accounting (8/byte + per-channel/global overhead), and deterministic B-bus stub storage for pre-PPU/APU validation. |
+| `src/snes/bus/system_bus.rs` | `SnesSystemBus` implementation: WRAM direct/mirror mapping, LoROM/HiROM/ExHiROM ROM decode, SRAM windows with wrap semantics, strict MDR/open-bus reads, scoped MMIO support (`$2180-$2183`, mul/div `$4202-$4206`, MEMSEL `$420D`, MDMAEN `$420B`, HDMAEN `$420C`), plus explicit `hdma_init()` / `hdma_do_line()` APIs used by tests and future PPU scanline wiring. |
+| `src/snes/bus/dma.rs` | `DmaController` for #2745/#2746: `$43x0-$43xB` channel register file, synchronous general-purpose DMA execution, HDMA per-frame init and per-line execution (direct+indirect tables, repeat/continue semantics, terminator handling, channel 0→7 ordering), modeled cycle accounting (global + per-channel + per-byte + indirect pointer loads), and deterministic B-bus stub storage for pre-PPU/APU validation. |
 | `src/snes/cpu/mod.rs` | SNES 65816 CPU module root. Re-exports `Cpu` and memory-speed helpers; instruction behavior and timing tests live in `cpu.rs`. |
 | `src/snes/ppu/mod.rs` | PPU module stub (SNES Picture Processing Unit — future implementation). |
 | `src/snes/apu/mod.rs` | APU module stub (SPC700 + DSP — future implementation). |

--- a/src/snes/bus/dma.rs
+++ b/src/snes/bus/dma.rs
@@ -10,6 +10,10 @@ pub trait DmaABus {
 pub struct DmaController {
     regs: [u8; DMA_REG_BYTES],
     bbus_ports: [u8; B_BUS_PORT_BYTES],
+    hdma_active_mask: u8,
+    hdma_do_transfer: [bool; 8],
+    hdma_repeat_mode: [bool; 8],
+    hdma_lines_left: [u16; 8],
 }
 
 impl DmaController {
@@ -17,6 +21,10 @@ impl DmaController {
         Self {
             regs: [0; DMA_REG_BYTES],
             bbus_ports: [0; B_BUS_PORT_BYTES],
+            hdma_active_mask: 0,
+            hdma_do_transfer: [false; 8],
+            hdma_repeat_mode: [false; 8],
+            hdma_lines_left: [0; 8],
         }
     }
 
@@ -55,6 +63,102 @@ impl DmaController {
 
             ticks += 8;
             ticks += self.run_channel(channel, abus, &mut open_bus);
+        }
+
+        (ticks, open_bus)
+    }
+
+    pub fn hdma_init<B: DmaABus>(
+        &mut self,
+        hdmaen: u8,
+        abus: &mut B,
+        seed_open_bus: u8,
+    ) -> (u64, u8) {
+        self.hdma_active_mask = 0;
+        self.hdma_do_transfer = [false; 8];
+        self.hdma_repeat_mode = [false; 8];
+        self.hdma_lines_left = [0; 8];
+
+        if hdmaen == 0 {
+            return (0, seed_open_bus);
+        }
+
+        let mut ticks = 18u64;
+        let mut open_bus = seed_open_bus;
+
+        for channel in 0u8..8 {
+            if (hdmaen & (1 << channel)) == 0 {
+                continue;
+            }
+
+            let dmap = self.get_reg(channel, 0x0);
+            let indirect = (dmap & 0x40) != 0;
+            ticks += 8;
+
+            let a1t_low = self.get_reg(channel, 0x2);
+            let a1t_high = self.get_reg(channel, 0x3);
+            self.set_reg(channel, 0x8, a1t_low);
+            self.set_reg(channel, 0x9, a1t_high);
+
+            let descriptor = self.read_hdma_table_byte(channel, abus, &mut open_bus);
+            self.set_reg(channel, 0xA, descriptor);
+            if descriptor == 0 {
+                continue;
+            }
+            let (repeat_mode, lines_left) = Self::decode_hdma_descriptor(descriptor);
+            self.hdma_repeat_mode[channel as usize] = repeat_mode;
+            self.hdma_lines_left[channel as usize] = lines_left;
+
+            if indirect {
+                ticks += 16;
+                let indirect_low = self.read_hdma_table_byte(channel, abus, &mut open_bus);
+                let indirect_high = self.read_hdma_table_byte(channel, abus, &mut open_bus);
+                self.set_reg(channel, 0x5, indirect_low);
+                self.set_reg(channel, 0x6, indirect_high);
+            }
+
+            self.hdma_active_mask |= 1 << channel;
+            self.hdma_do_transfer[channel as usize] = true;
+        }
+
+        (ticks, open_bus)
+    }
+
+    pub fn hdma_do_line<B: DmaABus>(&mut self, abus: &mut B, seed_open_bus: u8) -> (u64, u8) {
+        if self.hdma_active_mask == 0 {
+            return (0, seed_open_bus);
+        }
+
+        let mut ticks = 18u64;
+        let mut open_bus = seed_open_bus;
+
+        for channel in 0u8..8 {
+            if (self.hdma_active_mask & (1 << channel)) == 0 {
+                continue;
+            }
+
+            ticks += 8;
+            if self.hdma_do_transfer[channel as usize] {
+                ticks += self.run_hdma_transfer_unit(channel, abus, &mut open_bus);
+            }
+
+            let idx = channel as usize;
+            self.hdma_lines_left[idx] = self.hdma_lines_left[idx].saturating_sub(1);
+            self.set_reg(
+                channel,
+                0xA,
+                Self::encode_hdma_counter(self.hdma_repeat_mode[idx], self.hdma_lines_left[idx]),
+            );
+            self.hdma_do_transfer[idx] = self.hdma_repeat_mode[idx];
+
+            if self.hdma_lines_left[idx] == 0 {
+                if !self.reload_hdma_entry(channel, abus, &mut open_bus, &mut ticks) {
+                    self.hdma_active_mask &= !(1 << channel);
+                    self.hdma_do_transfer[idx] = false;
+                } else {
+                    self.hdma_do_transfer[idx] = true;
+                }
+            }
         }
 
         (ticks, open_bus)
@@ -149,6 +253,138 @@ impl DmaController {
 
     fn set_reg(&mut self, channel: u8, reg: usize, value: u8) {
         self.regs[(channel as usize) * 0x10 + reg] = value;
+    }
+
+    fn decode_hdma_descriptor(descriptor: u8) -> (bool, u16) {
+        if descriptor == 0 {
+            return (false, 0);
+        }
+        if descriptor <= 0x80 {
+            if descriptor == 0x80 {
+                (false, 128)
+            } else {
+                (false, descriptor as u16)
+            }
+        } else {
+            (true, (descriptor - 0x80) as u16)
+        }
+    }
+
+    fn encode_hdma_counter(repeat_mode: bool, lines_left: u16) -> u8 {
+        if lines_left == 0 {
+            0
+        } else if repeat_mode {
+            0x80 | (lines_left as u8)
+        } else if lines_left == 128 {
+            0x80
+        } else {
+            lines_left as u8
+        }
+    }
+
+    fn hdma_table_address(&self, channel: u8) -> u32 {
+        let bank = self.get_reg(channel, 0x4);
+        let low = self.get_reg(channel, 0x8);
+        let high = self.get_reg(channel, 0x9);
+        ((bank as u32) << 16) | u16::from_le_bytes([low, high]) as u32
+    }
+
+    fn read_hdma_table_byte<B: DmaABus>(
+        &mut self,
+        channel: u8,
+        abus: &mut B,
+        open_bus: &mut u8,
+    ) -> u8 {
+        let table_addr = self.hdma_table_address(channel);
+        let value = abus.dma_read_a_bus(table_addr, *open_bus);
+        *open_bus = value;
+
+        let next = u16::from_le_bytes([self.get_reg(channel, 0x8), self.get_reg(channel, 0x9)])
+            .wrapping_add(1);
+        let [next_low, next_high] = next.to_le_bytes();
+        self.set_reg(channel, 0x8, next_low);
+        self.set_reg(channel, 0x9, next_high);
+        value
+    }
+
+    fn run_hdma_transfer_unit<B: DmaABus>(
+        &mut self,
+        channel: u8,
+        abus: &mut B,
+        open_bus: &mut u8,
+    ) -> u64 {
+        let dmap = self.get_reg(channel, 0x0);
+        let bbad = self.get_reg(channel, 0x1);
+        let mode = Self::canonical_mode(dmap & 0x07);
+        let pattern = Self::transfer_offsets(mode);
+        let direction_b_to_a = (dmap & 0x80) != 0;
+        let indirect = (dmap & 0x40) != 0;
+
+        let bank = if indirect {
+            self.get_reg(channel, 0x7)
+        } else {
+            self.get_reg(channel, 0x4)
+        };
+        let mut addr = if indirect {
+            u16::from_le_bytes([self.get_reg(channel, 0x5), self.get_reg(channel, 0x6)])
+        } else {
+            u16::from_le_bytes([self.get_reg(channel, 0x8), self.get_reg(channel, 0x9)])
+        };
+
+        for offset in pattern {
+            let a_addr = ((bank as u32) << 16) | addr as u32;
+            let b_addr = bbad.wrapping_add(*offset);
+            if direction_b_to_a {
+                let value = self.read_b_bus(b_addr);
+                *open_bus = value;
+                abus.dma_write_a_bus(a_addr, value);
+            } else {
+                let value = abus.dma_read_a_bus(a_addr, *open_bus);
+                *open_bus = value;
+                self.write_b_bus(b_addr, value);
+            }
+            addr = addr.wrapping_add(1);
+        }
+
+        let [low, high] = addr.to_le_bytes();
+        if indirect {
+            self.set_reg(channel, 0x5, low);
+            self.set_reg(channel, 0x6, high);
+        } else {
+            self.set_reg(channel, 0x8, low);
+            self.set_reg(channel, 0x9, high);
+        }
+
+        (pattern.len() as u64) * 8
+    }
+
+    fn reload_hdma_entry<B: DmaABus>(
+        &mut self,
+        channel: u8,
+        abus: &mut B,
+        open_bus: &mut u8,
+        ticks: &mut u64,
+    ) -> bool {
+        let descriptor = self.read_hdma_table_byte(channel, abus, open_bus);
+        self.set_reg(channel, 0xA, descriptor);
+        if descriptor == 0 {
+            self.hdma_repeat_mode[channel as usize] = false;
+            self.hdma_lines_left[channel as usize] = 0;
+            return false;
+        }
+        let (repeat_mode, lines_left) = Self::decode_hdma_descriptor(descriptor);
+        self.hdma_repeat_mode[channel as usize] = repeat_mode;
+        self.hdma_lines_left[channel as usize] = lines_left;
+
+        if (self.get_reg(channel, 0x0) & 0x40) != 0 {
+            let low = self.read_hdma_table_byte(channel, abus, open_bus);
+            let high = self.read_hdma_table_byte(channel, abus, open_bus);
+            self.set_reg(channel, 0x5, low);
+            self.set_reg(channel, 0x6, high);
+            *ticks += 16;
+        }
+
+        true
     }
 }
 

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -27,6 +27,7 @@ pub struct SnesSystemBus {
     rddiv: u16,
     rdmpy: u16,
     memsel: u8,
+    hdmaen: u8,
     dma: DmaController,
     mdr: Cell<u8>,
     ticks: Cell<u64>,
@@ -49,6 +50,7 @@ impl SnesSystemBus {
             rddiv: 0,
             rdmpy: 0,
             memsel: 0,
+            hdmaen: 0,
             dma: DmaController::new(),
             mdr: Cell::new(0),
             ticks: Cell::new(0),
@@ -212,6 +214,24 @@ impl SnesSystemBus {
         self.dma = dma;
     }
 
+    pub fn hdma_init(&mut self) {
+        let mut dma = std::mem::take(&mut self.dma);
+        let (consumed_ticks, dma_open_bus) = dma.hdma_init(self.hdmaen, self, self.mdr.get());
+        self.ticks
+            .set(self.ticks.get().wrapping_add(consumed_ticks));
+        self.mdr.set(dma_open_bus);
+        self.dma = dma;
+    }
+
+    pub fn hdma_do_line(&mut self) {
+        let mut dma = std::mem::take(&mut self.dma);
+        let (consumed_ticks, dma_open_bus) = dma.hdma_do_line(self, self.mdr.get());
+        self.ticks
+            .set(self.ticks.get().wrapping_add(consumed_ticks));
+        self.mdr.set(dma_open_bus);
+        self.dma = dma;
+    }
+
     fn read_mmio(&self, addr: u32) -> Option<u8> {
         let offset = Self::decode_system_offset(addr)?;
         let value = match offset {
@@ -229,6 +249,7 @@ impl SnesSystemBus {
             0x4216 => (self.rdmpy & 0x00FF) as u8,
             0x4217 => (self.rdmpy >> 8) as u8,
             0x420D => self.memsel,
+            0x420C => self.hdmaen,
             0x4300..=0x437F => self.dma.read_register(offset)?,
             _ => return None,
         };
@@ -294,6 +315,10 @@ impl SnesSystemBus {
             }
             0x420D => {
                 self.memsel = value & 0x01;
+                true
+            }
+            0x420C => {
+                self.hdmaen = value;
                 true
             }
             0x420B => {
@@ -422,6 +447,15 @@ mod tests {
         bus.write(base + 0x4, ((a_addr >> 16) & 0xFF) as u8);
         bus.write(base + 0x5, (count & 0xFF) as u8);
         bus.write(base + 0x6, (count >> 8) as u8);
+    }
+
+    fn write_hdma_channel(bus: &mut SnesSystemBus, channel: u8, dmap: u8, bbad: u8, a_addr: u32) {
+        let base = 0x004300u32 + (channel as u32) * 0x10;
+        bus.write(base, dmap);
+        bus.write(base + 0x1, bbad);
+        bus.write(base + 0x2, (a_addr & 0xFF) as u8);
+        bus.write(base + 0x3, ((a_addr >> 8) & 0xFF) as u8);
+        bus.write(base + 0x4, ((a_addr >> 16) & 0xFF) as u8);
     }
 
     #[test]
@@ -755,5 +789,162 @@ mod tests {
 
         // Unmapped read returns MDR; after DMA it should be the last transferred byte.
         assert_eq!(bus.read(0x002200), 0x5C);
+    }
+
+    #[test]
+    fn hdmaen_register_latches_written_value() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x00420C, 0x81);
+        assert_eq!(bus.read(0x00420C), 0x81);
+    }
+
+    #[test]
+    fn hdma_init_loads_a2a_and_line_counter_from_table() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        write_hdma_channel(&mut bus, 0, 0x00, 0x20, 0x7E2100);
+        bus.write(0x7E2100, 0x02); // line descriptor (repeat clear, 2 lines)
+        bus.write(0x7E2101, 0xAA); // first direct data byte
+        bus.write(0x00420C, 0x01);
+
+        bus.hdma_init();
+
+        assert_eq!(bus.read(0x004308), 0x01); // table current ptr low advanced past descriptor
+        assert_eq!(bus.read(0x004309), 0x21);
+        assert_eq!(bus.read(0x00430A), 0x02);
+    }
+
+    #[test]
+    fn hdma_do_line_direct_mode_transfers_then_pauses_when_repeat_clear() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        write_hdma_channel(&mut bus, 0, 0x00, 0x30, 0x7E2200); // mode0 direct, A->B
+        bus.write(0x7E2200, 0x02); // transfer once, then pause one line
+        bus.write(0x7E2201, 0x5A); // data for first line
+        bus.write(0x7E2202, 0x01); // next descriptor
+        bus.write(0x7E2203, 0xC3); // second transfer data
+        bus.write(0x7E2204, 0x00); // terminator
+        bus.write(0x00420C, 0x01);
+
+        bus.hdma_init();
+        bus.hdma_do_line(); // transfer 0x5A
+        bus.hdma_do_line(); // pause
+        bus.hdma_do_line(); // transfer 0xC3
+
+        write_dma_channel(&mut bus, 0, 0x80, 0x30, 0x7E2210, 1);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E2210), 0xC3);
+    }
+
+    #[test]
+    fn hdma_do_line_indirect_mode_loads_pointer_and_advances_das() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        write_hdma_channel(&mut bus, 0, 0x40, 0x34, 0x7E2300); // indirect mode, mode0
+        bus.write(0x004307, 0x7E); // DASB
+        bus.write(0x7E2300, 0x81); // repeat set, 1 line
+        bus.write(0x7E2301, 0x20); // indirect low
+        bus.write(0x7E2302, 0x23); // indirect high -> 7E2320
+        bus.write(0x7E2320, 0x9B); // indirect data byte
+        bus.write(0x7E2303, 0x00); // next descriptor terminator
+        bus.write(0x00420C, 0x01);
+
+        bus.hdma_init();
+        bus.hdma_do_line();
+
+        assert_eq!(bus.read(0x004305), 0x21); // DAS advanced after one byte transfer
+        assert_eq!(bus.read(0x004306), 0x23);
+    }
+
+    #[test]
+    fn hdma_do_line_without_explicit_init_does_not_transfer() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        write_hdma_channel(&mut bus, 0, 0x00, 0x50, 0x7E2400);
+        bus.write(0x7E2400, 0x01);
+        bus.write(0x7E2401, 0x99);
+        bus.write(0x00420C, 0x01);
+
+        bus.hdma_do_line();
+
+        write_dma_channel(&mut bus, 0, 0x80, 0x50, 0x7E2410, 1);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E2410), 0x00);
+    }
+
+    #[test]
+    fn hdma_channels_execute_in_ascending_order_each_line() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        write_hdma_channel(&mut bus, 0, 0x00, 0x60, 0x7E2500);
+        write_hdma_channel(&mut bus, 1, 0x00, 0x60, 0x7E2600);
+        bus.write(0x7E2500, 0x01);
+        bus.write(0x7E2501, 0x11);
+        bus.write(0x7E2502, 0x00);
+        bus.write(0x7E2600, 0x01);
+        bus.write(0x7E2601, 0x22);
+        bus.write(0x7E2602, 0x00);
+        bus.write(0x00420C, 0x03);
+
+        bus.hdma_init();
+        bus.hdma_do_line();
+
+        write_dma_channel(&mut bus, 0, 0x80, 0x60, 0x7E2610, 1);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E2610), 0x22);
+    }
+
+    #[test]
+    fn hdma_descriptor_80_transfers_once_then_pauses() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        write_hdma_channel(&mut bus, 0, 0x00, 0x70, 0x7E2700);
+        bus.write(0x7E2700, 0x80);
+        bus.write(0x7E2701, 0x55);
+        bus.write(0x7E2702, 0x01);
+        bus.write(0x7E2703, 0x77);
+        bus.write(0x7E2704, 0x00);
+        bus.write(0x00420C, 0x01);
+
+        bus.hdma_init();
+        bus.hdma_do_line(); // transfer 0x55
+        bus.hdma_do_line(); // should pause, not transfer 0x77
+
+        write_dma_channel(&mut bus, 0, 0x80, 0x70, 0x7E2710, 1);
+        bus.write(0x00420B, 0x01);
+        assert_eq!(bus.read(0x7E2710), 0x55);
+    }
+
+    #[test]
+    fn hdma_init_cycle_accounting_matches_direct_and_indirect_costs() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        write_hdma_channel(&mut bus, 0, 0x00, 0x20, 0x7E2800);
+        bus.write(0x7E2800, 0x01);
+        bus.write(0x7E2801, 0xAA);
+        bus.write(0x7E2802, 0x00);
+
+        write_hdma_channel(&mut bus, 1, 0x40, 0x24, 0x7E2900);
+        bus.write(0x004317, 0x7E);
+        bus.write(0x7E2900, 0x01);
+        bus.write(0x7E2901, 0x40);
+        bus.write(0x7E2902, 0x29);
+        bus.write(0x7E2940, 0xBB);
+        bus.write(0x7E2903, 0x00);
+
+        bus.write(0x00420C, 0x03);
+        let ticks_before = bus.ticks.get();
+        bus.hdma_init();
+        let ticks_after = bus.ticks.get();
+
+        assert_eq!(ticks_after - ticks_before, 18 + 8 + 24);
+    }
+
+    #[test]
+    fn hdma_init_indirect_channel_with_terminator_does_not_charge_pointer_load_cycles() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        write_hdma_channel(&mut bus, 0, 0x40, 0x20, 0x7E2A00);
+        bus.write(0x004307, 0x7E);
+        bus.write(0x7E2A00, 0x00);
+        bus.write(0x00420C, 0x01);
+
+        let ticks_before = bus.ticks.get();
+        bus.hdma_init();
+        let ticks_after = bus.ticks.get();
+
+        assert_eq!(ticks_after - ticks_before, 18 + 8);
     }
 }


### PR DESCRIPTION
## Summary
- add SNES HDMAEN ($420C) latch and explicit SnesSystemBus hdma_init()/hdma_do_line() lifecycle APIs
- implement DmaController HDMA runtime engine for 8 channels with direct/indirect table parsing, repeat/continue behavior, terminator handling, and 0->7 channel order
- add HDMA cycle accounting (global/per-channel/per-byte + indirect pointer load costs) and preserve $420C latch while terminating channels per frame
- add focused SNES bus tests for explicit-init policy, descriptor 0x80 semantics, channel ordering, register progression, and timing deltas
- update architecture.md SNES section to document HDMA behavior and API lifecycle

## Validation
- cargo test --no-default-features --lib snes::bus::system_bus::tests::hdma
- ./scripts/test-dir.sh src/snes --skip-integration
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --no-default-features --lib
- wasm-pack test --headless --chrome --no-default-features --features wasm
- source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p \"test_*.py\" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p \"test_*.py\" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p \"test_*.py\"
- npm test

Closes #2746