### PR TITLE
Fix #2778: SNES stereo audio path

### DIFF
--- a/src/snes/apu/dsp/mod.rs
+++ b/src/snes/apu/dsp/mod.rs
@@ -34,6 +34,28 @@ pub struct Sdsp {
     master_vol_l: i8,
     #[serde(default)]
     master_vol_r: i8,
+    #[serde(default)]
+    echo_vol_l: i8,
+    #[serde(default)]
+    echo_vol_r: i8,
+    #[serde(default)]
+    echo_feedback: i8,
+    #[serde(default)]
+    echo_enable: u8,
+    #[serde(default)]
+    flg: u8,
+    #[serde(default)]
+    dir: u8,
+    #[serde(default)]
+    esa: u8,
+    #[serde(default)]
+    edl: u8,
+    #[serde(default)]
+    fir_coeffs: [i8; 8],
+    #[serde(default)]
+    fir_history: [i16; 8],
+    #[serde(default)]
+    fir_history_pos: usize,
     #[serde(default = "default_noise_lfsr")]
     noise_lfsr: u16,
     #[serde(default)]
@@ -61,6 +83,17 @@ impl Sdsp {
             voices: std::array::from_fn(|_| VoiceState::default()),
             master_vol_l: 0,
             master_vol_r: 0,
+            echo_vol_l: 0,
+            echo_vol_r: 0,
+            echo_feedback: 0,
+            echo_enable: 0,
+            flg: 0,
+            dir: 0,
+            esa: 0,
+            edl: 0,
+            fir_coeffs: [0; 8],
+            fir_history: [0; 8],
+            fir_history_pos: 0,
             noise_lfsr: default_noise_lfsr(),
             noise_counter: 0,
             envelope_counter: 0,
@@ -88,6 +121,14 @@ impl Sdsp {
     fn rebuild_cached_fields_from_regs(&mut self) {
         self.master_vol_l = self.regs[0x0C] as i8;
         self.master_vol_r = self.regs[0x1C] as i8;
+        self.echo_feedback = self.regs[0x0D] as i8;
+        self.echo_vol_l = self.regs[0x2C] as i8;
+        self.echo_vol_r = self.regs[0x3C] as i8;
+        self.echo_enable = self.regs[0x4D];
+        self.dir = self.regs[0x5D];
+        self.flg = self.regs[0x6C];
+        self.esa = self.regs[0x6D];
+        self.edl = self.regs[0x7D];
 
         for voice in 0..8usize {
             let base = voice << 4;
@@ -107,6 +148,7 @@ impl Sdsp {
             } else {
                 EnvelopeMode::Sustain
             };
+            self.fir_coeffs[voice] = self.regs[base + 0x0F] as i8;
         }
     }
 
@@ -141,6 +183,45 @@ impl Sdsp {
     pub fn set_master_volume(&mut self, left: i8, right: i8) {
         self.master_vol_l = left;
         self.master_vol_r = right;
+    }
+
+    #[must_use]
+    pub fn render_stereo_sample(&mut self) -> (f32, f32) {
+        let mut dry_l = 0i32;
+        let mut dry_r = 0i32;
+        let mut echo_input = 0i32;
+
+        for voice in 0..8usize {
+            let sample = i16::from(self.voices[voice].outx) << 8;
+            let (left, right) = self.mix_voice_sample(voice, sample);
+            dry_l += i32::from(left);
+            dry_r += i32::from(right);
+            if self.echo_enable & (1 << voice) != 0 {
+                echo_input += (i32::from(left) + i32::from(right)) >> 1;
+            }
+        }
+
+        let dry_mono =
+            ((dry_l + dry_r) >> 1).clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16;
+        self.fir_history[self.fir_history_pos] = dry_mono;
+        self.fir_history_pos = (self.fir_history_pos + 1) & 7;
+
+        let mut echo = 0i32;
+        for tap in 0..8usize {
+            let hist_idx = (self.fir_history_pos + 8 - tap - 1) & 7;
+            echo += i32::from(self.fir_coeffs[tap]) * i32::from(self.fir_history[hist_idx]);
+        }
+        echo = (echo >> 7) + ((echo_input * i32::from(self.echo_feedback)) >> 7);
+
+        let mut left = dry_l + ((echo * i32::from(self.echo_vol_l)) >> 7);
+        let mut right = dry_r + ((echo * i32::from(self.echo_vol_r)) >> 7);
+        if self.flg & 0x40 != 0 {
+            left = 0;
+            right = 0;
+        }
+        let left = left.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as f32 / 32768.0;
+        let right = right.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as f32 / 32768.0;
+        (left, right)
     }
 
     #[must_use]
@@ -258,6 +339,38 @@ impl Sdsp {
                 self.master_vol_r = value as i8;
                 return;
             }
+            0x0D => {
+                self.echo_feedback = value as i8;
+                return;
+            }
+            0x2C => {
+                self.echo_vol_l = value as i8;
+                return;
+            }
+            0x3C => {
+                self.echo_vol_r = value as i8;
+                return;
+            }
+            0x4D => {
+                self.echo_enable = value;
+                return;
+            }
+            0x5D => {
+                self.dir = value;
+                return;
+            }
+            0x6C => {
+                self.flg = value;
+                return;
+            }
+            0x6D => {
+                self.esa = value;
+                return;
+            }
+            0x7D => {
+                self.edl = value;
+                return;
+            }
             KON_REG => {
                 for voice in 0..8 {
                     if value & (1 << voice) != 0 {
@@ -299,6 +412,7 @@ impl Sdsp {
             0x06 => v.adsr2 = value,
             0x07 => v.gain = value,
             0x08 | 0x09 => {}
+            0x0F => self.fir_coeffs[voice] = value as i8,
             _ => {}
         }
     }

--- a/src/snes/apu/mod.rs
+++ b/src/snes/apu/mod.rs
@@ -11,13 +11,37 @@ pub mod timers;
 use crate::snes::apu::dsp::Sdsp;
 use serde::{Deserialize, Serialize};
 use spc700::{Spc700, Spc700Bus};
+use std::collections::VecDeque;
 use timers::SpcTimers;
 
 const ARAM_SIZE: usize = 0x1_0000;
+const MAX_PENDING_SAMPLES: usize = 16_384;
+const SNES_MASTER_CLOCK_HZ: f32 = 21_477_272.0;
+const NATIVE_AUDIO_SAMPLE_RATE_HZ: f32 = 32_000.0;
 const SPC_PER_MASTER_NUM: i64 = 1_024_000;
 const SPC_PER_MASTER_DEN: i64 = 21_477_272;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+fn default_pending_samples() -> Vec<(f32, f32)> {
+    Vec::new()
+}
+
+fn sanitize_non_negative_f32(value: f32) -> f32 {
+    if value.is_finite() && value >= 0.0 {
+        value
+    } else {
+        0.0
+    }
+}
+
+fn sanitize_positive_f32(value: f32, fallback: f32) -> f32 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        fallback
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct SnesApuState {
     #[serde(default)]
     pub aram: Vec<u8>,
@@ -37,6 +61,20 @@ pub struct SnesApuState {
     pub dsp: Sdsp,
     #[serde(default)]
     pub dsp_addr: u8,
+    #[serde(default)]
+    pub spc700: spc700::Spc700State,
+    #[serde(default)]
+    pub sample_acc: f32,
+    #[serde(default)]
+    pub cycles_per_sample: f32,
+    #[serde(default)]
+    pub native_sample_acc: f32,
+    #[serde(default)]
+    pub native_cycles_per_sample: f32,
+    #[serde(default)]
+    pub resample_phase: f32,
+    #[serde(default = "default_pending_samples")]
+    pub pending_samples: Vec<(f32, f32)>,
 }
 
 /// SNES APU bootstrap model: SPC700 + ARAM + IPL overlay + communication ports.
@@ -55,6 +93,13 @@ pub struct SnesApu {
     spc_cycle_budget: i64,
     dsp: Sdsp,
     dsp_addr: u8,
+    sample_acc: f32,
+    cycles_per_sample: f32,
+    native_sample_acc: f32,
+    native_cycles_per_sample: f32,
+    native_samples: VecDeque<(f32, f32)>,
+    resample_phase: f32,
+    pending_samples: VecDeque<(f32, f32)>,
 }
 
 impl SnesApu {
@@ -71,6 +116,13 @@ impl SnesApu {
             spc_cycle_budget: 0,
             dsp: Sdsp::new(),
             dsp_addr: 0,
+            sample_acc: 0.0,
+            cycles_per_sample: 0.0,
+            native_sample_acc: 0.0,
+            native_cycles_per_sample: SNES_MASTER_CLOCK_HZ / NATIVE_AUDIO_SAMPLE_RATE_HZ,
+            native_samples: VecDeque::with_capacity(MAX_PENDING_SAMPLES),
+            resample_phase: 0.0,
+            pending_samples: VecDeque::with_capacity(MAX_PENDING_SAMPLES),
         };
         apu.reset_spc700();
         apu
@@ -113,6 +165,8 @@ impl SnesApu {
             };
             self.spc_cycle_budget -= consumed_cycles * SPC_PER_MASTER_DEN;
         }
+
+        self.step_audio_clock();
     }
 
     pub fn master_ticks(&self) -> u64 {
@@ -130,6 +184,13 @@ impl SnesApu {
             timers: self.timers.clone(),
             dsp: self.dsp.clone(),
             dsp_addr: self.dsp_addr,
+            spc700: self.spc700.capture_state(),
+            sample_acc: self.sample_acc,
+            cycles_per_sample: self.cycles_per_sample,
+            native_sample_acc: self.native_sample_acc,
+            native_cycles_per_sample: self.native_cycles_per_sample,
+            resample_phase: self.resample_phase,
+            pending_samples: self.pending_samples.iter().copied().collect(),
         }
     }
 
@@ -151,6 +212,13 @@ impl SnesApu {
             self.timers = SpcTimers::default();
             self.dsp = Sdsp::new();
             self.dsp_addr = 0;
+            self.sample_acc = 0.0;
+            self.cycles_per_sample = 0.0;
+            self.native_sample_acc = 0.0;
+            self.native_cycles_per_sample = SNES_MASTER_CLOCK_HZ / NATIVE_AUDIO_SAMPLE_RATE_HZ;
+            self.native_samples.clear();
+            self.resample_phase = 0.0;
+            self.pending_samples.clear();
             self.reset_spc700();
             return Ok(());
         }
@@ -170,7 +238,22 @@ impl SnesApu {
         self.timers = state.timers.clone();
         self.dsp = normalized_dsp;
         self.dsp_addr = normalized_dsp_addr;
-        self.reset_spc700();
+        self.sample_acc = sanitize_non_negative_f32(state.sample_acc);
+        self.cycles_per_sample = sanitize_non_negative_f32(state.cycles_per_sample);
+        self.native_sample_acc = sanitize_non_negative_f32(state.native_sample_acc);
+        self.native_cycles_per_sample = sanitize_positive_f32(
+            state.native_cycles_per_sample,
+            SNES_MASTER_CLOCK_HZ / NATIVE_AUDIO_SAMPLE_RATE_HZ,
+        );
+        self.resample_phase = sanitize_non_negative_f32(state.resample_phase);
+        self.native_samples.clear();
+        self.pending_samples = state
+            .pending_samples
+            .iter()
+            .copied()
+            .take(MAX_PENDING_SAMPLES)
+            .collect();
+        self.spc700.restore_state(&state.spc700);
         Ok(())
     }
 
@@ -187,6 +270,98 @@ impl SnesApu {
             tick_timers: false,
         };
         self.spc700.reset(&mut bus_view);
+    }
+
+    fn step_audio_clock(&mut self) {
+        self.step_native_audio_clock();
+        self.step_output_audio_clock();
+    }
+
+    fn render_stereo_sample_internal(&mut self) -> (f32, f32) {
+        self.dsp.render_stereo_sample()
+    }
+
+    fn step_native_audio_clock(&mut self) {
+        if self.native_cycles_per_sample <= 0.0 {
+            return;
+        }
+        self.native_sample_acc += 1.0;
+        while self.native_sample_acc >= self.native_cycles_per_sample {
+            self.native_sample_acc -= self.native_cycles_per_sample;
+            if self.native_samples.len() < MAX_PENDING_SAMPLES {
+                let sample = self.render_stereo_sample_internal();
+                self.native_samples.push_back(sample);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn step_output_audio_clock(&mut self) {
+        if self.cycles_per_sample <= 0.0 {
+            return;
+        }
+        self.sample_acc += 1.0;
+        while self.sample_acc >= self.cycles_per_sample {
+            self.sample_acc -= self.cycles_per_sample;
+            let Some(sample) = self.resample_native_audio() else {
+                break;
+            };
+            if self.pending_samples.len() < MAX_PENDING_SAMPLES {
+                self.pending_samples.push_back(sample);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn resample_native_audio(&mut self) -> Option<(f32, f32)> {
+        let first = *self.native_samples.front()?;
+        let second = if self.native_samples.len() > 1 {
+            self.native_samples[1]
+        } else {
+            first
+        };
+        let t = self.resample_phase.clamp(0.0, 1.0);
+        let left = first.0 + (second.0 - first.0) * t;
+        let right = first.1 + (second.1 - first.1) * t;
+
+        self.resample_phase += NATIVE_AUDIO_SAMPLE_RATE_HZ / self.cycles_per_sample_rate_hz();
+        while self.resample_phase >= 1.0 && self.native_samples.len() > 1 {
+            self.resample_phase -= 1.0;
+            self.native_samples.pop_front();
+        }
+        Some((left, right))
+    }
+
+    fn cycles_per_sample_rate_hz(&self) -> f32 {
+        if self.cycles_per_sample <= 0.0 {
+            return NATIVE_AUDIO_SAMPLE_RATE_HZ;
+        }
+        SNES_MASTER_CLOCK_HZ / self.cycles_per_sample
+    }
+
+    pub fn sample_ready(&self) -> bool {
+        !self.pending_samples.is_empty()
+    }
+
+    pub fn take_stereo_sample(&mut self) -> Option<(f32, f32)> {
+        self.pending_samples.pop_front()
+    }
+
+    pub fn take_sample(&mut self) -> Option<f32> {
+        self.take_stereo_sample()
+            .map(|(left, right)| (left + right) * 0.5)
+    }
+
+    pub fn set_sample_rate(&mut self, rate: f32) {
+        if !rate.is_finite() || rate <= 0.0 {
+            return;
+        }
+        self.cycles_per_sample = SNES_MASTER_CLOCK_HZ / rate;
+        self.sample_acc = 0.0;
+        self.resample_phase = 0.0;
+        self.pending_samples.clear();
     }
 
     #[cfg(test)]
@@ -476,5 +651,26 @@ mod tests {
             0xCC,
             "failed restore must not partially mutate APU state"
         );
+    }
+
+    #[test]
+    fn save_state_round_trips_spc700_register_state() {
+        let mut apu = SnesApu::new(None);
+        apu.spc700
+            .load_state_for_processor_test(0x12, 0x34, 0x56, 0x78, 0x2468, 0xAF);
+
+        let state = apu.capture_state();
+
+        apu.spc700
+            .load_state_for_processor_test(0xFF, 0xEE, 0xDD, 0xCC, 0x0000, 0x00);
+
+        apu.restore_state(&state).expect("restore should succeed");
+
+        assert_eq!(apu.spc700.a(), 0x12);
+        assert_eq!(apu.spc700.x(), 0x34);
+        assert_eq!(apu.spc700.y(), 0x56);
+        assert_eq!(apu.spc700.sp(), 0x78);
+        assert_eq!(apu.spc700.pc(), 0x2468);
+        assert_eq!(apu.spc700.psw(), 0xAF);
     }
 }

--- a/src/snes/apu/spc700/cpu.rs
+++ b/src/snes/apu/spc700/cpu.rs
@@ -20,6 +20,7 @@
 //! ```
 
 use crate::snes::apu::spc700::bus::Spc700Bus;
+use serde::{Deserialize, Serialize};
 
 /// PSW carry flag (bit 0).
 pub const FLAG_CARRY: u8 = 0b0000_0001;
@@ -61,6 +62,24 @@ pub struct Spc700 {
     halted: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct Spc700State {
+    #[serde(default)]
+    pub a: u8,
+    #[serde(default)]
+    pub x: u8,
+    #[serde(default)]
+    pub y: u8,
+    #[serde(default)]
+    pub sp: u8,
+    #[serde(default)]
+    pub pc: u16,
+    #[serde(default)]
+    pub psw: u8,
+    #[serde(default)]
+    pub halted: bool,
+}
+
 impl Spc700 {
     /// SPC700 reset vector address (low byte at `$FFFE`, high byte at `$FFFF`).
     pub const RESET_VECTOR: u16 = 0xFFFE;
@@ -95,6 +114,28 @@ impl Spc700 {
         let lo = bus.read(Self::RESET_VECTOR) as u16;
         let hi = bus.read(Self::RESET_VECTOR.wrapping_add(1)) as u16;
         self.pc = (hi << 8) | lo;
+    }
+
+    pub fn capture_state(&self) -> Spc700State {
+        Spc700State {
+            a: self.a,
+            x: self.x,
+            y: self.y,
+            sp: self.sp,
+            pc: self.pc,
+            psw: self.psw,
+            halted: self.halted,
+        }
+    }
+
+    pub fn restore_state(&mut self, state: &Spc700State) {
+        self.a = state.a;
+        self.x = state.x;
+        self.y = state.y;
+        self.sp = state.sp;
+        self.pc = state.pc;
+        self.psw = state.psw;
+        self.halted = state.halted;
     }
 
     /// Accumulator register.

--- a/src/snes/apu/spc700/mod.rs
+++ b/src/snes/apu/spc700/mod.rs
@@ -14,5 +14,5 @@ pub use bus::{FlatRamBus, Spc700Bus};
 #[allow(unused_imports)] // Wired into the APU in later sub-issues.
 pub use cpu::{
     FLAG_BREAK, FLAG_CARRY, FLAG_DIRECT_PAGE, FLAG_HALF_CARRY, FLAG_INTERRUPT, FLAG_NEGATIVE,
-    FLAG_OVERFLOW, FLAG_ZERO, Spc700,
+    FLAG_OVERFLOW, FLAG_ZERO, Spc700, Spc700State,
 };

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -409,6 +409,22 @@ impl SnesSystemBus {
         Ok(())
     }
 
+    pub(crate) fn sample_ready(&self) -> bool {
+        self.apu.borrow().sample_ready()
+    }
+
+    pub(crate) fn take_stereo_sample(&mut self) -> Option<(f32, f32)> {
+        self.apu.get_mut().take_stereo_sample()
+    }
+
+    pub(crate) fn take_sample(&mut self) -> Option<f32> {
+        self.apu.get_mut().take_sample()
+    }
+
+    pub(crate) fn set_audio_sample_rate(&mut self, rate: f32) {
+        self.apu.get_mut().set_sample_rate(rate);
+    }
+
     #[cfg(test)]
     fn apu_read_spc_port_for_test(&self, port: usize) -> u8 {
         self.apu.borrow().read_spc_port(port)

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -96,7 +96,7 @@ pub struct SnesDmaState {
     pub hdma_lines_left: Vec<u16>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SnesBusState {
     #[serde(default)]
     pub wram: Vec<u8>,
@@ -288,7 +288,7 @@ pub struct SnesPpuState {
     pub mosaic_vcount: u8,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SnesSaveState {
     #[serde(default)]
     pub version: u32,

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -280,17 +280,27 @@ impl Emulator for Snes {
     }
 
     fn sample_ready(&self) -> bool {
-        // TODO: Implement audio sample ready detection
-        false
+        self.cpu
+            .as_ref()
+            .is_some_and(|cpu| cpu.bus().sample_ready())
     }
 
     fn get_sample(&mut self) -> Option<f32> {
-        // TODO: Implement audio sample retrieval
-        None
+        self.cpu
+            .as_mut()
+            .and_then(|cpu| cpu.bus_mut().take_sample())
     }
 
-    fn set_audio_sample_rate(&mut self, _rate: f32) {
-        // TODO: Implement audio sample rate configuration
+    fn get_stereo_sample(&mut self) -> Option<(f32, f32)> {
+        self.cpu
+            .as_mut()
+            .and_then(|cpu| cpu.bus_mut().take_stereo_sample())
+    }
+
+    fn set_audio_sample_rate(&mut self, rate: f32) {
+        if let Some(cpu) = self.cpu.as_mut() {
+            cpu.bus_mut().set_audio_sample_rate(rate);
+        }
     }
 
     fn set_button(&mut self, _port: u8, _button_id: u8, _pressed: bool) {
@@ -510,6 +520,32 @@ mod tests {
         let mut snes = make_snes();
         let cycles = snes.run_tick();
         assert_eq!(cycles, 0);
+    }
+
+    #[test]
+    fn snes_eventually_produces_stereo_audio_after_execution_advances() {
+        let mut snes = make_snes();
+        snes.load_rom(&valid_lorom_nop_rom(), "audio.sfc")
+            .expect("load ROM");
+        snes.set_audio_sample_rate(32_000.0);
+
+        let mut ticks = 0u32;
+        while !snes.sample_ready() && ticks < 100_000 {
+            let step_cycles = snes.run_tick();
+            assert!(step_cycles > 0, "loaded SNES should keep running");
+            ticks += 1;
+        }
+
+        assert!(
+            snes.sample_ready(),
+            "SNES should eventually expose a ready audio sample once emulation advances"
+        );
+
+        let stereo = snes.get_stereo_sample();
+        assert!(
+            stereo.is_some(),
+            "SNES should provide a stereo sample instead of relying on the mono default"
+        );
     }
 
     #[test]

--- a/src/snes/cpu/cpu.rs
+++ b/src/snes/cpu/cpu.rs
@@ -248,6 +248,14 @@ impl<B: SnesBus> Cpu<B> {
         self.p
     }
 
+    pub(crate) fn bus(&self) -> &B {
+        &self.bus
+    }
+
+    pub(crate) fn bus_mut(&mut self) -> &mut B {
+        &mut self.bus
+    }
+
     pub(crate) fn capture_state(&self) -> SnesCpuState {
         SnesCpuState {
             a: self.a,


### PR DESCRIPTION
Implements the SNES stereo audio path for #2778.

### Summary
- Adds queued stereo audio production for SNES.
- Extends SNES/APU save-state coverage to preserve SPC700 state and DSP echo/FIR/master-mix state.
- Keeps older save-states compatible via serde defaults.

### Validation
- SNES unit tests
- SNES save-state round-trip tests
