### PR TITLE
fix(snes): SPC timer stage-1 prescaler edge detector - test_timer_stop2 passes (#2908)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/README-SNES.md
+++ b/README-SNES.md
@@ -100,10 +100,10 @@ SNES integration tests live under `src/snes/integration_tests/`.
   detects pass/fail through a reserved WRAM marker at `$7E1FF0`, records
   diagnostics, and computes a screen CRC.
 - `rom_pass_fail` suite for #2876 vendors all 18 blargg SNES SPC700/APU test ROMs as
-  `snes-rom-pass-fail-blargg-spc-apu`. Fifteen are verified by the `rom_runner`
+  `snes-rom-pass-fail-blargg-spc-apu`. Seventeen are verified by the `rom_runner`
   screen-CRC oracle (run to a fixed frame, compare the screen CRC32 against a
-  human-approved PASS capture). The remaining 3 are committed with `#[ignore]`'d
-  tests pending emulator accuracy improvements.
+  human-approved PASS capture). The remaining one is committed with an `#[ignore]`'d
+  test pending emulator accuracy improvements.
 - Asset provenance is tracked in
   `roms/snes/automated_tests/manifest.json` and validated by
   `python -m scripts.validate_snes_test_assets`.
@@ -128,7 +128,7 @@ CRC32 against a human-approved PASS capture. To approve a new golden, run with
 committed integrity with
 `python -m scripts.compute_snes_rom_asset_integrity <dir>`.
 
-**Passing (16) — visually-approved screen-CRC goldens:**
+**Passing (17) — visually-approved screen-CRC goldens:**
 
 | ROM | Category | Golden CRC |
 | --- | --- | --- |
@@ -146,6 +146,7 @@ committed integrity with
 | `test_timer_speed_2` | Timers | `0x48DAACE9` |
 | `test_timer_speed3` | Timers | `0x8B6CB1A1` |
 | `test_timer_stop` | Timers | `0x7CC2B76B` |
+| `test_timer_stop2` | Timers | `0xB2CC2986` |
 | `speed_2_freezes2` | Timers | `0x6E1BF905` |
 | `timer_at_power_reset` | Timers | `0x9A3B5FC3` (mid-test reset, see below) |
 
@@ -159,7 +160,13 @@ models this handshake: the runner triggers a soft CPU reset every time PC
 reaches the trap address (capped at 16 auto-resets) so the ROM can continue
 into its post-reset comparison and reach its real Passed/Failed screen.
 
-**Currently failing (2) — committed with `#[ignore]`'d tests:**
+`test_timer_stop2` exercises the TEST-register ($F0) global timer stop: it
+rapidly pumps the stop/start bits and expects each stop issued while the
+timer's stage-1 prescaler square wave is high to inject one target-counter
+clock (the forced-low input is a falling edge at the timer's edge detector),
+with TnOUT preserved across the stop.
+
+**Currently failing (1) — committed with an `#[ignore]`'d test:**
 
 When the emulator is improved to produce a Passed screen, run
 `NESER_CAPTURE_SCREEN=1 cargo test … -- --ignored` to capture the golden,
@@ -168,7 +175,6 @@ replace the `0x0000_0000` placeholder CRC in the test, and remove `#[ignore]`.
 | ROM | Category | Known failure |
 | --- | --- | --- |
 | `spc_dsp6` | DSP | Failed 03: DSP echo/basics |
-| `test_timer_stop2` | Timers | timer stop |
 
 Run SNES tests during development with:
 

--- a/src/snes/apu/mod.rs
+++ b/src/snes/apu/mod.rs
@@ -27,6 +27,14 @@ fn default_test_reg() -> u8 {
     0x0A
 }
 
+/// fullsnes TEST $F0:
+///   bit 0 = Timer-Enable  (0=Normal/timers work, 1=Timers don't work)
+///   bit 3 = Timer-Disable (0=Timers don't work,  1=Normal/timers work)
+/// Both must be in the "Normal" state for timers to count.
+fn test_reg_allows_timers(test: u8) -> bool {
+    (test & 0x01 == 0) && (test & 0x08 != 0)
+}
+
 fn default_pending_samples() -> Vec<(f32, f32)> {
     Vec::new()
 }
@@ -331,6 +339,11 @@ impl SnesApu {
         self.master_ticks = state.master_ticks;
         self.spc_cycle_budget = state.spc_cycle_budget;
         self.timers = state.timers.clone();
+        // Older save-states predate the serialized timer global gate; always
+        // re-derive it from the restored TEST value (without running the
+        // edge detector, so no tick is injected by the restore itself).
+        self.timers
+            .restore_global_enabled(test_reg_allows_timers(self.test));
         self.dsp = normalized_dsp;
         self.dsp_addr = restored_dsp_addr;
         self.sample_acc = sanitize_non_negative_f32(state.sample_acc);
@@ -659,16 +672,12 @@ impl SpcBusView<'_> {
         // Every TEST write re-evaluates the global timer gate and runs the
         // stage-1 edge detector: a stop while stage 1 is high injects one
         // target-counter clock (blargg test_timer_stop2). TnOUT is preserved.
-        let allows = (value & 0x01 == 0) && (value & 0x08 != 0);
-        self.timers.set_global_enabled(allows);
+        self.timers
+            .set_global_enabled(test_reg_allows_timers(value));
     }
 
     fn test_allows_timers(&self) -> bool {
-        // fullsnes TEST $F0:
-        //   bit 0 = Timer-Enable  (0=Normal/timers work, 1=Timers don't work)
-        //   bit 3 = Timer-Disable (0=Timers don't work,  1=Normal/timers work)
-        // Both must be in the "Normal" state for timers to tick.
-        (self.test_reg() & 0x01 == 0) && (self.test_reg() & 0x08 != 0)
+        test_reg_allows_timers(self.test_reg())
     }
 
     fn tick_timers_multiple(&mut self, cycles: u8) {
@@ -1408,6 +1417,37 @@ mod tests {
             apu.read_spc_memory_for_test(0x00FF),
             0x01,
             "a TEST stop while stage 1 is high must inject one timer tick"
+        );
+    }
+
+    #[test]
+    fn restore_state_syncs_timer_global_gate_from_test_register() {
+        // Save-states written before the timer global gate was serialized
+        // deserialize SpcTimers with global_enabled defaulting to true. If
+        // the state was captured while TEST had timers stopped, the restore
+        // must re-derive the gate from the restored TEST value.
+        let mut apu = SnesApu::new(None);
+        apu.write_spc_memory_for_test(0x00FC, 0x01); // T2DIV = 1
+        apu.write_spc_control_for_test(0x04); // enable T2
+        apu.write_spc_memory_for_test(0x00F0, 0x0B); // TEST stop
+        let mut state = apu.capture_state();
+
+        // Simulate the pre-gate save-state: strip global_enabled so it
+        // deserializes to its default (true), contradicting TEST.
+        let mut timers_json = serde_json::to_value(&state.timers).unwrap();
+        timers_json
+            .as_object_mut()
+            .unwrap()
+            .remove("global_enabled");
+        state.timers = serde_json::from_value(timers_json).unwrap();
+
+        let mut restored = SnesApu::new(None);
+        restored.restore_state(&state).unwrap();
+        restored.advance_spc_bus_cycles_for_test(64);
+        assert_eq!(
+            restored.read_spc_memory_for_test(0x00FF),
+            0x00,
+            "timers must stay stopped after restoring a state whose TEST register stops them"
         );
     }
 

--- a/src/snes/apu/mod.rs
+++ b/src/snes/apu/mod.rs
@@ -655,15 +655,12 @@ impl SpcBusView<'_> {
     }
 
     fn write_test(&mut self, value: u8) {
-        let old_test = *self.test;
         *self.test = value;
-        // If TEST transitions from "timers allowed" to "timers stopped",
-        // clear TnOUT on all timers (analogous to CONTROL disable clearing TnOUT).
-        let old_allows = (old_test & 0x01 == 0) && (old_test & 0x08 != 0);
-        let new_allows = (value & 0x01 == 0) && (value & 0x08 != 0);
-        if old_allows && !new_allows {
-            self.timers.clear_all_tout();
-        }
+        // Every TEST write re-evaluates the global timer gate and runs the
+        // stage-1 edge detector: a stop while stage 1 is high injects one
+        // target-counter clock (blargg test_timer_stop2). TnOUT is preserved.
+        let allows = (value & 0x01 == 0) && (value & 0x08 != 0);
+        self.timers.set_global_enabled(allows);
     }
 
     fn test_allows_timers(&self) -> bool {
@@ -681,9 +678,14 @@ impl SpcBusView<'_> {
     }
 
     fn tick_timers_if_enabled(&mut self) {
-        if self.tick_timers && self.test_allows_timers() {
+        if self.tick_timers {
+            // The timer prescalers always run; a TEST-register stop only
+            // gates the edge detector inside SpcTimers (the stage-1 square
+            // wave keeps toggling, as on hardware).
             self.timers.tick_cycle();
-            self.dsp.step_phase_with_memory(&self.aram[..]);
+            if self.test_allows_timers() {
+                self.dsp.step_phase_with_memory(&self.aram[..]);
+            }
         }
     }
 }
@@ -1362,28 +1364,72 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // When TEST transitions from "timers allowed" to "timers stopped", TnOUT
-    // must be cleared to 0.  The test_timer_stop ROM fires T2 four times
-    // before calling STOP via TEST, and the test expects TnOUT = 0 afterwards
-    // — consistent with TEST stop behaving analogously to CONTROL disable
-    // ("set TnOUT=0") for the accumulated-but-unread counter.
+    // Hardware model of the timer prescaler (verified against Mesen2's
+    // SpcTimer and blargg's test_timer_stop2 ROM): stage 0 divides the SPC
+    // clock into a square wave (stage 1) that toggles every half-period
+    // (64 cycles for T0/T1, 8 for T2). The target counter clocks on stage-1
+    // falling edges. A TEST-register global stop forces the edge-detector
+    // input low WITHOUT clearing TnOUT — and if stage 1 was high at the stop,
+    // that forced low is itself a falling edge, injecting one target-counter
+    // clock. The prescaler keeps toggling while timers are stopped.
     // -----------------------------------------------------------------------
 
     #[test]
-    fn writing_test_to_stop_timers_clears_accumulated_tout() {
+    fn writing_test_to_stop_timers_preserves_accumulated_tout() {
         let mut apu = SnesApu::new(None);
         // Enable T2 with target=1 (fires every 16 cycles)
-        apu.write_spc_memory_for_test(0x00FC, 0x01); // T2DIV = 1
-        apu.write_spc_control_for_test(0x04); // enable T2 (bit 2)
-        // Let T2 fire 4 times (4 × 16 = 64 cycles; do NOT read TnOUT yet)
-        apu.advance_spc_bus_cycles_for_test(64);
-        // Now stop timers via TEST bit 0 = 1 (Timer-Enable = "don't work")
-        apu.write_spc_memory_for_test(0x00F0, 0x0B); // 0x0A | 0x01
-        // TnOUT must be 0 immediately after the TEST stop
+        apu.write_spc_memory_for_test(0x00FC, 0x01); // T2DIV = 1 (cycle 1)
+        apu.write_spc_control_for_test(0x04); // enable T2 (bit 2) (cycle 2)
+        // Let T2 fire 4 times (falling edges at cycles 16/32/48/64).
+        apu.advance_spc_bus_cycles_for_test(64); // cycles 3-66
+        // Stop timers via TEST bit 0 = 1. Stage 1 is low here (it toggled low
+        // at cycle 64), so the stop injects no extra tick.
+        apu.write_spc_memory_for_test(0x00F0, 0x0B); // 0x0A | 0x01 (cycle 67)
         assert_eq!(
             apu.read_spc_memory_for_test(0x00FF),
-            0x00,
-            "TnOUT must be cleared when TEST transitions to stop state"
+            0x04,
+            "TnOUT must survive a TEST stop (hardware does not clear it)"
+        );
+    }
+
+    #[test]
+    fn test_stop_while_stage1_high_injects_one_target_clock() {
+        let mut apu = SnesApu::new(None);
+        apu.write_spc_memory_for_test(0x00FC, 0x01); // T2DIV = 1 (cycle 1)
+        apu.write_spc_control_for_test(0x04); // enable T2 (cycle 2)
+        // After 8 more cycles the T2 stage-1 square wave toggles high
+        // (half-period = 8 cycles) at cycle 8.
+        apu.advance_spc_bus_cycles_for_test(8); // cycles 3-10
+        // Stopping the timers forces the edge-detector input low while
+        // stage 1 is high — a falling edge, so the target counter clocks
+        // once and (target=1) TnOUT increments.
+        apu.write_spc_memory_for_test(0x00F0, 0x0B); // cycle 11
+        assert_eq!(
+            apu.read_spc_memory_for_test(0x00FF),
+            0x01,
+            "a TEST stop while stage 1 is high must inject one timer tick"
+        );
+    }
+
+    #[test]
+    fn prescaler_keeps_toggling_while_timers_are_test_stopped() {
+        let mut apu = SnesApu::new(None);
+        apu.write_spc_memory_for_test(0x00FC, 0x01); // T2DIV = 1 (cycle 1)
+        apu.write_spc_control_for_test(0x04); // enable T2 (cycle 2)
+        apu.advance_spc_bus_cycles_for_test(2); // cycles 3-4 (stage 1 low)
+        apu.write_spc_memory_for_test(0x00F0, 0x0B); // stop (cycle 5)
+        // While stopped, stage 1 still toggles high at cycle 8 (edge detector
+        // sees a forced low, so no tick is counted during the stop).
+        apu.advance_spc_bus_cycles_for_test(8); // cycles 6-13
+        apu.write_spc_memory_for_test(0x00F0, 0x0A); // restart (cycle 14)
+        // Stage 1 (high since cycle 8) falls at cycle 16 → first tick, only
+        // 2 cycles after the restart. A prescaler frozen during the stop
+        // would need 16 more enabled cycles before its first tick.
+        apu.advance_spc_bus_cycles_for_test(2); // cycles 15-16
+        assert_eq!(
+            apu.read_spc_memory_for_test(0x00FF),
+            0x01,
+            "the stage-1 square wave must keep toggling during a TEST stop"
         );
     }
 

--- a/src/snes/apu/timers.rs
+++ b/src/snes/apu/timers.rs
@@ -116,6 +116,18 @@ impl SpcTimers {
         }
     }
 
+    /// Set the global gate from a restored TEST value without running the
+    /// edge detector (no injected tick). The detector's latched level is
+    /// settled to its steady-state value so the next stage-1 falling edge
+    /// counts normally. Used by save-state restore, where older states
+    /// don't carry the gate and default it to enabled.
+    pub fn restore_global_enabled(&mut self, enabled: bool) {
+        self.global_enabled = enabled;
+        for timer in &mut self.timers {
+            timer.prev_stage1 = timer.stage1 && enabled;
+        }
+    }
+
     pub fn tick_cycle(&mut self) {
         let global_enabled = self.global_enabled;
         for (timer_index, timer) in self.timers.iter_mut().enumerate() {

--- a/src/snes/apu/timers.rs
+++ b/src/snes/apu/timers.rs
@@ -1,10 +1,28 @@
 //! SPC700 timer subsystem.
 //!
-//! This module models the three SPC700 timers (T0/T1/T2) visible at `$FA-$FF`.
+//! This module models the three SPC700 timers (T0/T1/T2) visible at `$FA-$FF`
+//! using the hardware's two-stage prescaler (verified against Mesen2's
+//! `SpcTimer` and blargg's `test_timer_stop2` ROM):
+//!
+//! * Stage 0 divides the SPC clock into a square wave (stage 1) that toggles
+//!   every half-period — 64 SPC cycles for T0/T1, 8 for T2.
+//! * The 8-bit target counter (stage 2) clocks on stage-1 **falling edges**,
+//!   giving the documented full periods of 128 (T0/T1) and 16 (T2) cycles.
+//! * The TEST register's global stop (`$F0` bits 0/3) forces the edge
+//!   detector's input low without clearing TnOUT. If stage 1 is high at the
+//!   moment of the stop, that forced low is itself a falling edge and injects
+//!   one stage-2 clock — the quirk blargg's `test_timer_stop2` measures by
+//!   rapidly pumping the TEST stop/start bits.
+//! * Stage 0/1 keep running while a timer is disabled (per-timer via `$F1`
+//!   or globally via TEST), so re-enabling resumes mid-phase.
 
 use serde::{Deserialize, Serialize};
 
-const TIMER_INPUT_DIVIDERS: [u16; 3] = [128, 128, 16];
+const TIMER_HALF_PERIODS: [u16; 3] = [64, 64, 8];
+
+fn default_global_enabled() -> bool {
+    true
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 struct Timer {
@@ -13,28 +31,55 @@ struct Timer {
     #[serde(default)]
     target: u8,
     #[serde(default)]
-    input_divider_counter: u16,
+    stage0: u16,
     #[serde(default)]
-    target_counter: u16,
+    stage1: bool,
     #[serde(default)]
-    readable_counter: u8,
+    prev_stage1: bool,
+    #[serde(default)]
+    stage2: u8,
+    #[serde(default)]
+    output: u8,
 }
 
 impl Timer {
     fn reset_target_progress(&mut self) {
-        self.target_counter = 0;
-        self.readable_counter = 0;
+        self.stage2 = 0;
+        self.output = 0;
     }
 
-    fn target_compare_value(&self) -> u16 {
-        u16::from(self.target)
+    /// Feed the current stage-1 level (masked by the TEST-register global
+    /// enable) into the edge detector; clock stage 2 on a falling edge.
+    fn clock_edge_detector(&mut self, global_enabled: bool) {
+        let current = self.stage1 && global_enabled;
+        let previous = self.prev_stage1;
+        self.prev_stage1 = current;
+        if !self.enabled || !previous || current {
+            return;
+        }
+        self.stage2 = self.stage2.wrapping_add(1);
+        if self.stage2 == self.target {
+            self.stage2 = 0;
+            self.output = self.output.wrapping_add(1);
+        }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SpcTimers {
     #[serde(default)]
     timers: [Timer; 3],
+    #[serde(default = "default_global_enabled")]
+    global_enabled: bool,
+}
+
+impl Default for SpcTimers {
+    fn default() -> Self {
+        Self {
+            timers: Default::default(),
+            global_enabled: default_global_enabled(),
+        }
+    }
 }
 
 impl SpcTimers {
@@ -56,36 +101,31 @@ impl SpcTimers {
     }
 
     pub fn read_counter(&mut self, timer: usize) -> u8 {
-        let value = self.timers[timer].readable_counter & 0x0F;
-        self.timers[timer].readable_counter = 0;
+        let value = self.timers[timer].output & 0x0F;
+        self.timers[timer].output = 0;
         value
     }
 
-    pub fn clear_all_tout(&mut self) {
+    /// Apply the TEST register's global timer enable/disable. Runs the edge
+    /// detector immediately: a stop while stage 1 is high injects one
+    /// stage-2 clock (falling edge), matching real hardware.
+    pub fn set_global_enabled(&mut self, enabled: bool) {
+        self.global_enabled = enabled;
         for timer in &mut self.timers {
-            timer.readable_counter = 0;
+            timer.clock_edge_detector(enabled);
         }
     }
 
     pub fn tick_cycle(&mut self) {
+        let global_enabled = self.global_enabled;
         for (timer_index, timer) in self.timers.iter_mut().enumerate() {
-            timer.input_divider_counter = timer.input_divider_counter.wrapping_add(1);
-            if timer.input_divider_counter < TIMER_INPUT_DIVIDERS[timer_index] {
+            timer.stage0 += 1;
+            if timer.stage0 < TIMER_HALF_PERIODS[timer_index] {
                 continue;
             }
-
-            timer.input_divider_counter = 0;
-            if !timer.enabled {
-                continue;
-            }
-
-            timer.target_counter = timer.target_counter.wrapping_add(1) & 0x00FF;
-            if timer.target_counter != timer.target_compare_value() {
-                continue;
-            }
-
-            timer.target_counter = 0;
-            timer.readable_counter = (timer.readable_counter.wrapping_add(1)) & 0x0F;
+            timer.stage0 = 0;
+            timer.stage1 = !timer.stage1;
+            timer.clock_edge_detector(global_enabled);
         }
     }
 }
@@ -279,5 +319,72 @@ mod tests {
 
         advance_cycles(&mut timers, 128);
         assert_eq!(timers.read_counter(0), 0x01);
+    }
+
+    // -----------------------------------------------------------------------
+    // TEST-register global stop/start semantics (blargg test_timer_stop2):
+    // a stop forces the stage-1 edge-detector input low without clearing
+    // TnOUT; pumping stop/start while stage 1 is high injects one stage-2
+    // clock per stop.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn global_stop_start_pump_injects_one_target_clock_per_stop() {
+        let mut timers = SpcTimers::default();
+        timers.write_target(2, 2);
+        timers.write_control(0x00, 0x04); // enable T2
+        advance_cycles(&mut timers, 8); // stage 1 toggles high
+
+        // Four stop/start pairs with stage 1 held high: each stop is a
+        // falling edge at the detector, each start re-arms it.
+        for _ in 0..4 {
+            timers.set_global_enabled(false);
+            timers.set_global_enabled(true);
+        }
+
+        assert_eq!(
+            timers.read_counter(2),
+            0x02,
+            "4 injected clocks at target=2 must produce TnOUT=2"
+        );
+    }
+
+    #[test]
+    fn global_stop_with_stage1_low_injects_nothing_and_preserves_tout() {
+        let mut timers = SpcTimers::default();
+        timers.write_target(2, 1);
+        timers.write_control(0x00, 0x04); // enable T2
+        advance_cycles(&mut timers, 48); // 3 falling edges; stage 1 ends low
+
+        timers.set_global_enabled(false);
+
+        assert_eq!(
+            timers.read_counter(2),
+            0x03,
+            "a TEST stop must not clear TnOUT"
+        );
+    }
+
+    #[test]
+    fn globally_stopped_timer_does_not_count_but_stage1_keeps_toggling() {
+        let mut timers = SpcTimers::default();
+        timers.write_target(2, 1);
+        timers.write_control(0x00, 0x04); // enable T2
+        advance_cycles(&mut timers, 4);
+
+        timers.set_global_enabled(false);
+        advance_cycles(&mut timers, 160); // many toggles, no counting
+        assert_eq!(timers.read_counter(2), 0x00);
+
+        // Stage 1 toggled 20 times while stopped (cycles 8,16,...,160) and is
+        // low again, with stage 0 at 4 of 8. After the restart it toggles
+        // high 4 cycles in and falls 8 cycles later → tick at +12 exactly.
+        timers.set_global_enabled(true);
+        advance_cycles(&mut timers, 12);
+        assert_eq!(
+            timers.read_counter(2),
+            0x01,
+            "prescaler phase must be preserved across a TEST stop"
+        );
     }
 }

--- a/src/snes/integration_tests/rom_pass_fail_spc700.rs
+++ b/src/snes/integration_tests/rom_pass_fail_spc700.rs
@@ -142,9 +142,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "fails: timer stop — fix emulator then update CRC"]
     fn blargg_test_timer_stop2_passes() {
-        run_failing_rom("test_timer_stop2.smc");
+        run_rom_with_expected_crc("test_timer_stop2.smc", 0xB2CC_2986);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the last in-scope timer ROM of #2908: `test_timer_stop2.smc` now reaches `Passed`.

The ROM uploads a small SPC program that syncs to a T0 tick, then rapidly pumps the TEST register ($F0) global timer stop/start bits 14 times and reports the T0 counter. On real hardware each timer prescaler is a square wave ("stage 1") toggling every half-period (64 SPC cycles for T0/T1, 8 for T2), and the target counter clocks on stage-1 **falling edges**. A TEST stop forces the edge-detector input low **without clearing TnOUT** - so a stop issued while stage 1 is high is itself a falling edge and injects one target-counter clock. The pump therefore accumulates counts at a rate the ROM verifies. Model verified against Mesen2 (`Core/SNES/SpcTimer.h` + `Spc.cpp`), which passes this ROM.

Our previous model cleared TnOUT on a TEST stop and froze the prescaler entirely, so the ROM read back `00` and printed `Failed`.

## Changes

- Rewrite `SpcTimers` with the hardware stage0/stage1/stage2 pipeline and per-timer falling-edge detector; `$F0` writes run the detector immediately (phantom tick at stop while stage 1 is high).
- Prescalers keep toggling during a TEST stop; counting is gated at the edge detector, not the tick.
- Replace the incorrect `writing_test_to_stop_timers_clears_accumulated_tout` APU test (its premise about `test_timer_stop.smc` was a guess) with three tests for the hardware semantics, plus stop/start-pump unit tests in `timers.rs`. All written red-first (TDD).
- Promote `test_timer_stop2.smc` golden screen CRC `0xB2CC2986`, remove `#[ignore]`.
- README-SNES.md: pass count now 17 passing / 1 ignored (`spc_dsp6` remains, tracked in #2914); fixed the stale 15/3 summary bullet.

## Baseline artifact for reviewer approval

`target/snes_test_captures/test_timer_stop2_crc_B2CC2986.png` (regenerate with `NESER_CAPTURE_SCREEN=1 cargo test --no-default-features --lib blargg_test_timer_stop2_passes`) shows:

```
04
test_timer_stop2
Passed
```

Please visually confirm the capture reads `Passed` before approving the golden CRC.

## Validation (all pre-merge checkpoints pass)

- `cargo test --no-default-features --lib snes::integration_tests::rom_pass_fail_spc700` - all 17 verified ROMs incl. `test_timer_stop`, `spc_timer`, `test_timer_speed*`, `speed_2_freezes2` still pass; `test_timer_stop2` passes un-ignored
- `./scripts/test-dir.sh src/snes` - 1247 passed
- `cargo test --no-default-features --lib` - 12035 passed
- `cargo clippy --all-targets --all-features -- -D warnings` - clean
- `cargo fmt` - no diff
- `wasm-pack test --headless --chrome --no-default-features --features wasm` - 94 passed
- Python suites (scripts, metadata-scraper, nes-rom-db-scraper) - all OK
- `npm test` - 412 passed

Closes nothing automatically; #2908 umbrella acceptance is tracked there (this brings the in-scope ROM count to 9 of 10 passing, `spc_dsp6` pending under #2914).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
