### PR TITLE
Fix #2793: SNES PPU dot-phase timing

### DIFF
--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -149,6 +149,8 @@ pub struct SnesPpuState {
     #[serde(default)]
     pub master_cycle_accumulator: u32,
     #[serde(default)]
+    pub line_timing_profile: u8,
+    #[serde(default)]
     pub inidisp: u8,
     #[serde(default)]
     pub nmi_enable: bool,

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -76,6 +76,32 @@ pub struct ScanPosition {
     pub dot: u16,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum PpuLineTimingProfile {
+    #[default]
+    Normal,
+    Short,
+    Long,
+}
+
+impl PpuLineTimingProfile {
+    pub(crate) fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Short,
+            2 => Self::Long,
+            _ => Self::Normal,
+        }
+    }
+
+    pub(crate) fn as_u8(self) -> u8 {
+        match self {
+            Self::Normal => 0,
+            Self::Short => 1,
+            Self::Long => 2,
+        }
+    }
+}
+
 /// SNES Picture Processing Unit.
 #[derive(Debug, Clone)]
 pub struct Ppu {
@@ -85,6 +111,8 @@ pub struct Ppu {
     position: ScanPosition,
     /// Accumulated master clocks not yet converted into dots.
     master_cycle_accumulator: u32,
+    /// Latched timing profile for the active scanline.
+    line_timing_profile: PpuLineTimingProfile,
     inidisp: u8,
     nmi_enable: bool,
     /// RDNMI ($4210) bit 7: VBlank NMI flag (set at VBlank start, cleared at VBlank end / read).
@@ -245,6 +273,7 @@ impl Ppu {
             oam: vec![0; OAM_SIZE],
             position: ScanPosition::default(),
             master_cycle_accumulator: 0,
+            line_timing_profile: PpuLineTimingProfile::Normal,
             inidisp: 0,
             nmi_enable: false,
             nmi_flag: false,

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -5,9 +5,7 @@
 //! `$4212` HVBJOY). The bus passes the bare offset to [`Ppu::write_register`] /
 //! [`Ppu::read_register`].
 
-use super::{
-    CGRAM_SIZE, CPU_VERSION, HBLANK_START_DOT, PPU1_VERSION, PPU2_VERSION, Ppu, VRAM_SIZE,
-};
+use super::{CGRAM_SIZE, CPU_VERSION, PPU1_VERSION, PPU2_VERSION, Ppu, VRAM_SIZE};
 
 impl Ppu {
     /// Write a PPU register by its 16-bit address offset.
@@ -272,11 +270,7 @@ impl Ppu {
             // HVBJOY: VBlank flag (bit 7), HBlank flag (bit 6), auto-joypad busy (bit 0).
             0x4212 => {
                 let vblank = if self.vblank_active { 0x80 } else { 0x00 };
-                let hblank = if self.position.dot >= HBLANK_START_DOT {
-                    0x40
-                } else {
-                    0x00
-                };
+                let hblank = if self.hblank_active() { 0x40 } else { 0x00 };
                 vblank | hblank
             }
             // SLHV: software strobe to latch the H/V counters (data value is open bus).

--- a/src/snes/ppu/save_state.rs
+++ b/src/snes/ppu/save_state.rs
@@ -3,7 +3,9 @@
 //! The transient framebuffer is not serialized (it is regenerated each frame); on restore it is
 //! cleared and redrawn over the following frame.
 
-use super::{CGRAM_SIZE, OAM_SIZE, Ppu, ScanPosition, SnesVideoRegion, VRAM_SIZE};
+use super::{
+    CGRAM_SIZE, OAM_SIZE, Ppu, PpuLineTimingProfile, ScanPosition, SnesVideoRegion, VRAM_SIZE,
+};
 use crate::snes::console::save_state::SnesPpuState;
 
 impl Ppu {
@@ -15,6 +17,7 @@ impl Ppu {
             scanline: self.position.scanline,
             dot: self.position.dot,
             master_cycle_accumulator: self.master_cycle_accumulator,
+            line_timing_profile: self.line_timing_profile.as_u8(),
             inidisp: self.inidisp,
             nmi_enable: self.nmi_enable,
             nmi_flag: self.nmi_flag,
@@ -100,6 +103,7 @@ impl Ppu {
             dot: state.dot,
         };
         self.master_cycle_accumulator = state.master_cycle_accumulator;
+        self.line_timing_profile = PpuLineTimingProfile::from_u8(state.line_timing_profile);
         self.inidisp = state.inidisp;
         self.nmi_enable = state.nmi_enable;
         self.nmi_flag = state.nmi_flag;
@@ -208,7 +212,7 @@ fn restore_memory(dst: &mut [u8], src: &[u8], expected: usize, name: &str) -> Re
 
 #[cfg(test)]
 mod tests {
-    use super::super::Ppu;
+    use super::super::{Ppu, PpuLineTimingProfile};
 
     #[test]
     fn capture_restore_round_trips_ppu_state() {
@@ -224,6 +228,7 @@ mod tests {
         ppu.write_register(0x2119, 0xCD);
         ppu.write_register(0x2100, 0x0F);
         ppu.write_register(0x4200, 0x80);
+        ppu.line_timing_profile = PpuLineTimingProfile::Long;
         // BG register state (added in #2760).
         ppu.write_register(0x2105, 0x11); // BGMODE: mode 1, BG1 16x16
         ppu.write_register(0x2107, 0x14); // BG1SC

--- a/src/snes/ppu/timing.rs
+++ b/src/snes/ppu/timing.rs
@@ -5,25 +5,28 @@
 //! [`DOTS_PER_SCANLINE`] and the scanline counter at the active region's
 //! `scanlines_per_frame()` (262 NTSC / 312 PAL).
 //!
-//! Note: long/short-dot quirks (the extra/short dot at 323/327, and the 1364-vs-1360 master
-//! clocks on certain scanlines) are not yet modeled and are a documented refinement TODO.
+//! Note: long/short-dot quirks now use a latched per-scanline profile, including the paired
+//! long-dot phase around H=323/327 and the NTSC/PAL short/long scanline exceptions.
 
-use super::{DOTS_PER_SCANLINE, MASTER_CYCLES_PER_DOT, Ppu, VISIBLE_LINE_START};
+use super::{
+    DOTS_PER_SCANLINE, MASTER_CYCLES_PER_DOT, Ppu, PpuLineTimingProfile, VISIBLE_LINE_START,
+};
 
 impl Ppu {
     /// Advance the PPU by one master clock.
     pub fn tick(&mut self) {
         self.master_cycle_accumulator += 1;
-        if self.master_cycle_accumulator < MASTER_CYCLES_PER_DOT {
+        let cycles_per_dot = self.cycles_per_current_dot();
+        if self.master_cycle_accumulator < cycles_per_dot {
             return;
         }
-        self.master_cycle_accumulator -= MASTER_CYCLES_PER_DOT;
+        self.master_cycle_accumulator -= cycles_per_dot;
         self.advance_dot();
     }
 
     fn advance_dot(&mut self) {
         self.position.dot += 1;
-        if self.position.dot >= DOTS_PER_SCANLINE {
+        if self.position.dot >= self.dots_in_current_scanline() {
             self.position.dot = 0;
             self.position.scanline += 1;
             if self.position.scanline >= self.scanlines_per_frame() {
@@ -37,8 +40,50 @@ impl Ppu {
         self.render_dot();
     }
 
+    fn dots_in_current_scanline(&self) -> u16 {
+        match self.line_timing_profile {
+            PpuLineTimingProfile::Short => DOTS_PER_SCANLINE - 1,
+            PpuLineTimingProfile::Long => DOTS_PER_SCANLINE + 1,
+            PpuLineTimingProfile::Normal => DOTS_PER_SCANLINE,
+        }
+    }
+
+    fn cycles_per_current_dot(&self) -> u32 {
+        match self.line_timing_profile {
+            PpuLineTimingProfile::Short => MASTER_CYCLES_PER_DOT,
+            PpuLineTimingProfile::Normal | PpuLineTimingProfile::Long => match self.position.dot {
+                323 | 327 => MASTER_CYCLES_PER_DOT + 2,
+                324 | 328 => MASTER_CYCLES_PER_DOT - 2,
+                _ => MASTER_CYCLES_PER_DOT,
+            },
+        }
+    }
+
+    fn line_timing_profile_for_scanline(&self) -> PpuLineTimingProfile {
+        if self.video_region == super::SnesVideoRegion::Ntsc
+            && !self.interlace_enabled()
+            && self.interlace_field
+            && self.position.scanline == 240
+        {
+            PpuLineTimingProfile::Short
+        } else if self.video_region == super::SnesVideoRegion::Pal
+            && self.interlace_enabled()
+            && self.interlace_field
+            && self.position.scanline == 311
+        {
+            PpuLineTimingProfile::Long
+        } else {
+            PpuLineTimingProfile::Normal
+        }
+    }
+
+    fn latch_line_timing_profile(&mut self) {
+        self.line_timing_profile = self.line_timing_profile_for_scanline();
+    }
+
     fn on_scanline_start(&mut self) {
         let scanline = self.position.scanline;
+        self.latch_line_timing_profile();
         let vblank_start_line = self.vblank_start_line();
         // Advance the vertical mosaic block counter for visible scanlines.
         if (VISIBLE_LINE_START..vblank_start_line).contains(&scanline) {
@@ -57,9 +102,9 @@ impl Ppu {
                 // End of VBlank / top of a new frame: clear the VBlank + RDNMI flags.
                 self.vblank_active = false;
                 self.nmi_flag = false;
-                if self.interlace_enabled() {
-                    self.interlace_field = !self.interlace_field;
-                }
+                // The field parity still advances even when interlace output is disabled, because
+                // the short/long scanline exceptions are keyed off the latched field state.
+                self.interlace_field = !self.interlace_field;
                 self.update_nmi_line();
             }
             _ => {}
@@ -114,7 +159,8 @@ impl Ppu {
 #[cfg(test)]
 mod tests {
     use super::super::{
-        DOTS_PER_SCANLINE, MASTER_CYCLES_PER_DOT, Ppu, ScanPosition, SnesVideoRegion,
+        DOTS_PER_SCANLINE, MASTER_CYCLES_PER_DOT, Ppu, PpuLineTimingProfile, ScanPosition,
+        SnesVideoRegion,
     };
 
     #[test]
@@ -153,6 +199,12 @@ mod tests {
 
     fn tick_dots(ppu: &mut Ppu, dots: u32) {
         for _ in 0..(dots * MASTER_CYCLES_PER_DOT) {
+            ppu.tick();
+        }
+    }
+
+    fn tick_cycles(ppu: &mut Ppu, cycles: u32) {
+        for _ in 0..cycles {
             ppu.tick();
         }
     }
@@ -327,12 +379,53 @@ mod tests {
         assert_eq!(mid & 0x80, 0, "not in VBlank on scanline 0");
         assert_ne!(mid & 0x40, 0, "HBlank set at dot 300");
 
-        // Advance to VBlank entry (scanline 225, dot 0): VBlank set, HBlank clear.
+        // Advance to VBlank entry (scanline 225, dot 0): VBlank set, HBlank still set.
         let mut ppu = Ppu::new();
         tick_to_vblank(&mut ppu);
         let vb = ppu.read_register(0x4212);
         assert_ne!(vb & 0x80, 0, "VBlank flag set");
-        assert_eq!(vb & 0x40, 0, "HBlank clear at dot 0");
+        assert_ne!(vb & 0x40, 0, "HBlank remains set at dot 0");
+    }
+
+    #[test]
+    fn hblank_flag_stays_set_at_dot_0_and_clears_at_dot_1() {
+        let mut ppu = Ppu::new();
+        ppu.position.scanline = 5;
+        ppu.position.dot = 273;
+
+        // Enter HBlank at dot 274.
+        tick_dots(&mut ppu, 1);
+        assert_ne!(ppu.read_register(0x4212) & 0x40, 0, "HBlank set at dot 274");
+
+        // Advance to next scanline, dot 0: HBlank should still be set.
+        tick_dots(&mut ppu, (DOTS_PER_SCANLINE - 274) as u32);
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 6,
+                dot: 0
+            }
+        );
+        assert_ne!(
+            ppu.read_register(0x4212) & 0x40,
+            0,
+            "HBlank remains set at dot 0"
+        );
+
+        // Dot 1 clears HBlank.
+        tick_dots(&mut ppu, 1);
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 6,
+                dot: 1
+            }
+        );
+        assert_eq!(
+            ppu.read_register(0x4212) & 0x40,
+            0,
+            "HBlank clears at dot 1"
+        );
     }
 
     #[test]
@@ -478,6 +571,154 @@ mod tests {
             ppu.position(),
             ScanPosition {
                 scanline: 0,
+                dot: 0
+            }
+        );
+    }
+
+    #[test]
+    fn ntsc_short_scanline_240_field_1_is_1360_master_cycles() {
+        let mut ppu = Ppu::new();
+        ppu.position.scanline = 240;
+        ppu.position.dot = 0;
+        ppu.interlace_field = true;
+        ppu.line_timing_profile = PpuLineTimingProfile::Short;
+        ppu.write_register(0x2133, 0x00); // non-interlaced output
+
+        // fullsnes: NTSC short line at V=240, field=1, non-interlace is 1360 cycles.
+        for _ in 0..1360 {
+            ppu.tick();
+        }
+
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 241,
+                dot: 0
+            }
+        );
+    }
+
+    #[test]
+    fn pal_interlace_long_scanline_311_field_1_is_1368_master_cycles() {
+        let mut ppu = Ppu::new_with_region(SnesVideoRegion::Pal);
+        ppu.position.scanline = 311;
+        ppu.position.dot = 0;
+        ppu.interlace_field = true;
+        ppu.line_timing_profile = PpuLineTimingProfile::Long;
+        ppu.write_register(0x2133, 0x01); // interlaced output
+
+        // fullsnes: PAL interlaced line 311 in field=1 is a long 1368-cycle line.
+        for _ in 0..1364 {
+            ppu.tick();
+        }
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 311,
+                dot: 341
+            }
+        );
+
+        for _ in 0..4 {
+            ppu.tick();
+        }
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 0,
+                dot: 0
+            }
+        );
+    }
+
+    #[test]
+    fn pal_long_scanline_applies_extra_cycles_at_dot_327_not_line_end() {
+        let mut ppu = Ppu::new_with_region(SnesVideoRegion::Pal);
+        ppu.position.scanline = 311;
+        ppu.position.dot = 327;
+        ppu.interlace_field = true;
+        ppu.line_timing_profile = PpuLineTimingProfile::Long;
+        ppu.write_register(0x2133, 0x01); // interlaced output
+
+        for _ in 0..4 {
+            ppu.tick();
+        }
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 311,
+                dot: 327
+            }
+        );
+
+        for _ in 0..2 {
+            ppu.tick();
+        }
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 311,
+                dot: 328
+            }
+        );
+    }
+
+    #[test]
+    fn ntsc_short_scanline_has_no_extra_cycles_at_dot_327() {
+        let mut ppu = Ppu::new();
+        ppu.position.scanline = 240;
+        ppu.position.dot = 327;
+        ppu.interlace_field = true;
+        ppu.line_timing_profile = PpuLineTimingProfile::Short;
+        ppu.write_register(0x2133, 0x00); // non-interlaced output
+
+        for _ in 0..4 {
+            ppu.tick();
+        }
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 240,
+                dot: 328
+            }
+        );
+    }
+
+    #[test]
+    fn normal_scanline_uses_the_paired_long_dot_phase() {
+        let mut ppu = Ppu::new();
+        ppu.line_timing_profile = PpuLineTimingProfile::Normal;
+        ppu.position.scanline = 10;
+        ppu.position.dot = 323;
+
+        tick_cycles(&mut ppu, 4);
+        assert_eq!(ppu.position().dot, 323);
+        tick_cycles(&mut ppu, 2);
+        assert_eq!(ppu.position().dot, 324);
+
+        ppu.position.dot = 327;
+        tick_cycles(&mut ppu, 4);
+        assert_eq!(ppu.position().dot, 327);
+        tick_cycles(&mut ppu, 2);
+        assert_eq!(ppu.position().dot, 328);
+    }
+
+    #[test]
+    fn interlace_toggle_during_a_scanline_does_not_retime_the_active_line() {
+        let mut ppu = Ppu::new();
+        ppu.position.scanline = 240;
+        ppu.position.dot = 0;
+        ppu.interlace_field = true;
+        ppu.line_timing_profile = PpuLineTimingProfile::Short;
+
+        ppu.write_register(0x2133, 0x01);
+        tick_cycles(&mut ppu, 1360);
+
+        assert_eq!(
+            ppu.position(),
+            ScanPosition {
+                scanline: 241,
                 dot: 0
             }
         );

--- a/src/snes/ppu/timing.rs
+++ b/src/snes/ppu/timing.rs
@@ -1,9 +1,10 @@
 //! PPU dot/scanline timing.
 //!
 //! The bus calls [`Ppu::tick`] once per master clock. The PPU accumulates master clocks and
-//! advances one dot every [`MASTER_CYCLES_PER_DOT`] cycles, wrapping the dot counter at
-//! [`DOTS_PER_SCANLINE`] and the scanline counter at the active region's
-//! `scanlines_per_frame()` (262 NTSC / 312 PAL).
+//! advances one dot at a time using the active scanline timing profile, which can shorten/lengthen
+//! the line and insert paired long-dot phases. Normal dots are 4 master clocks wide; scanline
+//! totals still wrap the scanline counter at the active region's `scanlines_per_frame()` (262 NTSC
+//! / 312 PAL).
 //!
 //! Note: long/short-dot quirks now use a latched per-scanline profile, including the paired
 //! long-dot phase around H=323/327 and the NTSC/PAL short/long scanline exceptions.
@@ -57,6 +58,10 @@ impl Ppu {
                 _ => MASTER_CYCLES_PER_DOT,
             },
         }
+    }
+
+    pub(super) fn hblank_active(&self) -> bool {
+        self.position.dot == 0 || self.position.dot >= super::HBLANK_START_DOT
     }
 
     fn line_timing_profile_for_scanline(&self) -> PpuLineTimingProfile {
@@ -177,6 +182,34 @@ mod tests {
                 scanline: 0,
                 dot: 1
             }
+        );
+    }
+
+    #[test]
+    fn hblank_is_visible_for_the_entire_first_dot_of_a_scanline() {
+        let mut ppu = Ppu::new();
+        ppu.position.scanline = 6;
+        ppu.position.dot = 0;
+        ppu.line_timing_profile = PpuLineTimingProfile::Normal;
+
+        assert_ne!(
+            ppu.read_register(0x4212) & 0x40,
+            0,
+            "HBlank is set at dot 0"
+        );
+
+        tick_cycles(&mut ppu, 1);
+        assert_ne!(
+            ppu.read_register(0x4212) & 0x40,
+            0,
+            "HBlank is still set on dot 0"
+        );
+
+        tick_cycles(&mut ppu, 3);
+        assert_eq!(
+            ppu.read_register(0x4212) & 0x40,
+            0,
+            "HBlank clears on dot 1"
         );
     }
 
@@ -390,37 +423,20 @@ mod tests {
     #[test]
     fn hblank_flag_stays_set_at_dot_0_and_clears_at_dot_1() {
         let mut ppu = Ppu::new();
-        ppu.position.scanline = 5;
-        ppu.position.dot = 273;
+        ppu.position.scanline = 6;
+        ppu.position.dot = 0;
+        ppu.line_timing_profile = PpuLineTimingProfile::Normal;
 
-        // Enter HBlank at dot 274.
-        tick_dots(&mut ppu, 1);
-        assert_ne!(ppu.read_register(0x4212) & 0x40, 0, "HBlank set at dot 274");
+        assert_ne!(ppu.read_register(0x4212) & 0x40, 0, "HBlank set at dot 0");
 
-        // Advance to next scanline, dot 0: HBlank should still be set.
-        tick_dots(&mut ppu, (DOTS_PER_SCANLINE - 274) as u32);
-        assert_eq!(
-            ppu.position(),
-            ScanPosition {
-                scanline: 6,
-                dot: 0
-            }
-        );
+        tick_cycles(&mut ppu, 1);
         assert_ne!(
             ppu.read_register(0x4212) & 0x40,
             0,
-            "HBlank remains set at dot 0"
+            "HBlank remains set during dot 0"
         );
 
-        // Dot 1 clears HBlank.
-        tick_dots(&mut ppu, 1);
-        assert_eq!(
-            ppu.position(),
-            ScanPosition {
-                scanline: 6,
-                dot: 1
-            }
-        );
+        tick_cycles(&mut ppu, 3);
         assert_eq!(
             ppu.read_register(0x4212) & 0x40,
             0,


### PR DESCRIPTION
## Summary
- Adds a latched per-scanline SNES PPU timing profile.
- Models the paired long-dot phase and the NTSC short-line exception.
- Serializes the new timing state in save-states.

## Tests
- cargo test --lib timing:: -- --nocapture
- cargo test snes::ppu::save_state::tests:: -- --nocapture
