### PR TITLE
Sub-issue (2720): Windows + color math + main/sub-screen compositing

### DIFF
--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -210,7 +210,29 @@ pub struct SnesPpuState {
     #[serde(default)]
     pub tm: u8,
     #[serde(default)]
+    pub ts: u8,
+    #[serde(default)]
+    pub tmw: u8,
+    #[serde(default)]
+    pub tsw: u8,
+    #[serde(default)]
     pub cgwsel: u8,
+    #[serde(default)]
+    pub cgadsub: u8,
+    #[serde(default)]
+    pub coldata: u16,
+    #[serde(default)]
+    pub w12sel: u8,
+    #[serde(default)]
+    pub w34sel: u8,
+    #[serde(default)]
+    pub wobjsel: u8,
+    #[serde(default)]
+    pub wh: [u8; 4],
+    #[serde(default)]
+    pub wbglog: u8,
+    #[serde(default)]
+    pub wobjlog: u8,
     #[serde(default)]
     pub setini: u8,
     #[serde(default)]

--- a/src/snes/ppu/background.rs
+++ b/src/snes/ppu/background.rs
@@ -14,6 +14,33 @@ enum Slot {
     Obj(u8),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ScreenTarget {
+    Main,
+    Sub,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PixelSource {
+    Bg(usize),
+    Obj { priority: u8, palette: u8 },
+    Backdrop,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WindowLayer {
+    Bg(usize),
+    Obj,
+    Math,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ScreenPixel {
+    pub color: u16,
+    pub source: PixelSource,
+    pub layer_rank: u8,
+}
+
 impl Ppu {
     /// Handle a write to `BGnHOFS` (horizontal scroll, write-twice via the shared BG_old latch):
     /// `hofs = (data << 8) | (bg_old & ~7) | ((hofs >> 8) & 7)`.
@@ -38,48 +65,226 @@ impl Ppu {
 
     /// Compute the final BGR555 pixel for visible screen coordinate `(x, y)`.
     ///
-    /// Iterates the front-to-back priority slots for the current mode (per the fullsnes Background
-    /// Priority Chart), returning the first enabled, non-transparent BG or OBJ pixel. OBJ pixels
-    /// come from the cached per-scanline [`Ppu::obj_line`] and require TM bit 4.
+    /// Resolve the front-most main- and sub-screen pixels, then apply color math when enabled.
     pub(super) fn compute_pixel(&self, x: u16, y: u16) -> u16 {
         if self.bg_mode == 7 {
             return self.compute_pixel_mode7(x, y);
         }
-        for &slot in self.layer_order() {
+        let main = self.resolve_screen_pixel(ScreenTarget::Main, x, y);
+        let sub = self.resolve_screen_pixel(ScreenTarget::Sub, x, y);
+        self.compose_pixels(x, y, main, sub)
+    }
+
+    fn resolve_screen_pixel(&self, target: ScreenTarget, x: u16, y: u16) -> ScreenPixel {
+        for (rank, &slot) in self.layer_order().iter().enumerate() {
             match slot {
                 Slot::Bg(bg, priority) => {
-                    if self.tm & (1 << bg) == 0 {
+                    if self.screen_enable_mask(target) & (1 << bg) == 0 {
+                        continue;
+                    }
+                    if target == ScreenTarget::Sub && self.cgwsel & 0x02 == 0 {
+                        continue;
+                    }
+                    if self.layer_disabled_by_window(target, WindowLayer::Bg(bg), x, y) {
                         continue;
                     }
                     if let Some((color, pixel_priority)) = self.bg_pixel(bg, x, y)
                         && pixel_priority == priority
                     {
-                        return color;
+                        return ScreenPixel {
+                            color,
+                            source: PixelSource::Bg(bg),
+                            layer_rank: rank as u8,
+                        };
                     }
                 }
                 Slot::Obj(priority) => {
-                    if let Some(color) = self.obj_pixel(x, priority) {
-                        return color;
+                    if target == ScreenTarget::Sub && self.cgwsel & 0x02 == 0 {
+                        continue;
+                    }
+                    if self.layer_disabled_by_window(target, WindowLayer::Obj, x, y) {
+                        continue;
+                    }
+                    if let Some((color, palette)) = self.obj_pixel_for_screen(target, x, priority) {
+                        return ScreenPixel {
+                            color,
+                            source: PixelSource::Obj { priority, palette },
+                            layer_rank: rank as u8,
+                        };
                     }
                 }
             }
         }
-        self.backdrop_color()
+        ScreenPixel {
+            color: self.backdrop_color_for(target),
+            source: PixelSource::Backdrop,
+            layer_rank: u8::MAX,
+        }
     }
 
-    /// Sample the cached OBJ line buffer at `x` for OBJ priority level `priority` (0-3), returning
-    /// the BGR555 color if an opaque OBJ pixel of that priority is present and OBJ output is enabled
-    /// on the main screen (TM bit 4).
-    pub(super) fn obj_pixel(&self, x: u16, priority: u8) -> Option<u16> {
-        if self.tm & 0x10 == 0 {
+    pub(super) fn obj_pixel_for_screen(
+        &self,
+        target: ScreenTarget,
+        x: u16,
+        priority: u8,
+    ) -> Option<(u16, u8)> {
+        if self.screen_enable_mask(target) & 0x10 == 0 {
             return None;
         }
         let x = x as usize;
         if self.obj_line.present[x] && self.obj_line.priority[x] == priority {
-            Some(self.obj_line.color[x])
+            Some((self.obj_line.color[x], self.obj_line.palette[x]))
         } else {
             None
         }
+    }
+
+    pub(super) fn screen_enable_mask(&self, target: ScreenTarget) -> u8 {
+        match target {
+            ScreenTarget::Main => self.tm,
+            ScreenTarget::Sub => self.ts,
+        }
+    }
+
+    pub(super) fn backdrop_color_for(&self, target: ScreenTarget) -> u16 {
+        match target {
+            ScreenTarget::Main => self.backdrop_color(),
+            ScreenTarget::Sub => self.coldata & 0x7FFF,
+        }
+    }
+
+    pub(super) fn compose_pixels(
+        &self,
+        x: u16,
+        y: u16,
+        main: ScreenPixel,
+        sub: ScreenPixel,
+    ) -> u16 {
+        let mut main_color = main.color;
+        if self.force_main_black_at(x, y) {
+            main_color = 0;
+        }
+        if !self.color_math_source_enabled(main.source) {
+            return main_color;
+        }
+        if !self.color_math_enabled_at(x, y) {
+            return main_color;
+        }
+        if sub.layer_rank > main.layer_rank && !matches!(sub.source, PixelSource::Backdrop) {
+            return main_color;
+        }
+        self.apply_color_math(main_color, sub.color)
+    }
+
+    pub(super) fn color_math_enabled_at(&self, x: u16, y: u16) -> bool {
+        match (self.cgwsel >> 4) & 0x03 {
+            0 => true,
+            1 => self.window_area(WindowLayer::Math, x, y),
+            2 => !self.window_area(WindowLayer::Math, x, y),
+            3 => false,
+            _ => unreachable!(),
+        }
+    }
+
+    pub(super) fn force_main_black_at(&self, x: u16, y: u16) -> bool {
+        match (self.cgwsel >> 6) & 0x03 {
+            0 => false,
+            1 => !self.window_area(WindowLayer::Math, x, y),
+            2 => self.window_area(WindowLayer::Math, x, y),
+            3 => true,
+            _ => unreachable!(),
+        }
+    }
+
+    pub(super) fn color_math_source_enabled(&self, source: PixelSource) -> bool {
+        match source {
+            PixelSource::Bg(bg) => self.cgadsub & (1 << bg) != 0,
+            PixelSource::Obj { palette, .. } => palette >= 4 && self.cgadsub & 0x10 != 0,
+            PixelSource::Backdrop => self.cgadsub & 0x20 != 0,
+        }
+    }
+
+    pub(super) fn layer_disabled_by_window(
+        &self,
+        target: ScreenTarget,
+        layer: WindowLayer,
+        x: u16,
+        y: u16,
+    ) -> bool {
+        let disable_mask = match target {
+            ScreenTarget::Main => self.tmw,
+            ScreenTarget::Sub => self.tsw,
+        };
+        let bit = match layer {
+            WindowLayer::Bg(bg) => bg as u8,
+            WindowLayer::Obj => 4,
+            WindowLayer::Math => return false,
+        };
+        if disable_mask & (1 << bit) == 0 {
+            return false;
+        }
+        self.window_area(layer, x, y)
+    }
+
+    pub(super) fn window_area(&self, layer: WindowLayer, x: u16, _y: u16) -> bool {
+        let x = x as u8;
+        let (sel, logic, high_bits) = match layer {
+            WindowLayer::Bg(0) => (self.w12sel, self.wbglog, false),
+            WindowLayer::Bg(1) => (self.w12sel, self.wbglog, true),
+            WindowLayer::Bg(2) => (self.w34sel, self.wbglog, false),
+            WindowLayer::Bg(3) => (self.w34sel, self.wbglog, true),
+            WindowLayer::Obj => (self.wobjsel, self.wobjlog, false),
+            WindowLayer::Math => (self.wobjsel, self.wobjlog, true),
+            _ => unreachable!(),
+        };
+        let (one_shift, two_shift, logic_shift) = if high_bits { (4, 6, 2) } else { (0, 2, 0) };
+        let one = self.window_select(sel, one_shift, x);
+        let two = self.window_select(sel, two_shift, x);
+        match ((logic >> logic_shift) & 0x03, one, two) {
+            (_, false, false) => false,
+            (_, true, false) => one,
+            (_, false, true) => two,
+            (0, true, true) => one || two,
+            (1, true, true) => one && two,
+            (2, true, true) => one ^ two,
+            (3, true, true) => !(one ^ two),
+            _ => unreachable!(),
+        }
+    }
+
+    pub(super) fn window_select(&self, sel: u8, shift: u8, x: u8) -> bool {
+        let mode = (sel >> shift) & 0x03;
+        let enable = mode & 0x02 != 0;
+        let invert = mode & 0x01 != 0;
+        if !enable {
+            return false;
+        }
+        let one = self.window_contains(x, self.wh[0], self.wh[1]);
+        let two = self.window_contains(x, self.wh[2], self.wh[3]);
+        if shift & 0x02 == 0 {
+            one ^ invert
+        } else {
+            two ^ invert
+        }
+    }
+
+    pub(super) fn window_contains(&self, x: u8, left: u8, right: u8) -> bool {
+        left <= right && x >= left && x <= right
+    }
+
+    fn apply_color_math(&self, main: u16, sub: u16) -> u16 {
+        let subtract = self.cgadsub & 0x80 != 0;
+        let half = self.cgadsub & 0x40 != 0;
+        let mut out = 0u16;
+        for shift in [0, 5, 10] {
+            let a = ((main >> shift) & 0x1F) as i16;
+            let b = ((sub >> shift) & 0x1F) as i16;
+            let value = if subtract { a - b } else { a + b };
+            let value = if half { value / 2 } else { value };
+            let value = value.clamp(0, 0x1F) as u16;
+            out |= value << shift;
+        }
+        out
     }
 
     /// Front-to-back priority slots for the current mode per the fullsnes Background Priority Chart.
@@ -1085,6 +1290,120 @@ mod tests {
             pixel(&rgb, 8, 8),
             [255, 255, 255],
             "mode4 bit15 applies offset to V"
+        );
+    }
+
+    #[test]
+    fn color_math_combines_main_and_sub_screen_pixels() {
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x001F); // BG1 color 1 = red
+        set_cgram(&mut ppu, 33, 0x03E0); // BG2 color 1 = green
+        set_bg_map_base(&mut ppu, 0, 0x000);
+        set_bg_map_base(&mut ppu, 1, 0x400);
+        set_vram_word(&mut ppu, 0x000, 1); // BG1 entry -> char 1
+        set_vram_word(&mut ppu, 0x400, 2); // BG2 entry -> char 2
+        fill_2bpp_tile(&mut ppu, 0, 1, 1); // solid red
+        fill_2bpp_tile(&mut ppu, 0, 2, 1); // solid green
+
+        ppu.write_register(0x2105, 0x00); // mode 0
+        ppu.write_register(0x212C, 0x02); // main screen: BG2
+        ppu.write_register(0x212D, 0x01); // sub screen: BG1
+        ppu.write_register(0x2130, 0x02); // sub screen BG/OBJ enable
+        ppu.write_register(0x2131, 0x42); // add + div2 + BG2 math enable
+        ppu.write_register(0x2100, 0x0F);
+        render_frame(&mut ppu);
+
+        let rgb = ppu.screen_snapshot_rgb();
+        assert_eq!(
+            pixel(&rgb, 0, 0),
+            [123, 123, 0],
+            "main BG2 green should be color-mathed with sub BG1 red"
+        );
+    }
+
+    #[test]
+    fn window_area_can_disable_a_layer_inside_the_window() {
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x7FFF);
+        fill_2bpp_tile(&mut ppu, 0, 1, 1);
+        set_vram_word(&mut ppu, 0x000, 1);
+        set_vram_word(&mut ppu, 0x019, 1); // x=200 lands in tile column 25
+
+        ppu.write_register(0x2105, 0x00);
+        ppu.write_register(0x212C, 0x01); // main screen: BG1
+        ppu.write_register(0x2123, 0x02); // BG1 window1 enabled, not inverted
+        ppu.write_register(0x2126, 0x00); // WH0 = 0
+        ppu.write_register(0x2127, 0x7F); // WH1 = 127
+        ppu.write_register(0x212E, 0x01); // disable BG1 inside the window
+        ppu.write_register(0x2100, 0x0F);
+        render_frame(&mut ppu);
+
+        let rgb = ppu.screen_snapshot_rgb();
+        assert_eq!(pixel(&rgb, 0, 0), [0, 0, 0], "windowed pixel falls back");
+        assert_eq!(
+            pixel(&rgb, 200, 0),
+            [255, 255, 255],
+            "outside window remains visible"
+        );
+    }
+
+    #[test]
+    fn bg2_window_selection_uses_the_high_bits_of_w12sel() {
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 33, 0x7FFF);
+        set_bg_map_base(&mut ppu, 1, 0x400);
+        set_vram_word(&mut ppu, 0x400, 2);
+        fill_2bpp_tile(&mut ppu, 0, 2, 1);
+        set_vram_word(&mut ppu, 0x419, 2);
+
+        ppu.write_register(0x2105, 0x00);
+        ppu.write_register(0x212C, 0x02); // main screen: BG2
+        ppu.write_register(0x2123, 0x20); // BG2 window1 enabled, not inverted
+        ppu.write_register(0x2126, 0x00);
+        ppu.write_register(0x2127, 0x7F);
+        ppu.write_register(0x212E, 0x02); // disable BG2 inside the window
+        ppu.write_register(0x2100, 0x0F);
+        render_frame(&mut ppu);
+
+        let rgb = ppu.screen_snapshot_rgb();
+        assert_eq!(
+            pixel(&rgb, 0, 0),
+            [0, 0, 0],
+            "BG2 is masked inside the window"
+        );
+        assert_eq!(
+            pixel(&rgb, 200, 0),
+            [255, 255, 255],
+            "BG2 stays visible outside"
+        );
+    }
+
+    #[test]
+    fn sub_screen_backdrop_participates_in_color_math() {
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x001F); // BG1 color 1 = red
+        set_vram_word(&mut ppu, 0x000, 1);
+        fill_2bpp_tile(&mut ppu, 0, 1, 1);
+        ppu.write_register(0x2132, 0xE0); // sub backdrop black
+        ppu.write_register(0x2132, 0x5F); // sub backdrop green
+
+        ppu.write_register(0x2105, 0x00);
+        ppu.write_register(0x212C, 0x01); // main screen: BG1
+        ppu.write_register(0x212D, 0x00); // sub screen: backdrop only
+        ppu.write_register(0x2130, 0x02); // sub screen BG/OBJ enable
+        ppu.write_register(0x2131, 0x41); // add + div2 + BG1 math enable
+        ppu.write_register(0x2100, 0x0F);
+        render_frame(&mut ppu);
+
+        let rgb = ppu.screen_snapshot_rgb();
+        assert_eq!(
+            pixel(&rgb, 0, 0),
+            [123, 123, 0],
+            "sub-screen fixed color should blend with the main screen"
         );
     }
 }

--- a/src/snes/ppu/background.rs
+++ b/src/snes/ppu/background.rs
@@ -38,7 +38,6 @@ pub(crate) enum WindowLayer {
 pub(crate) struct ScreenPixel {
     pub color: u16,
     pub source: PixelSource,
-    pub layer_rank: u8,
 }
 
 impl Ppu {
@@ -76,7 +75,7 @@ impl Ppu {
     }
 
     fn resolve_screen_pixel(&self, target: ScreenTarget, x: u16, y: u16) -> ScreenPixel {
-        for (rank, &slot) in self.layer_order().iter().enumerate() {
+        for &slot in self.layer_order().iter() {
             match slot {
                 Slot::Bg(bg, priority) => {
                     if self.screen_enable_mask(target) & (1 << bg) == 0 {
@@ -94,7 +93,6 @@ impl Ppu {
                         return ScreenPixel {
                             color,
                             source: PixelSource::Bg(bg),
-                            layer_rank: rank as u8,
                         };
                     }
                 }
@@ -109,7 +107,6 @@ impl Ppu {
                         return ScreenPixel {
                             color,
                             source: PixelSource::Obj { priority, palette },
-                            layer_rank: rank as u8,
                         };
                     }
                 }
@@ -118,7 +115,6 @@ impl Ppu {
         ScreenPixel {
             color: self.backdrop_color_for(target),
             source: PixelSource::Backdrop,
-            layer_rank: u8::MAX,
         }
     }
 
@@ -170,17 +166,15 @@ impl Ppu {
         if !self.color_math_enabled_at(x, y) {
             return main_color;
         }
-        if sub.layer_rank > main.layer_rank && !matches!(sub.source, PixelSource::Backdrop) {
-            return main_color;
-        }
         self.apply_color_math(main_color, sub.color)
     }
 
     pub(super) fn color_math_enabled_at(&self, x: u16, y: u16) -> bool {
         match (self.cgwsel >> 4) & 0x03 {
             0 => true,
-            1 => self.window_area(WindowLayer::Math, x, y),
-            2 => !self.window_area(WindowLayer::Math, x, y),
+            // 01 = outside color window only, 10 = inside color window only.
+            1 => !self.window_area(WindowLayer::Math, x, y),
+            2 => self.window_area(WindowLayer::Math, x, y),
             3 => false,
             _ => unreachable!(),
         }
@@ -238,24 +232,31 @@ impl Ppu {
             _ => unreachable!(),
         };
         let (one_shift, two_shift, logic_shift) = if high_bits { (4, 6, 2) } else { (0, 2, 0) };
-        let one = self.window_select(sel, one_shift, x);
-        let two = self.window_select(sel, two_shift, x);
-        match ((logic >> logic_shift) & 0x03, one, two) {
-            (_, false, false) => false,
-            (_, true, false) => one,
-            (_, false, true) => two,
-            (0, true, true) => one || two,
-            (1, true, true) => one && two,
-            (2, true, true) => one ^ two,
-            (3, true, true) => !(one ^ two),
-            _ => unreachable!(),
+        let one_enabled = (sel >> one_shift) & 0x03 != 0;
+        let two_enabled = (sel >> two_shift) & 0x03 != 0;
+        match (one_enabled, two_enabled) {
+            (false, false) => false,
+            (true, false) => self.window_select(sel, one_shift, x),
+            (false, true) => self.window_select(sel, two_shift, x),
+            (true, true) => {
+                let one = self.window_select(sel, one_shift, x);
+                let two = self.window_select(sel, two_shift, x);
+                match (logic >> logic_shift) & 0x03 {
+                    0 => one || two,
+                    1 => one && two,
+                    2 => one ^ two,
+                    3 => !(one ^ two),
+                    _ => unreachable!(),
+                }
+            }
         }
     }
 
     pub(super) fn window_select(&self, sel: u8, shift: u8, x: u8) -> bool {
         let mode = (sel >> shift) & 0x03;
-        let enable = mode & 0x02 != 0;
-        let invert = mode & 0x01 != 0;
+        // WxxSEL 2-bit encoding: 0=disabled, 1=inside (not inverted), 2=outside (inverted), 3=outside.
+        let enable = mode != 0;
+        let invert = mode & 0x02 != 0;
         if !enable {
             return false;
         }
@@ -1333,7 +1334,7 @@ mod tests {
 
         ppu.write_register(0x2105, 0x00);
         ppu.write_register(0x212C, 0x01); // main screen: BG1
-        ppu.write_register(0x2123, 0x02); // BG1 window1 enabled, not inverted
+        ppu.write_register(0x2123, 0x01); // BG1 window1 enabled, inside (not inverted)
         ppu.write_register(0x2126, 0x00); // WH0 = 0
         ppu.write_register(0x2127, 0x7F); // WH1 = 127
         ppu.write_register(0x212E, 0x01); // disable BG1 inside the window
@@ -1361,7 +1362,7 @@ mod tests {
 
         ppu.write_register(0x2105, 0x00);
         ppu.write_register(0x212C, 0x02); // main screen: BG2
-        ppu.write_register(0x2123, 0x20); // BG2 window1 enabled, not inverted
+        ppu.write_register(0x2123, 0x10); // BG2 window1 enabled, inside (not inverted)
         ppu.write_register(0x2126, 0x00);
         ppu.write_register(0x2127, 0x7F);
         ppu.write_register(0x212E, 0x02); // disable BG2 inside the window
@@ -1404,6 +1405,97 @@ mod tests {
             pixel(&rgb, 0, 0),
             [123, 123, 0],
             "sub-screen fixed color should blend with the main screen"
+        );
+    }
+
+    #[test]
+    fn two_window_or_combination_masks_pixels_in_either_window() {
+        // When both windows are enabled for a layer (WBGLOG mode=OR) any pixel inside
+        // either W1 or W2 is masked; pixels outside both are visible.
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x7FFF);
+        // Keep tile data at char_base=0 (words 8-15 for tile 1).
+        fill_2bpp_tile(&mut ppu, 0, 1, 1);
+        // Place the BG1 map at 0x400 so it doesn't overlap with tile pixel data.
+        set_bg_map_base(&mut ppu, 0, 0x400);
+        for col in 0..32usize {
+            set_vram_word(&mut ppu, 0x400 + col, 1);
+        }
+
+        ppu.write_register(0x2105, 0x00);
+        ppu.write_register(0x212C, 0x01); // main screen: BG1
+        // W1=[0,40], W2=[60,100]; both enabled as "inside" for BG1 window1 and window2.
+        ppu.write_register(0x2123, 0x05); // BG1 window1=01 (inside), window2=01 (inside) at bits 3-2
+        ppu.write_register(0x2126, 0x00); // WH0=0
+        ppu.write_register(0x2127, 0x28); // WH1=40
+        ppu.write_register(0x2128, 0x3C); // WH2=60
+        ppu.write_register(0x2129, 0x64); // WH3=100
+        ppu.write_register(0x212A, 0x00); // WBGLOG: BG1 uses OR (bits 1-0 = 00)
+        ppu.write_register(0x212E, 0x01); // TMW: mask BG1 inside the window area
+        ppu.write_register(0x2100, 0x0F);
+        render_frame(&mut ppu);
+
+        let rgb = ppu.screen_snapshot_rgb();
+        assert_eq!(
+            pixel(&rgb, 10, 0),
+            [0, 0, 0],
+            "x=10 is inside W1, should be masked"
+        );
+        assert_eq!(
+            pixel(&rgb, 70, 0),
+            [0, 0, 0],
+            "x=70 is inside W2, should be masked"
+        );
+        assert_eq!(
+            pixel(&rgb, 50, 0),
+            [255, 255, 255],
+            "x=50 is outside both W1 and W2, should be visible"
+        );
+    }
+
+    #[test]
+    fn two_window_and_combination_masks_only_pixels_in_both_windows() {
+        // When both windows are enabled for a layer (WBGLOG mode=AND) only pixels inside
+        // both W1 and W2 are masked; pixels inside only one window remain visible.
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x7FFF);
+        fill_2bpp_tile(&mut ppu, 0, 1, 1);
+        // Place the BG1 map at 0x400 so it doesn't overlap with tile pixel data.
+        set_bg_map_base(&mut ppu, 0, 0x400);
+        for col in 0..32usize {
+            set_vram_word(&mut ppu, 0x400 + col, 1);
+        }
+
+        ppu.write_register(0x2105, 0x00);
+        ppu.write_register(0x212C, 0x01); // main screen: BG1
+        // W1=[0,80], W2=[40,120]; overlap [40,80]. Only overlap (AND) should be masked.
+        ppu.write_register(0x2123, 0x05); // BG1 window1=01 (inside), window2=01 (inside)
+        ppu.write_register(0x2126, 0x00); // WH0=0
+        ppu.write_register(0x2127, 0x50); // WH1=80
+        ppu.write_register(0x2128, 0x28); // WH2=40
+        ppu.write_register(0x2129, 0x78); // WH3=120
+        ppu.write_register(0x212A, 0x01); // WBGLOG: BG1 uses AND (bits 1-0 = 01)
+        ppu.write_register(0x212E, 0x01); // TMW: mask BG1 inside the window area
+        ppu.write_register(0x2100, 0x0F);
+        render_frame(&mut ppu);
+
+        let rgb = ppu.screen_snapshot_rgb();
+        assert_eq!(
+            pixel(&rgb, 20, 0),
+            [255, 255, 255],
+            "x=20 inside W1 only, not masked with AND"
+        );
+        assert_eq!(
+            pixel(&rgb, 100, 0),
+            [255, 255, 255],
+            "x=100 inside W2 only, not masked with AND"
+        );
+        assert_eq!(
+            pixel(&rgb, 60, 0),
+            [0, 0, 0],
+            "x=60 inside both W1 and W2, masked with AND"
         );
     }
 }

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -19,6 +19,8 @@ mod save_state;
 mod sprites;
 mod timing;
 
+pub(super) use background::{PixelSource, ScreenPixel, ScreenTarget, WindowLayer};
+
 const VRAM_SIZE: usize = 0x10_000;
 const CGRAM_SIZE: usize = 0x200;
 const OAM_SIZE: usize = 0x220;
@@ -123,8 +125,28 @@ pub struct Ppu {
     bg_old: u8,
     /// TM ($212C): main-screen layer enable (bits 0-3 = BG1-4, bit 4 = OBJ).
     tm: u8,
+    /// TS ($212D): sub-screen layer enable (bits 0-3 = BG1-4, bit 4 = OBJ).
+    ts: u8,
+    /// TMW ($212E): main-screen window disable mask.
+    tmw: u8,
+    /// TSW ($212F): sub-screen window disable mask.
+    tsw: u8,
     /// CGWSEL ($2130): only bit 0 (direct-color enable) is used here; rest is #2764.
     cgwsel: u8,
+    /// CGADSUB ($2131): color math control bits.
+    cgadsub: u8,
+    /// COLDATA ($2132): decoded sub-screen backdrop fixed color (BGR555).
+    coldata: u16,
+    /// W12SEL ($2123), W34SEL ($2124), WOBJSEL ($2125): window enable/area selectors.
+    w12sel: u8,
+    w34sel: u8,
+    wobjsel: u8,
+    /// WH0-WH3 ($2126-$2129): window coordinates.
+    wh: [u8; 4],
+    /// WBGLOG ($212A): window logic for BG1-BG4.
+    wbglog: u8,
+    /// WOBJLOG ($212B): window logic for OBJ/MATH.
+    wobjlog: u8,
     /// SETINI ($2133): only bit 6 (EXTBG enable for Mode 7) is used here.
     setini: u8,
     /// Mode 7 matrix parameters A-D ($211B-$211E), signed 1.7.8 fixed point (raw 16-bit).
@@ -213,7 +235,18 @@ impl Ppu {
             bg_vofs: [0; 4],
             bg_old: 0,
             tm: 0,
+            ts: 0,
+            tmw: 0,
+            tsw: 0,
             cgwsel: 0,
+            cgadsub: 0,
+            coldata: 0,
+            w12sel: 0,
+            w34sel: 0,
+            wobjsel: 0,
+            wh: [0; 4],
+            wbglog: 0,
+            wobjlog: 0,
             setini: 0,
             m7a: 0,
             m7b: 0,

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -131,7 +131,8 @@ pub struct Ppu {
     tmw: u8,
     /// TSW ($212F): sub-screen window disable mask.
     tsw: u8,
-    /// CGWSEL ($2130): only bit 0 (direct-color enable) is used here; rest is #2764.
+    /// CGWSEL ($2130): color math control A (direct-color bit 0, sub BG/OBJ enable bit 1,
+    /// color math enable region bits 5-4, force-main-black bits 7-6).
     cgwsel: u8,
     /// CGADSUB ($2131): color math control bits.
     cgadsub: u8,

--- a/src/snes/ppu/mode7.rs
+++ b/src/snes/ppu/mode7.rs
@@ -135,7 +135,6 @@ impl Ppu {
                         priority: 3,
                         palette,
                     },
-                    layer_rank: 0,
                 };
             }
             if let Some((color, palette)) = self.obj_pixel_for_screen(target, x, 2) {
@@ -145,7 +144,6 @@ impl Ppu {
                         priority: 2,
                         palette,
                     },
-                    layer_rank: 1,
                 };
             }
         }
@@ -153,7 +151,6 @@ impl Ppu {
             return ScreenPixel {
                 color,
                 source: PixelSource::Bg(1),
-                layer_rank: 2,
             };
         }
         if !self.layer_disabled_by_window(target, WindowLayer::Obj, x, y)
@@ -165,14 +162,12 @@ impl Ppu {
                     priority: 1,
                     palette,
                 },
-                layer_rank: 3,
             };
         }
         if let Some(color) = bg1_color {
             return ScreenPixel {
                 color,
                 source: PixelSource::Bg(0),
-                layer_rank: 4,
             };
         }
         if !self.layer_disabled_by_window(target, WindowLayer::Obj, x, y)
@@ -184,20 +179,17 @@ impl Ppu {
                     priority: 0,
                     palette,
                 },
-                layer_rank: 5,
             };
         }
         if let Some((color, false)) = bg2_color {
             return ScreenPixel {
                 color,
                 source: PixelSource::Bg(1),
-                layer_rank: 6,
             };
         }
         ScreenPixel {
             color: self.backdrop_color_for(target),
             source: PixelSource::Backdrop,
-            layer_rank: u8::MAX,
         }
     }
 }

--- a/src/snes/ppu/mode7.rs
+++ b/src/snes/ppu/mode7.rs
@@ -9,7 +9,7 @@
 //! Screen Y note: the hardware samples display line `N` (1..224) for framebuffer row `N-1`, so the
 //! per-pixel `y` passed in (0-based row) is offset by +1 to obtain the hardware SCREEN.Y.
 
-use super::{Ppu, VRAM_SIZE};
+use super::{PixelSource, Ppu, ScreenPixel, ScreenTarget, VRAM_SIZE, WindowLayer};
 
 impl Ppu {
     /// Apply the shared Mode 7 write-twice mechanism: `reg = value * 0x100 + M7_old`, then latch
@@ -33,52 +33,9 @@ impl Ppu {
     /// Priority chart (BG only; OBJ is added in #2763): BG2(prio=1) over BG1 over BG2(prio=0) over
     /// backdrop. BG2 exists only when EXTBG (SETINI bit 6) is enabled.
     pub(super) fn compute_pixel_mode7(&self, x: u16, y: u16) -> u16 {
-        let bg1_enabled = self.tm & 0x01 != 0;
-        let bg2_enabled = self.tm & 0x02 != 0;
-        let extbg = self.setini & 0x40 != 0;
-        let value = self.mode7_pixel_value(x, y);
-
-        // EXTBG (Mode 7 BG2) splits the layer by the pixel's high bit into a high/low priority
-        // plane; resolve it once here so it can be slotted into the priority chart below.
-        let bg2_color = if extbg && bg2_enabled && value & 0x7F != 0 {
-            Some((self.cgram_color(value & 0x7F), value & 0x80 != 0))
-        } else {
-            None
-        };
-        let bg1_color = if bg1_enabled && value != 0 {
-            // Direct-color (CGWSEL bit 0) resolves the 8-bit BG1 value straight to BGR555.
-            Some(if self.cgwsel & 0x01 != 0 {
-                mode7_direct_color(value)
-            } else {
-                self.cgram_color(value)
-            })
-        } else {
-            None
-        };
-
-        // Mode 7 chart (front-to-back): OBJ.3, OBJ.2, BG2.1p, OBJ.1, BG1, OBJ.0, BG2.0p, backdrop.
-        if let Some(color) = self.obj_pixel(x, 3) {
-            return color;
-        }
-        if let Some(color) = self.obj_pixel(x, 2) {
-            return color;
-        }
-        if let Some((color, true)) = bg2_color {
-            return color;
-        }
-        if let Some(color) = self.obj_pixel(x, 1) {
-            return color;
-        }
-        if let Some(color) = bg1_color {
-            return color;
-        }
-        if let Some(color) = self.obj_pixel(x, 0) {
-            return color;
-        }
-        if let Some((color, false)) = bg2_color {
-            return color;
-        }
-        self.backdrop_color()
+        let main = self.resolve_mode7_screen_pixel(ScreenTarget::Main, x, y);
+        let sub = self.resolve_mode7_screen_pixel(ScreenTarget::Sub, x, y);
+        self.compose_pixels(x, y, main, sub)
     }
 
     /// Sample the raw 8-bit Mode 7 pixel value at screen `(x, y)`, applying the affine transform,
@@ -126,7 +83,6 @@ impl Ppu {
                 }
                 self.vram[(tile_word << 1) & (VRAM_SIZE - 1)]
             }
-            // mode 3: outside uses tile 0.
             3 => {
                 if out_of_bounds {
                     0
@@ -139,6 +95,110 @@ impl Ppu {
         let palette_addr = (((pixel_y & 7) << 3) + (pixel_x & 7)) as usize;
         let pixel_word = ((tile as usize) << 6) | palette_addr;
         self.vram[((pixel_word << 1) | 1) & (VRAM_SIZE - 1)]
+    }
+
+    fn resolve_mode7_screen_pixel(&self, target: ScreenTarget, x: u16, y: u16) -> ScreenPixel {
+        let bg1_enabled = self.screen_enable_mask(target) & 0x01 != 0;
+        let bg2_enabled = self.screen_enable_mask(target) & 0x02 != 0;
+        let extbg = self.setini & 0x40 != 0;
+        let value = self.mode7_pixel_value(x, y);
+
+        let bg2_color = if extbg && bg2_enabled && value & 0x7F != 0 {
+            if self.layer_disabled_by_window(target, WindowLayer::Bg(1), x, y) {
+                None
+            } else {
+                Some((self.cgram_color(value & 0x7F), value & 0x80 != 0))
+            }
+        } else {
+            None
+        };
+        let bg1_color = if bg1_enabled && value != 0 {
+            if self.layer_disabled_by_window(target, WindowLayer::Bg(0), x, y) {
+                None
+            } else {
+                Some(if self.cgwsel & 0x01 != 0 {
+                    mode7_direct_color(value)
+                } else {
+                    self.cgram_color(value)
+                })
+            }
+        } else {
+            None
+        };
+
+        // Mode 7 chart (front-to-back): OBJ.3, OBJ.2, BG2.1p, OBJ.1, BG1, OBJ.0, BG2.0p, backdrop.
+        if !self.layer_disabled_by_window(target, WindowLayer::Obj, x, y) {
+            if let Some((color, palette)) = self.obj_pixel_for_screen(target, x, 3) {
+                return ScreenPixel {
+                    color,
+                    source: PixelSource::Obj {
+                        priority: 3,
+                        palette,
+                    },
+                    layer_rank: 0,
+                };
+            }
+            if let Some((color, palette)) = self.obj_pixel_for_screen(target, x, 2) {
+                return ScreenPixel {
+                    color,
+                    source: PixelSource::Obj {
+                        priority: 2,
+                        palette,
+                    },
+                    layer_rank: 1,
+                };
+            }
+        }
+        if let Some((color, true)) = bg2_color {
+            return ScreenPixel {
+                color,
+                source: PixelSource::Bg(1),
+                layer_rank: 2,
+            };
+        }
+        if !self.layer_disabled_by_window(target, WindowLayer::Obj, x, y)
+            && let Some((color, palette)) = self.obj_pixel_for_screen(target, x, 1)
+        {
+            return ScreenPixel {
+                color,
+                source: PixelSource::Obj {
+                    priority: 1,
+                    palette,
+                },
+                layer_rank: 3,
+            };
+        }
+        if let Some(color) = bg1_color {
+            return ScreenPixel {
+                color,
+                source: PixelSource::Bg(0),
+                layer_rank: 4,
+            };
+        }
+        if !self.layer_disabled_by_window(target, WindowLayer::Obj, x, y)
+            && let Some((color, palette)) = self.obj_pixel_for_screen(target, x, 0)
+        {
+            return ScreenPixel {
+                color,
+                source: PixelSource::Obj {
+                    priority: 0,
+                    palette,
+                },
+                layer_rank: 5,
+            };
+        }
+        if let Some((color, false)) = bg2_color {
+            return ScreenPixel {
+                color,
+                source: PixelSource::Bg(1),
+                layer_rank: 6,
+            };
+        }
+        ScreenPixel {
+            color: self.backdrop_color_for(target),
+            source: PixelSource::Backdrop,
+            layer_rank: u8::MAX,
+        }
     }
 }
 

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -77,7 +77,8 @@ impl Ppu {
             // TMW/TSW: window area layer disables.
             0x212E => self.tmw = value,
             0x212F => self.tsw = value,
-            // CGWSEL: Color Math Control A. Only bit 0 (direct-color enable) is used here.
+            // CGWSEL: Color Math Control A. Bit 0 = direct-color mode; bits 1 = sub-screen
+            // BG/OBJ enable; bits 5-4 = color math enable region; bits 7-6 = force-main-black.
             0x2130 => self.cgwsel = value,
             // CGADSUB: color math control B.
             0x2131 => self.cgadsub = value,

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -72,8 +72,36 @@ impl Ppu {
             0x2120 => self.m7y = self.write_m7_twice(value),
             // TM: main-screen layer enable.
             0x212C => self.tm = value,
+            // TS: sub-screen layer enable.
+            0x212D => self.ts = value,
+            // TMW/TSW: window area layer disables.
+            0x212E => self.tmw = value,
+            0x212F => self.tsw = value,
             // CGWSEL: Color Math Control A. Only bit 0 (direct-color enable) is used here.
             0x2130 => self.cgwsel = value,
+            // CGADSUB: color math control B.
+            0x2131 => self.cgadsub = value,
+            // COLDATA: sub-screen backdrop selector; each channel bit updates that channel to the
+            // current 5-bit intensity, preserving the others.
+            0x2132 => {
+                let intensity = (value & 0x1F) as u16;
+                if value & 0x20 != 0 {
+                    self.coldata = (self.coldata & !0x001F) | intensity;
+                }
+                if value & 0x40 != 0 {
+                    self.coldata = (self.coldata & !0x03E0) | (intensity << 5);
+                }
+                if value & 0x80 != 0 {
+                    self.coldata = (self.coldata & !0x7C00) | (intensity << 10);
+                }
+            }
+            // Window control registers.
+            0x2123 => self.w12sel = value,
+            0x2124 => self.w34sel = value,
+            0x2125 => self.wobjsel = value,
+            0x2126..=0x2129 => self.wh[(addr - 0x2126) as usize] = value,
+            0x212A => self.wbglog = value,
+            0x212B => self.wobjlog = value,
             // SETINI: Display Control 2. Only bit 6 (EXTBG enable for Mode 7) is used here.
             0x2133 => self.setini = value,
             // NMITIMEN: VBlank NMI enable (bit 7). Re-evaluate the NMI line so that enabling NMI

--- a/src/snes/ppu/save_state.rs
+++ b/src/snes/ppu/save_state.rs
@@ -47,7 +47,18 @@ impl Ppu {
             bg_vofs: self.bg_vofs,
             bg_old: self.bg_old,
             tm: self.tm,
+            ts: self.ts,
+            tmw: self.tmw,
+            tsw: self.tsw,
             cgwsel: self.cgwsel,
+            cgadsub: self.cgadsub,
+            coldata: self.coldata,
+            w12sel: self.w12sel,
+            w34sel: self.w34sel,
+            wobjsel: self.wobjsel,
+            wh: self.wh,
+            wbglog: self.wbglog,
+            wobjlog: self.wobjlog,
             setini: self.setini,
             m7a: self.m7a,
             m7b: self.m7b,
@@ -109,7 +120,18 @@ impl Ppu {
         self.bg_vofs = state.bg_vofs;
         self.bg_old = state.bg_old;
         self.tm = state.tm;
+        self.ts = state.ts;
+        self.tmw = state.tmw;
+        self.tsw = state.tsw;
         self.cgwsel = state.cgwsel;
+        self.cgadsub = state.cgadsub;
+        self.coldata = state.coldata;
+        self.w12sel = state.w12sel;
+        self.w34sel = state.w34sel;
+        self.wobjsel = state.wobjsel;
+        self.wh = state.wh;
+        self.wbglog = state.wbglog;
+        self.wobjlog = state.wobjlog;
         self.setini = state.setini;
         self.m7a = state.m7a;
         self.m7b = state.m7b;

--- a/src/snes/ppu/sprites.rs
+++ b/src/snes/ppu/sprites.rs
@@ -239,6 +239,7 @@ impl Ppu {
                 let cgindex = 128 + palette * 16 + color;
                 buf.color[sx] = self.cgram_color(cgindex);
                 buf.priority[sx] = priority;
+                buf.palette[sx] = palette;
                 buf.present[sx] = true;
             }
         }
@@ -281,6 +282,8 @@ pub(super) struct ObjLineEval {
 pub(super) struct ObjLine {
     /// Resolved BGR555 color per pixel (valid only where `present`).
     pub color: [u16; 256],
+    /// OBJ palette number (0-7) per pixel, for color math gating.
+    pub palette: [u8; 256],
     /// OBJ priority level (0-3, OAM attr bits 5-4) per pixel, for BG compositing.
     pub priority: [u8; 256],
     /// Whether an opaque OBJ pixel was written at this x.
@@ -291,6 +294,7 @@ impl Default for ObjLine {
     fn default() -> Self {
         Self {
             color: [0; 256],
+            palette: [0; 256],
             priority: [0; 256],
             present: [false; 256],
         }


### PR DESCRIPTION
Implements SNES PPU windowing, main/sub compositing, color math, decoded COLDATA handling, and Mode 7 integration for #2764.

Validation:
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test snes::ppu --lib`
- `cargo test --lib`
