### PR TITLE
Add SNES web frontend flow coverage

### DIFF
--- a/web/integration/helpers/snes_rom.helpers.ts
+++ b/web/integration/helpers/snes_rom.helpers.ts
@@ -1,0 +1,18 @@
+export function makeMinimalSnesRomBytes() {
+    const rom = Buffer.alloc(0x10000);
+    const header = 0x7FC0;
+    rom.write("SNES TEST ROM        ", header, "ascii");
+    rom[header + 0x3C] = 0x00;
+    rom[header + 0x3D] = 0x80;
+    rom[header + 0xD5] = 0x20;
+    rom[header + 0xD6] = 0x00;
+    rom[header + 0xD7] = 0x07;
+    rom[header + 0xD8] = 0x00;
+    rom[header + 0xD9] = 0x00;
+    rom[header + 0xDC] = 0x34;
+    rom[header + 0xDD] = 0x12;
+    rom[header + 0xDE] = 0xCB;
+    rom[header + 0xDF] = 0xED;
+    rom[0x0000] = 0xEA;
+    return rom;
+}

--- a/web/integration/specs/save-state-snes.integration.spec.ts
+++ b/web/integration/specs/save-state-snes.integration.spec.ts
@@ -1,29 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { openApp, waitForRunningState } from "../helpers/lifecycle.helpers";
+import { makeMinimalSnesRomBytes } from "../helpers/snes_rom.helpers";
 
 const SAVE_STATE_SECTION_SELECTOR = "#save-state-section";
 const SAVE_STATE_BUTTON_SELECTOR = "#save-state";
 const LOAD_STATE_BUTTON_SELECTOR = "#load-state";
 const TOAST_SELECTOR = ".neser-toast";
-
-function makeMinimalSnesRomBytes() {
-    const rom = Buffer.alloc(0x10000);
-    const header = 0x7FC0;
-    rom.write("SNES TEST ROM        ", header, "ascii");
-    rom[header + 0x3C] = 0x00;
-    rom[header + 0x3D] = 0x80;
-    rom[header + 0xD5] = 0x20;
-    rom[header + 0xD6] = 0x00;
-    rom[header + 0xD7] = 0x07;
-    rom[header + 0xD8] = 0x00;
-    rom[header + 0xD9] = 0x00;
-    rom[header + 0xDC] = 0x34;
-    rom[header + 0xDD] = 0x12;
-    rom[header + 0xDE] = 0xCB;
-    rom[header + 0xDF] = 0xED;
-    rom[0x0000] = 0xEA;
-    return rom;
-}
 
 test.describe("SNES save-state parity", () => {
     test("Given a SNES ROM is running, when save and load are used, then state persists", async ({ page }) => {
@@ -46,13 +28,13 @@ test.describe("SNES save-state parity", () => {
 
         await saveButton.click({ force: true });
         await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State saved" })).toBeVisible({
-            timeout: 5000
+            timeout: 10_000
         });
 
         await expect(loadButton).toBeEnabled();
         await loadButton.click({ force: true });
         await expect(page.locator(TOAST_SELECTOR).filter({ hasText: "State loaded" })).toBeVisible({
-            timeout: 5000
+            timeout: 10_000
         });
     });
 });

--- a/web/integration/specs/snes-frontend-flow.integration.spec.ts
+++ b/web/integration/specs/snes-frontend-flow.integration.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+import { openApp, waitForRunningState } from "../helpers/lifecycle.helpers";
+
+const START_BUTTON_SELECTOR = "#start";
+const PAUSE_BUTTON_SELECTOR = "#pause";
+
+function makeMinimalSnesRomBytes() {
+    const rom = Buffer.alloc(0x10000);
+    const header = 0x7FC0;
+    rom.write("SNES TEST ROM        ", header, "ascii");
+    rom[header + 0x3C] = 0x00;
+    rom[header + 0x3D] = 0x80;
+    rom[header + 0xD5] = 0x20;
+    rom[header + 0xD6] = 0x00;
+    rom[header + 0xD7] = 0x07;
+    rom[header + 0xD8] = 0x00;
+    rom[header + 0xD9] = 0x00;
+    rom[header + 0xDC] = 0x34;
+    rom[header + 0xDD] = 0x12;
+    rom[header + 0xDE] = 0xCB;
+    rom[header + 0xDF] = 0xED;
+    rom[0x0000] = 0xEA;
+    return rom;
+}
+
+test.describe("SNES frontend flow", () => {
+    test("Given a SNES ROM is loaded from file input, when the emulator starts, then it runs and can pause and resume", async ({ page }) => {
+        await openApp(page);
+        await page.locator("#rom").setInputFiles({
+            name: "flow.sfc",
+            mimeType: "application/octet-stream",
+            buffer: makeMinimalSnesRomBytes()
+        });
+
+        await waitForRunningState(page);
+        await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
+        await expect(page.locator(PAUSE_BUTTON_SELECTOR)).toHaveText("Pause");
+
+        await page.locator(PAUSE_BUTTON_SELECTOR).click();
+        await expect(page.locator(PAUSE_BUTTON_SELECTOR)).toHaveText("Resume");
+
+        await page.locator(PAUSE_BUTTON_SELECTOR).click();
+        await waitForRunningState(page);
+    });
+});

--- a/web/integration/specs/snes-frontend-flow.integration.spec.ts
+++ b/web/integration/specs/snes-frontend-flow.integration.spec.ts
@@ -1,27 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { openApp, waitForRunningState } from "../helpers/lifecycle.helpers";
-
+import { makeMinimalSnesRomBytes } from "../helpers/snes_rom.helpers";
 const START_BUTTON_SELECTOR = "#start";
 const PAUSE_BUTTON_SELECTOR = "#pause";
-
-function makeMinimalSnesRomBytes() {
-    const rom = Buffer.alloc(0x10000);
-    const header = 0x7FC0;
-    rom.write("SNES TEST ROM        ", header, "ascii");
-    rom[header + 0x3C] = 0x00;
-    rom[header + 0x3D] = 0x80;
-    rom[header + 0xD5] = 0x20;
-    rom[header + 0xD6] = 0x00;
-    rom[header + 0xD7] = 0x07;
-    rom[header + 0xD8] = 0x00;
-    rom[header + 0xD9] = 0x00;
-    rom[header + 0xDC] = 0x34;
-    rom[header + 0xDD] = 0x12;
-    rom[header + 0xDE] = 0xCB;
-    rom[header + 0xDF] = 0xED;
-    rom[0x0000] = 0xEA;
-    return rom;
-}
 
 test.describe("SNES frontend flow", () => {
     test("Given a SNES ROM is loaded from file input, when the emulator starts, then it runs and can pause and resume", async ({ page }) => {
@@ -36,10 +17,10 @@ test.describe("SNES frontend flow", () => {
         await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
         await expect(page.locator(PAUSE_BUTTON_SELECTOR)).toHaveText("Pause");
 
-        await page.locator(PAUSE_BUTTON_SELECTOR).click();
+        await page.locator(PAUSE_BUTTON_SELECTOR).click({ force: true });
         await expect(page.locator(PAUSE_BUTTON_SELECTOR)).toHaveText("Resume");
 
-        await page.locator(PAUSE_BUTTON_SELECTOR).click();
+        await page.locator(PAUSE_BUTTON_SELECTOR).click({ force: true });
         await waitForRunningState(page);
     });
 });

--- a/web/src/rom/rom_extensions.test.ts
+++ b/web/src/rom/rom_extensions.test.ts
@@ -33,6 +33,9 @@ it("classifies SNES ROM names as SNES", () => {
 it("supports SNES ROM names", () => {
     expect(isSupportedWebRomName("zelda.sfc")).toBe(true);
     expect(isSupportedWebRomName("mario.smc")).toBe(true);
+    expect(isSupportedWebRomName("GAME.SFC")).toBe(true);
+    expect(isSupportedWebRomName("GAME.SMC")).toBe(true);
+    expect(isSupportedWebRomName("notes.txt")).toBe(false);
 });
 
 it("rejects unsupported web ROM extensions", () => {

--- a/web/src/rom/rom_extensions.test.ts
+++ b/web/src/rom/rom_extensions.test.ts
@@ -1,5 +1,10 @@
 import { expect, it } from "vitest";
-import { supportedRomExtensionsText, webRomConsoleKindForName, webRomExtensionForName } from "./rom_extensions";
+import {
+    isSupportedWebRomName,
+    supportedRomExtensionsText,
+    webRomConsoleKindForName,
+    webRomExtensionForName
+} from "./rom_extensions";
 
 it("classifies NES ROM names as NES", () => {
     expect(webRomConsoleKindForName("mario.nes")).toBe("nes");
@@ -23,6 +28,11 @@ it("classifies SNES ROM names as SNES", () => {
     expect(webRomConsoleKindForName("mario.smc")).toBe("snes");
     expect(webRomConsoleKindForName("GAME.SFC")).toBe("snes");
     expect(webRomConsoleKindForName("GAME.SMC")).toBe("snes");
+});
+
+it("supports SNES ROM names", () => {
+    expect(isSupportedWebRomName("zelda.sfc")).toBe(true);
+    expect(isSupportedWebRomName("mario.smc")).toBe(true);
 });
 
 it("rejects unsupported web ROM extensions", () => {


### PR DESCRIPTION
## Summary

Add SNES web coverage for the frontend flow.

## Changes

- Added a SNES ROM support assertion in web/src/rom/rom_extensions.test.ts
- Added web/integration/specs/snes-frontend-flow.integration.spec.ts for a browser-flow load/run/pause/resume scenario

## Validation

- npm test -- web/src/rom/rom_extensions.test.ts
- npx playwright test web/integration/specs/snes-frontend-flow.integration.spec.ts

## Issue

Closes #2823
