### PR TITLE
fix(snes): H/V-IRQ one-dot dispatch delay + OPHCT/OPVCT sticky read (#2909)

### DIFF
--- a/src/snes/bus/bus.rs
+++ b/src/snes/bus/bus.rs
@@ -30,9 +30,14 @@ pub trait SnesBus {
         false
     }
 
-    /// Poll the current IRQ line level from the bus (e.g. PPU H/V timer IRQ).
+    /// Poll whether an IRQ is currently visible to the CPU for dispatch/WAI-wake purposes
+    /// (e.g. the PPU H/V timer IRQ).
     ///
-    /// IRQ is level-triggered. The default returns `false` for buses without an IRQ source.
+    /// IRQ is level-triggered, but implementations may model a real-hardware pipeline delay
+    /// between the underlying IRQ source's line level and when the CPU actually notices it
+    /// (see `SnesSystemBus::poll_irq`, which gates on `Ppu::poll_irq_dispatch`). Register
+    /// reads that expose the raw line (e.g. TIMEUP `$4211`) are unaffected by that delay and
+    /// must not use this method. The default returns `false` for buses without an IRQ source.
     fn poll_irq(&self) -> bool {
         false
     }

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -817,7 +817,7 @@ impl SnesBus for SnesSystemBus {
     }
 
     fn poll_irq(&self) -> bool {
-        self.ppu.borrow().poll_irq_level()
+        self.ppu.borrow().poll_irq_dispatch()
     }
 
     fn screen_dimensions(&self) -> (u32, u32) {
@@ -1645,7 +1645,25 @@ mod tests {
     }
 
     #[test]
-    fn bus_poll_irq_reflects_timeup_level_and_read_ack_clears_it() {
+    fn bus_timeup_reflects_irq_line_immediately_at_the_trigger_clock() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x004207, 0x01);
+        bus.write(0x004208, 0x00);
+        bus.write(0x004200, 0x10); // H-IRQ mode
+
+        // HTIME=1 fires at intra-scanline clock (1+1)*4 + 10 = 18.
+        for _ in 0..18 {
+            bus.tick(); // one master clock each
+        }
+        assert_ne!(
+            bus.read(0x004211) & 0x80,
+            0,
+            "TIMEUP reflects the raw IRQ line the instant it triggers, unlike poll_irq()"
+        );
+    }
+
+    #[test]
+    fn bus_poll_irq_has_a_one_dot_dispatch_delay_then_read_ack_clears_it() {
         let mut bus = SnesSystemBus::new(lorom_test_cart());
         bus.write(0x004207, 0x01);
         bus.write(0x004208, 0x00);
@@ -1656,7 +1674,22 @@ mod tests {
         for _ in 0..18 {
             bus.tick(); // one master clock each
         }
-        assert!(bus.poll_irq(), "IRQ line asserted at the H-IRQ clock");
+        // bsnes' `CPU::irqPoll` only turns a freshly-risen IRQ line into a CPU-visible
+        // dispatch/WAI-wake transition on the *next* 4-clock poll (it samples the
+        // previous poll's still-stale line value first) -- a fixed one-dot pipeline
+        // delay. `poll_irq()` (unlike TIMEUP) must not be visible yet at the exact
+        // trigger clock.
+        assert!(
+            !bus.poll_irq(),
+            "poll_irq() is not yet visible at the exact IRQ-line trigger clock"
+        );
+        for _ in 0..4 {
+            bus.tick();
+        }
+        assert!(
+            bus.poll_irq(),
+            "poll_irq() becomes visible one dot (4 master clocks) after the trigger"
+        );
 
         assert_ne!(bus.read(0x004211) & 0x80, 0, "TIMEUP read sees pending IRQ");
         assert!(

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -817,6 +817,8 @@ impl SnesBus for SnesSystemBus {
     }
 
     fn poll_irq(&self) -> bool {
+        // CPU-dispatch-visible signal (one-dot delayed vs. the raw PPU line) -- see
+        // `Ppu::poll_irq_dispatch` and the `SnesBus::poll_irq` trait doc.
         self.ppu.borrow().poll_irq_dispatch()
     }
 

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -219,6 +219,8 @@ pub struct SnesPpuState {
     #[serde(default)]
     pub irq_line: bool,
     #[serde(default)]
+    pub irq_edge_age: u32,
+    #[serde(default)]
     pub interlace_field: bool,
     #[serde(default)]
     pub video_region: u8,

--- a/src/snes/integration_tests/rom_pass_fail_spc700.rs
+++ b/src/snes/integration_tests/rom_pass_fail_spc700.rs
@@ -144,7 +144,9 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "fails: timer at power/reset — fix emulator then update CRC"]
+    #[ignore = "fails: timer at power/reset — see #2930 (H/V-IRQ dispatch delay fixed \
+                in #2909, but the ROM's Passed/Failed decision path hasn't been fully \
+                traced yet) — fix emulator then update CRC"]
     fn blargg_timer_at_power_reset_passes() {
         run_failing_rom("timer_at_power_reset.smc");
     }

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -66,6 +66,10 @@ pub(super) const DOTS_PER_SCANLINE: u16 = 341;
 pub(super) const NTSC_SCANLINES_PER_FRAME: u16 = 262;
 /// PAL scanlines per frame.
 pub(super) const PAL_SCANLINES_PER_FRAME: u16 = 312;
+/// Master clocks between the H/V-IRQ line's rising edge and the CPU noticing a
+/// dispatchable transition (one dot / one bsnes `CPU::irqPoll` cycle). See
+/// [`Ppu::poll_irq_dispatch`].
+pub(super) const IRQ_DISPATCH_EDGE_DELAY_CLOCKS: u32 = MASTER_CYCLES_PER_DOT;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SnesVideoRegion {
@@ -163,8 +167,16 @@ pub struct Ppu {
     vtime: u16,
     /// TIMEUP ($4211) bit 7 latch.
     timeup_flag: bool,
-    /// Current IRQ line level delivered to the CPU.
+    /// Current IRQ line level, readable instantaneously via TIMEUP ($4211).
     irq_line: bool,
+    /// Master clocks `irq_line` has been continuously asserted (0 on its rising edge).
+    /// bsnes' `CPU::irqPoll` only turns the level into a dispatch/WAI-wake "transition"
+    /// pulse on the *next* 4-clock poll after the line rises (it samples the previous
+    /// poll's stale line value first) -- i.e. real hardware has a fixed one-dot (4
+    /// master clock) pipeline delay before the CPU can act on a fresh H/V-IRQ. Gate
+    /// [`Ppu::poll_irq_dispatch`] on this so CPU dispatch/WAI-wake sees the same delay,
+    /// while TIMEUP reads (which reflect the raw hardware line) stay instantaneous.
+    irq_edge_age: u32,
     /// STAT78 ($213F) bit 7: interlace field flag.
     interlace_field: bool,
     video_region: SnesVideoRegion,
@@ -315,6 +327,7 @@ impl Ppu {
             vtime: 0x01FF,
             timeup_flag: false,
             irq_line: false,
+            irq_edge_age: 0,
             interlace_field: false,
             video_region,
             framebuffer: vec![0; SCREEN_WIDTH_MAX * SCREEN_HEIGHT_MAX],
@@ -387,6 +400,17 @@ impl Ppu {
     /// Poll the current level of the H/V IRQ line.
     pub fn poll_irq_level(&self) -> bool {
         self.irq_line
+    }
+
+    /// Poll whether the H/V IRQ is visible to the CPU for dispatch/WAI-wake purposes.
+    ///
+    /// This gates on [`Ppu::irq_edge_age`] to reproduce the fixed one-dot (4 master
+    /// clock) pipeline delay real hardware has between the IRQ line's rising edge and
+    /// the CPU noticing a dispatchable "transition" (see the field doc for the bsnes
+    /// `CPU::irqPoll` reasoning). TIMEUP ($4211) reads are unaffected by this delay --
+    /// they use [`Ppu::poll_irq_level`]/`timeup_flag` directly, matching bsnes' `timeup()`.
+    pub fn poll_irq_dispatch(&self) -> bool {
+        self.irq_line && self.irq_edge_age >= IRQ_DISPATCH_EDGE_DELAY_CLOCKS
     }
 
     /// Whether the PPU is currently in the VBlank period.

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -321,8 +321,11 @@ impl Ppu {
                 0
             }
             // OPHCT: horizontal counter latch. Per bsnes (`PPU::readIO` case 0x213c), the first
-            // read after a latch/STAT78-reset returns the low byte; every subsequent read
-            // (2nd, 3rd, ...) returns the high bit -- it does NOT toggle back to the low byte.
+            // read since the flip-flop was last reset by a STAT78 ($213F) read returns the low
+            // byte; every subsequent read (2nd, 3rd, ...) returns the high bit and does NOT
+            // toggle back to the low byte -- even across an intervening SLHV/WRIO re-latch,
+            // since `latch_counters` only updates the latched value, not this flip-flop (only
+            // a $213F read does, see below).
             0x213C => {
                 let value = if !self.ophct_read_high {
                     (self.ophct_latch & 0x00FF) as u8

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -320,24 +320,27 @@ impl Ppu {
                 self.latch_strobe();
                 0
             }
-            // OPHCT: horizontal counter latch, read-twice (low byte then high bit).
+            // OPHCT: horizontal counter latch. Per bsnes (`PPU::readIO` case 0x213c), the first
+            // read after a latch/STAT78-reset returns the low byte; every subsequent read
+            // (2nd, 3rd, ...) returns the high bit -- it does NOT toggle back to the low byte.
             0x213C => {
                 let value = if !self.ophct_read_high {
                     (self.ophct_latch & 0x00FF) as u8
                 } else {
                     ((self.ophct_latch >> 8) & 0x01) as u8
                 };
-                self.ophct_read_high = !self.ophct_read_high;
+                self.ophct_read_high = true;
                 value
             }
-            // OPVCT: vertical counter latch, read-twice (low byte then high bit).
+            // OPVCT: vertical counter latch. Same sticky first-read-then-high-bit semantics as
+            // OPHCT above (see bsnes `PPU::readIO` case 0x213d).
             0x213D => {
                 let value = if !self.opvct_read_high {
                     (self.opvct_latch & 0x00FF) as u8
                 } else {
                     ((self.opvct_latch >> 8) & 0x01) as u8
                 };
-                self.opvct_read_high = !self.opvct_read_high;
+                self.opvct_read_high = true;
                 value
             }
             // STAT77: PPU1 status + version. Bit 7 = OBJ time over-limit, bit 6 = OBJ range

--- a/src/snes/ppu/save_state.rs
+++ b/src/snes/ppu/save_state.rs
@@ -46,6 +46,7 @@ impl Ppu {
             vtime: self.vtime,
             timeup_flag: self.timeup_flag,
             irq_line: self.irq_line,
+            irq_edge_age: self.irq_edge_age,
             interlace_field: self.interlace_field,
             video_region: match self.video_region {
                 SnesVideoRegion::Ntsc => 0,
@@ -137,6 +138,7 @@ impl Ppu {
         self.vtime = state.vtime & 0x01FF;
         self.timeup_flag = state.timeup_flag;
         self.irq_line = state.irq_line;
+        self.irq_edge_age = state.irq_edge_age;
         self.interlace_field = state.interlace_field;
         self.video_region = match state.video_region {
             1 => SnesVideoRegion::Pal,

--- a/src/snes/ppu/timing.rs
+++ b/src/snes/ppu/timing.rs
@@ -190,70 +190,83 @@ impl Ppu {
     }
 
     fn evaluate_hv_irq(&mut self) {
-        if self.irq_mode == 0 {
-            return;
-        }
-        let v = self.position.scanline;
-        let lc = self.line_clock;
-        // bsnes (`CPU::irqPoll`) compares the delayed H/V counters against the timer
-        // targets. `hcounter(n)`/`vcounter(n)` return the counter value `n` clocks in the
-        // past, wrapping into the previous scanline (using its `hperiod`) when `n` reaches
-        // back past the current line start. The IRQ fires when:
-        //   H  : hcounter(10) == io.htime            (every scanline)
-        //   V  : vcounter(10) == vtime               (once, at the first poll)
-        //   HV : both of the above on the same line
-        // where `io.htime = (HTIME + 1) * 4`.
-        let io_htime = (self.htime + 1) * 4;
-        let hc10 = if lc >= 10 {
-            lc - 10
-        } else {
-            lc + self.last_hperiod - 10
-        };
-        let v10 = if lc >= 10 {
-            v
-        } else if v > 0 {
-            v - 1
-        } else {
-            self.scanlines_per_frame() - 1
-        };
-        // "IRQs cannot trigger on the last dot of the field": bsnes blocks a match whose
-        // 6-clock-delayed position is the frame origin (vcounter(6) == 0 && hcounter(6) == 0).
-        let hc6 = if lc >= 6 {
-            lc - 6
-        } else {
-            lc + self.last_hperiod - 6
-        };
-        let v6 = if lc >= 6 {
-            v
-        } else if v > 0 {
-            v - 1
-        } else {
-            self.scanlines_per_frame() - 1
-        };
-        let not_last_dot = v6 != 0 || hc6 != 0;
-        let triggered = not_last_dot
-            && match self.irq_mode {
-                // H IRQ each scanline when the delayed H counter reaches the compare value.
-                1 => hc10 == io_htime,
-                // V IRQ once on the matching scanline, at the first poll (rising edge).
-                2 => v == self.vtime && lc == 10,
-                // HV IRQ at the H compare of the VTIME line.
-                3 => hc10 == io_htime && v10 == self.vtime,
-                _ => false,
+        // Captured before any mutation below, so the edge-age update at the bottom can
+        // distinguish "already asserted last clock" from "just asserted this clock" even
+        // though `self.irq_line` may be set to `true` further down in this same call.
+        let was_asserted = self.irq_line;
+        if self.irq_mode != 0 {
+            let v = self.position.scanline;
+            let lc = self.line_clock;
+            // bsnes (`CPU::irqPoll`) compares the delayed H/V counters against the timer
+            // targets. `hcounter(n)`/`vcounter(n)` return the counter value `n` clocks in the
+            // past, wrapping into the previous scanline (using its `hperiod`) when `n` reaches
+            // back past the current line start. The IRQ fires when:
+            //   H  : hcounter(10) == io.htime            (every scanline)
+            //   V  : vcounter(10) == vtime               (once, at the first poll)
+            //   HV : both of the above on the same line
+            // where `io.htime = (HTIME + 1) * 4`.
+            let io_htime = (self.htime + 1) * 4;
+            let hc10 = if lc >= 10 {
+                lc - 10
+            } else {
+                lc + self.last_hperiod - 10
             };
-        if triggered && !self.timeup_flag {
-            trace_ppu!(2; "timeup y={} lc={} irq_mode={} htime={:03X} vtime={:03X}",
-                v,
-                lc,
-                self.irq_mode,
-                self.htime,
-                self.vtime,
-            );
+            let v10 = if lc >= 10 {
+                v
+            } else if v > 0 {
+                v - 1
+            } else {
+                self.scanlines_per_frame() - 1
+            };
+            // "IRQs cannot trigger on the last dot of the field": bsnes blocks a match whose
+            // 6-clock-delayed position is the frame origin (vcounter(6) == 0 && hcounter(6) == 0).
+            let hc6 = if lc >= 6 {
+                lc - 6
+            } else {
+                lc + self.last_hperiod - 6
+            };
+            let v6 = if lc >= 6 {
+                v
+            } else if v > 0 {
+                v - 1
+            } else {
+                self.scanlines_per_frame() - 1
+            };
+            let not_last_dot = v6 != 0 || hc6 != 0;
+            let triggered = not_last_dot
+                && match self.irq_mode {
+                    // H IRQ each scanline when the delayed H counter reaches the compare value.
+                    1 => hc10 == io_htime,
+                    // V IRQ once on the matching scanline, at the first poll (rising edge).
+                    2 => v == self.vtime && lc == 10,
+                    // HV IRQ at the H compare of the VTIME line.
+                    3 => hc10 == io_htime && v10 == self.vtime,
+                    _ => false,
+                };
+            if triggered && !self.timeup_flag {
+                trace_ppu!(2; "timeup y={} lc={} irq_mode={} htime={:03X} vtime={:03X}",
+                    v,
+                    lc,
+                    self.irq_mode,
+                    self.htime,
+                    self.vtime,
+                );
+            }
+            if triggered {
+                self.timeup_flag = true;
+                self.irq_line = true;
+            }
         }
-        if triggered {
-            self.timeup_flag = true;
-            self.irq_line = true;
-        }
+        // Track how many consecutive clocks `irq_line` has been asserted (0 on its rising
+        // edge), regardless of whether it changed above or was already latched from a
+        // previous scanline/tick, or cleared elsewhere (TIMEUP read, NMITIMEN disabling
+        // IRQs). This powers the one-dot CPU dispatch/WAI-wake delay in
+        // `Ppu::poll_irq_dispatch` -- see [`IRQ_DISPATCH_EDGE_DELAY_CLOCKS`].
+        self.irq_edge_age = match (self.irq_line, was_asserted) {
+            (true, true) => self.irq_edge_age.saturating_add(1),
+            (true, false) => 0,
+            (false, _) => 0,
+        };
     }
 }
 

--- a/src/snes/ppu/timing.rs
+++ b/src/snes/ppu/timing.rs
@@ -399,6 +399,39 @@ mod tests {
     }
 
     #[test]
+    fn ophct_read_flipflop_stays_high_across_a_relatch_without_a_stat78_read() {
+        // Per bsnes (`PPU::readIO` case 0x213c/0x213f), a fresh SLHV/WRIO latch does NOT
+        // reset the OPHCT/OPVCT read flip-flop -- only a STAT78 ($213F) read does. So once
+        // a program has read OPHCT twice (low then high), latching again *without* an
+        // intervening STAT78 read must keep returning the high bit, not toggle back to the
+        // (new) low byte.
+        let mut ppu = Ppu::new();
+        tick_dots(&mut ppu, 20);
+        ppu.read_register(0x2137); // first latch: H=20
+
+        assert_eq!(
+            ppu.read_register(0x213C),
+            20,
+            "first read returns the low byte"
+        );
+        assert_eq!(
+            ppu.read_register(0x213C),
+            0,
+            "second read returns the high bit"
+        );
+
+        tick_dots(&mut ppu, 5);
+        ppu.read_register(0x2137); // second latch, no STAT78 read in between: H=25
+
+        assert_eq!(
+            ppu.read_register(0x213C),
+            0,
+            "third read (no intervening STAT78 read) stays on the high bit, \
+             it must not toggle back to the new latch's low byte"
+        );
+    }
+
+    #[test]
     fn stat78_reports_and_clears_the_latch_flag() {
         let mut ppu = Ppu::new();
         ppu.read_register(0x2137); // latch (WRIO bit7 set on reset)


### PR DESCRIPTION
Investigates #2909 (`timer_at_power_reset.smc` — vendored in the blargg
SPC700/APU suite, but actually a SNES PPU H-counter latch / H-IRQ test).
Does not close #2909 — see below.

## Changes

- **H/V-IRQ one-dot CPU-dispatch delay** (the core fix): verified against
  bsnes source (`sfc/cpu/irq.cpp`, `io.cpp`, `memory.cpp`,
  `processor/wdc65816/instructions-other.cpp`) that real hardware has a
  fixed one-dot (4 master clock) pipeline delay between the H/V-IRQ line's
  rising edge and the CPU noticing a dispatchable transition —
  `CPU::irqPoll` samples the *previous* poll's stale line value before
  updating the new one. Added `Ppu::irq_edge_age` / `Ppu::poll_irq_dispatch`
  to reproduce this, wired into `SnesSystemBus::poll_irq`. TIMEUP (`$4211`)
  reads remain instantaneous (unaffected), matching bsnes' `timeup()`.
- **OPHCT/OPVCT sticky read fix**: the read-twice flip-flop incorrectly
  toggled back to the low byte on a 3rd+ read. Per bsnes (`PPU::readIO`
  cases `0x213c`/`0x213d`), only the *first* read after a latch/STAT78-reset
  returns the low byte; every subsequent read returns the high bit (sticky).
- Updated a stale bus-level unit test that assumed instantaneous
  `poll_irq()` visibility; split into two focused tests (TIMEUP's instant
  view vs. `poll_irq()`'s one-dot delay + read-ack clearing).
- Persisted the new `irq_edge_age` field in `SnesPpuState`
  (`#[serde(default)]` for save-state compatibility).

## Why this doesn't close #2909

The dispatch-delay fix is verified correct and measurably improves
accuracy — one hardware-checked H-latch comparison inside the ROM
(`CMP #$E8`) now matches **exactly** (0xE8 = 232) where it previously
landed 2 dots early (0xE6 = 230). But the ROM still renders `Failed` at
frame 600. Further tracing (300k+ ticks of full CPU+PPU instruction
tracing, plus manual 65816 disassembly of the ROM's own check routine)
followed program flow through a per-scanline self-check routine, a full
CPU/stack reinitialization mirroring the ROM's boot sequence, and into a
hex-print/CRC-checksum subsystem — without yet reaching the actual
Passed/Failed decision branch. This ROM has no available public source (a
GitHub code search found none), so the remaining work is black-box reverse
engineering.

Continuing that investigation is tracked in #2930.
`blargg_timer_at_power_reset_passes` remains `#[ignore]`'d with an updated
comment pointing at it.

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo fmt`: clean
- `./scripts/test-dir.sh src/snes`: 1239 passed, 0 failed (including every
  other timing-sensitive blargg ROM — zero regressions)
- `cargo test --no-default-features --lib`: 12027 passed, 0 failed
- `wasm-pack test --headless --chrome --no-default-features --features wasm`:
  94 passed, 0 failed
- Python test suites (`scripts`, `metadata-scraper`, `nes-rom-db-scraper`):
  all green
- `npm test`: 412 passed

## Notes for reviewers

- I could not visually inspect the ROM's rendered screen myself (`.png`
  files are a globally-blocked content type for this assistant); diagnosis
  instead used ASCII-art screen dumps (luminance-thresholded from the raw
  RGB framebuffer) and manual 65816 disassembly/tracing to read the ROM's
  on-screen text and understand its check logic without ever needing image
  access.
- Follow-up: #2930.

Closes: none (see above). Refs #2909.
