### PR TITLE
fix(snes): OPHCT/OPVCT read flip-flop and PPU2 open bus (#2953)

### DIFF
--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -596,6 +596,14 @@ impl SnesSystemBus {
                 trace_apu!(3; "CPU reads port[{}] -> ${:02X}", port, value);
                 value
             }
+            // SLHV: the strobe doesn't drive the PPU1/PPU2 data bus at all, so the CPU sees
+            // whatever was already on the bus (real open bus) rather than a fresh value --
+            // `read_register` still runs for its H/V-latch side effect, but its return value
+            // is discarded here in favor of the bus's own `open_bus`.
+            0x2137 => {
+                self.ppu.borrow_mut().read_register(offset);
+                open_bus
+            }
             0x2134..=0x213F => self.ppu.borrow_mut().read_register(offset),
             // HVBJOY: bit 0 reports auto-joypad busy, owned by the input ports.
             0x4212 => {
@@ -1313,6 +1321,20 @@ mod tests {
         assert_eq!(bus.read(0x7E1501), 0x20);
         assert_eq!(bus.read(0x7E1502), 0x40);
         assert_eq!(bus.read(0x7E1503), 0x40);
+    }
+
+    #[test]
+    fn slhv_read_returns_open_bus_instead_of_a_fixed_zero() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+
+        // Prime MDR with a nonzero value; SLHV ($2137) doesn't drive the data bus, so reading
+        // it must retain this value rather than clobbering it with a fixed 0.
+        bus.write(0x7E1500, 0x9A);
+        assert_eq!(bus.read(0x7E1500), 0x9A);
+
+        assert_eq!(bus.read(0x002137), 0x9A);
+        // The retained open-bus value carries over to the next open-bus-style read too.
+        assert_eq!(bus.read(0x002137), 0x9A);
     }
 
     #[test]

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -215,6 +215,8 @@ pub struct SnesPpuState {
     #[serde(default)]
     pub opvct_read_high: bool,
     #[serde(default)]
+    pub ppu2_open_bus: u8,
+    #[serde(default)]
     pub wrio: u8,
     #[serde(default)]
     pub irq_mode: u8,

--- a/src/snes/integration_tests/hblank_dma_vram_tests.rs
+++ b/src/snes/integration_tests/hblank_dma_vram_tests.rs
@@ -1,4 +1,4 @@
-//! Automates 1 of the 2 vendored 93143 hblank-dma-vram ROMs
+//! Automates both vendored 93143 hblank-dma-vram ROMs
 //! (`roms/snes/automated_tests/snes_test_roms/93143-hblank-dma-vram/`), mirrored
 //! from a NESdev forum post by user "93143"
 //! (<https://forums.nesdev.com/viewtopic.php?p=248408#p248408>) into the
@@ -30,13 +30,37 @@
 //! bus-residual coin-flip), so this golden is a genuine hardware-accuracy
 //! claim, not just a shared-limitation match.
 //!
-//! **Deliberately un-automated (1 of 2): `hvdma_max.sfc`.** Triggers a DMA
-//! from inside an H-IRQ (cycle-counted jump table) to measure how long a VRAM
-//! burst can run before force-blank release becomes visibly late. NESER
-//! renders a solid black screen where Mesen2 renders the documented solid
-//! green (100% pixel diff, stable across frames 600-610) -- a real,
-//! unrelated rendering gap (the #2952 fix above does not change this ROM's
-//! output at all), tracked as #2953.
+//! **Automated (2 of 2): `hvdma_max.sfc`.** Triggers a DMA from inside an
+//! H-IRQ (a cycle-counted jump table reads OPHCT/$213C to compensate for IRQ
+//! dispatch jitter) to measure how long a VRAM burst can run before
+//! force-blank release becomes visibly late. NESER used to render a solid
+//! black screen where Mesen2 renders the documented solid green (100% pixel
+//! diff), tracked as #2953. Root cause: two compounding PPU register-read
+//! bugs in `Ppu::read_register` (`src/snes/ppu/registers.rs`) broke the
+//! cycle-counted jump table's OPHCT read, which this ROM's H-IRQ handler
+//! calls on *every* firing (every scanline while armed) to compute its jump
+//! index:
+//!
+//! 1. The OPHCT/OPVCT ($213C/$213D) low/high-byte read flip-flop latched to
+//!    "high" permanently after the first read instead of alternating on every
+//!    read (per the Nocash SNES spec and bsnes/Mesen2's `ophct_byte =
+//!    ~ophct_byte`), so every *other* H-IRQ firing read the high bit instead
+//!    of the real position.
+//! 2. Even with the flip-flop toggling correctly, the "high" read's bits 1-7
+//!    are PPU2 open bus, not zero -- and since every $213B/$213C/$213D/$213F
+//!    read leaves its own return value sitting in that shared open-bus latch,
+//!    consecutive reads of an unchanged latched position (as here, since nothing
+//!    else relatches OPHCT between firings) make the "high" phase echo the
+//!    "low" phase's byte with bit 0 replaced by the real bit 8 -- not the
+//!    near-zero value NESER was computing. Real hardware/Mesen2 get a usable
+//!    jump-table index on *every* firing this way; NESER's missing open-bus
+//!    model meant every other firing computed a garbage index, jumped into
+//!    unmapped memory, and fell into a BRK loop whose stack pushes wrote
+//!    through the PPU register file, corrupting BGMODE/TM and leaving the
+//!    screen black.
+//!
+//! After fixing both, NESER's frame-600 capture is a byte-for-byte (0% pixel
+//! diff) match for a Mesen2 capture of the same ROM file.
 
 use super::rom_runner::{RunConfig, RunExitReason, RunOracle, run_rom_with_oracle};
 use std::fs;
@@ -102,4 +126,9 @@ mod tests {
         600,
         0x4EE7_C1E5
     );
+
+    // Confirmed hardware-accurate: NESER's frame-600 capture is a
+    // byte-for-byte (0% pixel diff) match for a Mesen2 capture of the same
+    // ROM file, both showing the documented solid green. See #2953.
+    hblank_dma_vram_rom_test!(hvdma_max_matches_mesen2, "hvdma_max.sfc", 600, 0x9E6A_0E5A);
 }

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -185,6 +185,10 @@ pub struct Ppu {
     ophct_read_high: bool,
     /// OPVCT read-twice flipflop (false = next read is the low byte).
     opvct_read_high: bool,
+    /// PPU2 open bus: bits 1-7 of the OPHCT/OPVCT high-byte read (and the RDCGRAM/STAT78
+    /// reads) are not real data -- they reflect whatever byte the PPU2 data bus last drove.
+    /// Updated by every $213B/$213C/$213D/$213F read to that read's own return value.
+    ppu2_open_bus: u8,
     /// Current WRIO ($4201) value; bit 7 gates counter latching.
     wrio: u8,
     /// NMITIMEN ($4200) IRQ mode (bits 5-4): 0=off, 1=H, 2=V, 3=H+V.
@@ -357,6 +361,7 @@ impl Ppu {
             counter_latch_flag: false,
             ophct_read_high: false,
             opvct_read_high: false,
+            ppu2_open_bus: 0,
             wrio: 0xFF,
             irq_mode: 0,
             htime: 0x01FF,

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -317,7 +317,10 @@ impl Ppu {
                 let hblank = if self.hblank_active() { 0x40 } else { 0x00 };
                 vblank | hblank
             }
-            // SLHV: software strobe to latch the H/V counters (data value is open bus).
+            // SLHV: software strobe to latch the H/V counters. Doesn't drive the data bus at
+            // all -- real hardware returns whatever was already on the bus (the caller,
+            // `SnesSystemBus::read_mmio`, substitutes its own tracked open-bus value for this
+            // address and ignores this return value).
             0x2137 => {
                 self.latch_strobe();
                 0

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -288,11 +288,13 @@ impl Ppu {
                 self.increment_oam_address();
                 value
             }
-            // RDCGRAM: CGRAM data read (auto-incrementing byte address).
+            // RDCGRAM: CGRAM data read (auto-incrementing byte address). Contributes to PPU2
+            // open bus like the other $213B/$213C/$213D/$213F reads (see OPHCT below).
             0x213B => {
                 let index = self.cgram_index();
                 let value = self.cgram[index];
                 self.increment_cgram_address();
+                self.ppu2_open_bus = value;
                 value
             }
             // RDNMI: VBlank NMI flag (bit 7) + CPU version. Read acknowledges/clears the flag.
@@ -320,30 +322,38 @@ impl Ppu {
                 self.latch_strobe();
                 0
             }
-            // OPHCT: horizontal counter latch. Per bsnes (`PPU::readIO` case 0x213c), the first
-            // read since the flip-flop was last reset by a STAT78 ($213F) read returns the low
-            // byte; every subsequent read (2nd, 3rd, ...) returns the high bit and does NOT
-            // toggle back to the low byte -- even across an intervening SLHV/WRIO re-latch,
-            // since `latch_counters` only updates the latched value, not this flip-flop (only
-            // a $213F read does, see below).
+            // OPHCT: horizontal counter latch. Per the Nocash SNES spec and bsnes/Mesen2
+            // (`ophct_byte = ~ophct_byte` on every $213C read), this flip-flop toggles
+            // unconditionally on every read -- alternating low byte, high bit, low byte, ...
+            // -- and is NOT reset by a fresh SLHV/WRIO re-latch (`latch_counters` only updates
+            // the latched value, not this flip-flop); only a $213F read resets it (see below).
+            // The high-byte read's bits 1-7 are PPU2 open bus, not zero: since every
+            // $213B/$213C/$213D/$213F read leaves its own return value sitting in open bus,
+            // and consecutive OPHCT/OPVCT reads without an intervening STAT78 reset just
+            // re-read the same latched position, the "high" read reflects the previous "low"
+            // read's byte (bits 1-7) with bit 0 replaced by the real bit 8 -- NOT a near-zero
+            // value. A ROM that reads OPHCT once per H-IRQ to compute a jump-table index
+            // relies on exactly this to keep getting a usable value on every firing.
             0x213C => {
                 let value = if !self.ophct_read_high {
                     (self.ophct_latch & 0x00FF) as u8
                 } else {
-                    ((self.ophct_latch >> 8) & 0x01) as u8
+                    (((self.ophct_latch >> 8) & 0x01) as u8) | (self.ppu2_open_bus & 0xFE)
                 };
-                self.ophct_read_high = true;
+                self.ophct_read_high = !self.ophct_read_high;
+                self.ppu2_open_bus = value;
                 value
             }
-            // OPVCT: vertical counter latch. Same sticky first-read-then-high-bit semantics as
-            // OPHCT above (see bsnes `PPU::readIO` case 0x213d).
+            // OPVCT: vertical counter latch. Same alternating-toggle and open-bus semantics as
+            // OPHCT above.
             0x213D => {
                 let value = if !self.opvct_read_high {
                     (self.opvct_latch & 0x00FF) as u8
                 } else {
-                    ((self.opvct_latch >> 8) & 0x01) as u8
+                    (((self.opvct_latch >> 8) & 0x01) as u8) | (self.ppu2_open_bus & 0xFE)
                 };
-                self.opvct_read_high = true;
+                self.opvct_read_high = !self.opvct_read_high;
+                self.ppu2_open_bus = value;
                 value
             }
             // STAT77: PPU1 status + version. Bit 7 = OBJ time over-limit, bit 6 = OBJ range
@@ -362,6 +372,7 @@ impl Ppu {
                 self.counter_latch_flag = false;
                 self.ophct_read_high = false;
                 self.opvct_read_high = false;
+                self.ppu2_open_bus = value;
                 value
             }
             _ => 0,

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -322,12 +322,14 @@ impl Ppu {
                 self.latch_strobe();
                 0
             }
-            // OPHCT: horizontal counter latch. Per the Nocash SNES spec and bsnes/Mesen2
-            // (`ophct_byte = ~ophct_byte` on every $213C read), this flip-flop toggles
-            // unconditionally on every read -- alternating low byte, high bit, low byte, ...
-            // -- and is NOT reset by a fresh SLHV/WRIO re-latch (`latch_counters` only updates
+            // OPHCT: horizontal counter latch. Cross-checked against three independent
+            // sources (bsnes `sfc/ppu/io.cpp`, Mesen2 `SnesPpu.cpp`, and the Nocash SNES
+            // spec), which all agree: this flip-flop toggles unconditionally on every read
+            // -- alternating low byte, high bit, low byte, ... (bsnes: `latch.hcounter++`) --
+            // and is NOT reset by a fresh SLHV/WRIO re-latch (`latch_counters` only updates
             // the latched value, not this flip-flop); only a $213F read resets it (see below).
-            // The high-byte read's bits 1-7 are PPU2 open bus, not zero: since every
+            // The high-byte read's bits 1-7 are PPU2 open bus, not zero (bsnes:
+            // `ppu2.mdr &= 0xfe; ppu2.mdr |= io.hcounter >> 8 & 1;`): since every
             // $213B/$213C/$213D/$213F read leaves its own return value sitting in open bus,
             // and consecutive OPHCT/OPVCT reads without an intervening STAT78 reset just
             // re-read the same latched position, the "high" read reflects the previous "low"

--- a/src/snes/ppu/save_state.rs
+++ b/src/snes/ppu/save_state.rs
@@ -43,6 +43,7 @@ impl Ppu {
             counter_latch_flag: self.counter_latch_flag,
             ophct_read_high: self.ophct_read_high,
             opvct_read_high: self.opvct_read_high,
+            ppu2_open_bus: self.ppu2_open_bus,
             wrio: self.wrio,
             irq_mode: self.irq_mode,
             htime: self.htime,
@@ -137,6 +138,7 @@ impl Ppu {
         self.counter_latch_flag = state.counter_latch_flag;
         self.ophct_read_high = state.ophct_read_high;
         self.opvct_read_high = state.opvct_read_high;
+        self.ppu2_open_bus = state.ppu2_open_bus;
         self.wrio = state.wrio;
         self.irq_mode = state.irq_mode & 0x03;
         self.htime = state.htime & 0x01FF;

--- a/src/snes/ppu/timing.rs
+++ b/src/snes/ppu/timing.rs
@@ -421,10 +421,15 @@ mod tests {
         // SLHV strobe (WRIO bit7 is set on reset) latches the current H/V counters.
         ppu.read_register(0x2137);
 
-        // OPHCT read-twice: low byte then high bit.
+        // OPHCT read-twice: low byte, then high bit (bit 8 = 0 here) OR'd with bits 1-7 of
+        // PPU2 open bus -- which the low-byte read we just did left sitting at 20 (0x14),
+        // so the high read echoes `20 & 0xFE` = 20 rather than a bare 0. See
+        // `ophct_read_flipflop_keeps_alternating_across_a_relatch_without_a_stat78_read` for
+        // why this open-bus echo matters.
         assert_eq!(ppu.read_register(0x213C), 20);
-        assert_eq!(ppu.read_register(0x213C), 0);
-        // OPVCT read-twice.
+        assert_eq!(ppu.read_register(0x213C), 20);
+        // OPVCT read-twice: low byte (scanline 0) leaves PPU2 open bus at 0, so the high
+        // read's `0 & 0xFE` echo is also 0.
         assert_eq!(ppu.read_register(0x213D), 0);
         assert_eq!(ppu.read_register(0x213D), 0);
     }
@@ -436,10 +441,12 @@ mod tests {
 
         ppu.read_register(0x2137);
 
+        // High-byte reads echo bits 1-7 of PPU2 open bus, i.e. the preceding low-byte read's
+        // own value masked with 0xFE (bit 8 is 0 for both H=5 and V=3, so it doesn't show).
         assert_eq!(ppu.read_register(0x213C), 5);
-        assert_eq!(ppu.read_register(0x213C), 0);
+        assert_eq!(ppu.read_register(0x213C), 5 & 0xFE);
         assert_eq!(ppu.read_register(0x213D), 3);
-        assert_eq!(ppu.read_register(0x213D), 0);
+        assert_eq!(ppu.read_register(0x213D), 3 & 0xFE);
     }
 
     #[test]
@@ -457,12 +464,19 @@ mod tests {
     }
 
     #[test]
-    fn ophct_read_flipflop_stays_high_across_a_relatch_without_a_stat78_read() {
-        // Per bsnes (`PPU::readIO` case 0x213c/0x213f), a fresh SLHV/WRIO latch does NOT
-        // reset the OPHCT/OPVCT read flip-flop -- only a STAT78 ($213F) read does. So once
-        // a program has read OPHCT twice (low then high), latching again *without* an
-        // intervening STAT78 read must keep returning the high bit, not toggle back to the
-        // (new) low byte.
+    fn ophct_read_flipflop_keeps_alternating_across_a_relatch_without_a_stat78_read() {
+        // Per the Nocash SNES spec ("the flipflops aren't automatically reset when latching
+        // occurs") and bsnes/Mesen2 (`ophct_byte = ~ophct_byte` on every $213C read), the
+        // OPHCT/OPVCT read flip-flop is NOT reset by a fresh SLHV/WRIO latch -- only a STAT78
+        // ($213F) read does that. But the flip-flop itself unconditionally *toggles* on every
+        // $213C/$213D read, regardless of any intervening latch: it alternates low, high, low,
+        // high, ... rather than sticking to "high" forever after the first read.
+        //
+        // The "high" read's bits 1-7 are PPU2 open bus rather than 0: since a $213C read
+        // leaves its own return value sitting in PPU2 open bus, and H=20/25 both have bit 8
+        // clear, the "high" reads below echo the preceding "low" read's byte (`& 0xFE`) --
+        // this is exactly what lets a ROM that reads OPHCT once per H-IRQ firing keep getting
+        // a usable (non-near-zero) value on every other firing. See #2953.
         let mut ppu = Ppu::new();
         tick_dots(&mut ppu, 20);
         ppu.read_register(0x2137); // first latch: H=20
@@ -474,8 +488,9 @@ mod tests {
         );
         assert_eq!(
             ppu.read_register(0x213C),
-            0,
-            "second read returns the high bit"
+            20 & 0xFE,
+            "second read returns the high bit (0, since H=20 < 256) OR'd with PPU2 open \
+             bus, which the first read left at 20"
         );
 
         tick_dots(&mut ppu, 5);
@@ -483,9 +498,16 @@ mod tests {
 
         assert_eq!(
             ppu.read_register(0x213C),
-            0,
-            "third read (no intervening STAT78 read) stays on the high bit, \
-             it must not toggle back to the new latch's low byte"
+            25,
+            "third read (no intervening STAT78 read) toggles back to the low byte of \
+             the new latch, since the flip-flop toggles on every read regardless of \
+             intervening latches"
+        );
+        assert_eq!(
+            ppu.read_register(0x213C),
+            25 & 0xFE,
+            "fourth read toggles back to the high bit, again echoing the preceding low \
+             read (25) through PPU2 open bus"
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes #2953: `hvdma_max.sfc` rendered solid black instead of Mesen2's solid green.
- Root cause was two compounding bugs in `Ppu::read_register` (`src/snes/ppu/registers.rs`):
  1. The OPHCT/OPVCT ($213C/$213D) low/high-byte read flip-flop latched to "high" permanently after the first read instead of alternating on every read, per the Nocash SNES spec and bsnes/Mesen2's `ophct_byte = ~ophct_byte`.
  2. Even with the flip-flop toggling correctly, the "high" read's bits 1-7 are PPU2 open bus, not zero. NESER didn't model PPU2 open bus at all, so the "high" phase returned a near-zero value instead of echoing the previous read (which is what real hardware does when nothing else relatches OPHCT in between).
- `hvdma_max.sfc`'s H-IRQ handler reads OPHCT once per firing (every scanline while armed) to compute a cycle-compensated jump-table index for a DMA trigger. With both bugs, every *other* firing computed a garbage index, jumped into unmapped memory, and fell into a BRK loop whose stack pushes corrupted the PPU register file (BGMODE/TM), leaving the screen black.
- Added PPU2 open-bus tracking (`ppu2_open_bus` field, fed by $213B/$213C/$213D/$213F reads) and fixed the OPHCT/OPVCT toggle to alternate correctly.
- `hvdma_max.sfc` is now automated (previously deliberately left un-automated pending this fix) with a Mesen2-cross-checked golden CRC; NESER's frame-600 capture is a byte-for-byte (0% pixel diff) match for Mesen2's capture of the same ROM file.
- Corrected 3 pre-existing unit tests in `src/snes/ppu/timing.rs` that had encoded the old (wrong) "sticky, no open bus" behavior.

## Test plan

- [x] `./scripts/test-dir.sh src/snes` -- full SNES suite (1347 tests, including the newly-passing `hvdma_max_matches_mesen2`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`
- [x] `cargo test --no-default-features --lib` -- full suite (12135 tests)
- [x] `wasm-pack test --headless --chrome --no-default-features --features wasm`
- [x] Python test suites (scripts, metadata-scraper, nes-rom-db-scraper)
- [x] `npm test`
- [x] Pixel-diffed NESER's fixed frame-600 capture against a fresh Mesen2 headless capture of the same ROM: 0% diff (57344/57344 pixels match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)