### PR TITLE
feat(snes/ppu): implement mosaic $2106 (horizontal + vertical + Mode 7)

### DIFF
--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -265,6 +265,12 @@ pub struct SnesPpuState {
     pub stat77_range_over: bool,
     #[serde(default)]
     pub stat77_time_over: bool,
+    #[serde(default)]
+    pub mosaic: u8,
+    #[serde(default)]
+    pub mosaic_vblock_size: u8,
+    #[serde(default)]
+    pub mosaic_vcount: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]

--- a/src/snes/ppu/background.rs
+++ b/src/snes/ppu/background.rs
@@ -404,6 +404,13 @@ impl Ppu {
         let cell_shift = if size16 { 4 } else { 3 };
         let cell_mask = (1u16 << cell_shift) - 1;
 
+        // Apply horizontal mosaic: snap x to the left edge of its block when enabled.
+        let x = if self.mosaic_bg_enabled(bg) {
+            self.mosaic_apply_x(x)
+        } else {
+            x
+        };
+
         let (scrolled_x, scrolled_y) = self.effective_offsets(bg, x, y);
 
         let entry = self.read_bg_map_entry(bg, scrolled_x >> cell_shift, scrolled_y >> cell_shift);
@@ -460,7 +467,13 @@ impl Ppu {
     /// to BG1/BG2. Algorithm follows bsnes (non-hires; Mode 5/6 hi-res output is #2766).
     fn effective_offsets(&self, bg: usize, x: u16, y: u16) -> (u16, u16) {
         let hscroll = self.bg_hofs[bg] & 0x03FF;
-        let vscroll = self.bg_vofs[bg] & 0x03FF;
+        // Vertical mosaic: subtract the block-internal scanline index from BGnVOFS before adding
+        // screen Y (fullsnes: "subtract the vertical index from the vertical scroll register").
+        let vscroll = if self.mosaic_bg_enabled(bg) {
+            self.bg_vofs[bg].wrapping_sub(self.mosaic_vcount as u16)
+        } else {
+            self.bg_vofs[bg]
+        } & 0x03FF;
         let mut hoffset = x.wrapping_add(hscroll);
         let mut voffset = y.wrapping_add(vscroll);
 
@@ -629,6 +642,30 @@ mod tests {
                 let off = base + (p / 2) * 16 + r * 2 + (p % 2);
                 ppu.vram[off] = if color & (1 << p) != 0 { 0xFF } else { 0x00 };
             }
+        }
+    }
+
+    /// Set a single pixel in a 2bpp 8×8 tile at (fine_x, fine_y) to `color` (0-3).
+    fn set_2bpp_tile_pixel(
+        ppu: &mut Ppu,
+        char_base: usize,
+        char_num: usize,
+        fine_x: u8,
+        fine_y: u8,
+        color: u8,
+    ) {
+        let base = (char_base + char_num * 8) * 2;
+        let row_offset = base + (fine_y as usize) * 2;
+        let bit = 7 - fine_x; // bit 7 is left-most
+        if color & 1 != 0 {
+            ppu.vram[row_offset] |= 1 << bit;
+        } else {
+            ppu.vram[row_offset] &= !(1 << bit);
+        }
+        if color & 2 != 0 {
+            ppu.vram[row_offset + 1] |= 1 << bit;
+        } else {
+            ppu.vram[row_offset + 1] &= !(1 << bit);
         }
     }
 
@@ -1496,6 +1533,171 @@ mod tests {
             pixel(&rgb, 60, 0),
             [0, 0, 0],
             "x=60 inside both W1 and W2, masked with AND"
+        );
+    }
+
+    // ── Mosaic rendering ─────────────────────────────────────────────────────
+
+    /// Set up a BG1 Mode 0 scene: BG1 enabled, no scroll, tilemap at word 0, char base at 0.
+    fn setup_bg1_mode0(ppu: &mut Ppu) {
+        ppu.write_register(0x2105, 0x00); // Mode 0
+        ppu.write_register(0x2107, 0x00); // BG1SC: tilemap base 0
+        ppu.write_register(0x210B, 0x00); // BG12NBA: char base 0
+        ppu.write_register(0x212C, 0x01); // TM: BG1 only
+        ppu.write_register(0x2100, 0x0F); // INIDISP: full brightness
+    }
+
+    #[test]
+    fn horizontal_mosaic_replicates_leftmost_pixel_of_each_block() {
+        // Tile 1: only column 0 (fine_x=0) is white; all other columns are black (color 0).
+        // With tilemap full of tile 1 and mosaic block_size=4: pixels 0-3 show white (x_mos=0),
+        // pixels 4-7 show black (x_mos=4, fine_x=4), pixels 8-11 show white (fine_x=0), etc.
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000); // color 0 = black (also backdrop)
+        set_cgram(&mut ppu, 1, 0x7FFF); // color 1 = white
+
+        // Tilemap: all entries point to char 1.
+        for col in 0..32usize {
+            set_vram_word(&mut ppu, col, 1);
+        }
+        // Tile 1: only fine_x=0 of every row is white.
+        for fine_y in 0..8 {
+            set_2bpp_tile_pixel(&mut ppu, 0, 1, 0, fine_y, 1); // col 0 = white
+        }
+
+        setup_bg1_mode0(&mut ppu);
+        ppu.write_register(0x2106, 0x31); // size=3 → block_size=4; BG1 enabled
+
+        render_frame(&mut ppu);
+        let rgb = ppu.screen_snapshot_rgb();
+
+        // Block 0 (x=0..3): x_mos=0 → fine_x=0 → white
+        assert_eq!(
+            pixel(&rgb, 0, 0),
+            [255, 255, 255],
+            "x=0 → leftmost pixel white"
+        );
+        assert_eq!(
+            pixel(&rgb, 1, 0),
+            [255, 255, 255],
+            "x=1 → replicated from x_mos=0"
+        );
+        assert_eq!(
+            pixel(&rgb, 2, 0),
+            [255, 255, 255],
+            "x=2 → replicated from x_mos=0"
+        );
+        assert_eq!(
+            pixel(&rgb, 3, 0),
+            [255, 255, 255],
+            "x=3 → replicated from x_mos=0"
+        );
+        // Block 1 (x=4..7): x_mos=4 → fine_x=4 → black
+        assert_eq!(
+            pixel(&rgb, 4, 0),
+            [0, 0, 0],
+            "x=4 → new block, fine_x=4 is black"
+        );
+        assert_eq!(
+            pixel(&rgb, 5, 0),
+            [0, 0, 0],
+            "x=5 → replicated from x_mos=4"
+        );
+        // Block 2 (x=8..11): x_mos=8 → fine_x=0 → white (new tile, col 0 again)
+        assert_eq!(
+            pixel(&rgb, 8, 0),
+            [255, 255, 255],
+            "x=8 → next-tile col 0, white"
+        );
+        assert_eq!(
+            pixel(&rgb, 9, 0),
+            [255, 255, 255],
+            "x=9 → replicated from x_mos=8"
+        );
+    }
+
+    #[test]
+    fn vertical_mosaic_replicates_top_row_of_each_block() {
+        // Tile 1: only row 0 (fine_y=0) is white; all other rows are black.
+        // With mosaic block_size=4 and no scroll: scanlines 0-3 (vcount=0,1,2,3) all look at
+        // effective_y=0 (the top row), so they all show white. Scanlines 4-7 look at effective_y=4
+        // which is row 4 of the tile (black).
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x7FFF);
+
+        // Tilemap: all entries char 1.
+        set_vram_word(&mut ppu, 0, 1);
+        // Tile 1: only fine_y=0 is white for all columns.
+        for fine_x in 0..8 {
+            set_2bpp_tile_pixel(&mut ppu, 0, 1, fine_x, 0, 1); // row 0 = white
+        }
+
+        setup_bg1_mode0(&mut ppu);
+        ppu.write_register(0x2106, 0x31); // size=3 → block_size=4; BG1 enabled
+
+        render_frame(&mut ppu);
+        let rgb = ppu.screen_snapshot_rgb();
+
+        // Scanlines 0-3: top of block (vcount=0,1,2,3 all map effective_y=0 → white row).
+        assert_eq!(
+            pixel(&rgb, 0, 0),
+            [255, 255, 255],
+            "scanline 0: effective_y=0, white"
+        );
+        assert_eq!(
+            pixel(&rgb, 0, 1),
+            [255, 255, 255],
+            "scanline 1: vcount=1 → effective_y=0"
+        );
+        assert_eq!(
+            pixel(&rgb, 0, 2),
+            [255, 255, 255],
+            "scanline 2: vcount=2 → effective_y=0"
+        );
+        assert_eq!(
+            pixel(&rgb, 0, 3),
+            [255, 255, 255],
+            "scanline 3: vcount=3 → effective_y=0"
+        );
+        // Scanline 4: new block (vcount=0), effective_y=4 → black row.
+        assert_eq!(
+            pixel(&rgb, 0, 4),
+            [0, 0, 0],
+            "scanline 4: new block, effective_y=4, black"
+        );
+        assert_eq!(
+            pixel(&rgb, 0, 5),
+            [0, 0, 0],
+            "scanline 5: vcount=1 → effective_y=4"
+        );
+    }
+
+    #[test]
+    fn no_mosaic_when_bg_bit_not_enabled() {
+        // With mosaic size set but BG1 bit NOT enabled, rendering should be unaffected.
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x7FFF);
+
+        set_vram_word(&mut ppu, 0, 1);
+        // Tile 1: only fine_x=0 column is white.
+        for fine_y in 0..8 {
+            set_2bpp_tile_pixel(&mut ppu, 0, 1, 0, fine_y, 1);
+        }
+
+        setup_bg1_mode0(&mut ppu);
+        ppu.write_register(0x2106, 0x30); // size=3 but BG1 NOT enabled (bits 3-0 = 0)
+
+        render_frame(&mut ppu);
+        let rgb = ppu.screen_snapshot_rgb();
+
+        // Without mosaic, x=1 should be black (not replicated from x=0).
+        assert_eq!(pixel(&rgb, 0, 0), [255, 255, 255], "x=0: fine_x=0 → white");
+        assert_eq!(
+            pixel(&rgb, 1, 0),
+            [0, 0, 0],
+            "x=1: fine_x=1 → black (no mosaic)"
         );
     }
 }

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -14,6 +14,7 @@
 mod background;
 mod framebuffer;
 mod mode7;
+mod mosaic;
 mod registers;
 mod save_state;
 mod sprites;
@@ -186,6 +187,16 @@ pub struct Ppu {
     obj_range_over_dot: Option<u16>,
     /// Time over-limit computed during the current scanline, applied at the next scanline's H=0.
     obj_time_over_pending: bool,
+    /// MOSAIC ($2106) raw register: bits 7-4 = pending vertical block size (0..=15), bits 3-0 =
+    /// per-BG enable (bit 0 = BG1 ... bit 3 = BG4). Horizontal mosaic and bg-enable bits take
+    /// effect immediately; vertical size change only applies at the start of the next block.
+    mosaic: u8,
+    /// Active vertical mosaic block size (0..=15, meaning 1..=16 scanlines). Updated at block
+    /// boundaries from `mosaic >> 4` to implement the "finish current block" hardware behavior.
+    mosaic_vblock_size: u8,
+    /// Number of scanlines elapsed into the current vertical mosaic block (0 = top of block).
+    /// Subtracted from BGnVOFS to produce the effective vertical scroll for mosaic-enabled BGs.
+    mosaic_vcount: u8,
 }
 
 impl Default for Ppu {
@@ -267,6 +278,9 @@ impl Ppu {
             stat77_time_over: false,
             obj_range_over_dot: None,
             obj_time_over_pending: false,
+            mosaic: 0,
+            mosaic_vblock_size: 0,
+            mosaic_vcount: 0,
         }
     }
 

--- a/src/snes/ppu/mode7.rs
+++ b/src/snes/ppu/mode7.rs
@@ -40,6 +40,10 @@ impl Ppu {
 
     /// Sample the raw 8-bit Mode 7 pixel value at screen `(x, y)`, applying the affine transform,
     /// screen H/V flip, and screen-over handling. Returns 0 (transparent) where appropriate.
+    ///
+    /// Mosaic: when BG1 mosaic is enabled, horizontal x is snapped to the block left edge and
+    /// vertical y is reduced by `mosaic_vcount` before the affine transform (fullsnes; BG2 EXTBG
+    /// vertical mosaic also uses BG1 enable per bsnes evidence).
     fn mode7_pixel_value(&self, x: u16, y: u16) -> u8 {
         let xflip = self.m7sel & 0x01 != 0;
         let yflip = self.m7sel & 0x02 != 0;
@@ -54,9 +58,22 @@ impl Ppu {
         let hoffset = sign_extend_13(self.m7hofs);
         let voffset = sign_extend_13(self.m7vofs);
 
-        let sx = if xflip { 255 - x } else { x } as i32;
+        // Apply mosaic to the affine sampling coordinates (BG1 enable controls both BG1 and
+        // EXTBG BG2 vertical mosaic, matching bsnes behavior).
+        let x_eff = if self.mosaic_bg_enabled(0) {
+            self.mosaic_apply_x(x)
+        } else {
+            x
+        };
+        let y_eff = if self.mosaic_bg_enabled(0) {
+            y.saturating_sub(self.mosaic_vcount as u16)
+        } else {
+            y
+        };
+
+        let sx = if xflip { 255 - x_eff } else { x_eff } as i32;
         // Hardware SCREEN.Y is the display line (1..224); framebuffer row `y` is line `y + 1`.
-        let screen_y = y as i32 + 1;
+        let screen_y = y_eff as i32 + 1;
         let sy = if yflip { 255 - screen_y } else { screen_y };
 
         let clip_h = mode7_clip(hoffset - hcenter);

--- a/src/snes/ppu/mosaic.rs
+++ b/src/snes/ppu/mosaic.rs
@@ -40,10 +40,7 @@ impl Ppu {
     ///   `mosaic_vblock_size` a new block starts — reset `mosaic_vcount` to 0 and latch the
     ///   pending size. This implements "finish current block before applying new size" (fullsnes).
     pub(super) fn advance_mosaic_vcount(&mut self, scanline: u16) {
-        if scanline == VISIBLE_LINE_START {
-            self.mosaic_vcount = 0;
-            self.mosaic_vblock_size = self.mosaic >> 4;
-        } else if self.mosaic_vcount == self.mosaic_vblock_size {
+        if scanline == VISIBLE_LINE_START || self.mosaic_vcount == self.mosaic_vblock_size {
             self.mosaic_vcount = 0;
             self.mosaic_vblock_size = self.mosaic >> 4;
         } else {
@@ -66,8 +63,7 @@ mod tests {
 
     #[test]
     fn size_0_means_1x1_no_horizontal_change() {
-        // size=1 (0x1 in bits 7-4), BG1 enabled — kept for reference, not exercised below
-        // Size 0 in the register means block_size 1 (1×1 = no mosaic).
+        // Size 0 in bits 7-4 means block_size 1 (1×1 = no mosaic).
         let ppu0 = ppu_with_mosaic(0x01); // size=0 in bits 7-4, BG1 enabled
         assert_eq!(ppu0.mosaic_h_block_size(), 1);
         // With block_size=1, every x maps to itself.

--- a/src/snes/ppu/mosaic.rs
+++ b/src/snes/ppu/mosaic.rs
@@ -1,0 +1,190 @@
+//! Mosaic effect helpers for BG and Mode 7 rendering.
+//!
+//! MOSAIC $2106 register layout:
+//! - Bits 7-4: mosaic size (0 = 1×1, 15 = 16×16)
+//! - Bits 3-0: per-BG enable (bit 0 = BG1 … bit 3 = BG4)
+//!
+//! **Horizontal mosaic**: `x_mos = x - (x % block_size)` where `block_size = size + 1`. The
+//! horizontal block starts at the left screen edge (x = 0) and uses the current register value
+//! (immediate effect on $2106 write).
+//!
+//! **Vertical mosaic**: implemented by subtracting the vertical index within the current block
+//! (`mosaic_vcount`) from BGnVOFS before adding the screen Y. The vertical block size change on a
+//! mid-frame $2106 write takes effect only at the start of the *next* vertical block (the current
+//! block finishes using the old size, per the fullsnes specification).
+
+use super::{Ppu, VISIBLE_LINE_START};
+
+impl Ppu {
+    /// The current horizontal mosaic block size in pixels (1..=16), derived from the raw register.
+    pub(super) fn mosaic_h_block_size(&self) -> u16 {
+        ((self.mosaic >> 4) as u16) + 1
+    }
+
+    /// Returns `true` if mosaic is enabled for background layer `bg` (0-based, 0 = BG1).
+    pub(super) fn mosaic_bg_enabled(&self, bg: usize) -> bool {
+        self.mosaic & (1 << bg) != 0
+    }
+
+    /// Snap screen X coordinate to the left edge of its horizontal mosaic block.
+    pub(super) fn mosaic_apply_x(&self, x: u16) -> u16 {
+        let block = self.mosaic_h_block_size();
+        x - x % block
+    }
+
+    /// Advance the vertical mosaic block counter at the start of a visible scanline.
+    ///
+    /// - At the first visible scanline (`VISIBLE_LINE_START`): reset `mosaic_vcount` to 0 and
+    ///   latch the current mosaic size into `mosaic_vblock_size` (start of first block).
+    /// - At subsequent visible scanlines: increment `mosaic_vcount`; when it equals
+    ///   `mosaic_vblock_size` a new block starts — reset `mosaic_vcount` to 0 and latch the
+    ///   pending size. This implements "finish current block before applying new size" (fullsnes).
+    pub(super) fn advance_mosaic_vcount(&mut self, scanline: u16) {
+        if scanline == VISIBLE_LINE_START {
+            self.mosaic_vcount = 0;
+            self.mosaic_vblock_size = self.mosaic >> 4;
+        } else if self.mosaic_vcount == self.mosaic_vblock_size {
+            self.mosaic_vcount = 0;
+            self.mosaic_vblock_size = self.mosaic >> 4;
+        } else {
+            self.mosaic_vcount += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Ppu;
+
+    fn ppu_with_mosaic(reg: u8) -> Ppu {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2106, reg);
+        ppu
+    }
+
+    // ── Horizontal mosaic ────────────────────────────────────────────────────
+
+    #[test]
+    fn size_0_means_1x1_no_horizontal_change() {
+        // size=1 (0x1 in bits 7-4), BG1 enabled — kept for reference, not exercised below
+        // Size 0 in the register means block_size 1 (1×1 = no mosaic).
+        let ppu0 = ppu_with_mosaic(0x01); // size=0 in bits 7-4, BG1 enabled
+        assert_eq!(ppu0.mosaic_h_block_size(), 1);
+        // With block_size=1, every x maps to itself.
+        for x in 0u16..=255 {
+            assert_eq!(ppu0.mosaic_apply_x(x), x, "x={x}");
+        }
+    }
+
+    #[test]
+    fn horizontal_snaps_x_to_left_of_block() {
+        let ppu = ppu_with_mosaic(0x31); // size=3 (bits 7-4=3) → block_size=4, BG1 enabled
+        assert_eq!(ppu.mosaic_h_block_size(), 4);
+        assert_eq!(ppu.mosaic_apply_x(0), 0);
+        assert_eq!(ppu.mosaic_apply_x(1), 0);
+        assert_eq!(ppu.mosaic_apply_x(3), 0);
+        assert_eq!(ppu.mosaic_apply_x(4), 4);
+        assert_eq!(ppu.mosaic_apply_x(7), 4);
+        assert_eq!(ppu.mosaic_apply_x(8), 8);
+        assert_eq!(ppu.mosaic_apply_x(255), 252);
+    }
+
+    #[test]
+    fn horizontal_block_starts_at_left_edge() {
+        let ppu = ppu_with_mosaic(0xF1); // size=15 → block_size=16, BG1 enabled
+        assert_eq!(ppu.mosaic_apply_x(0), 0);
+        assert_eq!(ppu.mosaic_apply_x(15), 0);
+        assert_eq!(ppu.mosaic_apply_x(16), 16);
+    }
+
+    #[test]
+    fn size_15_means_16x16_blocks() {
+        let ppu = ppu_with_mosaic(0xF1); // bits 7-4 = 0xF = 15 → block_size = 16
+        assert_eq!(ppu.mosaic_h_block_size(), 16);
+    }
+
+    // ── Per-BG enable ────────────────────────────────────────────────────────
+
+    #[test]
+    fn per_bg_enable_bit0_controls_bg1() {
+        let ppu_on = ppu_with_mosaic(0x11); // BG1 on
+        let ppu_off = ppu_with_mosaic(0x10); // BG1 off (bits 0 = 0)
+        assert!(ppu_on.mosaic_bg_enabled(0));
+        assert!(!ppu_off.mosaic_bg_enabled(0));
+    }
+
+    #[test]
+    fn per_bg_enable_controls_each_layer_independently() {
+        // 0b0000_1010 = BG2 + BG4 enabled
+        let ppu = ppu_with_mosaic(0x0A);
+        assert!(!ppu.mosaic_bg_enabled(0)); // BG1
+        assert!(ppu.mosaic_bg_enabled(1)); // BG2
+        assert!(!ppu.mosaic_bg_enabled(2)); // BG3
+        assert!(ppu.mosaic_bg_enabled(3)); // BG4
+    }
+
+    // ── Vertical mosaic block counter ────────────────────────────────────────
+
+    #[test]
+    fn frame_start_resets_vcount_and_latches_size() {
+        let mut ppu = ppu_with_mosaic(0x31); // size=3 → vblock_size should become 3
+        ppu.mosaic_vcount = 2;
+        ppu.mosaic_vblock_size = 7; // stale value from before
+
+        ppu.advance_mosaic_vcount(1); // scanline 1 = VISIBLE_LINE_START
+
+        assert_eq!(ppu.mosaic_vcount, 0);
+        assert_eq!(ppu.mosaic_vblock_size, 3);
+    }
+
+    #[test]
+    fn vcount_increments_each_visible_scanline() {
+        let mut ppu = ppu_with_mosaic(0x31); // size=3
+        ppu.advance_mosaic_vcount(1); // scanline 1: vcount=0, vblock_size=3
+        ppu.advance_mosaic_vcount(2); // scanline 2: vcount=1
+        ppu.advance_mosaic_vcount(3); // scanline 3: vcount=2
+        ppu.advance_mosaic_vcount(4); // scanline 4: vcount=3
+        assert_eq!(ppu.mosaic_vcount, 3);
+    }
+
+    #[test]
+    fn vcount_resets_at_block_boundary() {
+        let mut ppu = ppu_with_mosaic(0x31); // size=3 → 4-scanline blocks
+        ppu.advance_mosaic_vcount(1); // scanline 1: vcount=0
+        ppu.advance_mosaic_vcount(2); // vcount=1
+        ppu.advance_mosaic_vcount(3); // vcount=2
+        ppu.advance_mosaic_vcount(4); // vcount=3
+        ppu.advance_mosaic_vcount(5); // vcount==vblock_size → new block → vcount=0
+        assert_eq!(ppu.mosaic_vcount, 0);
+    }
+
+    #[test]
+    fn size_0_means_1x1_vcount_always_resets() {
+        let mut ppu = ppu_with_mosaic(0x01); // size=0 → vblock_size=0, 1-scanline blocks
+        ppu.advance_mosaic_vcount(1); // scanline 1: vcount=0
+        ppu.advance_mosaic_vcount(2); // vcount==vblock_size(0) → new block → vcount=0
+        assert_eq!(ppu.mosaic_vcount, 0);
+        ppu.advance_mosaic_vcount(3); // still 0
+        assert_eq!(ppu.mosaic_vcount, 0);
+    }
+
+    #[test]
+    fn mid_frame_size_change_finishes_current_block_before_applying_new_size() {
+        // Start with size=3 (4-scanline blocks): vblock_size=3, blocks at scanlines 1,5,9,...
+        let mut ppu = ppu_with_mosaic(0x31);
+        ppu.advance_mosaic_vcount(1); // vcount=0, vblock_size=3
+        ppu.advance_mosaic_vcount(2); // vcount=1
+        ppu.advance_mosaic_vcount(3); // vcount=2
+
+        // Mid-frame: change size to 1 (2-scanline blocks); should NOT take effect until next block
+        ppu.write_register(0x2106, 0x11); // size=1 in bits 7-4
+
+        ppu.advance_mosaic_vcount(4); // vcount=3 (still old block, vblock_size still 3)
+        assert_eq!(ppu.mosaic_vcount, 3);
+        assert_eq!(ppu.mosaic_vblock_size, 3); // old size still active
+
+        ppu.advance_mosaic_vcount(5); // vcount==vblock_size(3) → new block with NEW size
+        assert_eq!(ppu.mosaic_vcount, 0);
+        assert_eq!(ppu.mosaic_vblock_size, 1); // new size now active
+    }
+}

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -25,6 +25,8 @@ impl Ppu {
                     self.bg_tile_size_16[bg] = value & (0x10 << bg) != 0;
                 }
             }
+            // MOSAIC: mosaic size (bits 7-4) and per-BG enable (bits 3-0).
+            0x2106 => self.mosaic = value,
             // BGnSC: tilemap base (bits 2-7, 1K-word steps) + size (bits 0-1).
             0x2107..=0x210A => {
                 let bg = (addr - 0x2107) as usize;

--- a/src/snes/ppu/save_state.rs
+++ b/src/snes/ppu/save_state.rs
@@ -75,6 +75,9 @@ impl Ppu {
             oam_priority_rotation: self.oam_priority_rotation,
             stat77_range_over: self.stat77_range_over,
             stat77_time_over: self.stat77_time_over,
+            mosaic: self.mosaic,
+            mosaic_vblock_size: self.mosaic_vblock_size,
+            mosaic_vcount: self.mosaic_vcount,
         }
     }
 
@@ -148,6 +151,9 @@ impl Ppu {
         self.oam_priority_rotation = state.oam_priority_rotation;
         self.stat77_range_over = state.stat77_range_over;
         self.stat77_time_over = state.stat77_time_over;
+        self.mosaic = state.mosaic;
+        self.mosaic_vblock_size = state.mosaic_vblock_size;
+        self.mosaic_vcount = state.mosaic_vcount;
 
         // Reset the transient OBJ runtime state so stale pipeline data from before the load can't
         // leak into the first restored frame (the line buffer is rebuilt as rendering resumes).

--- a/src/snes/ppu/timing.rs
+++ b/src/snes/ppu/timing.rs
@@ -9,6 +9,7 @@
 
 use super::{
     DOTS_PER_SCANLINE, MASTER_CYCLES_PER_DOT, NTSC_SCANLINES_PER_FRAME, Ppu, VBLANK_START_LINE,
+    VISIBLE_LINE_START,
 };
 
 impl Ppu {
@@ -38,7 +39,12 @@ impl Ppu {
     }
 
     fn on_scanline_start(&mut self) {
-        match self.position.scanline {
+        let scanline = self.position.scanline;
+        // Advance the vertical mosaic block counter for visible scanlines.
+        if (VISIBLE_LINE_START..VBLANK_START_LINE).contains(&scanline) {
+            self.advance_mosaic_vcount(scanline);
+        }
+        match scanline {
             VBLANK_START_LINE => {
                 // Begin VBlank: a full visible frame has been produced. Set the VBlank + RDNMI
                 // flags (the flag is set even if NMI is disabled), then re-evaluate the NMI line.


### PR DESCRIPTION
## Summary

Implements MOSAIC $2106 per the fullsnes PPU specification (closes #2765).

## Changes

- **New `mosaic.rs` submodule** with helper methods shared by BG and Mode 7 rendering
- **`mod.rs`**: 3 new state fields (`mosaic`, `mosaic_vblock_size`, `mosaic_vcount`)
- **`registers.rs`**: $2106 write handler
- **`timing.rs`**: `advance_mosaic_vcount()` called in `on_scanline_start()` for visible scanlines
- **`background.rs`**: horizontal mosaic (snap x) in `bg_pixel()`; vertical mosaic (subtract vcount from BGnVOFS) in `effective_offsets()`
- **`mode7.rs`**: horizontal + vertical mosaic applied to affine input (BG1 enable; BG2 EXTBG vertical uses BG1 enable per bsnes evidence)
- **`save_state.rs` + `console/save_state.rs`**: 3 new fields with `#[serde(default)]`

## Behavior

| Feature | Implementation |
|---------|---------------|
| Horizontal | x_mos = x - (x % block_size), immediate effect |
| Vertical | vscroll = bg_vofs - mosaic_vcount, applied per-scanline |
| Mid-frame size change | Current block finishes with old size (fullsnes spec) |
| Mode 7 horizontal | Snap x before affine (BG1 enable) |
| Mode 7 vertical | Subtract vcount from y before affine (BG1 enable) |
| Block counter | Reset at scanline 1; block boundary updates pending size |

## Tests (14 new)
- 11 unit tests in mosaic.rs: size-0 no-op, h-block snapping, block boundary, vcount increment/reset, per-BG enable, mid-frame size-change, frame-start reset
- 3 integration rendering tests in background.rs: horizontal replication, vertical row replication, disabled-BG no-op

## Verification
- cargo test: 11,499 passed
- clippy: clean
- cargo fmt: clean
- wasm-pack: 66 passed
- python tests: 346 passed
- npm test: 364 passed