### PR TITLE
Promote passing SPC timer ROM

### DIFF
--- a/README-SNES.md
+++ b/README-SNES.md
@@ -100,9 +100,9 @@ SNES integration tests live under `src/snes/integration_tests/`.
   detects pass/fail through a reserved WRAM marker at `$7E1FF0`, records
   diagnostics, and computes a screen CRC.
 - `rom_pass_fail` suite for #2876 vendors all 18 blargg SNES SPC700/APU test ROMs as
-  `snes-rom-pass-fail-blargg-spc-apu`. Six are verified by the `rom_runner`
+  `snes-rom-pass-fail-blargg-spc-apu`. Fifteen are verified by the `rom_runner`
   screen-CRC oracle (run to a fixed frame, compare the screen CRC32 against a
-  human-approved PASS capture). The remaining 12 are committed with `#[ignore]`'d
+  human-approved PASS capture). The remaining 3 are committed with `#[ignore]`'d
   tests pending emulator accuracy improvements.
 - Asset provenance is tracked in
   `roms/snes/automated_tests/manifest.json` and validated by
@@ -128,7 +128,7 @@ CRC32 against a human-approved PASS capture. To approve a new golden, run with
 committed integrity with
 `python -m scripts.compute_snes_rom_asset_integrity <dir>`.
 
-**Passing (12) — visually-approved screen-CRC goldens at frame 600:**
+**Passing (15) — visually-approved screen-CRC goldens at frame 600:**
 
 | ROM | Category | Golden CRC |
 | --- | --- | --- |
@@ -139,13 +139,16 @@ committed integrity with
 | `test_ram_disable_ipl` | SMP | `0xD001765E` |
 | `spc_smp` | SMP | `0xE6CE0BCE` |
 | `spc_mem_access_times` | SMP | `0x3AC3E30F` |
+| `spc_timer` | Timers | `0x249738B2` |
 | `test_speed` | Timers | `0x8EAD6D95` |
-| `test_timer_speed_2` | Timers | `0x471F26BD` |
-| `test_timer_speed3` | Timers | `0x0BBB12C6` |
+| `test_timer_speed` | Timers | `0x03C41961` |
+| `test_timer_speed2` | Timers | `0x03C41961` |
+| `test_timer_speed_2` | Timers | `0x48DAACE9` |
+| `test_timer_speed3` | Timers | `0xCD83D4B0` |
 | `test_timer_stop` | Timers | `0x7CC2B76B` |
 | `speed_2_freezes2` | Timers | `0x6E1BF905` |
 
-**Currently failing (6) — committed with `#[ignore]`'d tests:**
+**Currently failing (3) — committed with `#[ignore]`'d tests:**
 
 When the emulator is improved to produce a Passed screen, run
 `NESER_CAPTURE_SCREEN=1 cargo test … -- --ignored` to capture the golden,
@@ -154,9 +157,6 @@ replace the `0x0000_0000` placeholder CRC in the test, and remove `#[ignore]`.
 | ROM | Category | Known failure |
 | --- | --- | --- |
 | `spc_dsp6` | DSP | Failed 03: DSP echo/basics |
-| `spc_timer` | Timers | Failed 02: SPC timer |
-| `test_timer_speed` | Timers | timer speed |
-| `test_timer_speed2` | Timers | timer speed |
 | `test_timer_stop2` | Timers | timer stop |
 | `timer_at_power_reset` | Timers | timer at power/reset |
 

--- a/roms/snes/automated_tests/manifest.json
+++ b/roms/snes/automated_tests/manifest.json
@@ -92,7 +92,7 @@
       },
       "license": "unknown",
       "oracle_type": "screen_crc",
-      "notes": "blargg (Shay Green) SNES SPC700/APU test ROMs. They report results via blargg's standard text shell (Passed / Failed #N / Internal error), so the committed subset is verified by comparing the rendered screen CRC32 at a fixed frame against a human-approved PASS capture (NESER_CAPTURE_SCREEN). License is informal: these are freely-redistributable test binaries with no formal license file, recorded as unknown; author site http://www.slack.net/~ant/. All 18 ROMs are committed. Twelve currently PASS in this emulator (verified goldens): 1-test_exec_from_io, 2-test_single_instr, 3-test_write_disable, 4-test_ram_disable, test_ram_disable_ipl, spc_smp, spc_mem_access_times, test_speed, test_timer_speed_2, test_timer_speed3, test_timer_stop, speed_2_freezes2. Six are committed with #[ignore]'d tests pending emulator accuracy improvements: spc_dsp6 (Failed 03), spc_timer (Failed 02), test_timer_speed, test_timer_speed2, test_timer_stop2, timer_at_power_reset. See README-SNES for details.",
+      "notes": "blargg (Shay Green) SNES SPC700/APU test ROMs. They report results via blargg's standard text shell (Passed / Failed #N / Internal error), so the committed subset is verified by comparing the rendered screen CRC32 at a fixed frame against a human-approved PASS capture (NESER_CAPTURE_SCREEN). License is informal: these are freely-redistributable test binaries with no formal license file, recorded as unknown; author site http://www.slack.net/~ant/. All 18 ROMs are committed. Fifteen currently PASS in this emulator (verified goldens): 1-test_exec_from_io, 2-test_single_instr, 3-test_write_disable, 4-test_ram_disable, test_ram_disable_ipl, spc_smp, spc_mem_access_times, spc_timer, test_speed, test_timer_speed, test_timer_speed2, test_timer_speed_2, test_timer_speed3, test_timer_stop, speed_2_freezes2. Three are committed with #[ignore]'d tests pending emulator accuracy improvements: spc_dsp6 (Failed 03), test_timer_stop2, timer_at_power_reset. See README-SNES for details.",
       "variants": [
         {
           "id": "ci_subset",
@@ -105,7 +105,7 @@
             "file_count": 18,
             "total_size_bytes": 1681408
           },
-          "notes": "All 18 blargg SPC700/APU ROMs. Eleven have visually-approved PASS goldens run by snes::integration_tests::rom_pass_fail_spc700 with the screen-CRC oracle (frame 600). Seven are committed with #[ignore]'d tests that will be promoted to regular tests once the emulator produces Passed results. tree_sha256 is the sorted per-file sha256 record hash; regenerate with scripts/compute_snes_rom_asset_integrity.py."
+          "notes": "All 18 blargg SPC700/APU ROMs. Fifteen have visually-approved PASS goldens run by snes::integration_tests::rom_pass_fail_spc700 with the screen-CRC oracle (frame 600). Three are committed with #[ignore]'d tests that will be promoted to regular tests once the emulator produces Passed results. tree_sha256 is the sorted per-file sha256 record hash; regenerate with scripts/compute_snes_rom_asset_integrity.py."
         }
       ]
     }

--- a/src/snes/integration_tests/rom_pass_fail_spc700.rs
+++ b/src/snes/integration_tests/rom_pass_fail_spc700.rs
@@ -18,6 +18,7 @@ mod tests {
         ("test_ram_disable_ipl.smc", 600, 0xD001_765E),
         ("spc_smp.sfc", 600, 0xE6CE_0BCE),
         ("spc_mem_access_times.sfc", 600, 0x3AC3_E30F),
+        ("spc_timer.sfc", 600, 0x2497_38B2),
         ("test_speed.smc", 600, 0x8EAD_6D95),
         ("test_timer_speed_2.smc", 600, 0x48DA_ACE9),
         ("test_timer_speed3.smc", 600, 0xCD83_D4B0),
@@ -122,9 +123,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "fails: SPC timer (Failed 02) — fix emulator then update CRC"]
     fn blargg_spc_timer_passes() {
-        run_failing_rom("spc_timer.sfc");
+        run_rom_with_expected_crc("spc_timer.sfc", 0x2497_38B2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Promote blargg `spc_timer.sfc` with verified PASS screen CRC `0x249738B2`.
- Add `spc_timer` to the verified SPC/APU catalog and remove its ignored/failing test status.
- Correct the SNES SPC/APU ROM README/manifest counts and stale timer-speed CRC documentation in the same catalog section.

## Validation
- `cargo test --no-default-features --lib blargg_spc_timer_passes -- --include-ignored --nocapture` (RED placeholder captured `0x249738B2` PASS screen before promotion)
- `cargo test --no-default-features --lib blargg_spc_timer_passes -- --nocapture`
- `cargo test --no-default-features --lib blargg_test_timer_speed_passes -- --nocapture`
- `cargo test --no-default-features --lib blargg_test_timer_speed2_passes -- --nocapture`
- `cargo test --no-default-features --lib verified_spc_apu_roms_pass_with_screen_crc_golden -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `./scripts/test-dir.sh src/snes --skip-integration`
