### PR TITLE
Follow up SNES save-state review fixes

### DIFF
--- a/web/integration/specs/save-state-snes.integration.spec.ts
+++ b/web/integration/specs/save-state-snes.integration.spec.ts
@@ -44,13 +44,13 @@ test.describe("SNES save-state parity", () => {
         await expect(saveButton).toBeEnabled();
         await expect(loadButton).toBeDisabled();
 
-        await saveButton.click();
+        await saveButton.click({ force: true });
         await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
             timeout: 5000
         });
 
         await expect(loadButton).toBeEnabled();
-        await loadButton.click();
+        await loadButton.click({ force: true });
         await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State loaded" })).toBeVisible({
             timeout: 5000
         });

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -9,6 +9,7 @@ import {
 } from "./save-state/save_state_storage";
 import { createSaveStateController } from "./save-state/save_state_controller";
 import { supportsWebSaveState } from "./save-state/save_state_support";
+import type { SaveStateRuntime } from "./save-state/save_state_runtime";
 import { applyJoypadButtonIfAllowed, applyMouseMotion, applyMouseButton, isZapperActive } from "./input/mouse_input";
 import {
     isSnesMouseActive,
@@ -1071,8 +1072,11 @@ async function applyRomBytes(bytes: Uint8Array, name: string) {
 }
 
 async function refreshSaveStateController() {
-    const saveStateEmulator = emulator && supportsWebSaveState(emulator.kind) ? emulator.inst : null;
-    if (!saveStateEmulator || !romMetadata) {
+    let saveStateRuntime: SaveStateRuntime | null = null;
+    if (emulator?.kind === "nes" || emulator?.kind === "snes") {
+        saveStateRuntime = emulator.inst;
+    }
+    if (!saveStateRuntime || !romMetadata) {
         saveStateController = null;
         saveStateAvailable = false;
         updateSaveStateButtons();
@@ -1080,7 +1084,7 @@ async function refreshSaveStateController() {
     }
     try {
         saveStateController = await createSaveStateContext({
-            nes: saveStateEmulator,
+            runtime: saveStateRuntime,
             romMetadata,
             openDb: openSaveStateDb,
             createRomSaveKey,

--- a/web/src/save-state/save_state_context.test.ts
+++ b/web/src/save-state/save_state_context.test.ts
@@ -8,12 +8,12 @@ it("createSaveStateContext returns controller when nes and rom metadata exist", 
     const controller = { save: async () => true, load: async () => true };
 
     const result = await createSaveStateContext({
-        nes,
+        runtime: nes,
         romMetadata,
         openDb: async () => ({ name: "db" }),
         createRomSaveKey: async () => "rom:Test.nes:3:hash",
-        createSaveStateController: ({ nes: passedNes, db, key }: any) => {
-            calls.push({ passedNes, db, key });
+        createSaveStateController: ({ runtime: passedRuntime, db, key }: any) => {
+            calls.push({ passedRuntime, db, key });
             return controller;
         },
         saveStateFn: async () => undefined,
@@ -23,7 +23,7 @@ it("createSaveStateContext returns controller when nes and rom metadata exist", 
 
     expect(result).toBe(controller);
     expect(calls[0]).toEqual({
-        passedNes: nes,
+        passedRuntime: nes,
         db: { name: "db" },
         key: "rom:Test.nes:3:hash"
     });
@@ -31,7 +31,7 @@ it("createSaveStateContext returns controller when nes and rom metadata exist", 
 
 it("createSaveStateContext returns null when missing nes or rom metadata", async () => {
     const result1 = await createSaveStateContext({
-        nes: null,
+        runtime: null,
         romMetadata: { name: "Test.nes", size: 3, bytes: new Uint8Array([1]) },
         openDb: async () => ({}),
         createRomSaveKey: async () => "key",
@@ -41,7 +41,7 @@ it("createSaveStateContext returns null when missing nes or rom metadata", async
         setStatus: () => undefined
     } as any);
     const result2 = await createSaveStateContext({
-        nes: { id: "nes" },
+        runtime: { id: "nes" },
         romMetadata: null,
         openDb: async () => ({}),
         createRomSaveKey: async () => "key",

--- a/web/src/save-state/save_state_context.ts
+++ b/web/src/save-state/save_state_context.ts
@@ -1,5 +1,7 @@
+import type { SaveStateRuntime } from "./save_state_runtime";
+
 export async function createSaveStateContext({
-    nes,
+    runtime,
     romMetadata,
     openDb,
     createRomSaveKey,
@@ -8,16 +10,23 @@ export async function createSaveStateContext({
     loadStateFn,
     setStatus
 }: {
-    nes: { save_state_bytes(): Uint8Array; load_state_bytes(bytes: Uint8Array): void } | null;
+    runtime: SaveStateRuntime | null;
     romMetadata: { name: string; size: number; bytes: Uint8Array } | null;
     openDb: () => Promise<IDBDatabase>;
     createRomSaveKey: (meta: { name: string; size: number; bytes: Uint8Array }) => Promise<string>;
-    createSaveStateController: (opts: any) => { save(): Promise<boolean>; load(): Promise<boolean> };
+    createSaveStateController: (opts: {
+        runtime: SaveStateRuntime;
+        db: IDBDatabase;
+        key: string;
+        saveStateFn: (db: IDBDatabase, key: string, bytes: Uint8Array) => Promise<void>;
+        loadStateFn: (db: IDBDatabase, key: string) => Promise<Uint8Array | null>;
+        setStatus: (message: string, isError: boolean) => void;
+    }) => { save(): Promise<boolean>; load(): Promise<boolean> };
     saveStateFn: (db: IDBDatabase, key: string, bytes: Uint8Array) => Promise<void>;
     loadStateFn: (db: IDBDatabase, key: string) => Promise<Uint8Array | null>;
     setStatus: (message: string, isError: boolean) => void;
 }) {
-    if (!nes || !romMetadata) {
+    if (!runtime || !romMetadata) {
         return null;
     }
 
@@ -29,7 +38,7 @@ export async function createSaveStateContext({
     });
 
     return createSaveStateController({
-        nes,
+        runtime,
         db,
         key,
         saveStateFn,

--- a/web/src/save-state/save_state_controller.test.ts
+++ b/web/src/save-state/save_state_controller.test.ts
@@ -4,7 +4,7 @@ import { createSaveStateController } from "./save_state_controller";
 it("save handler stores bytes and sets status", async () => {
     const calls: any[] = [];
     const controller = createSaveStateController({
-        nes: {
+        runtime: {
             save_state_bytes() {
                 return new Uint8Array([1, 2, 3]);
             }
@@ -34,7 +34,7 @@ it("save handler stores bytes and sets status", async () => {
 it("load handler loads bytes into nes and sets status", async () => {
     const calls: any[] = [];
     const controller = createSaveStateController({
-        nes: {
+        runtime: {
             load_state_bytes(bytes: any) {
                 calls.push({ loaded: Array.from(bytes) });
                 return undefined;
@@ -59,7 +59,7 @@ it("load handler loads bytes into nes and sets status", async () => {
 it("load handler reports missing state", async () => {
     const calls: any[] = [];
     const controller = createSaveStateController({
-        nes: {
+        runtime: {
             load_state_bytes() {
                 throw new Error("should not be called");
             }
@@ -85,7 +85,7 @@ it("save handler logs errors", async () => {
     console.error = (...args: any[]) => calls.push(args);
 
     const controller = createSaveStateController({
-        nes: {
+        runtime: {
             save_state_bytes() {
                 throw new Error("boom");
             }
@@ -110,7 +110,7 @@ it("load handler logs errors", async () => {
     console.error = (...args: any[]) => calls.push(args);
 
     const controller = createSaveStateController({
-        nes: {
+        runtime: {
             load_state_bytes() {
                 throw new Error("boom");
             }

--- a/web/src/save-state/save_state_controller.ts
+++ b/web/src/save-state/save_state_controller.ts
@@ -1,12 +1,14 @@
+import type { SaveStateRuntime } from "./save_state_runtime";
+
 export function createSaveStateController({
-    nes,
+    runtime,
     db,
     key,
     saveStateFn,
     loadStateFn,
     setStatus
 }: {
-    nes: { save_state_bytes(): Uint8Array; load_state_bytes(bytes: Uint8Array): void };
+    runtime: SaveStateRuntime;
     db: IDBDatabase;
     key: string;
     saveStateFn: (db: IDBDatabase, key: string, bytes: Uint8Array) => Promise<void>;
@@ -15,7 +17,7 @@ export function createSaveStateController({
 }) {
     async function save() {
         try {
-            const bytes = nes.save_state_bytes();
+            const bytes = runtime.save_state_bytes();
             if (!bytes || bytes.length === 0) {
                 setStatus("Failed to save state", true);
                 return false;
@@ -37,7 +39,7 @@ export function createSaveStateController({
                 setStatus("No save state found", true);
                 return false;
             }
-            nes.load_state_bytes(bytes);
+            runtime.load_state_bytes(bytes);
             setStatus("State loaded", false);
             return true;
         } catch (error) {

--- a/web/src/save-state/save_state_runtime.ts
+++ b/web/src/save-state/save_state_runtime.ts
@@ -1,0 +1,4 @@
+export interface SaveStateRuntime {
+    save_state_bytes(): Uint8Array;
+    load_state_bytes(bytes: Uint8Array): void;
+}


### PR DESCRIPTION
Summary

- Tightens the web save-state runtime type so only NES/SNES instances can reach save/load.
- Renames the save-state plumbing to use a console-agnostic runtime surface.
- Clarifies the PR scope so the delivered behavior matches the implementation.

Closes #2821
