### PR TITLE
Sub-issue (2720): H/V IRQ timing ($4207-$420A)

### DIFF
--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -530,6 +530,10 @@ impl SnesSystemBus {
                 self.ppu.borrow_mut().write_register(offset, value);
                 true
             }
+            0x4207..=0x420A => {
+                self.ppu.borrow_mut().write_register(offset, value);
+                true
+            }
             0x4300..=0x437F => self.dma.write_register(offset, value),
             _ => false,
         }
@@ -604,6 +608,10 @@ impl SnesBus for SnesSystemBus {
 
     fn poll_nmi(&mut self) -> bool {
         self.ppu.get_mut().poll_nmi()
+    }
+
+    fn poll_irq(&self) -> bool {
+        self.ppu.borrow().poll_irq_level()
     }
 
     fn screen_dimensions(&self) -> (u32, u32) {
@@ -1375,5 +1383,25 @@ mod tests {
             "NMI edge delivered through the bus at VBlank"
         );
         assert!(!bus.poll_nmi(), "edge consumed once");
+    }
+
+    #[test]
+    fn bus_poll_irq_reflects_timeup_level_and_read_ack_clears_it() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x004207, 0x01);
+        bus.write(0x004208, 0x00);
+        bus.write(0x004200, 0x10); // H-IRQ mode
+
+        assert!(!bus.poll_irq(), "IRQ line starts deasserted");
+        for _ in 0..4 {
+            bus.tick(); // one dot
+        }
+        assert!(bus.poll_irq(), "IRQ line asserted at HTIME");
+
+        assert_ne!(bus.read(0x004211) & 0x80, 0, "TIMEUP read sees pending IRQ");
+        assert!(
+            !bus.poll_irq(),
+            "TIMEUP read acknowledges and deasserts IRQ line"
+        );
     }
 }

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -191,6 +191,16 @@ pub struct SnesPpuState {
     #[serde(default)]
     pub wrio: u8,
     #[serde(default)]
+    pub irq_mode: u8,
+    #[serde(default)]
+    pub htime: u16,
+    #[serde(default)]
+    pub vtime: u16,
+    #[serde(default)]
+    pub timeup_flag: bool,
+    #[serde(default)]
+    pub irq_line: bool,
+    #[serde(default)]
     pub interlace_field: bool,
     #[serde(default)]
     pub bg_mode: u8,

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -748,6 +748,12 @@ mod tests {
             .as_object_mut()
             .expect("dma map")
             .remove("hdma_lines_left");
+        let ppu = json["ppu"].as_object_mut().expect("ppu object");
+        ppu.remove("irq_mode");
+        ppu.remove("htime");
+        ppu.remove("vtime");
+        ppu.remove("timeup_flag");
+        ppu.remove("irq_line");
 
         let bytes = serde_json::to_vec(&json).expect("serialize compat state");
         let loaded = SnesSaveState::from_bytes(&bytes).expect("compat state should load");
@@ -767,5 +773,10 @@ mod tests {
             crate::snes::console::save_state::SNES_SAVESTATE_VERSION
         );
         assert_eq!(loaded.bus.dma.hdma_lines_left, vec![0; 8]);
+        assert_eq!(loaded.ppu.irq_mode, 0);
+        assert_eq!(loaded.ppu.htime, 0);
+        assert_eq!(loaded.ppu.vtime, 0);
+        assert!(!loaded.ppu.timeup_flag);
+        assert!(!loaded.ppu.irq_line);
     }
 }

--- a/src/snes/cpu/cpu.rs
+++ b/src/snes/cpu/cpu.rs
@@ -568,6 +568,7 @@ impl<B: SnesBus> Cpu<B> {
         if self.bus.poll_nmi() {
             self.nmi_pending = true;
         }
+        let irq_line_asserted = self.bus.poll_irq() || self.irq_pending;
 
         // Poll hardware interrupts (higher priority than opcode fetch)
         if self.abort_pending {
@@ -578,7 +579,7 @@ impl<B: SnesBus> Cpu<B> {
             self.nmi_pending = false;
             return self.dispatch_nmi();
         }
-        if self.irq_pending && !self.flag_i() {
+        if irq_line_asserted && !self.flag_i() {
             // IRQ is level-triggered: do NOT clear irq_pending here; caller must deassert
             return self.dispatch_irq();
         }
@@ -9763,6 +9764,38 @@ mod interrupt_dispatch_tests {
         }
     }
 
+    struct PollIrqBus {
+        mem: Vec<u8>,
+        irq_level: bool,
+    }
+
+    impl PollIrqBus {
+        fn new() -> Self {
+            Self {
+                mem: vec![0; 0x100_0000],
+                irq_level: false,
+            }
+        }
+
+        fn load(&mut self, addr: u32, data: &[u8]) {
+            let a = (addr & 0xFF_FFFF) as usize;
+            self.mem[a..a + data.len()].copy_from_slice(data);
+        }
+    }
+
+    impl crate::snes::bus::SnesBus for PollIrqBus {
+        fn read(&self, addr: u32) -> u8 {
+            self.mem[(addr & 0xFF_FFFF) as usize]
+        }
+        fn write(&mut self, addr: u32, value: u8) {
+            self.mem[(addr & 0xFF_FFFF) as usize] = value;
+        }
+        fn tick(&mut self) {}
+        fn poll_irq(&self) -> bool {
+            self.irq_level
+        }
+    }
+
     #[test]
     fn step_polls_the_bus_nmi_edge_and_dispatches_nmi() {
         let mut cpu = Cpu::new(PollNmiBus::new()); // emulation mode
@@ -9776,6 +9809,40 @@ mod interrupt_dispatch_tests {
         assert_eq!(
             cpu.pc, 0x9000,
             "step() polled the bus NMI edge and dispatched NMI"
+        );
+    }
+
+    #[test]
+    fn step_polls_bus_irq_level_and_dispatches_irq() {
+        let mut cpu = Cpu::new(PollIrqBus::new()); // emulation mode
+        cpu.pc = 0x8000;
+        cpu.s = 0x01FF;
+        cpu.set_flag_i(false);
+        cpu.bus.load(0x00FFFE, &[0x00, 0x91]); // IRQ emulation vector -> $9100
+        cpu.bus.irq_level = true;
+
+        let cycles = cpu.step();
+
+        assert_eq!(cycles, 7, "IRQ dispatch cycles in emulation mode");
+        assert_eq!(cpu.pc, 0x9100, "step() should dispatch IRQ from bus level");
+    }
+
+    #[test]
+    fn bus_irq_deassertion_stops_redispatch() {
+        let mut cpu = Cpu::new(PollIrqBus::new()); // emulation mode
+        cpu.s = 0x01FF;
+        cpu.set_flag_i(false);
+        cpu.bus.load(0x00FFFE, &[0x00, 0x91]); // IRQ vector -> $9100
+        cpu.bus.irq_level = true;
+        assert_eq!(cpu.step(), 7, "first IRQ dispatch");
+
+        cpu.set_flag_i(false);
+        cpu.bus.irq_level = false;
+        cpu.bus.load(cpu.pc as u32, &[0xEA]); // NOP
+        assert_eq!(
+            cpu.step(),
+            2,
+            "IRQ should not redispatch once line is deasserted"
         );
     }
 

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -104,6 +104,16 @@ pub struct Ppu {
     opvct_read_high: bool,
     /// Current WRIO ($4201) value; bit 7 gates counter latching.
     wrio: u8,
+    /// NMITIMEN ($4200) IRQ mode (bits 5-4): 0=off, 1=H, 2=V, 3=H+V.
+    irq_mode: u8,
+    /// H timer target from HTIME ($4207/$4208), 9-bit.
+    htime: u16,
+    /// V timer target from VTIME ($4209/$420A), 9-bit.
+    vtime: u16,
+    /// TIMEUP ($4211) bit 7 latch.
+    timeup_flag: bool,
+    /// Current IRQ line level delivered to the CPU.
+    irq_line: bool,
     /// STAT78 ($213F) bit 7: interlace field flag.
     interlace_field: bool,
     /// Visible framebuffer in 15-bit BGR555 (converted to RGB888 at snapshot time).
@@ -239,6 +249,11 @@ impl Ppu {
             ophct_read_high: false,
             opvct_read_high: false,
             wrio: 0xFF,
+            irq_mode: 0,
+            htime: 0x01FF,
+            vtime: 0x01FF,
+            timeup_flag: false,
+            irq_line: false,
             interlace_field: false,
             framebuffer: vec![0; SCREEN_WIDTH_MAX * SCREEN_HEIGHT_MAX],
             frame_complete: false,
@@ -304,6 +319,11 @@ impl Ppu {
         let edge = self.nmi_edge;
         self.nmi_edge = false;
         edge
+    }
+
+    /// Poll the current level of the H/V IRQ line.
+    pub fn poll_irq_level(&self) -> bool {
+        self.irq_line
     }
 
     /// Whether the PPU is currently in the VBlank period.

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -111,6 +111,12 @@ impl Ppu {
             // NMITIMEN: VBlank NMI enable (bit 7). Re-evaluate the NMI line so that enabling NMI
             // while the VBlank flag is already set raises an edge.
             0x4200 => {
+                let irq_mode = (value >> 4) & 0x03;
+                if irq_mode == 0 {
+                    self.timeup_flag = false;
+                    self.irq_line = false;
+                }
+                self.irq_mode = irq_mode;
                 self.nmi_enable = value & 0x80 != 0;
                 self.update_nmi_line();
             }
@@ -122,6 +128,12 @@ impl Ppu {
                     self.latch_counters();
                 }
             }
+            // HTIMEL/HTIMEH: H timer compare target.
+            0x4207 => self.htime = (self.htime & 0x0100) | value as u16,
+            0x4208 => self.htime = (self.htime & 0x00FF) | (((value as u16) & 0x01) << 8),
+            // VTIMEL/VTIMEH: V timer compare target.
+            0x4209 => self.vtime = (self.vtime & 0x0100) | value as u16,
+            0x420A => self.vtime = (self.vtime & 0x00FF) | (((value as u16) & 0x01) << 8),
             // VMAIN: VRAM address increment mode/step.
             0x2115 => {
                 self.vram_increment_after_high = value & 0x80 != 0;
@@ -248,6 +260,13 @@ impl Ppu {
                 let value = (if self.nmi_flag { 0x80 } else { 0x00 }) | CPU_VERSION;
                 self.nmi_flag = false;
                 self.update_nmi_line();
+                value
+            }
+            // TIMEUP: H/V IRQ flag. Reading acknowledges.
+            0x4211 => {
+                let value = if self.timeup_flag { 0x80 } else { 0x00 };
+                self.timeup_flag = false;
+                self.irq_line = false;
                 value
             }
             // HVBJOY: VBlank flag (bit 7), HBlank flag (bit 6), auto-joypad busy (bit 0).

--- a/src/snes/ppu/save_state.rs
+++ b/src/snes/ppu/save_state.rs
@@ -36,6 +36,11 @@ impl Ppu {
             ophct_read_high: self.ophct_read_high,
             opvct_read_high: self.opvct_read_high,
             wrio: self.wrio,
+            irq_mode: self.irq_mode,
+            htime: self.htime,
+            vtime: self.vtime,
+            timeup_flag: self.timeup_flag,
+            irq_line: self.irq_line,
             interlace_field: self.interlace_field,
             bg_mode: self.bg_mode,
             bg3_priority: self.bg3_priority,
@@ -112,6 +117,11 @@ impl Ppu {
         self.ophct_read_high = state.ophct_read_high;
         self.opvct_read_high = state.opvct_read_high;
         self.wrio = state.wrio;
+        self.irq_mode = state.irq_mode & 0x03;
+        self.htime = state.htime & 0x01FF;
+        self.vtime = state.vtime & 0x01FF;
+        self.timeup_flag = state.timeup_flag;
+        self.irq_line = state.irq_line;
         self.interlace_field = state.interlace_field;
         self.bg_mode = state.bg_mode;
         self.bg3_priority = state.bg3_priority;

--- a/src/snes/ppu/timing.rs
+++ b/src/snes/ppu/timing.rs
@@ -33,6 +33,7 @@ impl Ppu {
             }
             self.on_scanline_start();
         }
+        self.evaluate_hv_irq();
         let forced_blank = self.inidisp & 0x80 != 0;
         self.update_obj_pipeline(forced_blank);
         self.render_dot();
@@ -86,6 +87,27 @@ impl Ppu {
     pub(super) fn latch_strobe(&mut self) {
         if self.wrio & 0x80 != 0 {
             self.latch_counters();
+        }
+    }
+
+    fn evaluate_hv_irq(&mut self) {
+        let h = self.position.dot;
+        let v = self.position.scanline;
+        let triggered = match self.irq_mode {
+            // H IRQ each scanline at HTIME.
+            1 => h == self.htime,
+            // V IRQ once on matching scanline (current dot model: dot 0 of that line).
+            2 => h == 0 && v == self.vtime,
+            // HV IRQ at HTIME of VTIME line, with HTIME=0 as the dot-0 special case.
+            3 => {
+                v == self.vtime
+                    && ((self.htime == 0 && h == 0) || (self.htime != 0 && h == self.htime))
+            }
+            _ => false,
+        };
+        if triggered {
+            self.timeup_flag = true;
+            self.irq_line = true;
         }
     }
 }
@@ -306,5 +328,114 @@ mod tests {
         let vb = ppu.read_register(0x4212);
         assert_ne!(vb & 0x80, 0, "VBlank flag set");
         assert_eq!(vb & 0x40, 0, "HBlank clear at dot 0");
+    }
+
+    #[test]
+    fn h_irq_sets_timeup_and_4211_read_acknowledges_it() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x4207, 0x01);
+        ppu.write_register(0x4208, 0x00);
+        ppu.write_register(0x4200, 0x10);
+
+        tick_dots(&mut ppu, 1);
+
+        let first = ppu.read_register(0x4211);
+        let second = ppu.read_register(0x4211);
+        assert_ne!(first & 0x80, 0, "TIMEUP should be set at the H-IRQ point");
+        assert_eq!(second & 0x80, 0, "reading TIMEUP should acknowledge it");
+    }
+
+    #[test]
+    fn h_irq_triggers_on_every_scanline() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x4207, 0x02);
+        ppu.write_register(0x4208, 0x00);
+        ppu.write_register(0x4200, 0x10);
+
+        tick_dots(&mut ppu, 2);
+        assert_ne!(ppu.read_register(0x4211) & 0x80, 0, "line 0 trigger");
+
+        tick_dots(&mut ppu, DOTS_PER_SCANLINE as u32);
+        assert_ne!(
+            ppu.read_register(0x4211) & 0x80,
+            0,
+            "line 1 trigger at same H position"
+        );
+    }
+
+    #[test]
+    fn disabling_irq_mode_clears_timeup_flag() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x4207, 0x01);
+        ppu.write_register(0x4208, 0x00);
+        ppu.write_register(0x4200, 0x10);
+        tick_dots(&mut ppu, 1);
+        assert_ne!(ppu.read_register(0x4211) & 0x80, 0);
+
+        ppu.write_register(0x4200, 0x00);
+        assert_eq!(
+            ppu.read_register(0x4211) & 0x80,
+            0,
+            "disabling IRQ mode must clear TIMEUP"
+        );
+    }
+
+    #[test]
+    fn v_irq_triggers_once_on_the_matching_scanline() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x4209, 0x02);
+        ppu.write_register(0x420A, 0x00);
+        ppu.write_register(0x4200, 0x20);
+
+        tick_dots(&mut ppu, DOTS_PER_SCANLINE as u32 * 2);
+        assert_ne!(
+            ppu.read_register(0x4211) & 0x80,
+            0,
+            "V-IRQ should trigger at VTIME"
+        );
+
+        tick_dots(&mut ppu, 1);
+        assert_eq!(
+            ppu.read_register(0x4211) & 0x80,
+            0,
+            "V-IRQ must not retrigger on every dot of the same line"
+        );
+    }
+
+    #[test]
+    fn hv_irq_triggers_on_htime_of_vtime_line() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x4207, 0x05);
+        ppu.write_register(0x4208, 0x00);
+        ppu.write_register(0x4209, 0x03);
+        ppu.write_register(0x420A, 0x00);
+        ppu.write_register(0x4200, 0x30);
+
+        tick_dots(&mut ppu, DOTS_PER_SCANLINE as u32 * 3 + 4);
+        assert_eq!(ppu.read_register(0x4211) & 0x80, 0);
+
+        tick_dots(&mut ppu, 1);
+        assert_ne!(
+            ppu.read_register(0x4211) & 0x80,
+            0,
+            "HV IRQ should trigger at the programmed H position on the programmed V line"
+        );
+    }
+
+    #[test]
+    fn hv_irq_with_htime_zero_triggers_at_dot_zero_of_vtime_line() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x4207, 0x00);
+        ppu.write_register(0x4208, 0x00);
+        ppu.write_register(0x4209, 0x04);
+        ppu.write_register(0x420A, 0x00);
+        ppu.write_register(0x4200, 0x30);
+
+        tick_dots(&mut ppu, DOTS_PER_SCANLINE as u32 * 4);
+        assert_ne!(
+            ppu.read_register(0x4211) & 0x80,
+            0,
+            "HTIME=0 HV mode should trigger at dot 0 of the VTIME line"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Implement SNES H/V IRQ timer register handling for `$4207-$420A` and IRQ mode bits in `$4200`.
- Add `TIMEUP` (`$4211`) flag/ack semantics, including IRQ-disable acknowledge behavior.
- Wire IRQ level delivery end-to-end: PPU -> `SnesSystemBus::poll_irq()` -> CPU `step()` IRQ polling.
- Persist new PPU IRQ state in save-states with `#[serde(default)]` compatibility for older states.
- Add deterministic unit coverage for H-only, V-only, H+V, `HTIME=0` HV special case, per-scanline H IRQ behavior, TIMEUP ack, and bus/CPU level-triggered behavior.

## Issue

Closes #2767

## Validation

- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/snes --skip-integration`
- `cargo test --no-default-features --lib`
- `wasm-pack test --headless --chrome --no-default-features --features wasm`
- `source .venv/bin/activate && python -m unittest discover -s scripts -t scripts -p "test_*.py" && python -m unittest discover -s scripts/metadata-scraper -t scripts/metadata-scraper -p "test_*.py" && python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-scraper -p "test_*.py"`
- `npm test`
