### PR TITLE
refactor(platform): default Emulator::cropped_screen_snapshot (#2836)

### DIFF
--- a/src/gb/console/gameboy.rs
+++ b/src/gb/console/gameboy.rs
@@ -280,11 +280,6 @@ impl GameBoy {
         self.gb.as_ref().map_or(0, |gb| gb.screen_crc32())
     }
 
-    /// Snapshot with no overscan (Game Boy has no overscan).
-    pub fn cropped_screen_snapshot(&self) -> Vec<u8> {
-        self.screen_snapshot()
-    }
-
     /// Set a single button state.
     ///
     /// Uses NES-convention IDs: A=0, B=1, Select=2, Start=3, Up=4, Down=5,
@@ -632,10 +627,6 @@ impl Emulator for GameBoy {
 
     fn screen_snapshot(&self) -> Vec<u8> {
         GameBoy::screen_snapshot(self)
-    }
-
-    fn cropped_screen_snapshot(&self, _h_overscan: u32, _v_overscan: u32) -> Vec<u8> {
-        GameBoy::cropped_screen_snapshot(self)
     }
 
     fn screen_crc32(&self) -> u32 {

--- a/src/gba/console/gba.rs
+++ b/src/gba/console/gba.rs
@@ -408,11 +408,6 @@ impl Emulator for Gba {
         self.bus.ppu.framebuffer().to_vec()
     }
 
-    fn cropped_screen_snapshot(&self, _h_overscan: u32, _v_overscan: u32) -> Vec<u8> {
-        // GBA has no overscan, return full screen
-        self.screen_snapshot()
-    }
-
     fn screen_crc32(&self) -> u32 {
         crate::platform::crc32::crc32(&[self.bus.ppu.framebuffer()])
     }

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -38,7 +38,15 @@ pub trait Emulator {
     fn screen_width(&self) -> u32;
     fn screen_height(&self) -> u32;
     fn screen_snapshot(&self) -> Vec<u8>;
-    fn cropped_screen_snapshot(&self, h_overscan: u32, v_overscan: u32) -> Vec<u8>;
+    /// Returns the screen with `h_overscan`/`v_overscan` pixels cropped from
+    /// each edge.
+    ///
+    /// The default implementation ignores overscan and returns the full
+    /// [`screen_snapshot`](Self::screen_snapshot).  Consoles that support
+    /// overscan (e.g. the NES) override this to crop the frame.
+    fn cropped_screen_snapshot(&self, _h_overscan: u32, _v_overscan: u32) -> Vec<u8> {
+        self.screen_snapshot()
+    }
     fn screen_crc32(&self) -> u32;
     fn sample_ready(&self) -> bool;
     fn get_sample(&mut self) -> Option<f32>;
@@ -875,6 +883,10 @@ mod tests_console_abstraction {
         Console::new_gba(AppContext::new_with_config(Config::default()))
     }
 
+    fn make_snes_console() -> Console {
+        Console::new_snes(AppContext::new_with_config(Config::default()))
+    }
+
     fn make_app_context_with_overscan(h: u8, v: u8) -> SharedAppContext {
         let mut config = Config::default();
         config.nes.horizontal_overscan = h;
@@ -1106,6 +1118,59 @@ mod tests_console_abstraction {
         assert!(
             (16.5..=17.0).contains(&ms),
             "GB frame duration should be ~16.74ms, got {ms:.2}ms"
+        );
+    }
+
+    // --- Console::cropped_screen_snapshot() byte output ---
+    // Locks the contract that consoles without overscan return the full frame,
+    // so the shared `Emulator::cropped_screen_snapshot` default (which simply
+    // returns `screen_snapshot()`) is behavior-preserving for GB/GBA/SNES, while
+    // the NES still honors its real overscan crop.
+
+    #[test]
+    fn test_gb_cropped_screen_snapshot_equals_full_snapshot() {
+        let console = make_gb_console();
+        assert_eq!(
+            console.cropped_screen_snapshot(8, 8),
+            console.screen_snapshot(),
+            "GB ignores overscan: cropped snapshot must equal the full snapshot"
+        );
+    }
+
+    #[test]
+    fn test_gba_cropped_screen_snapshot_equals_full_snapshot() {
+        let console = make_gba_console();
+        assert_eq!(
+            console.cropped_screen_snapshot(8, 8),
+            console.screen_snapshot(),
+            "GBA ignores overscan: cropped snapshot must equal the full snapshot"
+        );
+    }
+
+    #[test]
+    fn test_snes_cropped_screen_snapshot_equals_full_snapshot() {
+        let console = make_snes_console();
+        assert_eq!(
+            console.cropped_screen_snapshot(8, 8),
+            console.screen_snapshot(),
+            "SNES ignores overscan: cropped snapshot must equal the full snapshot"
+        );
+    }
+
+    #[test]
+    fn test_nes_cropped_screen_snapshot_honors_overscan() {
+        let console = make_nes_console_with_overscan(0, 0);
+        let full = console.screen_snapshot();
+        let cropped = console.cropped_screen_snapshot(8, 8);
+        let (cw, ch) = console.cropped_dims(8, 8);
+        assert_eq!(
+            cropped.len(),
+            (cw * ch * 3) as usize,
+            "NES cropped snapshot length must match the cropped RGB dimensions"
+        );
+        assert!(
+            cropped.len() < full.len(),
+            "NES must truly crop when overscan > 0, unlike the default"
         );
     }
 }

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -44,7 +44,8 @@ pub trait Emulator {
     /// The default implementation ignores overscan and returns the full
     /// [`screen_snapshot`](Self::screen_snapshot).  Consoles that support
     /// overscan (e.g. the NES) override this to crop the frame.
-    fn cropped_screen_snapshot(&self, _h_overscan: u32, _v_overscan: u32) -> Vec<u8> {
+    fn cropped_screen_snapshot(&self, h_overscan: u32, v_overscan: u32) -> Vec<u8> {
+        let _ = (h_overscan, v_overscan);
         self.screen_snapshot()
     }
     fn screen_crc32(&self) -> u32;

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -356,11 +356,6 @@ impl Emulator for Snes {
         }
     }
 
-    fn cropped_screen_snapshot(&self, _h_overscan: u32, _v_overscan: u32) -> Vec<u8> {
-        // SNES has no overscan, return full screen
-        self.screen_snapshot()
-    }
-
     fn screen_crc32(&self) -> u32 {
         let pixels = self.screen_snapshot();
         crate::platform::crc32::crc32(&[&pixels])


### PR DESCRIPTION
## Summary

Reduces the repetitive forwarding boilerplate in the per-console Emulator implementations, per item I2.3 of epic #2825.

Closes #2836.

## Approach

Adds a default method to the existing Emulator trait (the least-magic, fully discoverable option the issue calls for) rather than a macro. A macro was rejected because the mechanical 1:1-forwarder pattern is strong only in Game Boy, partial in NES, and mostly absent in GBA/SNES (whose bodies carry real inline logic), so a macro's reach is small and costs discoverability.

## Scope

Only cropped_screen_snapshot gets a default. It is the one method with a genuine shared default and zero perf cost:

- Default body returns the full screen_snapshot() (overscan ignored). This is exactly what Game Boy, GBA, and SNES already did, so their identical overrides are removed.
- The NES keeps its override (it truly crops via ScreenBuffer::cropped_snapshot).
- The now-orphaned inherent GameBoy::cropped_screen_snapshot helper (whose only caller was the removed override) is deleted.

A screen_crc32 default was deliberately NOT added: it would be output-identical but would force a per-frame snapshot clone (~115-184 KB) where NES/GBA currently CRC the framebuffer in place, including in the GBA integration-test hot loops. No functional gain, so it was left as-is.

## No behavior change

Added characterization tests (written before the refactor, green both before and after):

- GB / GBA / SNES: cropped_screen_snapshot(8, 8) equals screen_snapshot() (length + bytes).
- NES: cropped_screen_snapshot honors overscan (cropped length matches cropped dims and is smaller than the full frame).

## Validation (all green)

- cargo clippy --all-targets --all-features -- -D warnings: clean
- cargo fmt --check: clean
- ./scripts/test-dir.sh src/platform src/gb src/gba src/snes: 3989 passed
- cargo test --no-default-features --lib: 11902 passed
- wasm-pack test --headless --chrome --no-default-features --features wasm: 94 passed
- Python suites (scripts, metadata-scraper, nes-rom-db-scraper): all OK
- npm test (Vitest): 412 passed

## Diff

4 files changed, 66 insertions(+), 20 deletions(-). The four impl Emulator blocks are measurably smaller; the net line increase is the new trait default doc and the characterization tests.
