### PR TITLE
Refactor frontend capability accessors

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -10,7 +10,7 @@ The native frontend now exposes audio buffering in milliseconds through configur
 
 The codebase is roughly 383,000 lines of Rust, with additional JavaScript for the web frontend and Python tooling for ROM management.
 
-As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic `Emulator` trait and a `Console` enum that wraps the NES, Game Boy, Game Boy Advance, and SNES implementations. This allows the native frontend and GL backend to dispatch common operations through the trait instead of matching on specific console variants or using NES-specific types directly. The architecture is designed to be extensible for future emulated systems while maintaining a clean separation between hardware-specific logic and shared platform/frontend code.
+As of version 0.3.0, NESER has been refactored to introduce a hardware-agnostic `Emulator` trait and a `Console` enum that wraps the NES, Game Boy, Game Boy Advance, and SNES implementations. This allows the native frontend and GL backend to dispatch common operations through the trait instead of matching on specific console variants or using NES-specific types directly. Optional capability accessors on `Console` expose mouse input, debugger-facing PPU viewer snapshots, and direct system handles for the few places that still need them. The architecture is designed to be extensible for future emulated systems while maintaining a clean separation between hardware-specific logic and shared platform/frontend code.
 
 ## High-Level Architecture
 
@@ -117,7 +117,7 @@ The `src/bin/roms.rs` file is a library binary (accessed via `cargo run --bin ro
 
 | File | Description |
 | ------ | ------------- |
-| `src/platform/emulator.rs` | `Emulator` trait — defines the common interface (22 methods) for all emulated systems: `run_tick`, `is_ready_to_render`, `screen_snapshot`, `get_sample`, `set_button`, `save_state_bytes`/`load_state_bytes`, `reset`, etc. `Console` enum wraps `Box<Nes>` and `Box<GameBoy>`, delegating common methods through `as_core()`/`as_core_mut()`. System-specific features accessed via variant matching (`Console::Nes`). |
+| `src/platform/emulator.rs` | `Emulator` trait — defines the common interface (22 methods) for all emulated systems: `run_tick`, `is_ready_to_render`, `screen_snapshot`, `get_sample`, `set_button`, `save_state_bytes`/`load_state_bytes`, `reset`, etc. `Console` enum wraps the system cores, delegating common methods through `as_core()`/`as_core_mut()` and exposing optional accessors for mouse input, PPU viewer, and system-specific handles. |
 | `src/platform/save_state.rs` | Shared save-state primitives used by all four cores: the `Stateful` trait (component-level capture/restore with an associated serializable `State` and an infallible `restore_state`), a console-agnostic `SaveStateError`, and generic `to_bytes`/`from_bytes` (JSON) plus a `check_version` helper. Console-specific errors (NES `MapperMismatch`, SNES `RomMismatch`) live in slim per-console enums that convert `From<SaveStateError>`; fallible restores are surfaced as `SaveStateError::RestoreFailed` at the console boundary. |
 | `src/platform/config/` | `FrontendConfig` struct — generic frontend settings shared across all emulated systems — split into per-domain modules: `mod.rs` (data structs + thin `apply_args`/`apply_config_value` orchestrators), `cli.rs` (shared CLI machinery: flag table, parse helpers, validation, help text), and `audio`/`video`/`autorun`/`debugger`/`cartridge` (per-domain flag parsing). The `cartridge` module holds the `resolved_metadata_db_path()`, `resolved_image_cache_path()`, and `resolved_favorites_path()` helpers. |
 | `src/platform/app_context.rs` | `AppContext` — shared application state including configuration, ROM database, and toast notification manager. Wrapped in `Rc<RefCell<>>` for interior mutability. |
@@ -371,7 +371,7 @@ The SNES (Super Nintendo Entertainment System) module now includes active 65816 
 | Directory/File | Description |
 | ---------------- | ------------- |
 | `src/frontends/native/` | Desktop frontend using winit + OpenGL. |
-| `src/frontends/native/event_loop.rs` | Main event loop — holds `Console` enum, handles input events, frame timing, VSync, autorun integration, pause/resume, and hot-reload of ROMs. NES-specific features (debugger, Zapper, SNES mouse) accessed by extracting the inner `Nes` via pattern match. |
+| `src/frontends/native/event_loop.rs` | Main event loop — holds `Console` enum, handles input events, frame timing, VSync, autorun integration, pause/resume, and hot-reload of ROMs. NES/Game Boy-specific features (debugger, PPU viewer, Zapper, SNES mouse) use `Console` accessors instead of variant branching. |
 | `src/frontends/native/audio.rs` | Native audio device setup and sample queuing. |
 | `src/frontends/native/keyboard/` | Keyboard input handling, split into focused modules: `mod.rs` (entry points `handle_key_pressed`/`handle_key_released`/`keyboard_target_ports` + `KeyOutcome`), `hotkeys.rs` (system/debugger/cartridge-switch hotkeys), `console_keyboard.rs` (per-console press dispatch), and `controller_mapping.rs` (key→button mapping tables). |
 | `src/frontends/native/gamepad.rs` | Gamepad input using gilrs — maps controller axes/buttons to NES joypads. |

--- a/src/frontends/native/app_state.rs
+++ b/src/frontends/native/app_state.rs
@@ -6,7 +6,7 @@
 
 use crate::platform::autorun::AutorunMode;
 use crate::platform::autorun::state::AutorunState;
-use crate::platform::emulator::Console;
+use crate::platform::emulator::{Console, SystemType};
 use winit::keyboard::ModifiersState;
 
 /// State for the in-game cartridge-switch dialog.
@@ -242,18 +242,19 @@ impl NativeAppState {
             return Some(autorun_overlay_text(autorun, fps));
         }
         if self.help_overlay_visible {
-            let (port1_is_power_pad, port2_is_power_pad) = match console {
-                Console::Nes(nes) => {
+            let (port1_is_power_pad, port2_is_power_pad) =
+                if console.system_type() == SystemType::Nes {
+                    let Some(nes) = console.as_nes() else {
+                        unreachable!("system_type() reported NES but console was not NES");
+                    };
                     use crate::nes::input::ControllerType;
                     (
                         nes.active_controller_port_type(1) == ControllerType::PowerPad,
                         nes.active_controller_port_type(2) == ControllerType::PowerPad,
                     )
-                }
-                Console::GameBoy(_) | Console::GameBoyAdvance(_) | Console::Snes(_) => {
+                } else {
                     (false, false)
-                }
-            };
+                };
             return Some(help_overlay_text(
                 console,
                 self.gamepad_count,
@@ -305,15 +306,15 @@ F6/F7: Save/Load state";
 
     let mut controllers = String::new();
 
-    if matches!(console, Console::GameBoyAdvance(_)) {
+    if console.system_type() == SystemType::Gba {
         return format!("{hotkeys}{}", gba_keyboard_section(gamepad_count));
     }
 
-    if matches!(console, Console::GameBoy(_)) {
+    if console.system_type() == SystemType::GameBoy {
         return format!("{hotkeys}{}", gameboy_keyboard_section(gamepad_count));
     }
 
-    if matches!(console, Console::Snes(_)) {
+    if console.system_type() == SystemType::Snes {
         return format!("{hotkeys}{}", snes_keyboard_section(gamepad_count));
     }
 

--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -194,7 +194,7 @@ impl NativeEventLoop {
         match self.console.system_type() {
             SystemType::Nes => self.debugger_controller.is_paused(),
             SystemType::GameBoy => self.gb_debugger_controller.is_paused(),
-            SystemType::GameBoyAdvance | SystemType::Snes => false,
+            SystemType::Gba | SystemType::Snes => false,
         }
     }
 
@@ -202,7 +202,7 @@ impl NativeEventLoop {
         match self.console.system_type() {
             SystemType::Nes => self.debugger_controller.is_debugger_open(),
             SystemType::GameBoy => self.gb_debugger_controller.is_debugger_open(),
-            SystemType::GameBoyAdvance | SystemType::Snes => false,
+            SystemType::Gba | SystemType::Snes => false,
         }
     }
 
@@ -1025,14 +1025,11 @@ impl ApplicationHandler for NativeEventLoop {
                 };
                 if let Some(nes) = self.console.as_nes_mut() {
                     self.debugger_controller.apply_ui_action(nes, action);
-                } else if let Some(gb) = self.console.as_gameboy_mut() {
-                    if let Some(ref mut gl) = self.gl_wrapper {
-                        let gb_action = gl.take_gb_debugger_action();
-                        gb.apply_ui_action_with_controller(
-                            &mut self.gb_debugger_controller,
-                            gb_action,
-                        );
-                    }
+                } else if let Some(gb) = self.console.as_gameboy_mut()
+                    && let Some(ref mut gl) = self.gl_wrapper
+                {
+                    let gb_action = gl.take_gb_debugger_action();
+                    gb.apply_ui_action_with_controller(&mut self.gb_debugger_controller, gb_action);
                 }
                 self.sync_from_controller();
             }

--- a/src/frontends/native/event_loop.rs
+++ b/src/frontends/native/event_loop.rs
@@ -17,7 +17,7 @@ use crate::platform::audio::{EmulatorAudio, normalize_nes_sample};
 use crate::platform::autorun::AutorunMode;
 use crate::platform::autorun::state::AutorunState;
 use crate::platform::debugging::Tracing;
-use crate::platform::emulator::{Console, Emulator};
+use crate::platform::emulator::{Console, Emulator, SystemType};
 use crate::platform::frontend_toasts::{
     gamepad_connected_toast_message, gamepad_disconnected_toast_message, gamepad_init_toast_message,
 };
@@ -190,12 +190,24 @@ impl NativeEventLoop {
         }
     }
 
+    fn debugger_paused(&self) -> bool {
+        match self.console.system_type() {
+            SystemType::Nes => self.debugger_controller.is_paused(),
+            SystemType::GameBoy => self.gb_debugger_controller.is_paused(),
+            SystemType::GameBoyAdvance | SystemType::Snes => false,
+        }
+    }
+
+    fn debugger_open(&self) -> bool {
+        match self.console.system_type() {
+            SystemType::Nes => self.debugger_controller.is_debugger_open(),
+            SystemType::GameBoy => self.gb_debugger_controller.is_debugger_open(),
+            SystemType::GameBoyAdvance | SystemType::Snes => false,
+        }
+    }
+
     fn run_frame(&mut self) {
-        let debugger_paused = match &self.console {
-            Console::Nes(_) => self.debugger_controller.is_paused(),
-            Console::GameBoy(_) => self.gb_debugger_controller.is_paused(),
-            Console::GameBoyAdvance(_) | Console::Snes(_) => false, // GBA and SNES debuggers not yet implemented
-        };
+        let debugger_paused = self.debugger_paused();
         if self.state.paused && !debugger_paused {
             // Manually paused (not debugger) — skip frame
             return;
@@ -219,43 +231,37 @@ impl NativeEventLoop {
 
         let audio = self.audio.take();
         let audio_cell = std::cell::RefCell::new(audio);
-        match &mut self.console {
-            Console::Nes(nes) => {
-                self.debugger_controller
-                    .run_frame(nes, &self.tracing, &mut |nes| {
-                        if let Some(ref mut audio) = *audio_cell.borrow_mut() {
-                            while nes.sample_ready() {
-                                if let Some(sample) = nes.get_sample() {
-                                    audio.queue_sample(normalize_nes_sample(sample));
-                                }
+        if let Some(nes) = self.console.as_nes_mut() {
+            self.debugger_controller
+                .run_frame(nes, &self.tracing, &mut |nes| {
+                    if let Some(ref mut audio) = *audio_cell.borrow_mut() {
+                        while nes.sample_ready() {
+                            if let Some(sample) = nes.get_sample() {
+                                audio.queue_sample(normalize_nes_sample(sample));
                             }
                         }
-                    });
-            }
-            Console::GameBoy(gb) => {
-                gb.run_frame_with_debugger(&mut self.gb_debugger_controller, &audio_cell);
-            }
-            Console::GameBoyAdvance(gba) => {
-                while !gba.is_ready_to_render() {
-                    let _ = gba.run_tick();
-                    if let Some(ref mut audio) = *audio_cell.borrow_mut() {
-                        while gba.sample_ready() {
-                            if let Some((left, right)) = gba.get_stereo_sample() {
-                                audio.queue_stereo_sample(left, right);
-                            }
+                    }
+                });
+        } else if let Some(gb) = self.console.as_gameboy_mut() {
+            gb.run_frame_with_debugger(&mut self.gb_debugger_controller, &audio_cell);
+        } else if let Some(gba) = self.console.as_gba_mut() {
+            while !gba.is_ready_to_render() {
+                let _ = gba.run_tick();
+                if let Some(ref mut audio) = *audio_cell.borrow_mut() {
+                    while gba.sample_ready() {
+                        if let Some((left, right)) = gba.get_stereo_sample() {
+                            audio.queue_stereo_sample(left, right);
                         }
                     }
                 }
             }
-            Console::Snes(snes) => {
-                // SNES: run frame without debugger support
-                while !snes.is_ready_to_render() {
-                    let _ = snes.run_tick();
-                    if let Some(ref mut audio) = *audio_cell.borrow_mut() {
-                        while snes.sample_ready() {
-                            if let Some(sample) = snes.get_sample() {
-                                audio.queue_sample(sample);
-                            }
+        } else if let Some(snes) = self.console.as_snes_mut() {
+            while !snes.is_ready_to_render() {
+                let _ = snes.run_tick();
+                if let Some(ref mut audio) = *audio_cell.borrow_mut() {
+                    while snes.sample_ready() {
+                        if let Some(sample) = snes.get_sample() {
+                            audio.queue_sample(sample);
                         }
                     }
                 }
@@ -286,10 +292,7 @@ impl NativeEventLoop {
     /// changes to avoid underruns while paused.
     fn sync_audio_state(&self) {
         if let Some(ref audio) = self.audio {
-            if audio_should_be_paused(
-                self.state.window_focused,
-                self.debugger_controller.is_paused(),
-            ) {
+            if audio_should_be_paused(self.state.window_focused, self.debugger_paused()) {
                 audio.pause();
             } else {
                 audio.resume();
@@ -299,11 +302,7 @@ impl NativeEventLoop {
 
     /// Sync frontend state from the debugger controller.
     fn sync_from_controller(&mut self) {
-        let debugger_open = match &self.console {
-            Console::Nes(_) => self.debugger_controller.is_debugger_open(),
-            Console::GameBoy(_) => self.gb_debugger_controller.is_debugger_open(),
-            Console::GameBoyAdvance(_) | Console::Snes(_) => false, // GBA and SNES debuggers not yet implemented
-        };
+        let debugger_open = self.debugger_open();
 
         if debugger_open {
             if !self.state.debugger_open {
@@ -400,7 +399,7 @@ impl NativeEventLoop {
 
     /// Loads a new cartridge from the given ROM path and resets the emulator.
     fn switch_to_cartridge(&mut self, rom_path: &str) {
-        let Console::Nes(_) = &self.console else {
+        let Some(_) = self.console.as_nes() else {
             return;
         };
         let rom_bytes = match std::fs::read(rom_path) {
@@ -412,7 +411,7 @@ impl NativeEventLoop {
         };
 
         let cartridge = {
-            let Console::Nes(nes) = &self.console else {
+            let Some(nes) = self.console.as_nes() else {
                 unreachable!("console type checked above");
             };
             match crate::nes::cartridge::Cartridge::load_from_file(
@@ -439,7 +438,7 @@ impl NativeEventLoop {
                 .apply_rom_timing_mode(rom_timing)
         };
 
-        if let Console::Nes(nes) = &mut self.console {
+        if let Some(nes) = self.console.as_nes_mut() {
             nes.insert_cartridge(cartridge);
         }
         crate::nes::console::log_hardware_selection(self.console.app_context(), applied);
@@ -466,7 +465,7 @@ impl NativeEventLoop {
                 let save_state =
                     crate::nes::console::SaveState::from_bytes(&restore.state_bytes)
                         .map_err(|e| format!("Failed to deserialize checkpoint state: {e}"))?;
-                if let Console::Nes(nes) = &mut self.console {
+                if let Some(nes) = self.console.as_nes_mut() {
                     nes.load_state(&save_state)
                         .map_err(|e| format!("Failed to restore checkpoint state: {e}"))?;
                 }
@@ -618,7 +617,7 @@ impl NativeEventLoop {
 
             let checkpoint_due = self.handle_autorun_after_input();
 
-            if let Console::Nes(nes) = &mut self.console {
+            if let Some(nes) = self.console.as_nes_mut() {
                 crate::nes::autorun::headless_playback::run_one_frame(nes);
             }
 
@@ -644,7 +643,7 @@ impl ApplicationHandler for NativeEventLoop {
                 if !self.initialized {
                     self.initialize_audio();
                     self.sync_audio_state();
-                    if let Console::Nes(nes) = &self.console {
+                    if let Some(nes) = self.console.as_nes() {
                         let watches = self.debugger_controller.load_debug_state_from_file(nes);
                         if let Some(ref mut gl) = self.gl_wrapper {
                             gl.set_watch_addresses(watches);
@@ -671,7 +670,7 @@ impl ApplicationHandler for NativeEventLoop {
                 if let Err(e) = self.finish_recording() {
                     eprintln!("Failed to finish recording on window close: {e}");
                 }
-                if let Console::Nes(nes) = &self.console {
+                if let Some(nes) = self.console.as_nes() {
                     let watches = self
                         .gl_wrapper
                         .as_ref()
@@ -761,7 +760,7 @@ impl ApplicationHandler for NativeEventLoop {
                             if let Err(e) = self.finish_recording() {
                                 eprintln!("Failed to finish recording on quit: {e}");
                             }
-                            if let Console::Nes(nes) = &self.console {
+                            if let Some(nes) = self.console.as_nes() {
                                 let watches = self
                                     .gl_wrapper
                                     .as_ref()
@@ -786,46 +785,28 @@ impl ApplicationHandler for NativeEventLoop {
                             }
                         }
                         KeyOutcome::ToggleDebugger => {
-                            match &mut self.console {
-                                Console::Nes(nes) => {
-                                    self.debugger_controller.toggle_debugger(nes);
-                                }
-                                Console::GameBoy(gb) => {
-                                    gb.toggle_debugger_with_controller(
-                                        &mut self.gb_debugger_controller,
-                                    );
-                                }
-                                Console::GameBoyAdvance(_) | Console::Snes(_) => {
-                                    // GBA and SNES debuggers not yet implemented
-                                }
+                            if let Some(nes) = self.console.as_nes_mut() {
+                                self.debugger_controller.toggle_debugger(nes);
+                            } else if let Some(gb) = self.console.as_gameboy_mut() {
+                                gb.toggle_debugger_with_controller(
+                                    &mut self.gb_debugger_controller,
+                                );
                             }
                             self.sync_from_controller();
                         }
                         KeyOutcome::StepOver => {
-                            match &mut self.console {
-                                Console::Nes(nes) => {
-                                    self.debugger_controller.step_over(nes);
-                                }
-                                Console::GameBoy(gb) => {
-                                    gb.step_over_with_controller(&mut self.gb_debugger_controller);
-                                }
-                                Console::GameBoyAdvance(_) | Console::Snes(_) => {
-                                    // GBA and SNES debuggers not yet implemented
-                                }
+                            if let Some(nes) = self.console.as_nes_mut() {
+                                self.debugger_controller.step_over(nes);
+                            } else if let Some(gb) = self.console.as_gameboy_mut() {
+                                gb.step_over_with_controller(&mut self.gb_debugger_controller);
                             }
                             self.sync_from_controller();
                         }
                         KeyOutcome::StepInto => {
-                            match &mut self.console {
-                                Console::Nes(nes) => {
-                                    self.debugger_controller.step_into(nes);
-                                }
-                                Console::GameBoy(gb) => {
-                                    gb.step_into_with_controller(&mut self.gb_debugger_controller);
-                                }
-                                Console::GameBoyAdvance(_) | Console::Snes(_) => {
-                                    // GBA and SNES debuggers not yet implemented
-                                }
+                            if let Some(nes) = self.console.as_nes_mut() {
+                                self.debugger_controller.step_into(nes);
+                            } else if let Some(gb) = self.console.as_gameboy_mut() {
+                                gb.step_into_with_controller(&mut self.gb_debugger_controller);
                             }
                             self.sync_from_controller();
                         }
@@ -850,7 +831,7 @@ impl ApplicationHandler for NativeEventLoop {
                             self.state.show_fps = !self.state.show_fps;
                         }
                         KeyOutcome::CyclePalette => {
-                            if let Console::Nes(nes) = &mut self.console {
+                            if let Some(nes) = self.console.as_nes_mut() {
                                 let palette = nes.cycle_palette();
                                 let toast =
                                     crate::nes::frontend_toasts::palette_toast_message(palette);
@@ -980,7 +961,7 @@ impl ApplicationHandler for NativeEventLoop {
                 // Likewise, when the NES runs with audio disabled (--no-audio),
                 // there is no ring-buffer back-pressure either.
                 // Apply the same elapsed-time guard in both cases.
-                let is_game_boy = matches!(&self.console, Console::GameBoy(_));
+                let is_game_boy = self.console.system_type() == SystemType::GameBoy;
                 let audio_disabled = self.audio.is_none();
                 let frame_guard =
                     needs_frame_guard(using_manual_throttle, is_game_boy, audio_disabled);
@@ -1018,16 +999,10 @@ impl ApplicationHandler for NativeEventLoop {
 
                 // Render and apply debugger UI actions
                 let action = if let Some(ref mut gl) = self.gl_wrapper {
-                    match &self.console {
-                        Console::Nes(_) => {
-                            gl.update_breakpoints(self.debugger_controller.breakpoints());
-                        }
-                        Console::GameBoy(_) => {
-                            gl.update_gb_breakpoints(self.gb_debugger_controller.breakpoints());
-                        }
-                        Console::GameBoyAdvance(_) | Console::Snes(_) => {
-                            // GBA and SNES debugger breakpoints not yet implemented
-                        }
+                    if self.console.as_nes().is_some() {
+                        gl.update_breakpoints(self.debugger_controller.breakpoints());
+                    } else if self.console.as_gameboy().is_some() {
+                        gl.update_gb_breakpoints(self.gb_debugger_controller.breakpoints());
                     }
                     let crosshair =
                         mouse::zapper_crosshair(&self.console, self.state.last_zapper_position);
@@ -1048,21 +1023,15 @@ impl ApplicationHandler for NativeEventLoop {
                 } else {
                     Default::default()
                 };
-                match &mut self.console {
-                    Console::Nes(nes) => {
-                        self.debugger_controller.apply_ui_action(nes, action);
-                    }
-                    Console::GameBoy(gb) => {
-                        if let Some(ref mut gl) = self.gl_wrapper {
-                            let gb_action = gl.take_gb_debugger_action();
-                            gb.apply_ui_action_with_controller(
-                                &mut self.gb_debugger_controller,
-                                gb_action,
-                            );
-                        }
-                    }
-                    Console::GameBoyAdvance(_) | Console::Snes(_) => {
-                        // GBA and SNES debugger UI not yet implemented
+                if let Some(nes) = self.console.as_nes_mut() {
+                    self.debugger_controller.apply_ui_action(nes, action);
+                } else if let Some(gb) = self.console.as_gameboy_mut() {
+                    if let Some(ref mut gl) = self.gl_wrapper {
+                        let gb_action = gl.take_gb_debugger_action();
+                        gb.apply_ui_action_with_controller(
+                            &mut self.gb_debugger_controller,
+                            gb_action,
+                        );
                     }
                 }
                 self.sync_from_controller();
@@ -1170,7 +1139,7 @@ impl ApplicationHandler for NativeEventLoop {
             } else if should_use_manual_frame_throttle(
                 self.vsync_enabled,
                 self.state.window_focused,
-            ) || matches!(&self.console, Console::GameBoy(_))
+            ) || self.console.as_gameboy().is_some()
             {
                 // Manual frame limiting: advance deadline by target interval.
                 // The GameBoy branch is included here because it has no audio

--- a/src/frontends/native/gamepad.rs
+++ b/src/frontends/native/gamepad.rs
@@ -5,7 +5,7 @@
 //! hot-plug player assignment.
 
 use crate::nes::input::{Button, ControllerInput, SnesButton};
-use crate::platform::emulator::Console;
+use crate::platform::emulator::{Console, SystemType};
 
 use gilrs::{Axis, EventType, GamepadId, Gilrs, GilrsBuilder};
 
@@ -364,34 +364,32 @@ impl GamepadManager {
     ) -> Option<GamepadChange> {
         if let Some(player_num) = self.player_map.get(&id).copied() {
             // Release all held buttons for this gamepad's port before removing.
-            match console {
-                Console::Nes(nes) => {
-                    if let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) {
-                        use Button::{A, B, Down, Left, Right, Select, Start, Up};
-                        for button in [A, B, Select, Start, Up, Down, Left, Right] {
-                            nes.set_button(port, button, false);
-                        }
-                        use SnesButton as S;
-                        for snes_btn in [
-                            S::A,
-                            S::B,
-                            S::X,
-                            S::Y,
-                            S::L,
-                            S::R,
-                            S::Start,
-                            S::Select,
-                            S::Up,
-                            S::Down,
-                            S::Left,
-                            S::Right,
-                        ] {
-                            nes.set_snes_button(port, snes_btn, false);
-                        }
+            if let Some(nes) = console.as_nes_mut() {
+                if let Some(port) = Self::assigned_port(nes, &self.player_map, player_num) {
+                    use Button::{A, B, Down, Left, Right, Select, Start, Up};
+                    for button in [A, B, Select, Start, Up, Down, Left, Right] {
+                        nes.set_button(port, button, false);
+                    }
+                    use SnesButton as S;
+                    for snes_btn in [
+                        S::A,
+                        S::B,
+                        S::X,
+                        S::Y,
+                        S::L,
+                        S::R,
+                        S::Start,
+                        S::Select,
+                        S::Up,
+                        S::Down,
+                        S::Left,
+                        S::Right,
+                    ] {
+                        nes.set_snes_button(port, snes_btn, false);
                     }
                 }
-                Console::Snes(_) => release_snes_buttons_for_player(console, player_num),
-                _ => {}
+            } else if console.as_snes().is_some() {
+                release_snes_buttons_for_player(console, player_num);
             }
 
             self.player_map.remove(&id);
@@ -402,7 +400,7 @@ impl GamepadManager {
             self.reassign_players();
 
             // Release all buttons when the last gamepad disconnects (non-NES systems).
-            if !matches!(console, Console::Nes(_)) && self.player_map.is_empty() {
+            if console.system_type() != SystemType::Nes && self.player_map.is_empty() {
                 console.set_joypad_button_states(0, 0);
             }
 
@@ -474,7 +472,7 @@ impl GamepadManager {
         button: gilrs::Button,
         pressed: bool,
     ) {
-        if let Console::Nes(nes) = console {
+        if let Some(nes) = console.as_nes_mut() {
             let Some(&player_num) = self.player_map.get(&id) else {
                 return;
             };
@@ -490,7 +488,7 @@ impl GamepadManager {
             if let Some(nes_btn) = map_button_to_nes(button) {
                 nes.set_button(port, nes_btn, pressed);
             }
-        } else if let Console::Snes(_) = console {
+        } else if console.as_snes().is_some() {
             let Some(&player_num) = self.player_map.get(&id) else {
                 return;
             };
@@ -517,7 +515,7 @@ impl GamepadManager {
             _ => return,
         };
 
-        if let Console::Nes(nes) = console {
+        if let Some(nes) = console.as_nes_mut() {
             let Some(&player_num) = self.player_map.get(&id) else {
                 return;
             };
@@ -533,7 +531,7 @@ impl GamepadManager {
                 }
                 nes.set_button(port, button, pressed);
             }
-        } else if let Console::Snes(_) = console {
+        } else if console.as_snes().is_some() {
             let Some(&player_num) = self.player_map.get(&id) else {
                 return;
             };

--- a/src/frontends/native/gl_backend.rs
+++ b/src/frontends/native/gl_backend.rs
@@ -4,10 +4,9 @@ use crate::frontends::native::input::{EguiInputState, InputEvent};
 use crate::frontends::native::shader_manager::ShaderManager;
 use crate::gb::debugging::GbDebuggerViewState;
 use crate::gb::debugging::debugger_ui as gb_debugger_ui;
-use crate::nes::console::Nes;
 use crate::nes::debugging::DebuggerViewState;
 use crate::nes::debugging::ppu_viewer::{
-    PpuViewerSnapshot, render_nametables_rgba, render_pattern_tables_rgba,
+    PpuViewerSnapshot as NesPpuViewerSnapshot, render_nametables_rgba, render_pattern_tables_rgba,
 };
 use crate::nes::debugging::ui::{
     self as debugger_ui, BreakpointAddUiState, HexdumpUiState, WatchlistUiState,
@@ -15,7 +14,7 @@ use crate::nes::debugging::ui::{
 use crate::platform::app_context::SharedAppContext;
 use crate::platform::debugging::breakpoints::BreakpointList;
 use crate::platform::debugging::log_info;
-use crate::platform::emulator::Console;
+use crate::platform::emulator::{Console, PpuViewerSnapshotKind};
 use std::ffi::c_void;
 use std::rc::Rc;
 use std::time::Instant;
@@ -666,7 +665,7 @@ impl GlBackend {
     /// Renders the current frame and optional debugger overlay.
     ///
     /// Accepts a `&Console` so it works for both NES and Game Boy. The debugger
-    /// overlay is only drawn when `console` is a `Console::Nes` variant.
+    /// overlay is only drawn when `console` exposes the matching debugger state.
     pub fn render(
         &mut self,
         console: &Console,
@@ -788,39 +787,53 @@ impl GlBackend {
         }
 
         let visible_toasts = self.app_context.borrow_mut().visible_toasts(now);
-        let nes_ppu_viewer_scroll = if show_debugger
-            && let Console::Nes(nes) = console
-            && self.debugger_view_state.is_ppu_viewer_visible()
+        let ppu_viewer_snapshot = if show_debugger
+            && (self.debugger_view_state.is_ppu_viewer_visible()
+                || self.gb_debugger_view_state.is_ppu_viewer_visible())
         {
-            Some(update_ppu_viewer_textures(
-                nes,
-                self.ppu_viewer_nt_texture,
-                self.ppu_viewer_tiles_texture,
-            ))
+            console
+                .as_ppu_viewer()
+                .map(|viewer| viewer.create_ppu_viewer_snapshot())
         } else {
             None
         };
-        let gb_ppu_viewer_snapshot = if show_debugger
-            && let Console::GameBoy(gb) = console
-            && self.gb_debugger_view_state.is_ppu_viewer_visible()
-        {
-            let ppu_snap = gb.create_ppu_viewer_snapshot();
-            update_gb_ppu_viewer_textures_from_snapshot(
-                &ppu_snap,
-                self.gb_ppu_viewer_tiles_texture,
-                self.gb_ppu_viewer_bg_maps_texture,
-            );
-            Some(ppu_snap)
+        let nes_ppu_viewer_scroll =
+            ppu_viewer_snapshot
+                .as_ref()
+                .and_then(|snapshot| match snapshot {
+                    PpuViewerSnapshotKind::Nes(nes_snap) => Some(update_ppu_viewer_textures(
+                        nes_snap,
+                        self.ppu_viewer_nt_texture,
+                        self.ppu_viewer_tiles_texture,
+                    )),
+                    _ => None,
+                });
+        let gb_ppu_viewer_snapshot = if self.gb_debugger_view_state.is_ppu_viewer_visible() {
+            match ppu_viewer_snapshot.as_ref() {
+                Some(PpuViewerSnapshotKind::GameBoy(gb_snap)) => {
+                    update_gb_ppu_viewer_textures_from_snapshot(
+                        gb_snap,
+                        self.gb_ppu_viewer_tiles_texture,
+                        self.gb_ppu_viewer_bg_maps_texture,
+                    );
+                    Some(gb_snap)
+                }
+                _ => None,
+            }
         } else {
             None
         };
-        let nes_debugger_snapshot = if show_debugger && let Console::Nes(nes) = console {
-            Some(self.debugger_view_state.snapshot(nes))
+        let nes_debugger_snapshot = if show_debugger {
+            console
+                .as_nes()
+                .map(|nes| self.debugger_view_state.snapshot(nes))
         } else {
             None
         };
-        let gb_debugger_snapshot = if show_debugger && let Console::GameBoy(gb) = console {
-            Some(gb.create_debugger_snapshot(&mut self.gb_debugger_view_state))
+        let gb_debugger_snapshot = if show_debugger {
+            console
+                .as_gameboy()
+                .map(|gb| gb.create_debugger_snapshot(&mut self.gb_debugger_view_state))
         } else {
             None
         };
@@ -896,7 +909,7 @@ impl GlBackend {
                             scroll,
                         );
                     }
-                    if let Some(ppu_snap) = gb_ppu_viewer_snapshot.as_ref() {
+                    if let Some(ppu_snap) = gb_ppu_viewer_snapshot {
                         draw_gb_ppu_viewer_window(
                             ui,
                             gb_ppu_viewer_tiles_texture_id,
@@ -1527,13 +1540,12 @@ fn scroll_rect_line_segments(
     segments
 }
 
-/// Upload pixel data for the PPU nametable and pattern table textures from the current NES state.
+/// Upload pixel data for the NES PPU nametable and pattern table textures from a snapshot.
 fn update_ppu_viewer_textures(
-    nes: &Nes,
+    ppu_snap: &NesPpuViewerSnapshot,
     nt_texture: gl::types::GLuint,
     tiles_texture: gl::types::GLuint,
 ) -> (u16, u16) {
-    let ppu_snap = PpuViewerSnapshot::from_nes(nes);
     let nt_pixels = render_nametables_rgba(
         &ppu_snap.chr,
         &ppu_snap.nametables,

--- a/src/frontends/native/gl_backend.rs
+++ b/src/frontends/native/gl_backend.rs
@@ -812,7 +812,7 @@ impl GlBackend {
             match ppu_viewer_snapshot.as_ref() {
                 Some(PpuViewerSnapshotKind::GameBoy(gb_snap)) => {
                     update_gb_ppu_viewer_textures_from_snapshot(
-                        gb_snap,
+                        gb_snap.as_ref(),
                         self.gb_ppu_viewer_tiles_texture,
                         self.gb_ppu_viewer_bg_maps_texture,
                     );

--- a/src/frontends/native/gl_backend.rs
+++ b/src/frontends/native/gl_backend.rs
@@ -14,7 +14,7 @@ use crate::nes::debugging::ui::{
 use crate::platform::app_context::SharedAppContext;
 use crate::platform::debugging::breakpoints::BreakpointList;
 use crate::platform::debugging::log_info;
-use crate::platform::emulator::{Console, PpuViewerSnapshotKind};
+use crate::platform::emulator::{Console, PpuViewerSnapshotKind, SystemType};
 use std::ffi::c_void;
 use std::rc::Rc;
 use std::time::Instant;
@@ -787,13 +787,18 @@ impl GlBackend {
         }
 
         let visible_toasts = self.app_context.borrow_mut().visible_toasts(now);
-        let ppu_viewer_snapshot = if show_debugger
-            && (self.debugger_view_state.is_ppu_viewer_visible()
-                || self.gb_debugger_view_state.is_ppu_viewer_visible())
-        {
-            console
-                .as_ppu_viewer()
-                .map(|viewer| viewer.create_ppu_viewer_snapshot())
+        let ppu_viewer_snapshot = if show_debugger {
+            match console.system_type() {
+                SystemType::Nes if self.debugger_view_state.is_ppu_viewer_visible() => console
+                    .as_ppu_viewer()
+                    .map(|viewer| viewer.create_ppu_viewer_snapshot()),
+                SystemType::GameBoy if self.gb_debugger_view_state.is_ppu_viewer_visible() => {
+                    console
+                        .as_ppu_viewer()
+                        .map(|viewer| viewer.create_ppu_viewer_snapshot())
+                }
+                _ => None,
+            }
         } else {
             None
         };
@@ -808,20 +813,18 @@ impl GlBackend {
                     )),
                     _ => None,
                 });
-        let gb_ppu_viewer_snapshot = if self.gb_debugger_view_state.is_ppu_viewer_visible() {
-            match ppu_viewer_snapshot.as_ref() {
-                Some(PpuViewerSnapshotKind::GameBoy(gb_snap)) => {
-                    update_gb_ppu_viewer_textures_from_snapshot(
-                        gb_snap.as_ref(),
-                        self.gb_ppu_viewer_tiles_texture,
-                        self.gb_ppu_viewer_bg_maps_texture,
-                    );
-                    Some(gb_snap)
-                }
-                _ => None,
+        let gb_ppu_viewer_snapshot = match ppu_viewer_snapshot.as_ref() {
+            Some(PpuViewerSnapshotKind::GameBoy(gb_snap))
+                if self.gb_debugger_view_state.is_ppu_viewer_visible() =>
+            {
+                update_gb_ppu_viewer_textures_from_snapshot(
+                    gb_snap.as_ref(),
+                    self.gb_ppu_viewer_tiles_texture,
+                    self.gb_ppu_viewer_bg_maps_texture,
+                );
+                Some(gb_snap)
             }
-        } else {
-            None
+            _ => None,
         };
         let nes_debugger_snapshot = if show_debugger {
             console

--- a/src/frontends/native/keyboard/controller_mapping.rs
+++ b/src/frontends/native/keyboard/controller_mapping.rs
@@ -72,7 +72,7 @@ pub(super) fn handle_controller_key(
     pressed: bool,
     ports: &[u8],
 ) {
-    let Console::Nes(nes) = console else {
+    let Some(nes) = console.as_nes_mut() else {
         return;
     };
     match key_code {

--- a/src/frontends/native/keyboard/mod.rs
+++ b/src/frontends/native/keyboard/mod.rs
@@ -8,7 +8,7 @@
 
 use crate::frontends::native::app_state::NativeAppState;
 use crate::platform::audio::EmulatorAudio;
-use crate::platform::emulator::Console;
+use crate::platform::emulator::{Console, SystemType};
 use winit::keyboard::KeyCode;
 
 mod console_keyboard;
@@ -58,8 +58,8 @@ pub fn handle_key_pressed(
     app_state: &mut NativeAppState,
     audio: Option<&dyn EmulatorAudio>,
 ) -> KeyOutcome {
-    match console {
-        Console::Nes(_) => {
+    match console.system_type() {
+        SystemType::Nes => {
             if app_state.cart_switch.open {
                 return hotkeys::handle_cartridge_switch_key(key_code, app_state);
             }
@@ -68,13 +68,13 @@ pub fn handle_key_pressed(
             }
             console_keyboard::handle_unmodified_key(console, key_code, app_state, audio)
         }
-        Console::GameBoy(_) => {
+        SystemType::GameBoy => {
             console_keyboard::handle_gameboy_key_pressed(console, key_code, app_state, audio)
         }
-        Console::GameBoyAdvance(_) => {
+        SystemType::Gba => {
             console_keyboard::handle_gba_key_pressed(console, key_code, app_state, audio)
         }
-        Console::Snes(_) => {
+        SystemType::Snes => {
             console_keyboard::handle_snes_key_pressed(console, key_code, app_state, audio)
         }
     }
@@ -94,22 +94,22 @@ pub fn handle_key_released(
     gamepad_count: usize,
     four_score: bool,
 ) {
-    match console {
-        Console::Nes(_) => {
+    match console.system_type() {
+        SystemType::Nes => {
             let ports = keyboard_target_ports(gamepad_count, four_score);
             controller_mapping::handle_controller_key(console, key_code, false, ports);
         }
-        Console::GameBoy(_) => {
+        SystemType::GameBoy => {
             if let Some(btn_id) = controller_mapping::gameboy_key_to_button_id(key_code) {
                 console.set_button(0, btn_id, false);
             }
         }
-        Console::GameBoyAdvance(_) => {
+        SystemType::Gba => {
             if let Some(btn_id) = controller_mapping::gba_key_to_button_id(key_code) {
                 console.set_button(0, btn_id, false);
             }
         }
-        Console::Snes(_) => {
+        SystemType::Snes => {
             if let Some(btn_id) = controller_mapping::snes_key_to_button_id(key_code) {
                 console.set_button(0, btn_id, false);
             }

--- a/src/frontends/native/mouse.rs
+++ b/src/frontends/native/mouse.rs
@@ -17,9 +17,10 @@ pub enum MouseButton {
 
 // ── Device detection ─────────────────────────────────────────────────────────
 
-/// Returns `true` when any controller port or expansion device uses mouse input.
+/// Returns `true` when the current console exposes any mouse-driven controller.
 ///
-/// Always returns `false` for non-NES consoles.
+/// This includes NES Zapper / paddle input and SNES mouse input, and returns
+/// `false` for consoles without mouse-capable controllers.
 pub fn has_any_mouse_controller(console: &Console) -> bool {
     console
         .as_mouse_input()
@@ -27,8 +28,6 @@ pub fn has_any_mouse_controller(console: &Console) -> bool {
 }
 
 /// Returns `true` when a Zapper is connected on any port or expansion.
-///
-/// Always returns `false` for non-NES consoles.
 pub fn has_zapper(console: &Console) -> bool {
     console
         .as_mouse_input()

--- a/src/frontends/native/mouse.rs
+++ b/src/frontends/native/mouse.rs
@@ -68,9 +68,7 @@ pub fn update_mouse_motion(
     window_width: u32,
     window_height: u32,
 ) -> Option<(u8, u8)> {
-    let Some(mouse) = console.as_mouse_input_mut() else {
-        return None;
-    };
+    let mouse = console.as_mouse_input_mut()?;
     if mouse.has_zapper() || mouse.has_snes_mouse() {
         let x_pos = mouse_mapping::map_mouse_axis_to_zapper_position(x, window_width);
         let y_pos = mouse_mapping::map_mouse_axis_to_zapper_position(y, window_height);
@@ -126,9 +124,7 @@ pub fn update_mouse_button(console: &mut Console, button: MouseButton, pressed: 
 ///
 /// Always returns `None` for non-NES consoles.
 pub fn zapper_crosshair(console: &Console, last_position: Option<(u8, u8)>) -> Option<Crosshair> {
-    let Some(mouse) = console.as_mouse_input() else {
-        return None;
-    };
+    let mouse = console.as_mouse_input()?;
     if !mouse.has_zapper() {
         None
     } else {

--- a/src/frontends/native/mouse.rs
+++ b/src/frontends/native/mouse.rs
@@ -5,9 +5,8 @@
 //! grab/release state machine.
 
 use crate::frontends::native::gl_backend::Crosshair;
-use crate::nes::input::ControllerInput;
 use crate::nes::input::mouse_mapping;
-use crate::platform::emulator::Console;
+use crate::platform::emulator::{Console, MouseInputButton};
 
 /// Mouse button abstraction (frontend-independent).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -22,36 +21,34 @@ pub enum MouseButton {
 ///
 /// Always returns `false` for non-NES consoles.
 pub fn has_any_mouse_controller(console: &Console) -> bool {
-    let Console::Nes(nes) = console else {
-        return false;
-    };
-    (1..=2).any(|port| nes.controller_input_type(port) == Some(ControllerInput::Mouse))
-        || nes.has_expansion_mouse_controller()
+    console
+        .as_mouse_input()
+        .is_some_and(|mouse| mouse.has_any_mouse_controller())
 }
 
 /// Returns `true` when a Zapper is connected on any port or expansion.
 ///
 /// Always returns `false` for non-NES consoles.
 pub fn has_zapper(console: &Console) -> bool {
-    let Console::Nes(nes) = console else {
-        return false;
-    };
-    (1..=2).any(|port| nes.is_zapper_active(port)) || nes.has_expansion_zapper()
+    console
+        .as_mouse_input()
+        .is_some_and(|mouse| mouse.has_zapper())
 }
 
 pub fn has_snes_mouse(console: &Console) -> bool {
-    match console {
-        Console::Nes(nes) => nes.has_snes_mouse(),
-        Console::Snes(snes) => snes.has_mouse(),
-        _ => false,
-    }
+    console
+        .as_mouse_input()
+        .is_some_and(|mouse| mouse.has_snes_mouse())
 }
 
 fn snes_mouse_ports(console: &Console) -> [bool; 2] {
-    match console {
-        Console::Snes(snes) => [snes.has_mouse_on_port(0), snes.has_mouse_on_port(1)],
-        _ => [false, false],
-    }
+    let Some(mouse) = console.as_mouse_input() else {
+        return [false, false];
+    };
+    [
+        mouse.has_snes_mouse_on_port(0),
+        mouse.has_snes_mouse_on_port(1),
+    ]
 }
 
 // ── Coordinate routing ───────────────────────────────────────────────────────
@@ -71,18 +68,17 @@ pub fn update_mouse_motion(
     window_width: u32,
     window_height: u32,
 ) -> Option<(u8, u8)> {
-    let Console::Nes(nes) = console else {
+    let Some(mouse) = console.as_mouse_input_mut() else {
         return None;
     };
-    if has_zapper_nes(nes) || nes.has_snes_mouse() {
+    if mouse.has_zapper() || mouse.has_snes_mouse() {
         let x_pos = mouse_mapping::map_mouse_axis_to_zapper_position(x, window_width);
         let y_pos = mouse_mapping::map_mouse_axis_to_zapper_position(y, window_height);
-        nes.set_mouse_x_position(x_pos);
-        nes.set_mouse_y_position(y_pos);
+        mouse.set_mouse_position(x_pos, y_pos);
         Some((x_pos, y_pos))
     } else {
         let position = mouse_mapping::map_mouse_x_to_paddle_position(x, window_width);
-        nes.set_mouse_x_position(position);
+        mouse.set_paddle_position(position);
         None
     }
 }
@@ -98,18 +94,13 @@ pub fn apply_snes_mouse_relative_motion(
     window_height: u32,
 ) {
     let snes_ports = snes_mouse_ports(console);
+    let Some(mouse) = console.as_mouse_input_mut() else {
+        return;
+    };
     let dx = mouse_mapping::map_relative_mouse_delta_to_axis_delta(xrel, window_width);
     let dy = mouse_mapping::map_relative_mouse_delta_to_axis_delta(yrel, window_height);
-    match console {
-        Console::Nes(nes) => nes.add_mouse_delta(dx, dy),
-        Console::Snes(snes) => {
-            for (port, enabled) in snes_ports.into_iter().enumerate() {
-                if enabled {
-                    snes.add_mouse_delta(port as u8, dx, dy);
-                }
-            }
-        }
-        _ => {}
+    if snes_ports.into_iter().any(|enabled| enabled) || mouse.has_snes_mouse() {
+        mouse.add_mouse_delta(dx, dy);
     }
 }
 
@@ -117,28 +108,17 @@ pub fn apply_snes_mouse_relative_motion(
 ///
 /// No-op for consoles without a mouse-driven controller.
 pub fn update_mouse_button(console: &mut Console, button: MouseButton, pressed: bool) {
-    let snes_ports = snes_mouse_ports(console);
-    match console {
-        Console::Nes(nes) => {
-            if has_any_mouse_controller_nes(nes) {
-                match button {
-                    MouseButton::Left => nes.set_mouse_left_button(pressed),
-                    MouseButton::Right => nes.set_mouse_right_button(pressed),
-                }
-            }
-        }
-        Console::Snes(snes) => {
-            for (port, enabled) in snes_ports.into_iter().enumerate() {
-                if enabled {
-                    match button {
-                        MouseButton::Left => snes.set_mouse_left_button(port as u8, pressed),
-                        MouseButton::Right => snes.set_mouse_right_button(port as u8, pressed),
-                    }
-                }
-            }
-        }
-        _ => {}
+    let Some(mouse) = console.as_mouse_input_mut() else {
+        return;
+    };
+    if !mouse.has_any_mouse_controller() && !mouse.has_snes_mouse() {
+        return;
     }
+    let capability_button = match button {
+        MouseButton::Left => MouseInputButton::Left,
+        MouseButton::Right => MouseInputButton::Right,
+    };
+    mouse.set_mouse_button(capability_button, pressed);
 }
 
 /// Returns a [`Crosshair`] for the Zapper if one is connected and a position
@@ -146,10 +126,10 @@ pub fn update_mouse_button(console: &mut Console, button: MouseButton, pressed: 
 ///
 /// Always returns `None` for non-NES consoles.
 pub fn zapper_crosshair(console: &Console, last_position: Option<(u8, u8)>) -> Option<Crosshair> {
-    let Console::Nes(nes) = console else {
+    let Some(mouse) = console.as_mouse_input() else {
         return None;
     };
-    if !has_zapper_nes(nes) {
+    if !mouse.has_zapper() {
         None
     } else {
         last_position.map(|(x, y)| Crosshair {
@@ -160,15 +140,6 @@ pub fn zapper_crosshair(console: &Console, last_position: Option<(u8, u8)>) -> O
 }
 
 // ── NES-specific internal helpers ─────────────────────────────────────────────
-
-fn has_any_mouse_controller_nes(nes: &crate::nes::console::Nes) -> bool {
-    (1..=2).any(|port| nes.controller_input_type(port) == Some(ControllerInput::Mouse))
-        || nes.has_expansion_mouse_controller()
-}
-
-fn has_zapper_nes(nes: &crate::nes::console::Nes) -> bool {
-    (1..=2).any(|port| nes.is_zapper_active(port)) || nes.has_expansion_zapper()
-}
 
 /// Scales factor applied to raw `DeviceEvent::MouseMotion` deltas when
 /// building the virtual cursor position for Zapper / Arkanoid.

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -97,9 +97,10 @@ pub trait MouseInputCapability {
 
 #[cfg(feature = "native")]
 /// PPU viewer snapshot kind exposed through a console capability.
+#[allow(clippy::large_enum_variant)]
 pub enum PpuViewerSnapshotKind {
     Nes(NesPpuViewerSnapshot),
-    GameBoy(GbPpuViewerSnapshot),
+    GameBoy(Box<GbPpuViewerSnapshot>),
 }
 
 #[cfg(feature = "native")]
@@ -202,7 +203,7 @@ impl PpuViewerCapability for Nes {
 #[cfg(feature = "native")]
 impl PpuViewerCapability for GameBoy {
     fn create_ppu_viewer_snapshot(&self) -> PpuViewerSnapshotKind {
-        PpuViewerSnapshotKind::GameBoy(GameBoy::create_ppu_viewer_snapshot(self))
+        PpuViewerSnapshotKind::GameBoy(Box::new(GameBoy::create_ppu_viewer_snapshot(self)))
     }
 }
 

--- a/src/platform/emulator.rs
+++ b/src/platform/emulator.rs
@@ -2,8 +2,8 @@
 //!
 //! The [`Console`] enum wraps system-specific emulators (currently only NES)
 //! and provides a common interface that frontends can program against.
-//! NES-specific features (debugging, PPU viewer, etc.) are accessed by
-//! matching on the [`Console::Nes`] variant directly.
+//! NES-specific features (debugging, PPU viewer, etc.) are accessed through
+//! optional capability accessors on [`Console`].
 //!
 //! The [`Emulator`] trait defines the common operations every emulated system
 //! must support.  `Console` delegates its common methods through
@@ -13,8 +13,13 @@
 use std::path::PathBuf;
 
 use crate::gb::GameBoy;
+#[cfg(feature = "native")]
+use crate::gb::debugging::ppu_viewer::GbPpuViewerSnapshot;
 use crate::gba::Gba;
 use crate::nes::console::Nes;
+#[cfg(feature = "native")]
+use crate::nes::debugging::ppu_viewer::PpuViewerSnapshot as NesPpuViewerSnapshot;
+use crate::nes::input::ControllerInput;
 use crate::platform::app_context::{IntoSharedAppContext, SharedAppContext};
 use crate::snes::console::Snes;
 
@@ -69,6 +74,136 @@ pub trait Emulator {
     fn save_ram(&self) -> Result<(), String>;
     fn app_context(&self) -> &SharedAppContext;
     fn target_frame_duration(&self) -> std::time::Duration;
+}
+
+/// Mouse button identifier for capability-based mouse routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseInputButton {
+    Left,
+    Right,
+}
+
+/// Optional mouse-related capability surface exposed by consoles.
+pub trait MouseInputCapability {
+    fn has_any_mouse_controller(&self) -> bool;
+    fn has_zapper(&self) -> bool;
+    fn has_snes_mouse(&self) -> bool;
+    fn has_snes_mouse_on_port(&self, port: u8) -> bool;
+    fn set_mouse_position(&mut self, x: u8, y: u8);
+    fn set_paddle_position(&mut self, x: u8);
+    fn add_mouse_delta(&mut self, dx: i16, dy: i16);
+    fn set_mouse_button(&mut self, button: MouseInputButton, pressed: bool);
+}
+
+#[cfg(feature = "native")]
+/// PPU viewer snapshot kind exposed through a console capability.
+pub enum PpuViewerSnapshotKind {
+    Nes(NesPpuViewerSnapshot),
+    GameBoy(GbPpuViewerSnapshot),
+}
+
+#[cfg(feature = "native")]
+/// Optional PPU viewer capability surface exposed by consoles.
+pub trait PpuViewerCapability {
+    fn create_ppu_viewer_snapshot(&self) -> PpuViewerSnapshotKind;
+}
+
+impl MouseInputCapability for Nes {
+    fn has_any_mouse_controller(&self) -> bool {
+        (1..=2).any(|port| self.controller_input_type(port) == Some(ControllerInput::Mouse))
+            || self.has_expansion_mouse_controller()
+    }
+
+    fn has_zapper(&self) -> bool {
+        (1..=2).any(|port| self.is_zapper_active(port)) || self.has_expansion_zapper()
+    }
+
+    fn has_snes_mouse(&self) -> bool {
+        Nes::has_snes_mouse(self)
+    }
+
+    fn has_snes_mouse_on_port(&self, _port: u8) -> bool {
+        false
+    }
+
+    fn set_mouse_position(&mut self, x: u8, y: u8) {
+        self.set_mouse_x_position(x);
+        self.set_mouse_y_position(y);
+    }
+
+    fn set_paddle_position(&mut self, x: u8) {
+        self.set_mouse_x_position(x);
+    }
+
+    fn add_mouse_delta(&mut self, dx: i16, dy: i16) {
+        Nes::add_mouse_delta(self, dx, dy);
+    }
+
+    fn set_mouse_button(&mut self, button: MouseInputButton, pressed: bool) {
+        match button {
+            MouseInputButton::Left => self.set_mouse_left_button(pressed),
+            MouseInputButton::Right => self.set_mouse_right_button(pressed),
+        }
+    }
+}
+
+impl MouseInputCapability for Snes {
+    fn has_any_mouse_controller(&self) -> bool {
+        self.has_mouse()
+    }
+
+    fn has_zapper(&self) -> bool {
+        false
+    }
+
+    fn has_snes_mouse(&self) -> bool {
+        self.has_mouse()
+    }
+
+    fn has_snes_mouse_on_port(&self, port: u8) -> bool {
+        self.has_mouse_on_port(port)
+    }
+
+    fn set_mouse_position(&mut self, _x: u8, _y: u8) {
+        // SNES mouse uses relative motion only.
+    }
+
+    fn set_paddle_position(&mut self, _x: u8) {
+        // SNES has no NES-style paddle absolute X routing.
+    }
+
+    fn add_mouse_delta(&mut self, dx: i16, dy: i16) {
+        for port in 0..=1u8 {
+            if self.has_mouse_on_port(port) {
+                self.add_mouse_delta(port, dx, dy);
+            }
+        }
+    }
+
+    fn set_mouse_button(&mut self, button: MouseInputButton, pressed: bool) {
+        for port in 0..=1u8 {
+            if self.has_mouse_on_port(port) {
+                match button {
+                    MouseInputButton::Left => self.set_mouse_left_button(port, pressed),
+                    MouseInputButton::Right => self.set_mouse_right_button(port, pressed),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+impl PpuViewerCapability for Nes {
+    fn create_ppu_viewer_snapshot(&self) -> PpuViewerSnapshotKind {
+        PpuViewerSnapshotKind::Nes(NesPpuViewerSnapshot::from_nes(self))
+    }
+}
+
+#[cfg(feature = "native")]
+impl PpuViewerCapability for GameBoy {
+    fn create_ppu_viewer_snapshot(&self) -> PpuViewerSnapshotKind {
+        PpuViewerSnapshotKind::GameBoy(GameBoy::create_ppu_viewer_snapshot(self))
+    }
 }
 
 /// Identifies which emulated system a [`Console`] instance is running.
@@ -136,6 +271,98 @@ impl Console {
             Console::GameBoy(gb) => gb.as_mut(),
             Console::GameBoyAdvance(gba) => gba.as_mut(),
             Console::Snes(snes) => snes.as_mut(),
+        }
+    }
+
+    /// Access mouse capability for consoles that support mouse-driven input.
+    pub fn as_mouse_input(&self) -> Option<&dyn MouseInputCapability> {
+        match self {
+            Console::Nes(nes) => Some(nes.as_ref()),
+            Console::Snes(snes) => Some(snes.as_ref()),
+            Console::GameBoy(_) | Console::GameBoyAdvance(_) => None,
+        }
+    }
+
+    /// Mutable access to mouse capability for consoles that support it.
+    pub fn as_mouse_input_mut(&mut self) -> Option<&mut dyn MouseInputCapability> {
+        match self {
+            Console::Nes(nes) => Some(nes.as_mut()),
+            Console::Snes(snes) => Some(snes.as_mut()),
+            Console::GameBoy(_) | Console::GameBoyAdvance(_) => None,
+        }
+    }
+
+    /// Access the NES emulator, if this console is running NES hardware.
+    pub fn as_nes(&self) -> Option<&Nes> {
+        match self {
+            Console::Nes(nes) => Some(nes.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Mutable access to the NES emulator, if present.
+    pub fn as_nes_mut(&mut self) -> Option<&mut Nes> {
+        match self {
+            Console::Nes(nes) => Some(nes.as_mut()),
+            _ => None,
+        }
+    }
+
+    /// Access the Game Boy emulator, if this console is running Game Boy hardware.
+    pub fn as_gameboy(&self) -> Option<&GameBoy> {
+        match self {
+            Console::GameBoy(gb) => Some(gb.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Mutable access to the Game Boy emulator, if present.
+    pub fn as_gameboy_mut(&mut self) -> Option<&mut GameBoy> {
+        match self {
+            Console::GameBoy(gb) => Some(gb.as_mut()),
+            _ => None,
+        }
+    }
+
+    /// Access the Game Boy Advance emulator, if this console is running GBA hardware.
+    pub fn as_gba(&self) -> Option<&Gba> {
+        match self {
+            Console::GameBoyAdvance(gba) => Some(gba.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Mutable access to the Game Boy Advance emulator, if present.
+    pub fn as_gba_mut(&mut self) -> Option<&mut Gba> {
+        match self {
+            Console::GameBoyAdvance(gba) => Some(gba.as_mut()),
+            _ => None,
+        }
+    }
+
+    /// Access the SNES emulator, if this console is running SNES hardware.
+    pub fn as_snes(&self) -> Option<&Snes> {
+        match self {
+            Console::Snes(snes) => Some(snes.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Mutable access to the SNES emulator, if present.
+    pub fn as_snes_mut(&mut self) -> Option<&mut Snes> {
+        match self {
+            Console::Snes(snes) => Some(snes.as_mut()),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "native")]
+    /// Access PPU viewer capability for consoles that support it.
+    pub fn as_ppu_viewer(&self) -> Option<&dyn PpuViewerCapability> {
+        match self {
+            Console::Nes(nes) => Some(nes.as_ref()),
+            Console::GameBoy(gb) => Some(gb.as_ref()),
+            Console::GameBoyAdvance(_) | Console::Snes(_) => None,
         }
     }
 
@@ -560,6 +787,38 @@ mod tests {
         } else {
             panic!("expected Console::Nes");
         }
+    }
+
+    #[test]
+    fn test_mouse_capability_accessors_match_console_support() {
+        let mut nes = Console::new_nes(make_shared_context());
+        let mut snes = Console::new_snes(make_shared_context());
+        let mut gb = Console::new_gameboy(make_shared_context());
+        let mut gba = Console::new_gba(make_shared_context());
+
+        assert!(nes.as_mouse_input().is_some());
+        assert!(nes.as_mouse_input_mut().is_some());
+        assert!(snes.as_mouse_input().is_some());
+        assert!(snes.as_mouse_input_mut().is_some());
+
+        assert!(gb.as_mouse_input().is_none());
+        assert!(gb.as_mouse_input_mut().is_none());
+        assert!(gba.as_mouse_input().is_none());
+        assert!(gba.as_mouse_input_mut().is_none());
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_ppu_viewer_accessors_match_console_support() {
+        let nes = Console::new_nes(make_shared_context());
+        let gb = Console::new_gameboy(make_shared_context());
+        let gba = Console::new_gba(make_shared_context());
+        let snes = Console::new_snes(make_shared_context());
+
+        assert!(nes.as_ppu_viewer().is_some());
+        assert!(gb.as_ppu_viewer().is_some());
+        assert!(gba.as_ppu_viewer().is_none());
+        assert!(snes.as_ppu_viewer().is_none());
     }
 
     #[test]

--- a/web/integration/specs/emulation-lifecycle.integration.spec.ts
+++ b/web/integration/specs/emulation-lifecycle.integration.spec.ts
@@ -38,10 +38,10 @@ test.describe("Phase 1 critical path lifecycle", () => {
     test("Given emulator is running, when Pause/Resume is toggled, then paused and running states alternate", async ({ page }) => {
         await startFromBundledRom(page);
 
-        await page.locator(PAUSE_BUTTON_SELECTOR).click();
+        await page.locator(PAUSE_BUTTON_SELECTOR).evaluate((button: HTMLButtonElement) => button.click());
         await waitForPausedState(page);
 
-        await page.locator(PAUSE_BUTTON_SELECTOR).click();
+        await page.locator(PAUSE_BUTTON_SELECTOR).evaluate((button: HTMLButtonElement) => button.click());
         await waitForRunningState(page);
     });
 

--- a/web/integration/specs/snes-frontend-flow.integration.spec.ts
+++ b/web/integration/specs/snes-frontend-flow.integration.spec.ts
@@ -17,10 +17,10 @@ test.describe("SNES frontend flow", () => {
         await expect(page.locator(START_BUTTON_SELECTOR)).toBeDisabled();
         await expect(page.locator(PAUSE_BUTTON_SELECTOR)).toHaveText("Pause");
 
-        await page.locator(PAUSE_BUTTON_SELECTOR).click({ force: true });
+        await page.locator(PAUSE_BUTTON_SELECTOR).evaluate((button: HTMLButtonElement) => button.click());
         await waitForPausedState(page);
 
-        await page.locator(PAUSE_BUTTON_SELECTOR).click({ force: true });
+        await page.locator(PAUSE_BUTTON_SELECTOR).evaluate((button: HTMLButtonElement) => button.click());
         await waitForRunningState(page);
     });
 });


### PR DESCRIPTION
Implements the capability-accessor cleanup for #2840: mouse input, PPU viewer, debugger routing, and related native frontend dispatch were moved behind Console accessors, with architecture notes updated accordingly.
