### PR TITLE
feat(snes): add SA-1 dual-CPU core and $2200-$220F control/vector registers

### DIFF
--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -2,13 +2,16 @@ use crate::snes::apu::SnesApu;
 use crate::snes::bus::SnesBus;
 use crate::snes::bus::dma::{DmaABus, DmaController};
 use crate::snes::cartridge::Cartridge;
+use crate::snes::cartridge::EnhancementChip;
 use crate::snes::cartridge::Mapping;
 use crate::snes::console::save_state::{SnesBusState, SnesPpuState, SnesRomIdentity};
 use crate::snes::input::{InputPorts, SnesButton};
 use crate::snes::ppu::{DRAM_REFRESH_STOLEN_CLOCKS, Ppu, SnesVideoRegion};
+use crate::snes::sa1::{Sa1ControlRegisters, Sa1Core};
 use crate::trace_apu;
 use std::cell::{Cell, RefCell};
 use std::fs;
+use std::rc::Rc;
 
 const WRAM_SIZE: usize = 128 * 1024;
 
@@ -26,7 +29,7 @@ const WRAM_SIZE: usize = 128 * 1024;
 pub struct SnesSystemBus {
     _cartridge: Cartridge,
     mapping: Mapping,
-    rom: Vec<u8>,
+    rom: Rc<Vec<u8>>,
     sram: Vec<u8>,
     wram: Vec<u8>,
     wmadd: Cell<u32>,
@@ -47,6 +50,11 @@ pub struct SnesSystemBus {
     input: RefCell<InputPorts>,
     mdr: Cell<u8>,
     ticks: Cell<u64>,
+    /// `$2200-$220F` SA-1 control/vector register state, shared with [`Sa1Core`]'s own
+    /// `Sa1Bus` so both CPU sides see the same registers. `None` for non-SA-1 cartridges.
+    sa1_registers: Option<Rc<RefCell<Sa1ControlRegisters>>>,
+    /// The second 65816 CPU core for SA-1. `None` for non-SA-1 cartridges.
+    sa1_core: Option<Sa1Core>,
 }
 
 impl SnesSystemBus {
@@ -64,9 +72,17 @@ impl SnesSystemBus {
         video_region: SnesVideoRegion,
     ) -> Self {
         let mapping = cartridge.mapping();
-        let rom = cartridge.rom().to_vec();
+        let rom = Rc::new(cartridge.rom().to_vec());
         let sram = vec![0; cartridge.sram_size()];
         let spc_ipl = Self::load_spc_ipl_override(spc_ipl_path);
+        let (sa1_registers, sa1_core) =
+            if cartridge.enhancement_chip() == Some(EnhancementChip::Sa1) {
+                let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+                let core = Sa1Core::new(Rc::clone(&registers), Rc::clone(&rom));
+                (Some(registers), Some(core))
+            } else {
+                (None, None)
+            };
         Self {
             _cartridge: cartridge,
             mapping,
@@ -86,6 +102,8 @@ impl SnesSystemBus {
             input: RefCell::new(InputPorts::new()),
             mdr: Cell::new(0),
             ticks: Cell::new(0),
+            sa1_registers,
+            sa1_core,
         }
     }
 
@@ -571,6 +589,18 @@ impl SnesSystemBus {
         self.apu.get_mut().read_spc_memory_for_test(addr)
     }
 
+    /// Returns the SA-1 CPU's program counter, or `None` for non-SA-1 cartridges.
+    #[cfg(test)]
+    pub(crate) fn sa1_cpu_pc_for_tests(&self) -> Option<u16> {
+        self.sa1_core.as_ref().map(|core| core.cpu().read_pc())
+    }
+
+    /// Returns the SA-1 CPU's accumulator, or `None` for non-SA-1 cartridges.
+    #[cfg(test)]
+    pub(crate) fn sa1_cpu_a_for_tests(&self) -> Option<u16> {
+        self.sa1_core.as_ref().map(|core| core.cpu().read_a())
+    }
+
     fn read_mmio(&self, addr: u32) -> Option<u8> {
         let offset = Self::decode_system_offset(addr)?;
         let open_bus = self.mdr.get();
@@ -719,6 +749,16 @@ impl SnesSystemBus {
                 self.ppu.borrow_mut().write_register(offset, value);
                 true
             }
+            // SA-1 control/vector registers are write-only on real hardware (fullsnes lists
+            // them under "Write Only Registers"), so there is no matching read_mmio arm --
+            // reads of this range correctly fall through to open bus.
+            0x2200..=0x220F => match &self.sa1_registers {
+                Some(registers) => {
+                    registers.borrow_mut().write(offset, value);
+                    true
+                }
+                None => false,
+            },
             0x4300..=0x437F => self.dma.write_register(offset, value),
             _ => false,
         }
@@ -745,6 +785,9 @@ impl SnesSystemBus {
             self.input.get_mut().trigger_auto_read();
         }
         self.input.get_mut().tick();
+        if let Some(sa1_core) = &mut self.sa1_core {
+            sa1_core.tick_one_master_clock();
+        }
     }
 }
 

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -108,6 +108,24 @@ impl Snes {
             .map(|cpu| cpu.bus().read_for_debugger(addr))
     }
 
+    /// Returns the SA-1 CPU's program counter, or `None` if no ROM is loaded or the loaded
+    /// cartridge isn't SA-1-chipped.
+    #[cfg(test)]
+    pub(crate) fn sa1_cpu_pc_for_tests(&self) -> Option<u16> {
+        self.cpu
+            .as_ref()
+            .and_then(|cpu| cpu.bus().sa1_cpu_pc_for_tests())
+    }
+
+    /// Returns the SA-1 CPU's accumulator, or `None` if no ROM is loaded or the loaded
+    /// cartridge isn't SA-1-chipped.
+    #[cfg(test)]
+    pub(crate) fn sa1_cpu_a_for_tests(&self) -> Option<u16> {
+        self.cpu
+            .as_ref()
+            .and_then(|cpu| cpu.bus().sa1_cpu_a_for_tests())
+    }
+
     /// Load battery-backed cartridge SRAM from a `.sav` file if one exists.
     #[cfg(not(target_arch = "wasm32"))]
     fn load_save_ram_from_disk(&mut self) {

--- a/src/snes/cpu/cpu.rs
+++ b/src/snes/cpu/cpu.rs
@@ -406,6 +406,16 @@ impl<B: SnesBus> Cpu<B> {
         self.abort_pending = pending;
     }
 
+    /// Force the Fast/Slow memory-access speed classification (mirrors MEMSEL `$420D` bit 0).
+    ///
+    /// Used by the SA-1 core, which has no MEMSEL of its own but always accesses memory at
+    /// the uniformly-fast rate (see fullsnes: SA-1 CPU at 10.74MHz vs the main CPU's
+    /// 2.68/3.58MHz), so its `Cpu` instance is forced into the "Fast" classification once at
+    /// construction rather than toggled at runtime like the main CPU's.
+    pub fn set_fast_rom(&mut self, value: bool) {
+        self.fast_rom = value;
+    }
+
     /// Perform a hardware RESET.
     ///
     /// No bytes are pushed. The CPU enters emulation mode, sets I=1, clears D, PBR, DBR,

--- a/src/snes/integration_tests/mod.rs
+++ b/src/snes/integration_tests/mod.rs
@@ -9,4 +9,5 @@ mod hblank_dma_vram_tests;
 mod processor_tests_65816;
 mod processor_tests_spc700;
 mod rom_runner;
+mod sa1_boot_tests;
 mod undisbeliever_tests;

--- a/src/snes/integration_tests/sa1_boot_tests.rs
+++ b/src/snes/integration_tests/sa1_boot_tests.rs
@@ -1,0 +1,98 @@
+//! Black-box coverage for issue #2957 (SA-1 dual-CPU core and control registers): a hand-built
+//! SA-1-chipset ROM whose main-CPU program releases the SA-1 CPU from reset via `$2200`/
+//! `$2203`/`$2204`, and whose SA-1-side program executes independently once released.
+//!
+//! This is deliberately a tiny custom fixture, not one of the vendored absindx conformance
+//! ROMs (`SA1RamProtectionTest.sfc`/`SA1VersionCodeTest.sfc`) -- those need I-RAM, BW-RAM, and
+//! the full cross-CPU IRQ handshake (later sub-issues of #2956) and are automated separately
+//! under #2962.
+
+use crate::platform::app_context::AppContext;
+use crate::platform::emulator::Emulator;
+use crate::snes::console::Snes;
+
+const HEADER: usize = 0x7FC0;
+
+fn write_lorom_header(rom: &mut [u8], title: &[u8], chipset: u8) {
+    rom[HEADER..HEADER + 21].fill(b' ');
+    rom[HEADER..HEADER + title.len()].copy_from_slice(title);
+    rom[HEADER + 0x15] = 0x20; // Map mode: LoROM, slow.
+    rom[HEADER + 0x16] = chipset;
+    rom[HEADER + 0x17] = 0x07; // ROM size.
+    rom[HEADER + 0x18] = 0x00; // RAM size.
+    rom[HEADER + 0x1C] = 0x34; // Complement check (not validated by this codebase).
+    rom[HEADER + 0x1D] = 0x12;
+    rom[HEADER + 0x1E] = 0xCB; // Checksum (not validated by this codebase).
+    rom[HEADER + 0x1F] = 0xED;
+    rom[HEADER + 0x3C] = 0x00; // Main CPU reset vector low byte.
+    rom[HEADER + 0x3D] = 0x80; // Main CPU reset vector high byte -> $8000.
+}
+
+/// Builds a 64 KiB LoROM SA-1 ROM (chipset `$35`, matching the vendored absindx ROMs' own
+/// header byte) whose main-CPU program at bank `$00:$8000` writes the SA-1 reset vector
+/// ($9000) via `$2203`/`$2204`, releases SA-1 from reset via `$2200`, then idles; and whose
+/// SA-1-side program at bank `$00:$9000` loads a marker byte into A and idles.
+fn build_sa1_boot_rom() -> Vec<u8> {
+    let mut rom = vec![0u8; 0x1_0000];
+    write_lorom_header(&mut rom, b"SA1 BOOT TEST", 0x35);
+
+    // Main CPU program, bank $00:$8000 (file offset $0000).
+    #[rustfmt::skip]
+    let main_program: [u8; 18] = [
+        0xA9, 0x00,       // LDA #$00
+        0x8D, 0x03, 0x22, // STA $2203 (CRVL)
+        0xA9, 0x90,       // LDA #$90
+        0x8D, 0x04, 0x22, // STA $2204 (CRVH) -> SA-1 reset vector = $9000
+        0xA9, 0x00,       // LDA #$00
+        0x8D, 0x00, 0x22, // STA $2200 (CCNT) -> release SA-1 from reset
+        0x4C, 0x0F, 0x80, // JMP $800F (idle loop)
+    ];
+    rom[0x0000..main_program.len()].copy_from_slice(&main_program);
+
+    // SA-1 CPU program, bank $00:$9000 (file offset $1000).
+    #[rustfmt::skip]
+    let sa1_program: [u8; 5] = [
+        0xA9, 0x7B,       // LDA #$7B
+        0x4C, 0x02, 0x90, // JMP $9002 (idle loop)
+    ];
+    rom[0x1000..0x1000 + sa1_program.len()].copy_from_slice(&sa1_program);
+
+    rom
+}
+
+#[test]
+fn sa1_cpu_boots_and_executes_once_released_by_main_cpu() {
+    let rom = build_sa1_boot_rom();
+    let mut snes = Snes::new(AppContext::default());
+    snes.load_rom(&rom, "sa1-boot-test.sfc")
+        .expect("failed to load SA-1 boot fixture ROM");
+
+    for _ in 0..2000 {
+        snes.run_tick();
+    }
+
+    assert_eq!(
+        snes.sa1_cpu_a_for_tests(),
+        Some(0x7B),
+        "SA-1 CPU should have executed LDA #$7B once released from reset"
+    );
+    assert_eq!(
+        snes.sa1_cpu_pc_for_tests(),
+        Some(0x9002),
+        "SA-1 CPU should be idling in its own self-JMP loop at $9002"
+    );
+}
+
+#[test]
+fn non_sa1_cartridge_has_no_sa1_cpu() {
+    let mut rom = vec![0u8; 0x1_0000];
+    write_lorom_header(&mut rom, b"PLAIN ROM TEST", 0x00);
+    let mut snes = Snes::new(AppContext::default());
+    snes.load_rom(&rom, "plain.sfc")
+        .expect("failed to load plain ROM fixture");
+
+    snes.run_tick();
+
+    assert_eq!(snes.sa1_cpu_pc_for_tests(), None);
+    assert_eq!(snes.sa1_cpu_a_for_tests(), None);
+}

--- a/src/snes/mod.rs
+++ b/src/snes/mod.rs
@@ -10,6 +10,7 @@ pub mod console;
 pub mod cpu;
 pub mod input;
 pub mod ppu;
+pub mod sa1;
 
 #[cfg(test)]
 mod integration_tests;

--- a/src/snes/sa1/mod.rs
+++ b/src/snes/sa1/mod.rs
@@ -1,0 +1,495 @@
+//! SA-1 enhancement chip: dual-CPU core and `$2200-$220F` control/vector registers.
+//!
+//! Scope (issue #2957): a second, independently-clocked 65816 CPU core for SA-1, reusing the
+//! existing generic [`Cpu`] unmodified, plus enough of the SA-1 control/vector register block
+//! to boot it. I-RAM, BW-RAM, the cross-CPU IRQ/status handshake, and the version-code/read-only
+//! register block are separate sub-issues of #2956 and land on top of this.
+//!
+//! Register bit layouts and reset values are sourced from fullsnes ("SNES Cart SA-1 I/O Map" /
+//! "Interrupt/Control on SNES Side" / "Interrupt/Control on SA-1 Side" / "Memory Control"
+//! sections), per the `snes-hardware-research` skill's source priority.
+
+use crate::snes::bus::SnesBus;
+use crate::snes::cpu::Cpu;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// `$2200-$220F`: SA-1 CPU control and reset/NMI/IRQ vector registers.
+///
+/// All of these are write-only on real hardware (fullsnes lists them under "SA-1 I/O Map (Write
+/// Only Registers)"), so there is deliberately no read path here -- reads of this range fall
+/// through to open bus in [`crate::snes::bus::system_bus::SnesSystemBus`].
+#[derive(Debug, Clone)]
+pub struct Sa1ControlRegisters {
+    /// `$2200` CCNT (SNES-writable). Bits 0-3: message SNES->SA-1. Bit 4: NMI SNES->SA-1. Bit
+    /// 5: hold SA-1 in reset (1=reset, matches the `$20` power-on default). Bit 6: wait (freeze
+    /// the SA-1 CPU). Bit 7: IRQ SNES->SA-1.
+    ccnt: u8,
+    /// `$2201` SIE (SNES-writable): SNES CPU interrupt enable bits. Stored verbatim; behavior
+    /// lands with the cross-CPU IRQ handshake (#2960).
+    sie: u8,
+    /// `$2203`/`$2204` CRV: SA-1 CPU reset vector. Fullsnes: "Exception Vectors on SA-1 side
+    /// (these are ALWAYS replacing the normal vectors in ROM)".
+    reset_vector: u16,
+    /// `$2205`/`$2206` CNV: SA-1 CPU NMI vector (always replaces the ROM vector).
+    nmi_vector: u16,
+    /// `$2207`/`$2208` CIV: SA-1 CPU IRQ vector (always replaces the ROM vector).
+    irq_vector: u16,
+    /// `$2209` SCNT (SA-1-writable): SNES CPU control. Stored verbatim; behavior lands with #2960.
+    scnt: u8,
+    /// `$220A` CIE (SA-1-writable): SA-1 CPU interrupt enable bits. Stored verbatim; behavior
+    /// lands with #2960.
+    cie: u8,
+    /// `$220C`/`$220D` SNV: SNES CPU NMI vector override (optional, gated by `scnt` bit 4 per
+    /// fullsnes; the gating itself is #2960's job). Stored verbatim here.
+    snes_nmi_vector: u16,
+    /// `$220E`/`$220F` SIV: SNES CPU IRQ vector override (optional, gated by `scnt` bit 6).
+    /// Stored verbatim here.
+    snes_irq_vector: u16,
+}
+
+impl Sa1ControlRegisters {
+    /// Hardware reset values (fullsnes "Reset" table): `$2200`=`$20` (SA-1 held in reset);
+    /// everything else here resets to `$00` (the vector registers are individually listed as
+    /// "N/A" at reset, i.e. undefined until written -- `$00` is a safe deterministic default
+    /// since real software always writes them before releasing SA-1 from reset).
+    pub fn new() -> Self {
+        Self {
+            ccnt: 0x20,
+            sie: 0x00,
+            reset_vector: 0x0000,
+            nmi_vector: 0x0000,
+            irq_vector: 0x0000,
+            scnt: 0x00,
+            cie: 0x00,
+            snes_nmi_vector: 0x0000,
+            snes_irq_vector: 0x0000,
+        }
+    }
+
+    /// Dispatches a write to the raw `$2200-$220F` MMIO offset.
+    pub fn write(&mut self, port: u16, value: u8) {
+        match port {
+            0x2200 => self.ccnt = value,
+            0x2201 => self.sie = value,
+            // $2202 SIC: SNES CPU interrupt-acknowledge strobe. No persistent state of its own;
+            // applying its clear effect to pending-IRQ status lands with #2960.
+            0x2202 => {}
+            0x2203 => self.reset_vector = (self.reset_vector & 0xFF00) | u16::from(value),
+            0x2204 => self.reset_vector = (self.reset_vector & 0x00FF) | (u16::from(value) << 8),
+            0x2205 => self.nmi_vector = (self.nmi_vector & 0xFF00) | u16::from(value),
+            0x2206 => self.nmi_vector = (self.nmi_vector & 0x00FF) | (u16::from(value) << 8),
+            0x2207 => self.irq_vector = (self.irq_vector & 0xFF00) | u16::from(value),
+            0x2208 => self.irq_vector = (self.irq_vector & 0x00FF) | (u16::from(value) << 8),
+            0x2209 => self.scnt = value,
+            0x220A => self.cie = value,
+            // $220B CIC: SA-1 CPU interrupt-acknowledge strobe; same as $2202 above.
+            0x220B => {}
+            0x220C => {
+                self.snes_nmi_vector = (self.snes_nmi_vector & 0xFF00) | u16::from(value);
+            }
+            0x220D => {
+                self.snes_nmi_vector = (self.snes_nmi_vector & 0x00FF) | (u16::from(value) << 8);
+            }
+            0x220E => {
+                self.snes_irq_vector = (self.snes_irq_vector & 0xFF00) | u16::from(value);
+            }
+            0x220F => {
+                self.snes_irq_vector = (self.snes_irq_vector & 0x00FF) | (u16::from(value) << 8);
+            }
+            _ => {}
+        }
+    }
+
+    /// CCNT bit 5: SA-1 CPU is held in reset (fullsnes: "Reset from SNES to SA-1 (0=No Reset,
+    /// 1=Reset)"). The chip powers on with this set (`$20`) and stays halted until software
+    /// clears it.
+    pub fn is_held_in_reset(&self) -> bool {
+        self.ccnt & 0b0010_0000 != 0
+    }
+
+    /// CCNT bit 6: SA-1 CPU is frozen ("Wait from SNES to SA-1") without losing reset state.
+    pub fn is_waiting(&self) -> bool {
+        self.ccnt & 0b0100_0000 != 0
+    }
+
+    pub fn reset_vector(&self) -> u16 {
+        self.reset_vector
+    }
+
+    pub fn nmi_vector(&self) -> u16 {
+        self.nmi_vector
+    }
+
+    pub fn irq_vector(&self) -> u16 {
+        self.irq_vector
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sie(&self) -> u8 {
+        self.sie
+    }
+
+    #[cfg(test)]
+    pub(crate) fn scnt(&self) -> u8 {
+        self.scnt
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cie(&self) -> u8 {
+        self.cie
+    }
+
+    #[cfg(test)]
+    pub(crate) fn snes_nmi_vector(&self) -> u16 {
+        self.snes_nmi_vector
+    }
+
+    #[cfg(test)]
+    pub(crate) fn snes_irq_vector(&self) -> u16 {
+        self.snes_irq_vector
+    }
+}
+
+impl Default for Sa1ControlRegisters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// SA-1-side bus: serves the SA-1 CPU's reset/NMI/IRQ vectors from the control registers
+/// instead of ROM, and cartridge ROM through SA-1's default (pre-#2959) Super MMC mapping.
+///
+/// I-RAM, BW-RAM, and the `$2200-$230E` register block itself are not yet readable/writable
+/// from the SA-1 side (#2958/#2959/#2961); all other reads return open bus (`0`) and writes are
+/// no-ops.
+pub struct Sa1Bus {
+    registers: Rc<RefCell<Sa1ControlRegisters>>,
+    rom: Rc<Vec<u8>>,
+}
+
+impl Sa1Bus {
+    pub fn new(registers: Rc<RefCell<Sa1ControlRegisters>>, rom: Rc<Vec<u8>>) -> Self {
+        Self { registers, rom }
+    }
+
+    /// Fullsnes: "IRQ/NMI/Reset vectors can be mapped. Other vectors (BRK/COP etc) are always
+    /// taken from ROM (for BOTH CPUs)." -- so only these 5 vector-word addresses (reset has a
+    /// single pair; NMI/IRQ each have both a native- and emulation-mode pair, both always
+    /// replaced per "SNES Cart SA-1 Interrupt/Control on SNES Side") are intercepted.
+    fn vector_override_byte(addr: u32, registers: &Sa1ControlRegisters) -> Option<u8> {
+        let (vector, low_byte) = match addr {
+            0x00_FFFC => (registers.reset_vector(), true),
+            0x00_FFFD => (registers.reset_vector(), false),
+            0x00_FFEA | 0x00_FFFA => (registers.nmi_vector(), true),
+            0x00_FFEB | 0x00_FFFB => (registers.nmi_vector(), false),
+            0x00_FFEE | 0x00_FFFE => (registers.irq_vector(), true),
+            0x00_FFEF | 0x00_FFFF => (registers.irq_vector(), false),
+            _ => return None,
+        };
+        Some(if low_byte {
+            (vector & 0xFF) as u8
+        } else {
+            (vector >> 8) as u8
+        })
+    }
+
+    /// Default (pre-#2959) Super MMC mapping: CXB/DXB/EXB/FXB left at their hardware reset
+    /// values (`$00/$01/$02/$03`, i.e. ROM slots 0-3 in order, fullsnes "Reset" table) with no
+    /// remapping -- equivalent to a plain LoROM decode for banks `$00-$3F`/`$80-$BF` at offset
+    /// `$8000-$FFFF` (fullsnes "Memory Map (SA-1 Side)": "Four mappable 1MByte LoROM blocks").
+    /// Configurable banking via `$2220-$2223` (including the HiROM-only vs LoROM+HiROM bit 7
+    /// distinction) lands in #2959.
+    fn decode_rom_index(addr: u32) -> Option<usize> {
+        let addr = addr & 0xFF_FFFF;
+        let bank = ((addr >> 16) & 0xFF) as u8;
+        let offset = (addr & 0xFFFF) as u16;
+        if matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && offset >= 0x8000 {
+            let bank_index = (bank & 0x7F) as usize;
+            Some(bank_index * 0x8000 + (offset as usize - 0x8000))
+        } else {
+            None
+        }
+    }
+}
+
+impl SnesBus for Sa1Bus {
+    fn read(&self, addr: u32) -> u8 {
+        let addr = addr & 0xFF_FFFF;
+        if let Some(byte) = Self::vector_override_byte(addr, &self.registers.borrow()) {
+            return byte;
+        }
+        Self::decode_rom_index(addr)
+            .and_then(|index| self.rom.get(index).copied())
+            .unwrap_or(0)
+    }
+
+    fn write(&mut self, _addr: u32, _value: u8) {
+        // ROM is read-only; I-RAM/BW-RAM writes land in #2958/#2959.
+    }
+
+    fn tick(&mut self) {
+        // SA-1's own clock-domain bookkeeping lives on `Sa1Core`, not the bus (see the
+        // module-level clock note): unlike `SnesSystemBus`, this bus has no PPU/APU/input of
+        // its own to advance per tick.
+    }
+}
+
+/// Owns the second 65816 CPU core for SA-1 and reconciles its clock against the master-clock
+/// tick loop driven by the main CPU's own bus accesses (see `SnesSystemBus::tick_one_master_clock`).
+///
+/// Clock model: SA-1's own CPU clock (10.74MHz, fullsnes) is uniformly fast, unlike the main
+/// CPU's FastROM/SlowROM-gated access. Rather than modeling an independent SA-1 clock domain,
+/// the SA-1 `Cpu` is constructed with `fast_rom` forced on (see [`Cpu::set_fast_rom`]), so
+/// `Cpu::step()`'s returned cycle count is already expressed in the same "master clock ticks"
+/// unit the main CPU uses internally -- [`Sa1Core::tick_one_master_clock`] treats that return
+/// value directly as a master-clock debt rather than converting between two clock domains. This
+/// is a deliberate simplification: real SA-1/SNES cycle-for-cycle bus arbitration (fullsnes:
+/// "SA-1 CPU can access memory at 10.74MHz rate, or less if the SNES does simultaneously access
+/// cartridge memory") is not modeled. Revisit if a conformance ROM proves timing-sensitive.
+pub struct Sa1Core {
+    cpu: Cpu<Sa1Bus>,
+    registers: Rc<RefCell<Sa1ControlRegisters>>,
+    /// Whether `do_reset()` has run since the last time SA-1 was held in reset. Cleared
+    /// whenever CCNT's reset-hold bit is (re-)asserted, so releasing reset again re-boots.
+    booted: bool,
+    /// Master clocks already "spent" on the SA-1 instruction in flight; see the module-level
+    /// clock note for why this is a direct debt rather than a fractional-budget conversion.
+    master_clock_debt: i64,
+}
+
+impl Sa1Core {
+    pub fn new(registers: Rc<RefCell<Sa1ControlRegisters>>, rom: Rc<Vec<u8>>) -> Self {
+        let bus = Sa1Bus::new(Rc::clone(&registers), rom);
+        let mut cpu = Cpu::new(bus);
+        cpu.set_fast_rom(true);
+        Self {
+            cpu,
+            registers,
+            booted: false,
+            master_clock_debt: 0,
+        }
+    }
+
+    /// Advances SA-1 by one master clock. Must be called once per real master clock --
+    /// including during `SnesSystemBus`'s DRAM-refresh stolen-clock replay -- or SA-1 drifts
+    /// off the shared timeline (the same lesson already learned for the APU/PPU/input; see
+    /// `SnesSystemBus::tick_one_master_clock`'s doc comment).
+    pub fn tick_one_master_clock(&mut self) {
+        if self.registers.borrow().is_held_in_reset() {
+            self.booted = false;
+            self.master_clock_debt = 0;
+            return;
+        }
+        if !self.booted {
+            self.cpu.do_reset();
+            self.booted = true;
+        }
+        if self.registers.borrow().is_waiting() {
+            return;
+        }
+        if self.master_clock_debt > 0 {
+            self.master_clock_debt -= 1;
+            return;
+        }
+        let cycles = i64::from(self.cpu.step());
+        self.master_clock_debt = cycles.saturating_sub(1);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cpu(&self) -> &Cpu<Sa1Bus> {
+        &self.cpu
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registers_with(
+        setup: impl FnOnce(&mut Sa1ControlRegisters),
+    ) -> Rc<RefCell<Sa1ControlRegisters>> {
+        let mut registers = Sa1ControlRegisters::new();
+        setup(&mut registers);
+        Rc::new(RefCell::new(registers))
+    }
+
+    fn write_vector(registers: &mut Sa1ControlRegisters, lo_port: u16, hi_port: u16, value: u16) {
+        registers.write(lo_port, (value & 0xFF) as u8);
+        registers.write(hi_port, (value >> 8) as u8);
+    }
+
+    #[test]
+    fn new_control_registers_hold_sa1_in_reset_by_default() {
+        let registers = Sa1ControlRegisters::new();
+        assert!(registers.is_held_in_reset());
+        assert!(!registers.is_waiting());
+    }
+
+    #[test]
+    fn writing_ccnt_zero_releases_reset() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0x00);
+        assert!(!registers.is_held_in_reset());
+    }
+
+    #[test]
+    fn writing_ccnt_wait_bit_freezes_without_clearing_reset() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0b0110_0000); // reset + wait both set
+        assert!(registers.is_held_in_reset());
+        assert!(registers.is_waiting());
+    }
+
+    #[test]
+    fn reset_nmi_irq_vectors_store_low_and_high_bytes() {
+        let mut registers = Sa1ControlRegisters::new();
+        write_vector(&mut registers, 0x2203, 0x2204, 0x9ABC);
+        write_vector(&mut registers, 0x2205, 0x2206, 0x1234);
+        write_vector(&mut registers, 0x2207, 0x2208, 0x5678);
+        assert_eq!(registers.reset_vector(), 0x9ABC);
+        assert_eq!(registers.nmi_vector(), 0x1234);
+        assert_eq!(registers.irq_vector(), 0x5678);
+    }
+
+    #[test]
+    fn snes_side_registers_store_verbatim_for_later_sub_issues() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2201, 0xA0);
+        registers.write(0x2209, 0x55);
+        registers.write(0x220A, 0xF0);
+        write_vector(&mut registers, 0x220C, 0x220D, 0x4242);
+        write_vector(&mut registers, 0x220E, 0x220F, 0x8181);
+        assert_eq!(registers.sie(), 0xA0);
+        assert_eq!(registers.scnt(), 0x55);
+        assert_eq!(registers.cie(), 0xF0);
+        assert_eq!(registers.snes_nmi_vector(), 0x4242);
+        assert_eq!(registers.snes_irq_vector(), 0x8181);
+    }
+
+    #[test]
+    fn unhandled_offset_write_is_ignored() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2202, 0xFF); // SIC strobe: no stored state
+        registers.write(0x220B, 0xFF); // CIC strobe: no stored state
+        registers.write(0x2299, 0xFF); // out of range for this block
+        // None of the above touch CCNT bits 5/6, so the power-on reset/wait state must be
+        // unchanged.
+        assert!(registers.is_held_in_reset());
+        assert!(!registers.is_waiting());
+    }
+
+    #[test]
+    fn bus_serves_reset_vector_instead_of_rom() {
+        let registers = registers_with(|r| write_vector(r, 0x2203, 0x2204, 0x9000));
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let bus = Sa1Bus::new(registers, rom);
+        assert_eq!(bus.read(0x00_FFFC), 0x00);
+        assert_eq!(bus.read(0x00_FFFD), 0x90);
+    }
+
+    #[test]
+    fn bus_serves_nmi_and_irq_vectors_for_both_native_and_emulation_addresses() {
+        let registers = registers_with(|r| {
+            write_vector(r, 0x2205, 0x2206, 0x1234);
+            write_vector(r, 0x2207, 0x2208, 0x5678);
+        });
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let bus = Sa1Bus::new(registers, rom);
+        assert_eq!(bus.read(0x00_FFEA), 0x34);
+        assert_eq!(bus.read(0x00_FFEB), 0x12);
+        assert_eq!(bus.read(0x00_FFFA), 0x34);
+        assert_eq!(bus.read(0x00_FFFB), 0x12);
+        assert_eq!(bus.read(0x00_FFEE), 0x78);
+        assert_eq!(bus.read(0x00_FFEF), 0x56);
+        assert_eq!(bus.read(0x00_FFFE), 0x78);
+        assert_eq!(bus.read(0x00_FFFF), 0x56);
+    }
+
+    #[test]
+    fn bus_reads_rom_through_default_lorom_shaped_mapping() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x0000] = 0xAA; // bank $00 offset $8000
+        rom[0x1000] = 0xBB; // bank $00 offset $9000
+        let bus = Sa1Bus::new(registers, Rc::new(rom));
+        assert_eq!(bus.read(0x00_8000), 0xAA);
+        assert_eq!(bus.read(0x00_9000), 0xBB);
+    }
+
+    #[test]
+    fn bus_returns_open_bus_zero_outside_mapped_rom_and_vectors() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let rom = Rc::new(vec![0xFFu8; 0x8000]);
+        let bus = Sa1Bus::new(registers, rom);
+        // Bank $40 offset $0000 is not in the default LoROM-shaped window.
+        assert_eq!(bus.read(0x40_0000), 0x00);
+    }
+
+    #[test]
+    fn core_stays_halted_while_held_in_reset() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let mut core = Sa1Core::new(Rc::clone(&registers), rom);
+        for _ in 0..1000 {
+            core.tick_one_master_clock();
+        }
+        assert_eq!(core.cpu().read_pc(), 0);
+    }
+
+    #[test]
+    fn core_boots_and_executes_once_released_from_reset() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let mut rom = vec![0u8; 0x8000];
+        // Program at bank $00 offset $9000 (rom index $1000): SEI; LDA #$42; self-branch.
+        rom[0x1000] = 0x78; // SEI
+        rom[0x1001] = 0xA9; // LDA #imm
+        rom[0x1002] = 0x42;
+        rom[0x1003] = 0x80; // BRA -2 (infinite self-loop)
+        rom[0x1004] = 0xFE;
+        {
+            let mut regs = registers.borrow_mut();
+            write_vector(&mut regs, 0x2203, 0x2204, 0x9000);
+        }
+        let mut core = Sa1Core::new(Rc::clone(&registers), Rc::new(rom));
+        registers.borrow_mut().write(0x2200, 0x00); // release reset
+
+        for _ in 0..100 {
+            core.tick_one_master_clock();
+        }
+
+        assert_eq!(core.cpu().read_a() & 0xFF, 0x42);
+        assert_eq!(core.cpu().read_pc(), 0x9003);
+    }
+
+    #[test]
+    fn core_reboots_if_reset_is_reasserted_and_released_again() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let mut rom = vec![0u8; 0x8000];
+        rom[0x1000] = 0xA9; // LDA #imm
+        rom[0x1001] = 0x11;
+        rom[0x1002] = 0x80; // BRA -2
+        rom[0x1003] = 0xFE;
+        {
+            let mut regs = registers.borrow_mut();
+            write_vector(&mut regs, 0x2203, 0x2204, 0x9000);
+        }
+        let mut core = Sa1Core::new(Rc::clone(&registers), Rc::new(rom));
+        registers.borrow_mut().write(0x2200, 0x00);
+        for _ in 0..50 {
+            core.tick_one_master_clock();
+        }
+        assert_eq!(core.cpu().read_a() & 0xFF, 0x11);
+
+        // Re-assert reset, then release again: SA-1 must re-run do_reset().
+        registers.borrow_mut().write(0x2200, 0x20);
+        core.tick_one_master_clock();
+        registers.borrow_mut().write(0x2200, 0x00);
+        for _ in 0..50 {
+            core.tick_one_master_clock();
+        }
+        // This fixture has no leading SEI (unlike the boot test above), so its 2-byte
+        // `LDA #imm` + 2-byte `BRA -2` settle the infinite self-loop at $9002, not $9003.
+        assert_eq!(core.cpu().read_pc(), 0x9002);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a second, independently-clocked 65816 CPU core for the SA-1 enhancement chip (`src/snes/sa1`), reusing the existing generic `Cpu<B: SnesBus>` unmodified -- no changes to the 65816 core itself beyond one small additive `set_fast_rom` setter.
- SA-1's reset/NMI/IRQ vectors are *always* served from the SNES-writable `$2203-$2208` (CRV/CNV/CIV) registers instead of ROM (per fullsnes), so `Sa1Bus` intercepts those fixed vector addresses; `Cpu::do_reset()`/`dispatch_nmi`/`dispatch_irq` work completely unmodified as a result.
- `Sa1Core` is owned by `SnesSystemBus` (constructed only for SA-1-chipped cartridges) and ticked once per master clock alongside the APU/PPU/input, gated on CCNT's reset-hold/wait bits (`$2200`).
- Register bit layouts, reset values, and the default (pre-configurable) Super MMC bank mapping are sourced from fullsnes ("SNES Cart SA-1" sections), not guessed.

This is the foundational sub-issue of epic #2956 (SA-1 support, promoted out of the deferred-chips epic #2725 because the vendored absindx `SA1RamProtectionTest.sfc`/`SA1VersionCodeTest.sfc` conformance ROMs need it). I-RAM, BW-RAM, the cross-CPU IRQ/status handshake, and the version-code register land in later sub-issues (#2958-#2961). **Neither vendored absindx ROM passes yet** -- wiring them up is #2962, which depends on all of these.

Fixes #2957.

## Test plan

- [x] `./scripts/test-dir.sh src/snes --skip-integration` -- 1217 passed
- [x] `cargo test --no-default-features --lib` (full suite) -- 12151 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo fmt`
- [x] `npm test` -- 412 passed
- [x] Python test suites -- 149 passed
- [ ] `wasm-pack test --headless --chrome` -- fails in this environment due to a ChromeDriver 148 / installed Chrome 150 version mismatch; confirmed this reproduces identically on unmodified `main` (not a regression from this change). Rust code compiles cleanly for the `wasm32-unknown-unknown` target either way.
- [x] New unit tests in `src/snes/sa1/mod.rs` covering control-register bit semantics, vector interception, default ROM mapping, and boot/reboot gating.
- [x] New black-box integration test (`src/snes/integration_tests/sa1_boot_tests.rs`): a hand-built SA-1-chipset ROM where the main CPU releases SA-1 from reset via `$2200`/`$2203`/`$2204`, and the SA-1 CPU executes independently once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)