### PR TITLE
Add web SNES save-state parity

### DIFF
--- a/web/integration/specs/save-state-snes.integration.spec.ts
+++ b/web/integration/specs/save-state-snes.integration.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+import { openApp, waitForRunningState } from "../helpers/lifecycle.helpers";
+
+const SAVE_STATE_SECTION_SELECTOR = "#save-state-section";
+const SAVE_STATE_BUTTON_SELECTOR = "#save-state";
+const LOAD_STATE_BUTTON_SELECTOR = "#load-state";
+const TOAST_SELECTOR = ".neser-toast";
+
+function makeMinimalSnesRomBytes() {
+    const rom = Buffer.alloc(0x10000);
+    const header = 0x7FC0;
+    rom.write("SNES TEST ROM        ", header, "ascii");
+    rom[header + 0x3C] = 0x00;
+    rom[header + 0x3D] = 0x80;
+    rom[header + 0xD5] = 0x20;
+    rom[header + 0xD6] = 0x00;
+    rom[header + 0xD7] = 0x07;
+    rom[header + 0xD8] = 0x00;
+    rom[header + 0xD9] = 0x00;
+    rom[header + 0xDC] = 0x34;
+    rom[header + 0xDD] = 0x12;
+    rom[header + 0xDE] = 0xCB;
+    rom[header + 0xDF] = 0xED;
+    rom[0x0000] = 0xEA;
+    return rom;
+}
+
+test.describe("SNES save-state parity", () => {
+    test("Given a SNES ROM is running, when save and load are used, then state persists", async ({ page }) => {
+        await openApp(page);
+        await page.locator("#rom").setInputFiles({
+            name: "suite.sfc",
+            mimeType: "application/octet-stream",
+            buffer: makeMinimalSnesRomBytes()
+        });
+
+        await waitForRunningState(page);
+
+        const saveStateSection = page.locator(SAVE_STATE_SECTION_SELECTOR);
+        const saveButton = page.locator(SAVE_STATE_BUTTON_SELECTOR);
+        const loadButton = page.locator(LOAD_STATE_BUTTON_SELECTOR);
+
+        await expect(saveStateSection).toBeVisible();
+        await expect(saveButton).toBeEnabled();
+        await expect(loadButton).toBeDisabled();
+
+        await saveButton.click();
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
+            timeout: 5000
+        });
+
+        await expect(loadButton).toBeEnabled();
+        await loadButton.click();
+        await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State loaded" })).toBeVisible({
+            timeout: 5000
+        });
+    });
+});

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -8,6 +8,7 @@ import {
     saveState
 } from "./save-state/save_state_storage";
 import { createSaveStateController } from "./save-state/save_state_controller";
+import { supportsWebSaveState } from "./save-state/save_state_support";
 import { applyJoypadButtonIfAllowed, applyMouseMotion, applyMouseButton, isZapperActive } from "./input/mouse_input";
 import {
     isSnesMouseActive,
@@ -780,8 +781,8 @@ function createEmulatorInstance(kind: WebRomConsoleKind): void {
 }
 
 /**
- * Show or hide NES-only UI elements depending on which emulator is active.
- * Called whenever the emulator kind changes (NES ↔ GB).
+ * Show or hide emulator-specific UI elements depending on which emulator is active.
+ * Called whenever the emulator kind changes.
  */
 function updateEmulatorKindUI() {
     const isNes = emulator?.kind === "nes";
@@ -794,10 +795,10 @@ function updateEmulatorKindUI() {
     if (autorunSection) {
         autorunSection.style.display = isNes ? "" : "none";
     }
-    // Save-state buttons are NES-only
+    // Save-state buttons are shown for consoles with browser save/load support.
     const saveStateSection = document.getElementById("save-state-section");
     if (saveStateSection) {
-        saveStateSection.style.display = isNes ? "" : "none";
+        saveStateSection.style.display = supportsWebSaveState(emulator?.kind ?? null) ? "" : "none";
     }
     // Switch to a console-appropriate filter if the current one isn't valid
     const kind = emulator?.kind ?? "nes";
@@ -1070,8 +1071,8 @@ async function applyRomBytes(bytes: Uint8Array, name: string) {
 }
 
 async function refreshSaveStateController() {
-    // Save states are NES-only in the web frontend MVP.
-    if (!nes || !romMetadata) {
+    const saveStateEmulator = emulator && supportsWebSaveState(emulator.kind) ? emulator.inst : null;
+    if (!saveStateEmulator || !romMetadata) {
         saveStateController = null;
         saveStateAvailable = false;
         updateSaveStateButtons();
@@ -1079,7 +1080,7 @@ async function refreshSaveStateController() {
     }
     try {
         saveStateController = await createSaveStateContext({
-            nes,
+            nes: saveStateEmulator,
             romMetadata,
             openDb: openSaveStateDb,
             createRomSaveKey,

--- a/web/src/save-state/save_state_support.test.ts
+++ b/web/src/save-state/save_state_support.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from "vitest";
+import { supportsWebSaveState } from "./save_state_support";
+
+it("supports web save-state for NES and SNES only", () => {
+    expect(supportsWebSaveState("nes")).toBe(true);
+    expect(supportsWebSaveState("snes")).toBe(true);
+    expect(supportsWebSaveState("gb")).toBe(false);
+    expect(supportsWebSaveState("gba")).toBe(false);
+    expect(supportsWebSaveState(null)).toBe(false);
+});

--- a/web/src/save-state/save_state_support.ts
+++ b/web/src/save-state/save_state_support.ts
@@ -1,0 +1,5 @@
+import type { WebRomConsoleKind } from "../rom/rom_extensions";
+
+export function supportsWebSaveState(kind: WebRomConsoleKind | null) {
+    return kind === "nes" || kind === "snes";
+}


### PR DESCRIPTION
Summary\n\n- Enables SNES web save/load through the existing IndexedDB-backed save-state flow.\n- Reuses the existing save/load controls and toasts for SNES.\n- The saved state blob already carries SRAM, so restore/load behavior includes cartridge RAM when a state is saved.\n- Keeps the existing web storage backend unchanged.\n\nCloses #2821