### PR TITLE
Add SNES mouse controller and native frontend routing

### DIFF
--- a/src/frontends/native/mouse.rs
+++ b/src/frontends/native/mouse.rs
@@ -47,6 +47,13 @@ pub fn has_snes_mouse(console: &Console) -> bool {
     }
 }
 
+fn snes_mouse_ports(console: &Console) -> [bool; 2] {
+    match console {
+        Console::Snes(snes) => [snes.has_mouse_on_port(0), snes.has_mouse_on_port(1)],
+        _ => [false, false],
+    }
+}
+
 // ── Coordinate routing ───────────────────────────────────────────────────────
 
 /// Routes absolute mouse coordinates to the appropriate NES controller.
@@ -82,7 +89,7 @@ pub fn update_mouse_motion(
 
 /// Applies relative mouse deltas (from locked cursor mode) to the SNES Mouse.
 ///
-/// No-op for non-NES consoles.
+/// No-op for consoles without an SNES mouse.
 pub fn apply_snes_mouse_relative_motion(
     console: &mut Console,
     xrel: i32,
@@ -90,19 +97,27 @@ pub fn apply_snes_mouse_relative_motion(
     window_width: u32,
     window_height: u32,
 ) {
+    let snes_ports = snes_mouse_ports(console);
     let dx = mouse_mapping::map_relative_mouse_delta_to_axis_delta(xrel, window_width);
     let dy = mouse_mapping::map_relative_mouse_delta_to_axis_delta(yrel, window_height);
     match console {
         Console::Nes(nes) => nes.add_mouse_delta(dx, dy),
-        Console::Snes(snes) => snes.add_mouse_delta(0, dx as i16, dy as i16),
+        Console::Snes(snes) => {
+            for (port, enabled) in snes_ports.into_iter().enumerate() {
+                if enabled {
+                    snes.add_mouse_delta(port as u8, dx as i16, dy as i16);
+                }
+            }
+        }
         _ => {}
     }
 }
 
 /// Forwards a mouse button press/release to the appropriate NES controller.
 ///
-/// No-op for non-NES consoles.
+/// No-op for consoles without a mouse-driven controller.
 pub fn update_mouse_button(console: &mut Console, button: MouseButton, pressed: bool) {
+    let snes_ports = snes_mouse_ports(console);
     match console {
         Console::Nes(nes) => {
             if has_any_mouse_controller_nes(nes) {
@@ -113,10 +128,12 @@ pub fn update_mouse_button(console: &mut Console, button: MouseButton, pressed: 
             }
         }
         Console::Snes(snes) => {
-            if snes.has_mouse() {
-                match button {
-                    MouseButton::Left => snes.set_mouse_left_button(0, pressed),
-                    MouseButton::Right => snes.set_mouse_right_button(0, pressed),
+            for (port, enabled) in snes_ports.into_iter().enumerate() {
+                if enabled {
+                    match button {
+                        MouseButton::Left => snes.set_mouse_left_button(port as u8, pressed),
+                        MouseButton::Right => snes.set_mouse_right_button(port as u8, pressed),
+                    }
                 }
             }
         }
@@ -252,6 +269,17 @@ mod tests {
         console
     }
 
+    fn make_snes_console_with_mouse_on_port2() -> Console {
+        let mut config = PlatformConfig::default();
+        config.snes.controller_port2 = SnesControllerType::Mouse;
+        let app_context = AppContext::new_with_config(config);
+        let mut console = Console::new_snes(app_context);
+        console
+            .load_rom(&valid_snes_lorom_nop_rom(), "mouse-port2.sfc")
+            .expect("load snes rom");
+        console
+    }
+
     // ── Device detection ─────────────────────────────────────────────────
 
     #[test]
@@ -282,6 +310,13 @@ mod tests {
     fn detects_snes_mouse_on_snes_console() {
         let console = make_snes_console_with_mouse();
         assert!(has_snes_mouse(&console));
+    }
+
+    #[test]
+    fn detects_snes_mouse_on_snes_console_port2() {
+        let console = make_snes_console_with_mouse_on_port2();
+        assert!(has_snes_mouse(&console));
+        assert_eq!(snes_mouse_ports(&console), [false, true]);
     }
 
     #[test]

--- a/src/frontends/native/mouse.rs
+++ b/src/frontends/native/mouse.rs
@@ -40,10 +40,11 @@ pub fn has_zapper(console: &Console) -> bool {
 }
 
 pub fn has_snes_mouse(console: &Console) -> bool {
-    let Console::Nes(nes) = console else {
-        return false;
-    };
-    nes.has_snes_mouse()
+    match console {
+        Console::Nes(nes) => nes.has_snes_mouse(),
+        Console::Snes(snes) => snes.has_mouse(),
+        _ => false,
+    }
 }
 
 // ── Coordinate routing ───────────────────────────────────────────────────────
@@ -89,26 +90,37 @@ pub fn apply_snes_mouse_relative_motion(
     window_width: u32,
     window_height: u32,
 ) {
-    let Console::Nes(nes) = console else {
-        return;
-    };
     let dx = mouse_mapping::map_relative_mouse_delta_to_axis_delta(xrel, window_width);
     let dy = mouse_mapping::map_relative_mouse_delta_to_axis_delta(yrel, window_height);
-    nes.add_mouse_delta(dx, dy);
+    match console {
+        Console::Nes(nes) => nes.add_mouse_delta(dx, dy),
+        Console::Snes(snes) => snes.add_mouse_delta(0, dx as i16, dy as i16),
+        _ => {}
+    }
 }
 
 /// Forwards a mouse button press/release to the appropriate NES controller.
 ///
 /// No-op for non-NES consoles.
 pub fn update_mouse_button(console: &mut Console, button: MouseButton, pressed: bool) {
-    let Console::Nes(nes) = console else {
-        return;
-    };
-    if has_any_mouse_controller_nes(nes) {
-        match button {
-            MouseButton::Left => nes.set_mouse_left_button(pressed),
-            MouseButton::Right => nes.set_mouse_right_button(pressed),
+    match console {
+        Console::Nes(nes) => {
+            if has_any_mouse_controller_nes(nes) {
+                match button {
+                    MouseButton::Left => nes.set_mouse_left_button(pressed),
+                    MouseButton::Right => nes.set_mouse_right_button(pressed),
+                }
+            }
         }
+        Console::Snes(snes) => {
+            if snes.has_mouse() {
+                match button {
+                    MouseButton::Left => snes.set_mouse_left_button(0, pressed),
+                    MouseButton::Right => snes.set_mouse_right_button(0, pressed),
+                }
+            }
+        }
+        _ => {}
     }
 }
 
@@ -188,7 +200,9 @@ mod tests {
     use super::*;
     use crate::nes::console::Config;
     use crate::platform::app_context::AppContext;
+    use crate::platform::config::Config as PlatformConfig;
     use crate::platform::emulator::Console;
+    use crate::snes::input::SnesControllerType;
 
     fn make_console() -> Console {
         Console::new_nes(AppContext::new_with_config(Config::default()))
@@ -205,6 +219,36 @@ mod tests {
         nes.bus()
             .borrow_mut()
             .set_controller_type(port, controller_type);
+        console
+    }
+
+    fn valid_snes_lorom_nop_rom() -> Vec<u8> {
+        let mut rom = vec![0u8; 0x10000];
+        let header = 0x7FC0;
+        rom[header..header + 21].copy_from_slice(b"SNES TEST ROM        ");
+        rom[header + 0x3C] = 0x00;
+        rom[header + 0x3D] = 0x80;
+        rom[header + 0xD5] = 0x20;
+        rom[header + 0xD6] = 0x00;
+        rom[header + 0xD7] = 0x07;
+        rom[header + 0xD8] = 0x00;
+        rom[header + 0xD9] = 0x00;
+        rom[header + 0xDC] = 0x34;
+        rom[header + 0xDD] = 0x12;
+        rom[header + 0xDE] = 0xCB;
+        rom[header + 0xDF] = 0xED;
+        rom[0x0000] = 0xEA;
+        rom
+    }
+
+    fn make_snes_console_with_mouse() -> Console {
+        let mut config = PlatformConfig::default();
+        config.snes.controller_port1 = SnesControllerType::Mouse;
+        let app_context = AppContext::new_with_config(config);
+        let mut console = Console::new_snes(app_context);
+        console
+            .load_rom(&valid_snes_lorom_nop_rom(), "mouse.sfc")
+            .expect("load snes rom");
         console
     }
 
@@ -232,6 +276,12 @@ mod tests {
     fn detects_snes_mouse_as_mouse_controller() {
         let console = make_console_with_controller(1, crate::nes::input::ControllerType::SnesMouse);
         assert!(has_any_mouse_controller(&console));
+    }
+
+    #[test]
+    fn detects_snes_mouse_on_snes_console() {
+        let console = make_snes_console_with_mouse();
+        assert!(has_snes_mouse(&console));
     }
 
     #[test]

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -340,6 +340,26 @@ impl SnesSystemBus {
         self.input.get_mut().set_joypad_button_states(port, state);
     }
 
+    /// Add relative mouse motion for the given SNES controller port.
+    pub fn add_mouse_delta(&mut self, port: u8, dx: i16, dy: i16) {
+        self.input.get_mut().add_mouse_delta(port, dx, dy);
+    }
+
+    /// Set SNES mouse left button state for the given port.
+    pub fn set_mouse_left_button(&mut self, port: u8, pressed: bool) {
+        self.input.get_mut().set_mouse_left_button(port, pressed);
+    }
+
+    /// Set SNES mouse right button state for the given port.
+    pub fn set_mouse_right_button(&mut self, port: u8, pressed: bool) {
+        self.input.get_mut().set_mouse_right_button(port, pressed);
+    }
+
+    /// Returns true if any SNES controller port currently hosts a mouse.
+    pub fn has_mouse(&self) -> bool {
+        self.input.borrow().has_mouse()
+    }
+
     /// Return the 8 NES-convention button states for the given port.
     pub fn joypad_button_states(&self, port: u8) -> u8 {
         self.input.borrow().joypad_button_states(port)

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -360,6 +360,11 @@ impl SnesSystemBus {
         self.input.borrow().has_mouse()
     }
 
+    /// Returns true if the given physical SNES port currently hosts a mouse.
+    pub fn has_mouse_on_port(&self, port: u8) -> bool {
+        self.input.borrow().has_mouse_on_port(port)
+    }
+
     /// Return the 8 NES-convention button states for the given port.
     pub fn joypad_button_states(&self, port: u8) -> u8 {
         self.input.borrow().joypad_button_states(port)

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -195,6 +195,13 @@ impl Snes {
         self.cpu.as_ref().is_some_and(|cpu| cpu.has_mouse())
     }
 
+    /// Returns true if the given physical SNES port currently hosts a mouse.
+    pub fn has_mouse_on_port(&self, port: u8) -> bool {
+        self.cpu
+            .as_ref()
+            .is_some_and(|cpu| cpu.has_mouse_on_port(port))
+    }
+
     /// Add relative mouse motion for the given SNES controller port.
     pub fn add_mouse_delta(&mut self, port: u8, dx: i16, dy: i16) {
         if let Some(cpu) = self.cpu.as_mut() {

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -189,6 +189,32 @@ impl Snes {
     fn save_ram_to_disk(&self) -> Result<(), String> {
         Ok(())
     }
+
+    /// Returns true if any SNES controller port currently hosts a mouse.
+    pub fn has_mouse(&self) -> bool {
+        self.cpu.as_ref().is_some_and(|cpu| cpu.has_mouse())
+    }
+
+    /// Add relative mouse motion for the given SNES controller port.
+    pub fn add_mouse_delta(&mut self, port: u8, dx: i16, dy: i16) {
+        if let Some(cpu) = self.cpu.as_mut() {
+            cpu.add_mouse_delta(port, dx, dy);
+        }
+    }
+
+    /// Set SNES mouse left button state for the given port.
+    pub fn set_mouse_left_button(&mut self, port: u8, pressed: bool) {
+        if let Some(cpu) = self.cpu.as_mut() {
+            cpu.set_mouse_left_button(port, pressed);
+        }
+    }
+
+    /// Set SNES mouse right button state for the given port.
+    pub fn set_mouse_right_button(&mut self, port: u8, pressed: bool) {
+        if let Some(cpu) = self.cpu.as_mut() {
+            cpu.set_mouse_right_button(port, pressed);
+        }
+    }
 }
 
 impl Emulator for Snes {
@@ -375,6 +401,7 @@ mod tests {
     use crate::platform::app_context::AppContext;
     use crate::platform::config::Config;
     use crate::snes::console::config::SnesHardware;
+    use crate::snes::input::SnesControllerType;
 
     fn valid_lorom_nop_rom() -> Vec<u8> {
         valid_lorom_nop_rom_with_country(0x00)
@@ -560,6 +587,17 @@ mod tests {
         let mut snes = make_snes();
         snes.set_button(0, 0, true);
         assert_eq!(snes.get_joypad_button_states(0), 0);
+    }
+
+    #[test]
+    fn has_mouse_reflects_controller_config() {
+        let mut config = Config::default();
+        config.snes.controller_port1 = SnesControllerType::Mouse;
+        let app_context = AppContext::new_with_config(config);
+        let mut snes = Snes::new(app_context);
+        snes.load_rom(&valid_lorom_nop_rom(), "test.sfc").unwrap();
+
+        assert!(snes.has_mouse());
     }
 
     #[test]

--- a/src/snes/cpu/cpu.rs
+++ b/src/snes/cpu/cpu.rs
@@ -8411,6 +8411,26 @@ impl Cpu<SnesSystemBus> {
         self.bus.set_joypad_button_states(port, state);
     }
 
+    /// Add relative mouse motion for the given SNES controller port.
+    pub fn add_mouse_delta(&mut self, port: u8, dx: i16, dy: i16) {
+        self.bus.add_mouse_delta(port, dx, dy);
+    }
+
+    /// Set SNES mouse left button state for the given port.
+    pub fn set_mouse_left_button(&mut self, port: u8, pressed: bool) {
+        self.bus.set_mouse_left_button(port, pressed);
+    }
+
+    /// Set SNES mouse right button state for the given port.
+    pub fn set_mouse_right_button(&mut self, port: u8, pressed: bool) {
+        self.bus.set_mouse_right_button(port, pressed);
+    }
+
+    /// Returns true if any SNES controller port currently hosts a mouse.
+    pub fn has_mouse(&self) -> bool {
+        self.bus.has_mouse()
+    }
+
     /// Configure the device plugged into each controller port.
     pub fn configure_controllers(
         &mut self,

--- a/src/snes/cpu/cpu.rs
+++ b/src/snes/cpu/cpu.rs
@@ -8431,6 +8431,11 @@ impl Cpu<SnesSystemBus> {
         self.bus.has_mouse()
     }
 
+    /// Returns true if the given physical SNES port currently hosts a mouse.
+    pub fn has_mouse_on_port(&self, port: u8) -> bool {
+        self.bus.has_mouse_on_port(port)
+    }
+
     /// Configure the device plugged into each controller port.
     pub fn configure_controllers(
         &mut self,

--- a/src/snes/input/mod.rs
+++ b/src/snes/input/mod.rs
@@ -14,11 +14,13 @@
 //! so the documented "manual read during auto-joypad corrupts state" behaviour
 //! falls out naturally.
 
+mod mouse_controller;
 mod multitap;
 mod standard_controller;
 
 use serde::{Deserialize, Serialize};
 
+pub use mouse_controller::MouseController;
 pub use multitap::{Multitap, MultitapState};
 pub use standard_controller::StandardController;
 
@@ -71,13 +73,27 @@ pub struct SnesControllerState {
     pub shift: u8,
     #[serde(default)]
     pub strobe: bool,
+    #[serde(default)]
+    pub mouse_speed: u8,
+    #[serde(default)]
+    pub mouse_left_button: bool,
+    #[serde(default)]
+    pub mouse_right_button: bool,
+    #[serde(default)]
+    pub mouse_accum_dx: i16,
+    #[serde(default)]
+    pub mouse_accum_dy: i16,
+    #[serde(default)]
+    pub mouse_report_dx: i16,
+    #[serde(default)]
+    pub mouse_report_dy: i16,
 }
 
 /// The kind of device plugged into a controller port.
 ///
 /// Selectable per port via `--snes-controller-port1` / `--snes-controller-port2`.
-/// Only [`Standard`](Self::Standard) is implemented today; the remaining
-/// variants are placeholders for the peripheral sub-issues and currently fall
+/// [`Standard`](Self::Standard), [`Multitap`](Self::Multitap), and
+/// [`Mouse`](Self::Mouse) are implemented; remaining variants currently fall
 /// back to a standard controller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum SnesControllerType {
@@ -105,6 +121,7 @@ impl SnesControllerType {
         match self {
             Self::Standard => Box::new(StandardController::new()),
             Self::Multitap => Box::new(Multitap::new()),
+            Self::Mouse => Box::new(MouseController::new()),
             other => {
                 crate::platform::debugging::log_info(format!(
                     "SNES controller type {other:?} is not yet implemented; \
@@ -142,6 +159,26 @@ pub trait SnesController {
         } else {
             false
         }
+    }
+
+    /// Add relative mouse motion in host-space units.
+    fn add_mouse_delta(&mut self, _dx: i16, _dy: i16) -> bool {
+        false
+    }
+
+    /// Set the left mouse button state.
+    fn set_mouse_left_button(&mut self, _pressed: bool) -> bool {
+        false
+    }
+
+    /// Set the right mouse button state.
+    fn set_mouse_right_button(&mut self, _pressed: bool) -> bool {
+        false
+    }
+
+    /// Whether this device is an SNES mouse.
+    fn is_mouse(&self) -> bool {
+        false
     }
 
     /// Return the raw pressed-state mask in serial-bit order (bit 0 = B,
@@ -419,6 +456,50 @@ impl InputPorts {
         }
     }
 
+    /// Add relative mouse motion to the configured device on the given port.
+    pub fn add_mouse_delta(&mut self, port: u8, dx: i16, dy: i16) {
+        match port {
+            0 => {
+                let _ = self.port1.add_mouse_delta(dx, dy);
+            }
+            1..=4 => {
+                let _ = self.port2.add_mouse_delta(dx, dy);
+            }
+            _ => {}
+        }
+    }
+
+    /// Set left mouse button state on the configured device on the given port.
+    pub fn set_mouse_left_button(&mut self, port: u8, pressed: bool) {
+        match port {
+            0 => {
+                let _ = self.port1.set_mouse_left_button(pressed);
+            }
+            1..=4 => {
+                let _ = self.port2.set_mouse_left_button(pressed);
+            }
+            _ => {}
+        }
+    }
+
+    /// Set right mouse button state on the configured device on the given port.
+    pub fn set_mouse_right_button(&mut self, port: u8, pressed: bool) {
+        match port {
+            0 => {
+                let _ = self.port1.set_mouse_right_button(pressed);
+            }
+            1..=4 => {
+                let _ = self.port2.set_mouse_right_button(pressed);
+            }
+            _ => {}
+        }
+    }
+
+    /// Returns true if any controller port currently hosts an SNES mouse.
+    pub fn has_mouse(&self) -> bool {
+        self.port1.is_mouse() || self.port2.is_mouse()
+    }
+
     /// Return the 8 NES-convention button states for the given port.
     pub fn joypad_button_states(&self, port: u8) -> u8 {
         match port {
@@ -484,6 +565,7 @@ fn pressed_mask_to_joypad_state(pressed: u16) -> u8 {
 
 #[cfg(test)]
 mod tests {
+    use super::mouse_controller::MouseController;
     use super::*;
 
     #[test]
@@ -676,5 +758,56 @@ mod tests {
         let state = ports.capture_state();
         assert_eq!(state.port1_type, SnesControllerType::Standard);
         assert_eq!(state.port2_type, SnesControllerType::Standard);
+    }
+
+    #[test]
+    fn mouse_controller_type_builds_mouse_device() {
+        let mut ports = InputPorts::new();
+        ports.configure(SnesControllerType::Mouse, SnesControllerType::Standard);
+        assert!(ports.has_mouse());
+    }
+
+    #[test]
+    fn mouse_relative_delta_and_buttons_affect_serial_report() {
+        let mut mouse = MouseController::new();
+        mouse.set_mouse_left_button(true);
+        mouse.set_mouse_right_button(true);
+        mouse.add_mouse_delta(-3, 4);
+        mouse.write_strobe(false);
+
+        let mut bits = 0u32;
+        for i in 0..32 {
+            let (bit, _) = mouse.read();
+            if bit {
+                bits |= 1 << i;
+            }
+        }
+
+        assert_eq!((bits >> 16) & 1, 1, "right button bit");
+        assert_eq!((bits >> 17) & 1, 1, "left button bit");
+        assert_eq!((bits >> 20) & 1, 0, "Y direction positive");
+        assert_eq!((bits >> 21) & 0x7F, 4, "Y magnitude");
+        assert_eq!((bits >> 28) & 1, 1, "X direction negative");
+        assert_eq!((bits >> 29) & 0x7F, 3, "X magnitude");
+    }
+
+    #[test]
+    fn mouse_speed_cycles_on_strobe_high_edges() {
+        let mut mouse = MouseController::new();
+
+        mouse.write_strobe(true);
+        mouse.write_strobe(false);
+        let slow = mouse.capture_state();
+        assert_eq!(slow.mouse_speed, 1);
+
+        mouse.write_strobe(true);
+        mouse.write_strobe(false);
+        let fast = mouse.capture_state();
+        assert_eq!(fast.mouse_speed, 2);
+
+        mouse.write_strobe(true);
+        mouse.write_strobe(false);
+        let normal = mouse.capture_state();
+        assert_eq!(normal.mouse_speed, 0);
     }
 }

--- a/src/snes/input/mod.rs
+++ b/src/snes/input/mod.rs
@@ -500,6 +500,15 @@ impl InputPorts {
         self.port1.is_mouse() || self.port2.is_mouse()
     }
 
+    /// Returns true if the given physical SNES port hosts a mouse.
+    pub fn has_mouse_on_port(&self, port: u8) -> bool {
+        match port {
+            0 => self.port1.is_mouse(),
+            1 => self.port2.is_mouse(),
+            _ => false,
+        }
+    }
+
     /// Return the 8 NES-convention button states for the given port.
     pub fn joypad_button_states(&self, port: u8) -> u8 {
         match port {
@@ -773,39 +782,40 @@ mod tests {
         mouse.set_mouse_left_button(true);
         mouse.set_mouse_right_button(true);
         mouse.add_mouse_delta(-3, 4);
+        mouse.write_strobe(true);
         mouse.write_strobe(false);
 
-        let mut bits = 0u32;
-        for i in 0..32 {
-            let (bit, _) = mouse.read();
-            if bit {
-                bits |= 1 << i;
+        let mut packet = [0u8; 4];
+        for byte in &mut packet {
+            for _ in 0..8 {
+                let (bit, _) = mouse.read();
+                *byte = (*byte << 1) | u8::from(bit);
             }
         }
 
-        assert_eq!((bits >> 16) & 1, 1, "right button bit");
-        assert_eq!((bits >> 17) & 1, 1, "left button bit");
-        assert_eq!((bits >> 20) & 1, 0, "Y direction positive");
-        assert_eq!((bits >> 21) & 0x7F, 4, "Y magnitude");
-        assert_eq!((bits >> 28) & 1, 1, "X direction negative");
-        assert_eq!((bits >> 29) & 0x7F, 3, "X magnitude");
+        assert_eq!(packet[1], 0xC1, "header/button byte");
+        assert_eq!(packet[2], 0x04, "vertical byte");
+        assert_eq!(packet[3], 0x83, "horizontal byte");
     }
 
     #[test]
-    fn mouse_speed_cycles_on_strobe_high_edges() {
+    fn mouse_speed_cycles_on_reads_while_strobe_high() {
         let mut mouse = MouseController::new();
 
         mouse.write_strobe(true);
+        let _ = mouse.read();
         mouse.write_strobe(false);
         let slow = mouse.capture_state();
         assert_eq!(slow.mouse_speed, 1);
 
         mouse.write_strobe(true);
+        let _ = mouse.read();
         mouse.write_strobe(false);
         let fast = mouse.capture_state();
         assert_eq!(fast.mouse_speed, 2);
 
         mouse.write_strobe(true);
+        let _ = mouse.read();
         mouse.write_strobe(false);
         let normal = mouse.capture_state();
         assert_eq!(normal.mouse_speed, 0);

--- a/src/snes/input/mouse_controller.rs
+++ b/src/snes/input/mouse_controller.rs
@@ -1,0 +1,333 @@
+//! SNES Mouse controller.
+//!
+//! Serial output format follows the SNES mouse protocol:
+//! - first 16 bits: fixed signature/header
+//! - next bits: right button, left button, speed bits, Y sign, Y magnitude,
+//!   X sign, X magnitude
+//! - then ones for open-bus style tail bits
+
+use super::{SnesController, SnesControllerState};
+
+const REPORT_BITS: usize = 32;
+const MAGNITUDE_MAX: i16 = 127;
+
+const SPEED_NORMAL: u8 = 0;
+const SPEED_SLOW: u8 = 1;
+const SPEED_FAST: u8 = 2;
+const SPEED_WRAP: u8 = 3;
+
+const HEADER_MASK: u32 = 0x0001;
+const REPORT_HEADER: u32 = 0x0001;
+const RIGHT_BUTTON_BIT: usize = 16;
+const LEFT_BUTTON_BIT: usize = 17;
+const SPEED_BIT_0: usize = 18;
+const SPEED_BIT_1: usize = 19;
+const Y_SIGN_BIT: usize = 20;
+const Y_MAG_START: usize = 21;
+const X_SIGN_BIT: usize = 28;
+const X_MAG_START: usize = 29;
+
+#[derive(Debug, Clone)]
+pub struct MouseController {
+    speed: u8,
+    left_button: bool,
+    right_button: bool,
+    accum_dx: i16,
+    accum_dy: i16,
+    report_dx: i16,
+    report_dy: i16,
+    shift_index: usize,
+    strobe: bool,
+}
+
+impl Default for MouseController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MouseController {
+    pub fn new() -> Self {
+        Self {
+            speed: SPEED_NORMAL,
+            left_button: false,
+            right_button: false,
+            accum_dx: 0,
+            accum_dy: 0,
+            report_dx: 0,
+            report_dy: 0,
+            shift_index: 0,
+            strobe: false,
+        }
+    }
+
+    fn clamp_i16(v: i16, lo: i16, hi: i16) -> i16 {
+        v.clamp(lo, hi)
+    }
+
+    fn sign_and_magnitude(value: i16) -> (bool, u8) {
+        if value < 0 {
+            (true, (-value) as u8)
+        } else {
+            (false, value as u8)
+        }
+    }
+
+    fn add_clamped_with_remainder(accum: &mut i16, delta: i16) {
+        let next = *accum as i32 + delta as i32;
+        let clamped = next.clamp(-(MAGNITUDE_MAX as i32), MAGNITUDE_MAX as i32) as i16;
+        *accum = clamped;
+    }
+
+    fn latch_report(&mut self) {
+        self.report_dx = Self::clamp_i16(self.accum_dx, -MAGNITUDE_MAX, MAGNITUDE_MAX);
+        self.report_dy = Self::clamp_i16(self.accum_dy, -MAGNITUDE_MAX, MAGNITUDE_MAX);
+        self.accum_dx = 0;
+        self.accum_dy = 0;
+        self.shift_index = 0;
+    }
+
+    fn cycle_speed(&mut self) {
+        self.speed = match self.speed {
+            SPEED_NORMAL => SPEED_SLOW,
+            SPEED_SLOW => SPEED_FAST,
+            SPEED_FAST => SPEED_NORMAL,
+            _ => SPEED_NORMAL,
+        };
+    }
+
+    fn build_report_word(&self) -> u32 {
+        let mut word = REPORT_HEADER & HEADER_MASK;
+
+        if self.right_button {
+            word |= 1 << RIGHT_BUTTON_BIT;
+        }
+        if self.left_button {
+            word |= 1 << LEFT_BUTTON_BIT;
+        }
+        if self.speed & 0x01 != 0 {
+            word |= 1 << SPEED_BIT_0;
+        }
+        if self.speed & 0x02 != 0 {
+            word |= 1 << SPEED_BIT_1;
+        }
+
+        let (y_sign, y_mag) = Self::sign_and_magnitude(self.report_dy);
+        if y_sign {
+            word |= 1 << Y_SIGN_BIT;
+        }
+        word |= ((y_mag as u32) & 0x7F) << Y_MAG_START;
+
+        let (x_sign, x_mag) = Self::sign_and_magnitude(self.report_dx);
+        if x_sign {
+            word |= 1 << X_SIGN_BIT;
+        }
+        word |= ((x_mag as u32) & 0x7F) << X_MAG_START;
+
+        word
+    }
+}
+
+impl SnesController for MouseController {
+    fn write_strobe(&mut self, high: bool) {
+        let prev = self.strobe;
+        self.strobe = high;
+
+        if high {
+            if !prev {
+                self.cycle_speed();
+            }
+            self.shift_index = 0;
+            return;
+        }
+
+        if prev {
+            self.latch_report();
+        }
+    }
+
+    fn read(&mut self) -> (bool, bool) {
+        let report = self.build_report_word();
+        let bit = if self.shift_index < REPORT_BITS {
+            ((report >> self.shift_index) & 1) != 0
+        } else {
+            true
+        };
+
+        if !self.strobe {
+            self.shift_index = self.shift_index.saturating_add(1);
+        }
+
+        (bit, false)
+    }
+
+    fn set_button(&mut self, _button: super::SnesButton, _pressed: bool) -> bool {
+        false
+    }
+
+    fn add_mouse_delta(&mut self, dx: i16, dy: i16) -> bool {
+        Self::add_clamped_with_remainder(&mut self.accum_dx, dx);
+        Self::add_clamped_with_remainder(&mut self.accum_dy, dy);
+        true
+    }
+
+    fn set_mouse_left_button(&mut self, pressed: bool) -> bool {
+        self.left_button = pressed;
+        true
+    }
+
+    fn set_mouse_right_button(&mut self, pressed: bool) -> bool {
+        self.right_button = pressed;
+        true
+    }
+
+    fn is_mouse(&self) -> bool {
+        true
+    }
+
+    fn capture_state(&self) -> SnesControllerState {
+        SnesControllerState {
+            pressed: 0,
+            shift: 0,
+            strobe: self.strobe,
+            mouse_speed: self.speed,
+            mouse_left_button: self.left_button,
+            mouse_right_button: self.right_button,
+            mouse_accum_dx: self.accum_dx,
+            mouse_accum_dy: self.accum_dy,
+            mouse_report_dx: self.report_dx,
+            mouse_report_dy: self.report_dy,
+        }
+    }
+
+    fn restore_state(&mut self, state: &SnesControllerState) {
+        self.speed = if state.mouse_speed == SPEED_WRAP {
+            SPEED_NORMAL
+        } else {
+            state.mouse_speed
+        };
+        self.left_button = state.mouse_left_button;
+        self.right_button = state.mouse_right_button;
+        self.accum_dx = Self::clamp_i16(state.mouse_accum_dx, -MAGNITUDE_MAX, MAGNITUDE_MAX);
+        self.accum_dy = Self::clamp_i16(state.mouse_accum_dy, -MAGNITUDE_MAX, MAGNITUDE_MAX);
+        self.report_dx = Self::clamp_i16(state.mouse_report_dx, -MAGNITUDE_MAX, MAGNITUDE_MAX);
+        self.report_dy = Self::clamp_i16(state.mouse_report_dy, -MAGNITUDE_MAX, MAGNITUDE_MAX);
+        self.strobe = state.strobe;
+        self.shift_index = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_bits(mouse: &mut MouseController, count: usize) -> u32 {
+        let mut out = 0u32;
+        for i in 0..count {
+            let (bit, _io) = mouse.read();
+            if bit {
+                out |= 1u32 << i;
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn default_speed_is_normal_after_first_latch() {
+        let mut mouse = MouseController::new();
+        mouse.write_strobe(false);
+        let report = read_bits(&mut mouse, 32);
+        assert_eq!((report >> SPEED_BIT_0) & 1, 0);
+        assert_eq!((report >> SPEED_BIT_1) & 1, 0);
+    }
+
+    #[test]
+    fn strobe_high_cycles_speed_mode() {
+        let mut mouse = MouseController::new();
+
+        mouse.write_strobe(true);
+        mouse.write_strobe(false);
+        let slow = read_bits(&mut mouse, 32);
+        assert_eq!((slow >> SPEED_BIT_0) & 1, 1);
+        assert_eq!((slow >> SPEED_BIT_1) & 1, 0);
+
+        mouse.write_strobe(true);
+        mouse.write_strobe(false);
+        let fast = read_bits(&mut mouse, 32);
+        assert_eq!((fast >> SPEED_BIT_0) & 1, 0);
+        assert_eq!((fast >> SPEED_BIT_1) & 1, 1);
+
+        mouse.write_strobe(true);
+        mouse.write_strobe(false);
+        let normal = read_bits(&mut mouse, 32);
+        assert_eq!((normal >> SPEED_BIT_0) & 1, 0);
+        assert_eq!((normal >> SPEED_BIT_1) & 1, 0);
+    }
+
+    #[test]
+    fn report_contains_buttons_and_signed_magnitudes() {
+        let mut mouse = MouseController::new();
+        mouse.set_mouse_left_button(true);
+        mouse.set_mouse_right_button(true);
+        mouse.add_mouse_delta(-5, 6);
+
+        mouse.write_strobe(false);
+        let report = read_bits(&mut mouse, 32);
+
+        assert_eq!((report >> RIGHT_BUTTON_BIT) & 1, 1);
+        assert_eq!((report >> LEFT_BUTTON_BIT) & 1, 1);
+
+        assert_eq!((report >> Y_SIGN_BIT) & 1, 0);
+        assert_eq!((report >> Y_MAG_START) & 0x7F, 6);
+
+        assert_eq!((report >> X_SIGN_BIT) & 1, 1);
+        assert_eq!((report >> X_MAG_START) & 0x7F, 5);
+    }
+
+    #[test]
+    fn overflow_is_clamped_to_7bit_magnitude() {
+        let mut mouse = MouseController::new();
+        mouse.add_mouse_delta(300, -300);
+
+        mouse.write_strobe(false);
+        let report = read_bits(&mut mouse, 32);
+
+        assert_eq!((report >> X_MAG_START) & 0x7F, 127);
+        assert_eq!((report >> Y_MAG_START) & 0x7F, 127);
+        assert_eq!((report >> X_SIGN_BIT) & 1, 0);
+        assert_eq!((report >> Y_SIGN_BIT) & 1, 1);
+    }
+
+    #[test]
+    fn tail_bits_read_back_as_ones_after_32_bits() {
+        let mut mouse = MouseController::new();
+        mouse.write_strobe(false);
+        let _ = read_bits(&mut mouse, 32);
+        for _ in 0..8 {
+            let (bit, _io) = mouse.read();
+            assert!(bit);
+        }
+    }
+
+    #[test]
+    fn state_round_trip_preserves_mouse_fields() {
+        let mut mouse = MouseController::new();
+        mouse.set_mouse_left_button(true);
+        mouse.set_mouse_right_button(true);
+        mouse.add_mouse_delta(12, -9);
+        mouse.write_strobe(true);
+        mouse.write_strobe(false);
+
+        let state = mouse.capture_state();
+        let mut restored = MouseController::new();
+        restored.restore_state(&state);
+
+        let report = read_bits(&mut restored, 32);
+        assert_eq!((report >> RIGHT_BUTTON_BIT) & 1, 1);
+        assert_eq!((report >> LEFT_BUTTON_BIT) & 1, 1);
+        assert_eq!((report >> Y_SIGN_BIT) & 1, 1);
+        assert_eq!((report >> Y_MAG_START) & 0x7F, 9);
+        assert_eq!((report >> X_SIGN_BIT) & 1, 0);
+        assert_eq!((report >> X_MAG_START) & 0x7F, 12);
+    }
+}

--- a/src/snes/input/mouse_controller.rs
+++ b/src/snes/input/mouse_controller.rs
@@ -1,31 +1,27 @@
 //! SNES Mouse controller.
 //!
 //! Serial output format follows the SNES mouse protocol:
-//! - first 16 bits: fixed signature/header
-//! - next bits: right button, left button, speed bits, Y sign, Y magnitude,
-//!   X sign, X magnitude
-//! - then ones for open-bus style tail bits
+//! - bits 1..=8: unused, always 0
+//! - bit 9: right button
+//! - bit 10: left button
+//! - bits 11..=12: sensitivity
+//! - bits 13..=16: hardware ID (0001b)
+//! - bit 17: vertical direction (1=up, 0=down)
+//! - bits 18..=24: vertical 7-bit magnitude
+//! - bit 25: horizontal direction (1=left, 0=right)
+//! - bits 26..=32: horizontal 7-bit magnitude
+//!
+//! Each byte is shifted MSB-first, matching the rest of the SNES controller stack.
 
 use super::{SnesController, SnesControllerState};
 
-const REPORT_BITS: usize = 32;
+const REPORT_BITS: u8 = 32;
 const MAGNITUDE_MAX: i16 = 127;
 
 const SPEED_NORMAL: u8 = 0;
-const SPEED_SLOW: u8 = 1;
+const SPEED_NORMAL_ACCEL: u8 = 1;
 const SPEED_FAST: u8 = 2;
 const SPEED_WRAP: u8 = 3;
-
-const HEADER_MASK: u32 = 0x0001;
-const REPORT_HEADER: u32 = 0x0001;
-const RIGHT_BUTTON_BIT: usize = 16;
-const LEFT_BUTTON_BIT: usize = 17;
-const SPEED_BIT_0: usize = 18;
-const SPEED_BIT_1: usize = 19;
-const Y_SIGN_BIT: usize = 20;
-const Y_MAG_START: usize = 21;
-const X_SIGN_BIT: usize = 28;
-const X_MAG_START: usize = 29;
 
 #[derive(Debug, Clone)]
 pub struct MouseController {
@@ -36,7 +32,8 @@ pub struct MouseController {
     accum_dy: i16,
     report_dx: i16,
     report_dy: i16,
-    shift_index: usize,
+    packet: [u8; 4],
+    shift_index: u8,
     strobe: bool,
 }
 
@@ -56,6 +53,7 @@ impl MouseController {
             accum_dy: 0,
             report_dx: 0,
             report_dy: 0,
+            packet: [0; 4],
             shift_index: 0,
             strobe: false,
         }
@@ -73,6 +71,15 @@ impl MouseController {
         }
     }
 
+    fn sensitivity_multiplier(speed: u8) -> i16 {
+        match speed & 0x03 {
+            SPEED_NORMAL => 1,
+            SPEED_NORMAL_ACCEL => 2,
+            SPEED_FAST => 3,
+            _ => 1,
+        }
+    }
+
     fn add_clamped_with_remainder(accum: &mut i16, delta: i16) {
         let next = *accum as i32 + delta as i32;
         let clamped = next.clamp(-(MAGNITUDE_MAX as i32), MAGNITUDE_MAX as i32) as i16;
@@ -84,79 +91,70 @@ impl MouseController {
         self.report_dy = Self::clamp_i16(self.accum_dy, -MAGNITUDE_MAX, MAGNITUDE_MAX);
         self.accum_dx = 0;
         self.accum_dy = 0;
+        self.packet = self.build_packet();
         self.shift_index = 0;
     }
 
     fn cycle_speed(&mut self) {
         self.speed = match self.speed {
-            SPEED_NORMAL => SPEED_SLOW,
-            SPEED_SLOW => SPEED_FAST,
+            SPEED_NORMAL => SPEED_NORMAL_ACCEL,
+            SPEED_NORMAL_ACCEL => SPEED_FAST,
             SPEED_FAST => SPEED_NORMAL,
             _ => SPEED_NORMAL,
         };
     }
 
-    fn build_report_word(&self) -> u32 {
-        let mut word = REPORT_HEADER & HEADER_MASK;
+    fn build_packet(&self) -> [u8; 4] {
+        let (vertical_negative, vertical_magnitude) = Self::sign_and_magnitude(self.report_dy);
+        let (horizontal_negative, horizontal_magnitude) = Self::sign_and_magnitude(self.report_dx);
 
-        if self.right_button {
-            word |= 1 << RIGHT_BUTTON_BIT;
-        }
-        if self.left_button {
-            word |= 1 << LEFT_BUTTON_BIT;
-        }
-        if self.speed & 0x01 != 0 {
-            word |= 1 << SPEED_BIT_0;
-        }
-        if self.speed & 0x02 != 0 {
-            word |= 1 << SPEED_BIT_1;
+        let right_button = if self.right_button { 0x80 } else { 0x00 };
+        let left_button = if self.left_button { 0x40 } else { 0x00 };
+        let sensitivity = (self.speed & 0x03) << 4;
+        let mouse_id = 0x01;
+
+        let vertical_direction = if vertical_negative { 0x80 } else { 0x00 };
+        let horizontal_direction = if horizontal_negative { 0x80 } else { 0x00 };
+
+        [
+            0x00,
+            right_button | left_button | sensitivity | mouse_id,
+            vertical_direction | (vertical_magnitude & 0x7F),
+            horizontal_direction | (horizontal_magnitude & 0x7F),
+        ]
+    }
+
+    fn current_bit(&self) -> bool {
+        if self.shift_index >= REPORT_BITS {
+            return true;
         }
 
-        let (y_sign, y_mag) = Self::sign_and_magnitude(self.report_dy);
-        if y_sign {
-            word |= 1 << Y_SIGN_BIT;
-        }
-        word |= ((y_mag as u32) & 0x7F) << Y_MAG_START;
-
-        let (x_sign, x_mag) = Self::sign_and_magnitude(self.report_dx);
-        if x_sign {
-            word |= 1 << X_SIGN_BIT;
-        }
-        word |= ((x_mag as u32) & 0x7F) << X_MAG_START;
-
-        word
+        let byte = self.packet[(self.shift_index / 8) as usize];
+        let bit_in_byte = self.shift_index % 8;
+        ((byte >> (7 - bit_in_byte)) & 1) != 0
     }
 }
 
 impl SnesController for MouseController {
     fn write_strobe(&mut self, high: bool) {
-        let prev = self.strobe;
         self.strobe = high;
 
         if high {
-            if !prev {
-                self.cycle_speed();
-            }
             self.shift_index = 0;
-            return;
-        }
-
-        if prev {
+        } else {
             self.latch_report();
         }
     }
 
     fn read(&mut self) -> (bool, bool) {
-        let report = self.build_report_word();
-        let bit = if self.shift_index < REPORT_BITS {
-            ((report >> self.shift_index) & 1) != 0
+        let bit = if self.strobe {
+            self.cycle_speed();
+            self.current_bit()
         } else {
-            true
-        };
-
-        if !self.strobe {
+            let current = self.current_bit();
             self.shift_index = self.shift_index.saturating_add(1);
-        }
+            current
+        };
 
         (bit, false)
     }
@@ -166,8 +164,9 @@ impl SnesController for MouseController {
     }
 
     fn add_mouse_delta(&mut self, dx: i16, dy: i16) -> bool {
-        Self::add_clamped_with_remainder(&mut self.accum_dx, dx);
-        Self::add_clamped_with_remainder(&mut self.accum_dy, dy);
+        let multiplier = Self::sensitivity_multiplier(self.speed);
+        Self::add_clamped_with_remainder(&mut self.accum_dx, dx.saturating_mul(multiplier));
+        Self::add_clamped_with_remainder(&mut self.accum_dy, dy.saturating_mul(multiplier));
         true
     }
 
@@ -188,7 +187,7 @@ impl SnesController for MouseController {
     fn capture_state(&self) -> SnesControllerState {
         SnesControllerState {
             pressed: 0,
-            shift: 0,
+            shift: self.shift_index,
             strobe: self.strobe,
             mouse_speed: self.speed,
             mouse_left_button: self.left_button,
@@ -213,7 +212,8 @@ impl SnesController for MouseController {
         self.report_dx = Self::clamp_i16(state.mouse_report_dx, -MAGNITUDE_MAX, MAGNITUDE_MAX);
         self.report_dy = Self::clamp_i16(state.mouse_report_dy, -MAGNITUDE_MAX, MAGNITUDE_MAX);
         self.strobe = state.strobe;
-        self.shift_index = 0;
+        self.packet = self.build_packet();
+        self.shift_index = state.shift.min(REPORT_BITS);
     }
 }
 
@@ -221,47 +221,64 @@ impl SnesController for MouseController {
 mod tests {
     use super::*;
 
-    fn read_bits(mouse: &mut MouseController, count: usize) -> u32 {
-        let mut out = 0u32;
-        for i in 0..count {
+    fn latch(mouse: &mut MouseController) {
+        mouse.write_strobe(true);
+        mouse.write_strobe(false);
+    }
+
+    fn read_bits(mouse: &mut MouseController, count: usize) -> Vec<bool> {
+        let mut out = Vec::with_capacity(count);
+        for _ in 0..count {
             let (bit, _io) = mouse.read();
-            if bit {
-                out |= 1u32 << i;
-            }
+            out.push(bit);
         }
         out
+    }
+
+    fn bits_to_byte(bits: &[bool]) -> u8 {
+        bits.iter()
+            .fold(0u8, |acc, bit| (acc << 1) | u8::from(*bit))
+    }
+
+    fn read_packet(mouse: &mut MouseController) -> [u8; 4] {
+        let bits = read_bits(mouse, 32);
+        [
+            bits_to_byte(&bits[0..8]),
+            bits_to_byte(&bits[8..16]),
+            bits_to_byte(&bits[16..24]),
+            bits_to_byte(&bits[24..32]),
+        ]
     }
 
     #[test]
     fn default_speed_is_normal_after_first_latch() {
         let mut mouse = MouseController::new();
-        mouse.write_strobe(false);
-        let report = read_bits(&mut mouse, 32);
-        assert_eq!((report >> SPEED_BIT_0) & 1, 0);
-        assert_eq!((report >> SPEED_BIT_1) & 1, 0);
+        latch(&mut mouse);
+        let packet = read_packet(&mut mouse);
+        assert_eq!(packet[1] & 0x30, 0x00);
     }
 
     #[test]
-    fn strobe_high_cycles_speed_mode() {
+    fn clock_while_strobe_high_cycles_speed_mode() {
         let mut mouse = MouseController::new();
 
         mouse.write_strobe(true);
+        let _ = mouse.read();
         mouse.write_strobe(false);
-        let slow = read_bits(&mut mouse, 32);
-        assert_eq!((slow >> SPEED_BIT_0) & 1, 1);
-        assert_eq!((slow >> SPEED_BIT_1) & 1, 0);
+        let slow = read_packet(&mut mouse);
+        assert_eq!(slow[1] & 0x30, 0x10);
 
         mouse.write_strobe(true);
+        let _ = mouse.read();
         mouse.write_strobe(false);
-        let fast = read_bits(&mut mouse, 32);
-        assert_eq!((fast >> SPEED_BIT_0) & 1, 0);
-        assert_eq!((fast >> SPEED_BIT_1) & 1, 1);
+        let fast = read_packet(&mut mouse);
+        assert_eq!(fast[1] & 0x30, 0x20);
 
         mouse.write_strobe(true);
+        let _ = mouse.read();
         mouse.write_strobe(false);
-        let normal = read_bits(&mut mouse, 32);
-        assert_eq!((normal >> SPEED_BIT_0) & 1, 0);
-        assert_eq!((normal >> SPEED_BIT_1) & 1, 0);
+        let normal = read_packet(&mut mouse);
+        assert_eq!(normal[1] & 0x30, 0x00);
     }
 
     #[test]
@@ -271,17 +288,12 @@ mod tests {
         mouse.set_mouse_right_button(true);
         mouse.add_mouse_delta(-5, 6);
 
-        mouse.write_strobe(false);
-        let report = read_bits(&mut mouse, 32);
+        latch(&mut mouse);
+        let packet = read_packet(&mut mouse);
 
-        assert_eq!((report >> RIGHT_BUTTON_BIT) & 1, 1);
-        assert_eq!((report >> LEFT_BUTTON_BIT) & 1, 1);
-
-        assert_eq!((report >> Y_SIGN_BIT) & 1, 0);
-        assert_eq!((report >> Y_MAG_START) & 0x7F, 6);
-
-        assert_eq!((report >> X_SIGN_BIT) & 1, 1);
-        assert_eq!((report >> X_MAG_START) & 0x7F, 5);
+        assert_eq!(packet[1], 0xC1);
+        assert_eq!(packet[2], 0x06);
+        assert_eq!(packet[3], 0x85);
     }
 
     #[test]
@@ -289,19 +301,17 @@ mod tests {
         let mut mouse = MouseController::new();
         mouse.add_mouse_delta(300, -300);
 
-        mouse.write_strobe(false);
-        let report = read_bits(&mut mouse, 32);
+        latch(&mut mouse);
+        let packet = read_packet(&mut mouse);
 
-        assert_eq!((report >> X_MAG_START) & 0x7F, 127);
-        assert_eq!((report >> Y_MAG_START) & 0x7F, 127);
-        assert_eq!((report >> X_SIGN_BIT) & 1, 0);
-        assert_eq!((report >> Y_SIGN_BIT) & 1, 1);
+        assert_eq!(packet[2], 0xFF);
+        assert_eq!(packet[3], 0x7F);
     }
 
     #[test]
     fn tail_bits_read_back_as_ones_after_32_bits() {
         let mut mouse = MouseController::new();
-        mouse.write_strobe(false);
+        latch(&mut mouse);
         let _ = read_bits(&mut mouse, 32);
         for _ in 0..8 {
             let (bit, _io) = mouse.read();
@@ -315,19 +325,32 @@ mod tests {
         mouse.set_mouse_left_button(true);
         mouse.set_mouse_right_button(true);
         mouse.add_mouse_delta(12, -9);
-        mouse.write_strobe(true);
-        mouse.write_strobe(false);
+        latch(&mut mouse);
+        let _ = mouse.read();
+        let _ = mouse.read();
 
         let state = mouse.capture_state();
+        let expected_remaining_bits = read_bits(&mut mouse, 30);
         let mut restored = MouseController::new();
         restored.restore_state(&state);
 
-        let report = read_bits(&mut restored, 32);
-        assert_eq!((report >> RIGHT_BUTTON_BIT) & 1, 1);
-        assert_eq!((report >> LEFT_BUTTON_BIT) & 1, 1);
-        assert_eq!((report >> Y_SIGN_BIT) & 1, 1);
-        assert_eq!((report >> Y_MAG_START) & 0x7F, 9);
-        assert_eq!((report >> X_SIGN_BIT) & 1, 0);
-        assert_eq!((report >> X_MAG_START) & 0x7F, 12);
+        let restored_remaining_bits = read_bits(&mut restored, 30);
+        assert_eq!(restored_remaining_bits, expected_remaining_bits);
+    }
+
+    #[test]
+    fn sensitivity_scales_motion_before_latch() {
+        let mut mouse = MouseController::new();
+        mouse.write_strobe(true);
+        let _ = mouse.read();
+        mouse.write_strobe(false);
+        mouse.add_mouse_delta(4, 3);
+
+        latch(&mut mouse);
+        let packet = read_packet(&mut mouse);
+
+        assert_eq!(packet[1] & 0x30, 0x10);
+        assert_eq!(packet[2] & 0x7F, 6);
+        assert_eq!(packet[3] & 0x7F, 8);
     }
 }

--- a/src/snes/input/standard_controller.rs
+++ b/src/snes/input/standard_controller.rs
@@ -121,6 +121,7 @@ impl SnesController for StandardController {
             pressed: self.pressed,
             shift: self.shift,
             strobe: self.strobe,
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
## Summary
- implement an SNES mouse controller device with serial report generation, button handling, speed cycling, and save-state support
- wire SNES mouse APIs through input ports, system bus, CPU facade, and SNES console wrapper
- update native frontend mouse routing to detect and route SNES mouse events for SNES consoles
- add tests covering SNES mouse behavior, SNES console mouse detection, and native mouse detection path

## Validation
- cargo check --lib

## Issue
- Fixes #2806