### PR TITLE
feat(snes): add SA-1 I-RAM and per-CPU-side write protection

### DIFF
--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -4,7 +4,7 @@ use crate::snes::bus::dma::{DmaABus, DmaController};
 use crate::snes::cartridge::Cartridge;
 use crate::snes::cartridge::EnhancementChip;
 use crate::snes::cartridge::Mapping;
-use crate::snes::console::save_state::{SnesBusState, SnesPpuState, SnesRomIdentity};
+use crate::snes::console::save_state::{SnesBusState, SnesPpuState, SnesRomIdentity, SnesSa1State};
 use crate::snes::input::{InputPorts, SnesButton};
 use crate::snes::ppu::{DRAM_REFRESH_STOLEN_CLOCKS, Ppu, SnesVideoRegion};
 use crate::snes::sa1::{Sa1ControlRegisters, Sa1Core, Sa1IRam, decode_mirror_offset};
@@ -518,7 +518,39 @@ impl SnesSystemBus {
             sram: self.sram.clone(),
             apu: self.apu.borrow().capture_state(),
             input: self.input.borrow().capture_state(),
+            sa1: self.capture_sa1_state(),
         }
+    }
+
+    /// `None` for non-SA-1 cartridges; see the [`SnesSa1State`] doc comment.
+    fn capture_sa1_state(&self) -> Option<SnesSa1State> {
+        let registers = self.sa1_registers.as_ref()?.borrow();
+        let iram = self
+            .sa1_iram
+            .as_ref()
+            .expect("sa1_iram is constructed alongside sa1_registers")
+            .borrow();
+        let core = self
+            .sa1_core
+            .as_ref()
+            .expect("sa1_core is constructed alongside sa1_registers");
+        Some(SnesSa1State {
+            ccnt: registers.ccnt(),
+            sie: registers.sie(),
+            reset_vector: registers.reset_vector(),
+            nmi_vector: registers.nmi_vector(),
+            irq_vector: registers.irq_vector(),
+            scnt: registers.scnt(),
+            cie: registers.cie(),
+            snes_nmi_vector: registers.snes_nmi_vector(),
+            snes_irq_vector: registers.snes_irq_vector(),
+            iram: iram.data().to_vec(),
+            iram_snes_write_protect: iram.snes_write_protect_raw(),
+            iram_sa1_write_protect: iram.sa1_write_protect_raw(),
+            cpu: core.cpu_state(),
+            booted: core.booted(),
+            master_clock_debt: core.master_clock_debt(),
+        })
     }
 
     pub(crate) fn restore_state(&mut self, state: &SnesBusState) -> Result<(), String> {
@@ -569,7 +601,39 @@ impl SnesSystemBus {
         self.sram.copy_from_slice(&state.sram);
         self.apu.get_mut().restore_state(&state.apu)?;
         self.input.get_mut().restore_state(&state.input);
+        self.restore_sa1_state(state.sa1.as_ref());
         Ok(())
+    }
+
+    /// `None` (e.g. non-SA-1 cartridge, or a save state predating SA-1 support) leaves SA-1 at
+    /// its current power-on-reset state rather than erroring -- matches this codebase's general
+    /// `#[serde(default)]` backward-compatibility approach elsewhere in save states.
+    fn restore_sa1_state(&mut self, state: Option<&SnesSa1State>) {
+        let Some(state) = state else { return };
+        let (Some(registers), Some(iram), Some(core)) =
+            (&self.sa1_registers, &self.sa1_iram, &mut self.sa1_core)
+        else {
+            return;
+        };
+        registers.borrow_mut().restore_raw(
+            state.ccnt,
+            state.sie,
+            state.reset_vector,
+            state.nmi_vector,
+            state.irq_vector,
+            state.scnt,
+            state.cie,
+            state.snes_nmi_vector,
+            state.snes_irq_vector,
+        );
+        iram.borrow_mut().restore_raw(
+            &state.iram,
+            state.iram_snes_write_protect,
+            state.iram_sa1_write_protect,
+        );
+        core.restore_cpu_state(&state.cpu);
+        core.set_booted(state.booted);
+        core.set_master_clock_debt(state.master_clock_debt);
     }
 
     pub(crate) fn sample_ready(&self) -> bool {
@@ -2181,5 +2245,50 @@ mod tests {
         let mut bus = SnesSystemBus::new(lorom_test_cart());
         bus.write(0x00_3000, 0x42); // no SA-1 I-RAM backing this cartridge: must be a no-op
         assert_eq!(bus.read(0x00_3000), 0x00);
+    }
+
+    #[test]
+    fn save_state_round_trips_sa1_registers_iram_and_cpu() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart());
+        // I-RAM: write-enable only chunks 0-1 ($3000-$31FF) and store distinct marker bytes,
+        // leaving chunk 7 ($3700-$37FF) protected so the protection state itself is exercised.
+        bus.write(0x00_2229, 0x03);
+        bus.write(0x00_3000, 0x11);
+        bus.write(0x00_3100, 0x22);
+        // Boot SA-1: point its reset vector at a real (if trivial) idle loop and release it.
+        bus.write(0x00_2203, 0x00);
+        bus.write(0x00_2204, 0x80); // SA-1 reset vector = $8000 (ROM is zeroed: JMP $0000 loop)
+        bus.write(0x00_2200, 0x00);
+        for _ in 0..300 {
+            bus.tick();
+        }
+        let pc_before = bus.sa1_cpu_pc_for_tests();
+        let a_before = bus.sa1_cpu_a_for_tests();
+
+        let state = bus.capture_state();
+
+        let mut restored = SnesSystemBus::new(sa1_test_cart());
+        restored.restore_state(&state).expect("restore");
+
+        assert_eq!(restored.read_for_debugger(0x00_3000), 0x11);
+        assert_eq!(restored.read_for_debugger(0x00_3100), 0x22);
+        assert_eq!(restored.sa1_cpu_pc_for_tests(), pc_before);
+        assert_eq!(restored.sa1_cpu_a_for_tests(), a_before);
+
+        // The restored I-RAM protection state must survive too: a chunk that was never
+        // enabled stays protected.
+        restored.write(0x00_3700, 0x99);
+        assert_eq!(restored.read(0x00_3700), 0x00);
+    }
+
+    #[test]
+    fn save_state_round_trip_is_a_no_op_for_non_sa1_cartridges() {
+        let bus = SnesSystemBus::new(lorom_test_cart());
+        let state = bus.capture_state();
+        assert_eq!(state.sa1, None);
+
+        let mut restored = SnesSystemBus::new(lorom_test_cart());
+        restored.restore_state(&state).expect("restore");
+        assert_eq!(restored.sa1_cpu_pc_for_tests(), None);
     }
 }

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -7,7 +7,7 @@ use crate::snes::cartridge::Mapping;
 use crate::snes::console::save_state::{SnesBusState, SnesPpuState, SnesRomIdentity};
 use crate::snes::input::{InputPorts, SnesButton};
 use crate::snes::ppu::{DRAM_REFRESH_STOLEN_CLOCKS, Ppu, SnesVideoRegion};
-use crate::snes::sa1::{Sa1ControlRegisters, Sa1Core};
+use crate::snes::sa1::{Sa1ControlRegisters, Sa1Core, Sa1IRam, decode_mirror_offset};
 use crate::trace_apu;
 use std::cell::{Cell, RefCell};
 use std::fs;
@@ -53,6 +53,10 @@ pub struct SnesSystemBus {
     /// `$2200-$220F` SA-1 control/vector register state, shared with [`Sa1Core`]'s own
     /// `Sa1Bus` so both CPU sides see the same registers. `None` for non-SA-1 cartridges.
     sa1_registers: Option<Rc<RefCell<Sa1ControlRegisters>>>,
+    /// SA-1's 2KB I-RAM, shared with `Sa1Bus` so both CPU sides see the same bytes and their
+    /// own independent write-protection registers (`$2229`/`$222A`). `None` for non-SA-1
+    /// cartridges.
+    sa1_iram: Option<Rc<RefCell<Sa1IRam>>>,
     /// The second 65816 CPU core for SA-1. `None` for non-SA-1 cartridges.
     sa1_core: Option<Sa1Core>,
 }
@@ -75,13 +79,14 @@ impl SnesSystemBus {
         let rom = Rc::new(cartridge.rom().to_vec());
         let sram = vec![0; cartridge.sram_size()];
         let spc_ipl = Self::load_spc_ipl_override(spc_ipl_path);
-        let (sa1_registers, sa1_core) =
+        let (sa1_registers, sa1_iram, sa1_core) =
             if cartridge.enhancement_chip() == Some(EnhancementChip::Sa1) {
                 let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
-                let core = Sa1Core::new(Rc::clone(&registers), Rc::clone(&rom));
-                (Some(registers), Some(core))
+                let iram = Rc::new(RefCell::new(Sa1IRam::new()));
+                let core = Sa1Core::new(Rc::clone(&registers), Rc::clone(&iram), Rc::clone(&rom));
+                (Some(registers), Some(iram), Some(core))
             } else {
-                (None, None)
+                (None, None, None)
             };
         Self {
             _cartridge: cartridge,
@@ -103,6 +108,7 @@ impl SnesSystemBus {
             mdr: Cell::new(0),
             ticks: Cell::new(0),
             sa1_registers,
+            sa1_iram,
             sa1_core,
         }
     }
@@ -254,6 +260,8 @@ impl SnesSystemBus {
 
         if let Some(index) = Self::decode_wram_index(addr) {
             self.wram[index]
+        } else if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            iram.borrow().read(offset)
         } else if let Some(index) = self.decode_rom_index(addr) {
             self.rom.get(index).copied().unwrap_or(open_bus)
         } else if let Some(index) = self.decode_sram_index(addr) {
@@ -270,6 +278,10 @@ impl SnesSystemBus {
     fn read_for_debugger_impl(&self, addr: u32) -> u8 {
         if let Some(index) = Self::decode_wram_index(addr) {
             return self.wram[index];
+        }
+
+        if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            return iram.borrow().read(offset);
         }
 
         if let Some(index) = self.decode_rom_index(addr) {
@@ -294,6 +306,8 @@ impl SnesSystemBus {
 
         if let Some(index) = Self::decode_wram_index(addr) {
             self.wram[index] = value;
+        } else if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            iram.borrow_mut().write_from_snes(offset, value);
         } else if let Some(index) = self.decode_sram_index(addr) {
             let len = self.sram.len();
             if len != 0 {
@@ -759,6 +773,14 @@ impl SnesSystemBus {
                 }
                 None => false,
             },
+            // $2229 SIWP: write-only (fullsnes "Write Only Registers"), so no read_mmio arm.
+            0x2229 => match &self.sa1_iram {
+                Some(iram) => {
+                    iram.borrow_mut().set_snes_write_protect(value);
+                    true
+                }
+                None => false,
+            },
             0x4300..=0x437F => self.dma.write_register(offset, value),
             _ => false,
         }
@@ -832,6 +854,10 @@ impl SnesBus for SnesSystemBus {
             let value = self.wram[index];
             self.mdr.set(value);
             value
+        } else if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            let value = iram.borrow().read(offset);
+            self.mdr.set(value);
+            value
         } else if let Some(index) = self.decode_rom_index(addr) {
             if let Some(&value) = self.rom.get(index) {
                 self.mdr.set(value);
@@ -864,6 +890,8 @@ impl SnesBus for SnesSystemBus {
 
         if let Some(index) = Self::decode_wram_index(addr) {
             self.wram[index] = value;
+        } else if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            iram.borrow_mut().write_from_snes(offset, value);
         } else if let Some(index) = self.decode_sram_index(addr) {
             let len = self.sram.len();
             if len != 0 {
@@ -936,6 +964,23 @@ mod tests {
     fn lorom_cart_with_sram() -> Cartridge {
         let mut rom = vec![0u8; 0x20000];
         build_cart(&mut rom, 0x7FC0, 0x20, 0x05)
+    }
+
+    fn sa1_test_cart() -> Cartridge {
+        let mut rom = vec![0u8; 0x10000];
+        let base = 0x7FC0;
+        rom[base..base + 21].copy_from_slice(b"SYSTEM BUS TEST      ");
+        rom[base + 0x3C] = 0x00;
+        rom[base + 0x3D] = 0x80;
+        rom[base + 0x15] = 0x20;
+        rom[base + 0x16] = 0x35; // SA-1 chipset (matches the vendored absindx ROMs' own header)
+        rom[base + 0x17] = 0x07;
+        rom[base + 0x18] = 0x00;
+        rom[base + 0x1C] = 0x34;
+        rom[base + 0x1D] = 0x12;
+        rom[base + 0x1E] = 0xCB;
+        rom[base + 0x1F] = 0xED;
+        Cartridge::from_bytes(&rom).expect("valid SA-1 test cartridge")
     }
 
     fn lorom_cart_with_battery_sram() -> Cartridge {
@@ -2091,5 +2136,50 @@ mod tests {
         }
         let joy1 = (restored.read(0x004219) as u16) << 8 | restored.read(0x004218) as u16;
         assert_ne!(joy1 & (1 << 6), 0, "X preserved across save-state");
+    }
+
+    #[test]
+    fn sa1_iram_mirror_write_is_blocked_until_siwp_enables_its_chunk() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart());
+        bus.write(0x00_3000, 0x42); // SIWP is $00 at reset: write must be dropped.
+        assert_eq!(bus.read(0x00_3000), 0x00);
+
+        bus.write(0x00_2229, 0x01); // enable chunk 0 ($3000-$30FF)
+        bus.write(0x00_3000, 0x42);
+        assert_eq!(bus.read(0x00_3000), 0x42);
+    }
+
+    #[test]
+    fn sa1_iram_mirror_is_visible_through_the_debugger_read_path() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart());
+        bus.write(0x00_2229, 0xFF);
+        bus.write(0x80_31FF, 0x7A); // banks $80-$BF mirror the same window
+        assert_eq!(bus.read_for_debugger(0x00_31FF), 0x7A);
+    }
+
+    #[test]
+    fn sa1_iram_mirror_is_reachable_as_a_general_dma_a_bus_source() {
+        // Modeled directly on `dma_a_to_b_wmdata_writes_wram_and_advances_wmadd` above, with the
+        // A-bus source moved from plain WRAM to the SA-1 I-RAM mirror.
+        let mut bus = SnesSystemBus::new(sa1_test_cart());
+        bus.write(0x00_2229, 0xFF); // write-enable all I-RAM chunks from the SNES side
+        bus.write(0x00_3000, 0x55); // I-RAM source byte, via the mirror window
+
+        // Point WMDATA's auto-increment pointer at $000010.
+        bus.write(0x002181, 0x10);
+        bus.write(0x002182, 0x00);
+        bus.write(0x002183, 0x00);
+
+        write_dma_channel(&mut bus, 0, 0x00, 0x80, 0x00_3000, 1);
+        bus.write(0x00420B, 0x01);
+
+        assert_eq!(bus.read(0x7E0010), 0x55);
+    }
+
+    #[test]
+    fn non_sa1_cartridge_iram_mirror_addresses_are_open_bus() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        bus.write(0x00_3000, 0x42); // no SA-1 I-RAM backing this cartridge: must be a no-op
+        assert_eq!(bus.read(0x00_3000), 0x00);
     }
 }

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -110,6 +110,44 @@ pub struct SnesDmaState {
     pub hdma_lines_left: Vec<u16>,
 }
 
+/// SA-1 enhancement chip state: control/vector registers (`$2200-$220F`), I-RAM plus its two
+/// independent write-protection registers (`$2229`/`$222A`), and the second 65816 CPU core's
+/// own architectural state. `None`/absent on `SnesBusState` for non-SA-1 cartridges and for
+/// save states captured before SA-1 support existed.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct SnesSa1State {
+    #[serde(default)]
+    pub ccnt: u8,
+    #[serde(default)]
+    pub sie: u8,
+    #[serde(default)]
+    pub reset_vector: u16,
+    #[serde(default)]
+    pub nmi_vector: u16,
+    #[serde(default)]
+    pub irq_vector: u16,
+    #[serde(default)]
+    pub scnt: u8,
+    #[serde(default)]
+    pub cie: u8,
+    #[serde(default)]
+    pub snes_nmi_vector: u16,
+    #[serde(default)]
+    pub snes_irq_vector: u16,
+    #[serde(default)]
+    pub iram: Vec<u8>,
+    #[serde(default)]
+    pub iram_snes_write_protect: u8,
+    #[serde(default)]
+    pub iram_sa1_write_protect: u8,
+    #[serde(default)]
+    pub cpu: SnesCpuState,
+    #[serde(default)]
+    pub booted: bool,
+    #[serde(default)]
+    pub master_clock_debt: i64,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SnesBusState {
     #[serde(default)]
@@ -140,6 +178,10 @@ pub struct SnesBusState {
     pub apu: SnesApuState,
     #[serde(default)]
     pub input: InputPortsState,
+    /// `None` for non-SA-1 cartridges, and for save states captured before SA-1 support existed
+    /// (`#[serde(default)]` keeps those loadable).
+    #[serde(default)]
+    pub sa1: Option<SnesSa1State>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]

--- a/src/snes/integration_tests/mod.rs
+++ b/src/snes/integration_tests/mod.rs
@@ -10,4 +10,5 @@ mod processor_tests_65816;
 mod processor_tests_spc700;
 mod rom_runner;
 mod sa1_boot_tests;
+mod sa1_iram_tests;
 mod undisbeliever_tests;

--- a/src/snes/integration_tests/sa1_iram_tests.rs
+++ b/src/snes/integration_tests/sa1_iram_tests.rs
@@ -1,0 +1,94 @@
+//! Black-box coverage for issue #2958 (SA-1 I-RAM and write protection): a hand-built
+//! SA-1-chipset ROM where the main CPU writes a marker byte into I-RAM (via the `$003000`
+//! mirror, after enabling `$2229` SIWP), releases SA-1, and the SA-1 CPU -- after enabling its
+//! own `$222A` CIWP -- reads that byte through the *same* physical I-RAM (its own address space
+//! sees it at `$3000` too) and writes a transformed copy back for the main CPU to observe.
+//!
+//! This is the mechanism `SA1RamProtectionTest.sfc` (automated separately under #2962, once all
+//! of #2956's sub-issues land) depends on for its cross-CPU message passing.
+
+use crate::platform::app_context::AppContext;
+use crate::platform::emulator::Emulator;
+use crate::snes::console::Snes;
+
+const HEADER: usize = 0x7FC0;
+
+fn write_lorom_header(rom: &mut [u8], title: &[u8], chipset: u8) {
+    rom[HEADER..HEADER + 21].fill(b' ');
+    rom[HEADER..HEADER + title.len()].copy_from_slice(title);
+    rom[HEADER + 0x15] = 0x20; // Map mode: LoROM, slow.
+    rom[HEADER + 0x16] = chipset;
+    rom[HEADER + 0x17] = 0x07; // ROM size.
+    rom[HEADER + 0x18] = 0x00; // RAM size.
+    rom[HEADER + 0x1C] = 0x34; // Complement check (not validated by this codebase).
+    rom[HEADER + 0x1D] = 0x12;
+    rom[HEADER + 0x1E] = 0xCB; // Checksum (not validated by this codebase).
+    rom[HEADER + 0x1F] = 0xED;
+    rom[HEADER + 0x3C] = 0x00; // Main CPU reset vector low byte.
+    rom[HEADER + 0x3D] = 0x80; // Main CPU reset vector high byte -> $8000.
+}
+
+/// Builds a 64 KiB LoROM SA-1 ROM whose main-CPU program at bank `$00:$8000` enables I-RAM
+/// writes from the SNES side (`$2229`=`$FF`), stores a marker byte (`$99`) into I-RAM via the
+/// `$003000` mirror, points the SA-1 reset vector at `$9000`, releases SA-1 from reset, then
+/// idles; and whose SA-1-side program at bank `$00:$9000` enables I-RAM writes from its own
+/// side (`$222A`=`$01`), reads the marker byte back, increments it, stores the result at
+/// I-RAM offset `$10`, then idles.
+fn build_sa1_iram_roundtrip_rom() -> Vec<u8> {
+    let mut rom = vec![0u8; 0x1_0000];
+    write_lorom_header(&mut rom, b"SA1 IRAM TEST", 0x35);
+
+    // Main CPU program, bank $00:$8000 (file offset $0000).
+    #[rustfmt::skip]
+    let main_program: [u8; 28] = [
+        0xA9, 0xFF,       // LDA #$FF
+        0x8D, 0x29, 0x22, // STA $2229 (SIWP: write-enable all I-RAM chunks from SNES side)
+        0xA9, 0x99,       // LDA #$99
+        0x8D, 0x00, 0x30, // STA $3000 (marker byte into I-RAM)
+        0xA9, 0x00,       // LDA #$00
+        0x8D, 0x03, 0x22, // STA $2203 (CRVL)
+        0xA9, 0x90,       // LDA #$90
+        0x8D, 0x04, 0x22, // STA $2204 (CRVH) -> SA-1 reset vector = $9000
+        0xA9, 0x00,       // LDA #$00
+        0x8D, 0x00, 0x22, // STA $2200 (CCNT) -> release SA-1 from reset
+        0x4C, 0x19, 0x80, // JMP $8019 (idle loop)
+    ];
+    rom[0x0000..main_program.len()].copy_from_slice(&main_program);
+
+    // SA-1 CPU program, bank $00:$9000 (file offset $1000).
+    #[rustfmt::skip]
+    let sa1_program: [u8; 15] = [
+        0xA9, 0x01,       // LDA #$01
+        0x8D, 0x2A, 0x22, // STA $222A (CIWP: write-enable chunk 0 from SA-1 side)
+        0xAD, 0x00, 0x30, // LDA $3000 (read the marker byte)
+        0x1A,             // INC A
+        0x8D, 0x10, 0x30, // STA $3010 (write the transformed byte, still within chunk 0)
+        0x4C, 0x0C, 0x90, // JMP $900C (idle loop)
+    ];
+    rom[0x1000..0x1000 + sa1_program.len()].copy_from_slice(&sa1_program);
+
+    rom
+}
+
+#[test]
+fn sa1_and_main_cpu_exchange_data_through_shared_iram() {
+    let rom = build_sa1_iram_roundtrip_rom();
+    let mut snes = Snes::new(AppContext::default());
+    snes.load_rom(&rom, "sa1-iram-roundtrip-test.sfc")
+        .expect("failed to load SA-1 I-RAM roundtrip fixture ROM");
+
+    for _ in 0..4000 {
+        snes.run_tick();
+    }
+
+    assert_eq!(
+        snes.read_bus_for_debugger_for_tests(0x00_3000),
+        Some(0x99),
+        "main CPU's marker byte should still be readable through the I-RAM mirror"
+    );
+    assert_eq!(
+        snes.read_bus_for_debugger_for_tests(0x00_3010),
+        Some(0x9A),
+        "SA-1 should have read the marker byte and written back its increment"
+    );
+}

--- a/src/snes/sa1/iram.rs
+++ b/src/snes/sa1/iram.rs
@@ -65,6 +65,34 @@ impl Sa1IRam {
     pub fn set_sa1_write_protect(&mut self, value: u8) {
         self.sa1_write_protect = value;
     }
+
+    /// Raw I-RAM bytes, for save-state capture.
+    pub(crate) fn data(&self) -> &[u8; IRAM_SIZE] {
+        &self.data
+    }
+
+    pub(crate) fn snes_write_protect_raw(&self) -> u8 {
+        self.snes_write_protect
+    }
+
+    pub(crate) fn sa1_write_protect_raw(&self) -> u8 {
+        self.sa1_write_protect
+    }
+
+    /// Restores I-RAM bytes and both protection registers exactly, for save-state loading.
+    /// `data` shorter than [`IRAM_SIZE`] leaves the remaining tail zeroed; longer is truncated.
+    pub(crate) fn restore_raw(
+        &mut self,
+        data: &[u8],
+        snes_write_protect: u8,
+        sa1_write_protect: u8,
+    ) {
+        self.data = [0; IRAM_SIZE];
+        let len = data.len().min(IRAM_SIZE);
+        self.data[..len].copy_from_slice(&data[..len]);
+        self.snes_write_protect = snes_write_protect;
+        self.sa1_write_protect = sa1_write_protect;
+    }
 }
 
 impl Default for Sa1IRam {
@@ -178,5 +206,25 @@ mod tests {
         assert_eq!(decode_direct_offset(0x80_0100), Some(0x100));
         assert_eq!(decode_direct_offset(0x00_0800), None);
         assert_eq!(decode_direct_offset(0x40_0000), None);
+    }
+
+    #[test]
+    fn restore_raw_reinstates_bytes_and_both_protection_registers() {
+        let mut iram = Sa1IRam::new();
+        iram.restore_raw(&[0xAA, 0xBB, 0xCC], 0x01, 0x80);
+        assert_eq!(iram.read(0), 0xAA);
+        assert_eq!(iram.read(1), 0xBB);
+        assert_eq!(iram.read(2), 0xCC);
+        assert_eq!(iram.snes_write_protect_raw(), 0x01);
+        assert_eq!(iram.sa1_write_protect_raw(), 0x80);
+    }
+
+    #[test]
+    fn restore_raw_zero_fills_the_tail_when_given_fewer_bytes_than_iram_size() {
+        let mut iram = Sa1IRam::new();
+        iram.set_snes_write_protect(0xFF);
+        iram.write_from_snes(IRAM_SIZE - 1, 0x77);
+        iram.restore_raw(&[0x01], 0x00, 0x00);
+        assert_eq!(iram.read(IRAM_SIZE - 1), 0x00);
     }
 }

--- a/src/snes/sa1/iram.rs
+++ b/src/snes/sa1/iram.rs
@@ -1,0 +1,182 @@
+//! SA-1 I-RAM (2KB on-chip RAM) and its per-256-byte-chunk write protection.
+//!
+//! Scope (issue #2958): the 2KB I-RAM buffer itself, addressable from the SA-1 side directly at
+//! `$000000-$0007FF` *and* mirrored at `$003000-$0037FF` (fullsnes "Memory Map (SA-1 Side)"), and
+//! from the SNES side only via the `$003000-$0037FF` mirror (banks `$00-$3F`/`$80-$BF`). Register
+//! bit layouts and reset values are sourced from fullsnes ("SNES Cart SA-1 I/O Map" / "Memory
+//! Control" sections), per the `snes-hardware-research` skill's source priority.
+
+/// Size of SA-1's on-chip I-RAM in bytes (fullsnes: "2Kbytes internal I-RAM").
+pub const IRAM_SIZE: usize = 0x800;
+
+/// The 2KB I-RAM buffer plus its two independent write-protection registers.
+///
+/// fullsnes ("SNES Cart SA-1 Memory Control", `$2229`/`$222A`): "Write enable flags for eight
+/// 256-byte chunks (0=Protect, 1=Write Enable). Bit0 for I-RAM `3000h..30FFh`, bit1 for
+/// `3100h..31FFh`, etc, bit7 for `3700h..37FFh`." Both registers reset to `$00`, so I-RAM is
+/// fully write-protected from both CPU sides at power-on until software enables it -- reads are
+/// never protected, from either side.
+pub struct Sa1IRam {
+    data: [u8; IRAM_SIZE],
+    /// `$2229` SIWP: gates writes arriving from the SNES side.
+    snes_write_protect: u8,
+    /// `$222A` CIWP: gates writes arriving from the SA-1 side.
+    sa1_write_protect: u8,
+}
+
+impl Sa1IRam {
+    pub fn new() -> Self {
+        Self {
+            data: [0; IRAM_SIZE],
+            snes_write_protect: 0x00,
+            sa1_write_protect: 0x00,
+        }
+    }
+
+    fn chunk_bit(offset: usize) -> u8 {
+        1 << ((offset & (IRAM_SIZE - 1)) >> 8)
+    }
+
+    /// Reads are never protected, from either CPU side.
+    pub fn read(&self, offset: usize) -> u8 {
+        self.data[offset & (IRAM_SIZE - 1)]
+    }
+
+    /// Writes a byte from the SNES side, honoring `$2229` SIWP.
+    pub fn write_from_snes(&mut self, offset: usize, value: u8) {
+        if self.snes_write_protect & Self::chunk_bit(offset) != 0 {
+            self.data[offset & (IRAM_SIZE - 1)] = value;
+        }
+    }
+
+    /// Writes a byte from the SA-1 side, honoring `$222A` CIWP.
+    pub fn write_from_sa1(&mut self, offset: usize, value: u8) {
+        if self.sa1_write_protect & Self::chunk_bit(offset) != 0 {
+            self.data[offset & (IRAM_SIZE - 1)] = value;
+        }
+    }
+
+    /// `$2229` SIWP write.
+    pub fn set_snes_write_protect(&mut self, value: u8) {
+        self.snes_write_protect = value;
+    }
+
+    /// `$222A` CIWP write.
+    pub fn set_sa1_write_protect(&mut self, value: u8) {
+        self.sa1_write_protect = value;
+    }
+}
+
+impl Default for Sa1IRam {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decodes an address into an I-RAM byte offset (`0..IRAM_SIZE`) if it falls within the
+/// `$003000-$0037FF` mirror window (banks `$00-$3F`/`$80-$BF`), used by both the SNES-side bus
+/// and the SA-1-side bus (SA-1 also sees this same mirror per fullsnes).
+pub fn decode_mirror_offset(addr: u32) -> Option<usize> {
+    let addr = addr & 0xFF_FFFF;
+    let bank = ((addr >> 16) & 0xFF) as u8;
+    let offset = (addr & 0xFFFF) as u16;
+    if matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && (0x3000..=0x37FF).contains(&offset) {
+        Some((offset - 0x3000) as usize)
+    } else {
+        None
+    }
+}
+
+/// Decodes an address into an I-RAM byte offset if it falls within the SA-1-side-only direct
+/// window `$000000-$0007FF` (banks `$00-$3F`/`$80-$BF`; fullsnes: "I-RAM (at both `0000h-07FFh`
+/// and `3000h-37FFh`)").
+pub fn decode_direct_offset(addr: u32) -> Option<usize> {
+    let addr = addr & 0xFF_FFFF;
+    let bank = ((addr >> 16) & 0xFF) as u8;
+    let offset = (addr & 0xFFFF) as u16;
+    if matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && offset <= 0x07FF {
+        Some(offset as usize)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_are_never_protected() {
+        let mut iram = Sa1IRam::new();
+        iram.data[0] = 0xAB;
+        assert_eq!(iram.read(0), 0xAB);
+    }
+
+    #[test]
+    fn snes_write_is_blocked_by_default() {
+        let mut iram = Sa1IRam::new();
+        iram.write_from_snes(0, 0x11);
+        assert_eq!(iram.read(0), 0x00);
+    }
+
+    #[test]
+    fn sa1_write_is_blocked_by_default() {
+        let mut iram = Sa1IRam::new();
+        iram.write_from_sa1(0, 0x11);
+        assert_eq!(iram.read(0), 0x00);
+    }
+
+    #[test]
+    fn snes_write_succeeds_once_its_chunk_is_enabled() {
+        let mut iram = Sa1IRam::new();
+        iram.set_snes_write_protect(0b0000_0001); // chunk 0 ($3000-$30FF) writable
+        iram.write_from_snes(0x0000, 0x22);
+        assert_eq!(iram.read(0x0000), 0x22);
+    }
+
+    #[test]
+    fn snes_write_is_blocked_outside_its_enabled_chunk() {
+        let mut iram = Sa1IRam::new();
+        iram.set_snes_write_protect(0b0000_0001); // only chunk 0 writable
+        iram.write_from_snes(0x0100, 0x22); // chunk 1
+        assert_eq!(iram.read(0x0100), 0x00);
+    }
+
+    #[test]
+    fn sa1_write_succeeds_once_its_chunk_is_enabled() {
+        let mut iram = Sa1IRam::new();
+        iram.set_sa1_write_protect(0b1000_0000); // chunk 7 ($3700-$37FF) writable
+        iram.write_from_sa1(0x07FF, 0x33);
+        assert_eq!(iram.read(0x07FF), 0x33);
+    }
+
+    #[test]
+    fn snes_and_sa1_write_protection_are_independent() {
+        let mut iram = Sa1IRam::new();
+        iram.set_snes_write_protect(0xFF); // all chunks writable from SNES
+        // CIWP stays at its $00 reset value: SA-1-side writes remain blocked.
+        iram.write_from_sa1(0x0000, 0x44);
+        assert_eq!(iram.read(0x0000), 0x00);
+        iram.write_from_snes(0x0000, 0x55);
+        assert_eq!(iram.read(0x0000), 0x55);
+    }
+
+    #[test]
+    fn decode_mirror_offset_covers_the_3000_37ff_window_in_system_banks() {
+        assert_eq!(decode_mirror_offset(0x00_3000), Some(0x000));
+        assert_eq!(decode_mirror_offset(0x00_37FF), Some(0x7FF));
+        assert_eq!(decode_mirror_offset(0x80_3100), Some(0x100));
+        assert_eq!(decode_mirror_offset(0x00_2FFF), None);
+        assert_eq!(decode_mirror_offset(0x00_3800), None);
+        assert_eq!(decode_mirror_offset(0x40_3000), None); // bank $40 is outside 00-3F/80-BF
+    }
+
+    #[test]
+    fn decode_direct_offset_covers_the_0000_07ff_window_in_system_banks() {
+        assert_eq!(decode_direct_offset(0x00_0000), Some(0x000));
+        assert_eq!(decode_direct_offset(0x00_07FF), Some(0x7FF));
+        assert_eq!(decode_direct_offset(0x80_0100), Some(0x100));
+        assert_eq!(decode_direct_offset(0x00_0800), None);
+        assert_eq!(decode_direct_offset(0x40_0000), None);
+    }
+}

--- a/src/snes/sa1/mod.rs
+++ b/src/snes/sa1/mod.rs
@@ -14,7 +14,9 @@ mod iram;
 
 pub use iram::{Sa1IRam, decode_mirror_offset};
 
+use crate::platform::save_state::Stateful;
 use crate::snes::bus::SnesBus;
+use crate::snes::console::save_state::SnesCpuState;
 use crate::snes::cpu::Cpu;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -130,29 +132,55 @@ impl Sa1ControlRegisters {
         self.irq_vector
     }
 
-    #[cfg(test)]
+    pub(crate) fn ccnt(&self) -> u8 {
+        self.ccnt
+    }
+
     pub(crate) fn sie(&self) -> u8 {
         self.sie
     }
 
-    #[cfg(test)]
     pub(crate) fn scnt(&self) -> u8 {
         self.scnt
     }
 
-    #[cfg(test)]
     pub(crate) fn cie(&self) -> u8 {
         self.cie
     }
 
-    #[cfg(test)]
     pub(crate) fn snes_nmi_vector(&self) -> u16 {
         self.snes_nmi_vector
     }
 
-    #[cfg(test)]
     pub(crate) fn snes_irq_vector(&self) -> u16 {
         self.snes_irq_vector
+    }
+
+    /// Restores every register to an exact byte value, for save-state loading. Unlike
+    /// [`Self::write`], this bypasses per-port dispatch semantics (there's no "message" or
+    /// "strobe" to interpret -- just raw state to reinstate).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn restore_raw(
+        &mut self,
+        ccnt: u8,
+        sie: u8,
+        reset_vector: u16,
+        nmi_vector: u16,
+        irq_vector: u16,
+        scnt: u8,
+        cie: u8,
+        snes_nmi_vector: u16,
+        snes_irq_vector: u16,
+    ) {
+        self.ccnt = ccnt;
+        self.sie = sie;
+        self.reset_vector = reset_vector;
+        self.nmi_vector = nmi_vector;
+        self.irq_vector = irq_vector;
+        self.scnt = scnt;
+        self.cie = cie;
+        self.snes_nmi_vector = snes_nmi_vector;
+        self.snes_irq_vector = snes_irq_vector;
     }
 }
 
@@ -344,6 +372,33 @@ impl Sa1Core {
     #[cfg(test)]
     pub(crate) fn cpu(&self) -> &Cpu<Sa1Bus> {
         &self.cpu
+    }
+
+    /// Captures the inner 65816 CPU's register/flag state, for save-state serialization. This
+    /// reuses `Cpu<B>`'s existing bus-agnostic `Stateful` impl -- the same mechanism the main
+    /// CPU already uses -- since `Cpu<Sa1Bus>`'s architectural state doesn't depend on the bus.
+    pub(crate) fn cpu_state(&self) -> SnesCpuState {
+        self.cpu.capture_state()
+    }
+
+    pub(crate) fn restore_cpu_state(&mut self, state: &SnesCpuState) {
+        self.cpu.restore_state(state);
+    }
+
+    pub(crate) fn booted(&self) -> bool {
+        self.booted
+    }
+
+    pub(crate) fn set_booted(&mut self, booted: bool) {
+        self.booted = booted;
+    }
+
+    pub(crate) fn master_clock_debt(&self) -> i64 {
+        self.master_clock_debt
+    }
+
+    pub(crate) fn set_master_clock_debt(&mut self, master_clock_debt: i64) {
+        self.master_clock_debt = master_clock_debt;
     }
 }
 

--- a/src/snes/sa1/mod.rs
+++ b/src/snes/sa1/mod.rs
@@ -1,13 +1,18 @@
-//! SA-1 enhancement chip: dual-CPU core and `$2200-$220F` control/vector registers.
+//! SA-1 enhancement chip: dual-CPU core, `$2200-$220F` control/vector registers, and I-RAM.
 //!
-//! Scope (issue #2957): a second, independently-clocked 65816 CPU core for SA-1, reusing the
-//! existing generic [`Cpu`] unmodified, plus enough of the SA-1 control/vector register block
-//! to boot it. I-RAM, BW-RAM, the cross-CPU IRQ/status handshake, and the version-code/read-only
+//! Scope so far (issues #2957, #2958): a second, independently-clocked 65816 CPU core for SA-1,
+//! reusing the existing generic [`Cpu`] unmodified, the SA-1 control/vector register block
+//! needed to boot it, and SA-1's 2KB I-RAM (see [`iram`]) with its per-CPU-side write
+//! protection. BW-RAM, the cross-CPU IRQ/status handshake, and the version-code/read-only
 //! register block are separate sub-issues of #2956 and land on top of this.
 //!
 //! Register bit layouts and reset values are sourced from fullsnes ("SNES Cart SA-1 I/O Map" /
 //! "Interrupt/Control on SNES Side" / "Interrupt/Control on SA-1 Side" / "Memory Control"
 //! sections), per the `snes-hardware-research` skill's source priority.
+
+mod iram;
+
+pub use iram::{Sa1IRam, decode_mirror_offset};
 
 use crate::snes::bus::SnesBus;
 use crate::snes::cpu::Cpu;
@@ -158,19 +163,29 @@ impl Default for Sa1ControlRegisters {
 }
 
 /// SA-1-side bus: serves the SA-1 CPU's reset/NMI/IRQ vectors from the control registers
-/// instead of ROM, and cartridge ROM through SA-1's default (pre-#2959) Super MMC mapping.
+/// instead of ROM, its 2KB I-RAM (direct `$0000-$07FF` and mirrored `$3000-$37FF`, gated by
+/// `$222A` CIWP on writes), and cartridge ROM through SA-1's default (pre-#2959) Super MMC
+/// mapping.
 ///
-/// I-RAM, BW-RAM, and the `$2200-$230E` register block itself are not yet readable/writable
-/// from the SA-1 side (#2958/#2959/#2961); all other reads return open bus (`0`) and writes are
-/// no-ops.
+/// BW-RAM and the rest of the `$2200-$230E` register block are not yet readable/writable from
+/// the SA-1 side (#2959/#2961); all other reads return open bus (`0`) and writes are no-ops.
 pub struct Sa1Bus {
     registers: Rc<RefCell<Sa1ControlRegisters>>,
+    iram: Rc<RefCell<Sa1IRam>>,
     rom: Rc<Vec<u8>>,
 }
 
 impl Sa1Bus {
-    pub fn new(registers: Rc<RefCell<Sa1ControlRegisters>>, rom: Rc<Vec<u8>>) -> Self {
-        Self { registers, rom }
+    pub fn new(
+        registers: Rc<RefCell<Sa1ControlRegisters>>,
+        iram: Rc<RefCell<Sa1IRam>>,
+        rom: Rc<Vec<u8>>,
+    ) -> Self {
+        Self {
+            registers,
+            iram,
+            rom,
+        }
     }
 
     /// Fullsnes: "IRQ/NMI/Reset vectors can be mapped. Other vectors (BRK/COP etc) are always
@@ -211,6 +226,14 @@ impl Sa1Bus {
             None
         }
     }
+
+    /// True if `addr` is `system_offset` within a system bank (`$00-$3F`/`$80-$BF`), the same
+    /// bank range the `$2200-$23FF` register block lives in.
+    fn is_system_offset(addr: u32, system_offset: u16) -> bool {
+        let bank = ((addr >> 16) & 0xFF) as u8;
+        let offset = (addr & 0xFFFF) as u16;
+        matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && offset == system_offset
+    }
 }
 
 impl SnesBus for Sa1Bus {
@@ -219,13 +242,31 @@ impl SnesBus for Sa1Bus {
         if let Some(byte) = Self::vector_override_byte(addr, &self.registers.borrow()) {
             return byte;
         }
+        if let Some(offset) =
+            iram::decode_direct_offset(addr).or_else(|| iram::decode_mirror_offset(addr))
+        {
+            return self.iram.borrow().read(offset);
+        }
         Self::decode_rom_index(addr)
             .and_then(|index| self.rom.get(index).copied())
             .unwrap_or(0)
     }
 
-    fn write(&mut self, _addr: u32, _value: u8) {
-        // ROM is read-only; I-RAM/BW-RAM writes land in #2958/#2959.
+    fn write(&mut self, addr: u32, value: u8) {
+        let addr = addr & 0xFF_FFFF;
+        if let Some(offset) =
+            iram::decode_direct_offset(addr).or_else(|| iram::decode_mirror_offset(addr))
+        {
+            self.iram.borrow_mut().write_from_sa1(offset, value);
+            return;
+        }
+        // $222A CIWP is SA-1-side-writable (fullsnes I/O map "Side" column); the SNES-side
+        // register block ($2200-$220F, $2229 SIWP) is written from `SnesSystemBus` instead --
+        // see the module doc comment.
+        if Self::is_system_offset(addr, 0x222A) {
+            self.iram.borrow_mut().set_sa1_write_protect(value);
+        }
+        // ROM is read-only; BW-RAM writes land in #2959.
     }
 
     fn tick(&mut self) {
@@ -259,8 +300,12 @@ pub struct Sa1Core {
 }
 
 impl Sa1Core {
-    pub fn new(registers: Rc<RefCell<Sa1ControlRegisters>>, rom: Rc<Vec<u8>>) -> Self {
-        let bus = Sa1Bus::new(Rc::clone(&registers), rom);
+    pub fn new(
+        registers: Rc<RefCell<Sa1ControlRegisters>>,
+        iram: Rc<RefCell<Sa1IRam>>,
+        rom: Rc<Vec<u8>>,
+    ) -> Self {
+        let bus = Sa1Bus::new(Rc::clone(&registers), iram, rom);
         let mut cpu = Cpu::new(bus);
         cpu.set_fast_rom(true);
         Self {
@@ -317,6 +362,10 @@ mod tests {
     fn write_vector(registers: &mut Sa1ControlRegisters, lo_port: u16, hi_port: u16, value: u16) {
         registers.write(lo_port, (value & 0xFF) as u8);
         registers.write(hi_port, (value >> 8) as u8);
+    }
+
+    fn fresh_iram() -> Rc<RefCell<Sa1IRam>> {
+        Rc::new(RefCell::new(Sa1IRam::new()))
     }
 
     #[test]
@@ -383,7 +432,7 @@ mod tests {
     fn bus_serves_reset_vector_instead_of_rom() {
         let registers = registers_with(|r| write_vector(r, 0x2203, 0x2204, 0x9000));
         let rom = Rc::new(vec![0u8; 0x8000]);
-        let bus = Sa1Bus::new(registers, rom);
+        let bus = Sa1Bus::new(registers, fresh_iram(), rom);
         assert_eq!(bus.read(0x00_FFFC), 0x00);
         assert_eq!(bus.read(0x00_FFFD), 0x90);
     }
@@ -395,7 +444,7 @@ mod tests {
             write_vector(r, 0x2207, 0x2208, 0x5678);
         });
         let rom = Rc::new(vec![0u8; 0x8000]);
-        let bus = Sa1Bus::new(registers, rom);
+        let bus = Sa1Bus::new(registers, fresh_iram(), rom);
         assert_eq!(bus.read(0x00_FFEA), 0x34);
         assert_eq!(bus.read(0x00_FFEB), 0x12);
         assert_eq!(bus.read(0x00_FFFA), 0x34);
@@ -412,7 +461,7 @@ mod tests {
         let mut rom = vec![0u8; 0x8000];
         rom[0x0000] = 0xAA; // bank $00 offset $8000
         rom[0x1000] = 0xBB; // bank $00 offset $9000
-        let bus = Sa1Bus::new(registers, Rc::new(rom));
+        let bus = Sa1Bus::new(registers, fresh_iram(), Rc::new(rom));
         assert_eq!(bus.read(0x00_8000), 0xAA);
         assert_eq!(bus.read(0x00_9000), 0xBB);
     }
@@ -421,16 +470,42 @@ mod tests {
     fn bus_returns_open_bus_zero_outside_mapped_rom_and_vectors() {
         let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
         let rom = Rc::new(vec![0xFFu8; 0x8000]);
-        let bus = Sa1Bus::new(registers, rom);
+        let bus = Sa1Bus::new(registers, fresh_iram(), rom);
         // Bank $40 offset $0000 is not in the default LoROM-shaped window.
         assert_eq!(bus.read(0x40_0000), 0x00);
+    }
+
+    #[test]
+    fn bus_reads_iram_through_both_direct_and_mirror_windows() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let iram = fresh_iram();
+        iram.borrow_mut().set_sa1_write_protect(0xFF);
+        iram.borrow_mut().write_from_sa1(0x0010, 0x7E);
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let bus = Sa1Bus::new(registers, Rc::clone(&iram), rom);
+        assert_eq!(bus.read(0x00_0010), 0x7E); // direct window
+        assert_eq!(bus.read(0x00_3010), 0x7E); // mirror window
+    }
+
+    #[test]
+    fn bus_write_honors_sa1_side_iram_protection() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let iram = fresh_iram();
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let mut bus = Sa1Bus::new(registers, Rc::clone(&iram), rom);
+        bus.write(0x00_0000, 0x99); // blocked: CIWP is $00 at reset
+        assert_eq!(iram.borrow().read(0x0000), 0x00);
+
+        iram.borrow_mut().set_sa1_write_protect(0x01);
+        bus.write(0x00_3000, 0xAB); // via mirror window this time
+        assert_eq!(iram.borrow().read(0x0000), 0xAB);
     }
 
     #[test]
     fn core_stays_halted_while_held_in_reset() {
         let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
         let rom = Rc::new(vec![0u8; 0x8000]);
-        let mut core = Sa1Core::new(Rc::clone(&registers), rom);
+        let mut core = Sa1Core::new(Rc::clone(&registers), fresh_iram(), rom);
         for _ in 0..1000 {
             core.tick_one_master_clock();
         }
@@ -451,7 +526,7 @@ mod tests {
             let mut regs = registers.borrow_mut();
             write_vector(&mut regs, 0x2203, 0x2204, 0x9000);
         }
-        let mut core = Sa1Core::new(Rc::clone(&registers), Rc::new(rom));
+        let mut core = Sa1Core::new(Rc::clone(&registers), fresh_iram(), Rc::new(rom));
         registers.borrow_mut().write(0x2200, 0x00); // release reset
 
         for _ in 0..100 {
@@ -474,7 +549,7 @@ mod tests {
             let mut regs = registers.borrow_mut();
             write_vector(&mut regs, 0x2203, 0x2204, 0x9000);
         }
-        let mut core = Sa1Core::new(Rc::clone(&registers), Rc::new(rom));
+        let mut core = Sa1Core::new(Rc::clone(&registers), fresh_iram(), Rc::new(rom));
         registers.borrow_mut().write(0x2200, 0x00);
         for _ in 0..50 {
             core.tick_one_master_clock();


### PR DESCRIPTION
## Summary

- Adds SA-1's 2KB I-RAM (`src/snes/sa1/iram.rs`), addressable directly from the SA-1 side at `$000000-$0007FF` and mirrored (both CPU sides) at `$003000-$0037FF` in system banks (`$00-$3F`/`$80-$BF`), per fullsnes.
- Writes are gated per 256-byte chunk by two independent registers: `$2229` SIWP (SNES-side-writable) and `$222A` CIWP (SA-1-side-writable, so it's written from `Sa1Bus`, not `SnesSystemBus` -- matches fullsnes's I/O map "Side" column). Both reset to `$00`, so I-RAM is fully write-protected from *both* sides at power-on until software enables it; reads are never protected.
- Wired into `SnesSystemBus`'s normal `read()`/`write()`, the debugger-read path, and both general-DMA A-bus helpers (mirroring the existing WRAM handling), plus `Sa1Bus`'s own direct+mirror windows.

This is the second sub-issue of epic #2956 (SA-1 support). A new integration test proves the main CPU and SA-1 CPU can now round-trip data through shared I-RAM -- the mechanism `SA1RamProtectionTest.sfc`'s message-passing handshake depends on. That ROM itself still isn't wired up (#2962), pending BW-RAM (#2959) and the cross-CPU IRQ handshake (#2960).

Fixes #2958.

## Test plan

- [x] `./scripts/test-dir.sh src/snes --skip-integration` -- 1232 passed
- [x] `cargo test --no-default-features --lib` (full suite) -- 12167 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo fmt`
- [x] `npm test` -- 412 passed
- [x] Python test suites -- 149 passed
- [ ] `wasm-pack test --headless --chrome` -- fails in this environment due to the same pre-existing ChromeDriver/Chrome version mismatch noted in #2963 (confirmed there to reproduce on unmodified `main`); Rust code compiles cleanly for `wasm32-unknown-unknown` regardless.
- [x] New unit tests in `src/snes/sa1/iram.rs` (protection bit semantics, independence between the two sides, mirror/direct address decoding) and `src/snes/sa1/mod.rs` (`Sa1Bus` I-RAM read/write through both windows).
- [x] New `SnesSystemBus`-level tests: SIWP-gated mirror writes, the debugger-read path, and a general-DMA-from-I-RAM test modeled on the existing WRAM DMA test.
- [x] New black-box integration test (`src/snes/integration_tests/sa1_iram_tests.rs`): main CPU writes a marker byte into I-RAM and releases SA-1; SA-1 reads it back through its own address space, transforms it, and writes the result back for the main CPU to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)