### PR TITLE
feat(snes): add SA-1 Super MMC ROM banking and BW-RAM mapping/protection

### DIFF
--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -7,7 +7,9 @@ use crate::snes::cartridge::Mapping;
 use crate::snes::console::save_state::{SnesBusState, SnesPpuState, SnesRomIdentity, SnesSa1State};
 use crate::snes::input::{InputPorts, SnesButton};
 use crate::snes::ppu::{DRAM_REFRESH_STOLEN_CLOCKS, Ppu, SnesVideoRegion};
-use crate::snes::sa1::{Sa1ControlRegisters, Sa1Core, Sa1IRam, decode_mirror_offset};
+use crate::snes::sa1::{
+    self, Sa1ControlRegisters, Sa1Core, Sa1IRam, Sa1MemoryControl, decode_mirror_offset,
+};
 use crate::trace_apu;
 use std::cell::{Cell, RefCell};
 use std::fs;
@@ -30,7 +32,7 @@ pub struct SnesSystemBus {
     _cartridge: Cartridge,
     mapping: Mapping,
     rom: Rc<Vec<u8>>,
-    sram: Vec<u8>,
+    sram: Rc<RefCell<Vec<u8>>>,
     wram: Vec<u8>,
     wmadd: Cell<u32>,
     wrmpya: u8,
@@ -57,6 +59,9 @@ pub struct SnesSystemBus {
     /// own independent write-protection registers (`$2229`/`$222A`). `None` for non-SA-1
     /// cartridges.
     sa1_iram: Option<Rc<RefCell<Sa1IRam>>>,
+    /// `$2220-$2228` SA-1 Super MMC ROM banking and BW-RAM mapping/write-protection registers,
+    /// shared with `Sa1Bus`. `None` for non-SA-1 cartridges.
+    sa1_memory_control: Option<Rc<RefCell<Sa1MemoryControl>>>,
     /// The second 65816 CPU core for SA-1. `None` for non-SA-1 cartridges.
     sa1_core: Option<Sa1Core>,
 }
@@ -77,16 +82,28 @@ impl SnesSystemBus {
     ) -> Self {
         let mapping = cartridge.mapping();
         let rom = Rc::new(cartridge.rom().to_vec());
-        let sram = vec![0; cartridge.sram_size()];
+        let sram = Rc::new(RefCell::new(vec![0; cartridge.sram_size()]));
         let spc_ipl = Self::load_spc_ipl_override(spc_ipl_path);
-        let (sa1_registers, sa1_iram, sa1_core) =
+        let (sa1_registers, sa1_iram, sa1_memory_control, sa1_core) =
             if cartridge.enhancement_chip() == Some(EnhancementChip::Sa1) {
                 let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
                 let iram = Rc::new(RefCell::new(Sa1IRam::new()));
-                let core = Sa1Core::new(Rc::clone(&registers), Rc::clone(&iram), Rc::clone(&rom));
-                (Some(registers), Some(iram), Some(core))
+                let memory_control = Rc::new(RefCell::new(Sa1MemoryControl::new()));
+                let core = Sa1Core::new(
+                    Rc::clone(&registers),
+                    Rc::clone(&iram),
+                    Rc::clone(&memory_control),
+                    Rc::clone(&rom),
+                    Rc::clone(&sram),
+                );
+                (
+                    Some(registers),
+                    Some(iram),
+                    Some(memory_control),
+                    Some(core),
+                )
             } else {
-                (None, None, None)
+                (None, None, None, None)
             };
         Self {
             _cartridge: cartridge,
@@ -109,6 +126,7 @@ impl SnesSystemBus {
             ticks: Cell::new(0),
             sa1_registers,
             sa1_iram,
+            sa1_memory_control,
             sa1_core,
         }
     }
@@ -253,26 +271,63 @@ impl SnesSystemBus {
                 || (0x4300..=0x437F).contains(&offset))
     }
 
+    /// SA-1 Super MMC ROM decode, used instead of the generic LoROM/HiROM/ExHiROM decode for
+    /// SA-1-chipped cartridges (fullsnes: "The registers do affect both SNES and SA-1
+    /// mapping"). `None` for non-SA-1 cartridges.
+    fn sa1_rom_index(&self, addr: u32) -> Option<usize> {
+        let control = self.sa1_memory_control.as_ref()?.borrow();
+        sa1::decode_rom_index(addr, &control)
+    }
+
+    /// SA-1 BW-RAM linear offset from the SNES CPU's own perspective: its `$2224` BMAPS block
+    /// select for the windowed `$6000-$7FFF` view, or the direct `$40-$4F` banks. `None` for
+    /// non-SA-1 cartridges.
+    fn sa1_bwram_index(&self, addr: u32) -> Option<usize> {
+        let control = self.sa1_memory_control.as_ref()?.borrow();
+        if let Some(window_offset) = sa1::decode_bwram_windowed_offset(addr) {
+            Some(control.snes_bwram_block() * 0x2000 + window_offset)
+        } else {
+            sa1::decode_bwram_direct_offset(addr)
+        }
+    }
+
     fn dma_read_a_bus_impl(&self, addr: u32, open_bus: u8) -> u8 {
         if Self::is_dma_a_bus_mmio(addr) {
             return open_bus;
         }
 
         if let Some(index) = Self::decode_wram_index(addr) {
-            self.wram[index]
-        } else if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
-            iram.borrow().read(offset)
-        } else if let Some(index) = self.decode_rom_index(addr) {
-            self.rom.get(index).copied().unwrap_or(open_bus)
-        } else if let Some(index) = self.decode_sram_index(addr) {
-            if self.sram.is_empty() {
+            return self.wram[index];
+        }
+        if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            return iram.borrow().read(offset);
+        }
+        if self.sa1_memory_control.is_some() {
+            if let Some(index) = self.sa1_bwram_index(addr) {
+                let sram = self.sram.borrow();
+                return if sram.is_empty() {
+                    open_bus
+                } else {
+                    sram[index % sram.len()]
+                };
+            }
+            return self
+                .sa1_rom_index(addr)
+                .and_then(|index| self.rom.get(index).copied())
+                .unwrap_or(open_bus);
+        }
+        if let Some(index) = self.decode_rom_index(addr) {
+            return self.rom.get(index).copied().unwrap_or(open_bus);
+        }
+        if let Some(index) = self.decode_sram_index(addr) {
+            let sram = self.sram.borrow();
+            return if sram.is_empty() {
                 open_bus
             } else {
-                self.sram[index % self.sram.len()]
-            }
-        } else {
-            open_bus
+                sram[index % sram.len()]
+            };
         }
+        open_bus
     }
 
     fn read_for_debugger_impl(&self, addr: u32) -> u8 {
@@ -284,15 +339,31 @@ impl SnesSystemBus {
             return iram.borrow().read(offset);
         }
 
+        if self.sa1_memory_control.is_some() {
+            if let Some(index) = self.sa1_bwram_index(addr) {
+                let sram = self.sram.borrow();
+                return if sram.is_empty() {
+                    self.mdr.get()
+                } else {
+                    sram[index % sram.len()]
+                };
+            }
+            return self
+                .sa1_rom_index(addr)
+                .and_then(|index| self.rom.get(index).copied())
+                .unwrap_or(self.mdr.get());
+        }
+
         if let Some(index) = self.decode_rom_index(addr) {
             return self.rom.get(index).copied().unwrap_or(self.mdr.get());
         }
 
         if let Some(index) = self.decode_sram_index(addr) {
-            return if self.sram.is_empty() {
+            let sram = self.sram.borrow();
+            return if sram.is_empty() {
                 self.mdr.get()
             } else {
-                self.sram[index % self.sram.len()]
+                sram[index % sram.len()]
             };
         }
 
@@ -306,13 +377,41 @@ impl SnesSystemBus {
 
         if let Some(index) = Self::decode_wram_index(addr) {
             self.wram[index] = value;
-        } else if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            return;
+        }
+        if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
             iram.borrow_mut().write_from_snes(offset, value);
-        } else if let Some(index) = self.decode_sram_index(addr) {
-            let len = self.sram.len();
-            if len != 0 {
-                self.sram[index % len] = value;
+            return;
+        }
+        if self.sa1_memory_control.is_some() {
+            if let Some(index) = self.sa1_bwram_index(addr) {
+                self.write_sa1_bwram(index, value);
             }
+            // ROM is read-only.
+            return;
+        }
+        if let Some(index) = self.decode_sram_index(addr) {
+            let mut sram = self.sram.borrow_mut();
+            let len = sram.len();
+            if len != 0 {
+                sram[index % len] = value;
+            }
+        }
+    }
+
+    /// Writes `value` to BW-RAM at linear offset `index`, honoring the shared write-protection
+    /// rule (`$2226`/`$2227`/`$2228`; see [`Sa1MemoryControl::is_bwram_write_protected`]).
+    fn write_sa1_bwram(&self, index: usize, value: u8) {
+        let Some(control) = &self.sa1_memory_control else {
+            return;
+        };
+        if control.borrow().is_bwram_write_protected(index) {
+            return;
+        }
+        let mut sram = self.sram.borrow_mut();
+        let len = sram.len();
+        if len != 0 {
+            sram[index % len] = value;
         }
     }
 
@@ -369,7 +468,7 @@ impl SnesSystemBus {
 
     /// Returns a snapshot of the current SRAM contents.
     pub fn sram_snapshot(&self) -> Vec<u8> {
-        self.sram.clone()
+        self.sram.borrow().clone()
     }
 
     /// Snapshot the PPU's visible framebuffer as packed RGB888.
@@ -489,9 +588,10 @@ impl SnesSystemBus {
     /// Restores SRAM from a byte slice. If the slice is larger than SRAM,
     /// only the first `sram_size()` bytes are used.
     pub fn restore_sram(&mut self, data: &[u8]) {
-        let len = self.sram.len().min(data.len());
+        let mut sram = self.sram.borrow_mut();
+        let len = sram.len().min(data.len());
         if len > 0 {
-            self.sram[..len].copy_from_slice(&data[..len]);
+            sram[..len].copy_from_slice(&data[..len]);
         }
     }
 
@@ -515,7 +615,7 @@ impl SnesSystemBus {
             dma: self.dma.capture_state(),
             mdr: self.mdr.get(),
             ticks: self.ticks.get(),
-            sram: self.sram.clone(),
+            sram: self.sram.borrow().clone(),
             apu: self.apu.borrow().capture_state(),
             input: self.input.borrow().capture_state(),
             sa1: self.capture_sa1_state(),
@@ -529,6 +629,11 @@ impl SnesSystemBus {
             .sa1_iram
             .as_ref()
             .expect("sa1_iram is constructed alongside sa1_registers")
+            .borrow();
+        let memory_control = self
+            .sa1_memory_control
+            .as_ref()
+            .expect("sa1_memory_control is constructed alongside sa1_registers")
             .borrow();
         let core = self
             .sa1_core
@@ -547,6 +652,15 @@ impl SnesSystemBus {
             iram: iram.data().to_vec(),
             iram_snes_write_protect: iram.snes_write_protect_raw(),
             iram_sa1_write_protect: iram.sa1_write_protect_raw(),
+            cxb: memory_control.cxb(),
+            dxb: memory_control.dxb(),
+            exb: memory_control.exb(),
+            fxb: memory_control.fxb(),
+            bmaps: memory_control.bmaps(),
+            bmap: memory_control.bmap(),
+            sbwe: memory_control.sbwe(),
+            cbwe: memory_control.cbwe(),
+            bwpa: memory_control.bwpa(),
             cpu: core.cpu_state(),
             booted: core.booted(),
             master_clock_debt: core.master_clock_debt(),
@@ -579,10 +693,10 @@ impl SnesSystemBus {
         {
             return Err("DMA HDMA state size mismatch".to_string());
         }
-        if state.sram.len() != self.sram.len() {
+        if state.sram.len() != self.sram.borrow().len() {
             return Err(format!(
                 "SRAM size mismatch (expected {}, found {})",
-                self.sram.len(),
+                self.sram.borrow().len(),
                 state.sram.len()
             ));
         }
@@ -598,7 +712,7 @@ impl SnesSystemBus {
         self.dma.restore_state(&state.dma)?;
         self.mdr.set(state.mdr);
         self.ticks.set(state.ticks);
-        self.sram.copy_from_slice(&state.sram);
+        self.sram.borrow_mut().copy_from_slice(&state.sram);
         self.apu.get_mut().restore_state(&state.apu)?;
         self.input.get_mut().restore_state(&state.input);
         self.restore_sa1_state(state.sa1.as_ref());
@@ -610,9 +724,12 @@ impl SnesSystemBus {
     /// `#[serde(default)]` backward-compatibility approach elsewhere in save states.
     fn restore_sa1_state(&mut self, state: Option<&SnesSa1State>) {
         let Some(state) = state else { return };
-        let (Some(registers), Some(iram), Some(core)) =
-            (&self.sa1_registers, &self.sa1_iram, &mut self.sa1_core)
-        else {
+        let (Some(registers), Some(iram), Some(memory_control), Some(core)) = (
+            &self.sa1_registers,
+            &self.sa1_iram,
+            &self.sa1_memory_control,
+            &mut self.sa1_core,
+        ) else {
             return;
         };
         registers.borrow_mut().restore_raw(
@@ -630,6 +747,17 @@ impl SnesSystemBus {
             &state.iram,
             state.iram_snes_write_protect,
             state.iram_sa1_write_protect,
+        );
+        memory_control.borrow_mut().restore_raw(
+            state.cxb,
+            state.dxb,
+            state.exb,
+            state.fxb,
+            state.bmaps,
+            state.bmap,
+            state.sbwe,
+            state.cbwe,
+            state.bwpa,
         );
         core.restore_cpu_state(&state.cpu);
         core.set_booted(state.booted);
@@ -845,6 +973,17 @@ impl SnesSystemBus {
                 }
                 None => false,
             },
+            // $2220-$2224/$2226/$2228 are the SNES-side-writable subset of the Super MMC/BW-RAM
+            // register block; $2225 BMAP and $2227 CBWE are SA-1-side-writable instead (handled
+            // by `Sa1Bus`). All are write-only (fullsnes "Write Only Registers"), so no
+            // read_mmio arm.
+            0x2220..=0x2224 | 0x2226 | 0x2228 => match &self.sa1_memory_control {
+                Some(memory_control) => {
+                    memory_control.borrow_mut().write(offset, value);
+                    true
+                }
+                None => false,
+            },
             0x4300..=0x437F => self.dma.write_register(offset, value),
             _ => false,
         }
@@ -917,30 +1056,56 @@ impl SnesBus for SnesSystemBus {
         if let Some(index) = Self::decode_wram_index(addr) {
             let value = self.wram[index];
             self.mdr.set(value);
-            value
-        } else if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            return value;
+        }
+        if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
             let value = iram.borrow().read(offset);
             self.mdr.set(value);
-            value
-        } else if let Some(index) = self.decode_rom_index(addr) {
+            return value;
+        }
+        if self.sa1_memory_control.is_some() {
+            if let Some(index) = self.sa1_bwram_index(addr) {
+                let sram = self.sram.borrow();
+                let value = if sram.is_empty() {
+                    self.mdr.get()
+                } else {
+                    sram.get(index % sram.len())
+                        .copied()
+                        .unwrap_or_else(|| self.mdr.get())
+                };
+                self.mdr.set(value);
+                return value;
+            }
+            return if let Some(index) = self.sa1_rom_index(addr) {
+                if let Some(&value) = self.rom.get(index) {
+                    self.mdr.set(value);
+                    value
+                } else {
+                    self.mdr.get()
+                }
+            } else {
+                self.mdr.get()
+            };
+        }
+        if let Some(index) = self.decode_rom_index(addr) {
             if let Some(&value) = self.rom.get(index) {
                 self.mdr.set(value);
-                value
-            } else {
-                self.mdr.get()
+                return value;
             }
-        } else if let Some(index) = self.decode_sram_index(addr) {
-            if self.sram.is_empty() {
-                self.mdr.get()
-            } else if let Some(&value) = self.sram.get(index % self.sram.len()) {
-                self.mdr.set(value);
-                value
-            } else {
-                self.mdr.get()
-            }
-        } else {
-            self.mdr.get()
+            return self.mdr.get();
         }
+        if let Some(index) = self.decode_sram_index(addr) {
+            let sram = self.sram.borrow();
+            if sram.is_empty() {
+                return self.mdr.get();
+            }
+            if let Some(&value) = sram.get(index % sram.len()) {
+                self.mdr.set(value);
+                return value;
+            }
+            return self.mdr.get();
+        }
+        self.mdr.get()
     }
 
     fn read_for_debugger(&self, addr: u32) -> u8 {
@@ -954,13 +1119,25 @@ impl SnesBus for SnesSystemBus {
 
         if let Some(index) = Self::decode_wram_index(addr) {
             self.wram[index] = value;
-        } else if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
+            return;
+        }
+        if let (Some(iram), Some(offset)) = (&self.sa1_iram, decode_mirror_offset(addr)) {
             iram.borrow_mut().write_from_snes(offset, value);
-        } else if let Some(index) = self.decode_sram_index(addr) {
-            let len = self.sram.len();
+            return;
+        }
+        if self.sa1_memory_control.is_some() {
+            if let Some(index) = self.sa1_bwram_index(addr) {
+                self.write_sa1_bwram(index, value);
+            }
+            // ROM is read-only.
+            return;
+        }
+        if let Some(index) = self.decode_sram_index(addr) {
+            let mut sram = self.sram.borrow_mut();
+            let len = sram.len();
             if len != 0 {
                 let wrapped = index % len;
-                if let Some(slot) = self.sram.get_mut(wrapped) {
+                if let Some(slot) = sram.get_mut(wrapped) {
                     *slot = value;
                 }
             }
@@ -1045,6 +1222,24 @@ mod tests {
         rom[base + 0x1E] = 0xCB;
         rom[base + 0x1F] = 0xED;
         Cartridge::from_bytes(&rom).expect("valid SA-1 test cartridge")
+    }
+
+    /// Same as [`sa1_test_cart`] but with a non-zero BW-RAM (SRAM) size, for BW-RAM tests.
+    fn sa1_test_cart_with_bwram() -> Cartridge {
+        let mut rom = vec![0u8; 0x10000];
+        let base = 0x7FC0;
+        rom[base..base + 21].copy_from_slice(b"SYSTEM BUS TEST      ");
+        rom[base + 0x3C] = 0x00;
+        rom[base + 0x3D] = 0x80;
+        rom[base + 0x15] = 0x20;
+        rom[base + 0x16] = 0x35; // SA-1 chipset
+        rom[base + 0x17] = 0x07;
+        rom[base + 0x18] = 0x05; // 32 KB BW-RAM
+        rom[base + 0x1C] = 0x34;
+        rom[base + 0x1D] = 0x12;
+        rom[base + 0x1E] = 0xCB;
+        rom[base + 0x1F] = 0xED;
+        Cartridge::from_bytes(&rom).expect("valid SA-1 test cartridge with BW-RAM")
     }
 
     fn lorom_cart_with_battery_sram() -> Cartridge {
@@ -1813,12 +2008,13 @@ mod tests {
 
     #[test]
     fn sram_snapshot_returns_current_sram_contents() {
-        let mut bus = SnesSystemBus::new(lorom_cart_with_battery_sram());
+        let bus = SnesSystemBus::new(lorom_cart_with_battery_sram());
         // Write some values to SRAM directly
         if bus.sram_size() > 0 {
-            bus.sram[0] = 0xAA;
-            bus.sram[1] = 0xBB;
-            bus.sram[2] = 0xCC;
+            let mut sram = bus.sram.borrow_mut();
+            sram[0] = 0xAA;
+            sram[1] = 0xBB;
+            sram[2] = 0xCC;
         }
 
         let snapshot = bus.sram_snapshot();
@@ -2290,5 +2486,108 @@ mod tests {
         let mut restored = SnesSystemBus::new(lorom_test_cart());
         restored.restore_state(&state).expect("restore");
         assert_eq!(restored.sa1_cpu_pc_for_tests(), None);
+    }
+
+    #[test]
+    fn sa1_bwram_windowed_write_succeeds_once_either_side_enables_writes() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart_with_bwram());
+        bus.write(0x00_6000, 0x42); // BWPA defaults to $FF (protect everything); write dropped.
+        assert_eq!(bus.read(0x00_6000), 0x00);
+
+        // Confirmed against bsnes (KDL3 quirk comment in SA1::BWRAM::writeLinear): BWPA only
+        // protects when *both* SBWE and CBWE are disabled -- enabling just one side already
+        // lifts protection entirely, it isn't independent per-side gating like I-RAM's.
+        bus.write(0x00_2226, 0x80); // SNES side enables writes; SA-1 side (CBWE) stays disabled.
+        bus.write(0x00_6000, 0x42);
+        assert_eq!(bus.read(0x00_6000), 0x42);
+    }
+
+    #[test]
+    fn sa1_bwram_windowed_write_succeeds_once_bwpa_shrinks_below_the_target_offset() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart_with_bwram());
+        bus.write(0x00_2228, 0x00); // protect only the first 256 bytes
+        bus.write(0x00_6100, 0x42); // offset $100, outside the protected region
+        assert_eq!(bus.read(0x00_6100), 0x42);
+    }
+
+    #[test]
+    fn sa1_bwram_windowed_access_honors_bmaps_block_select() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart_with_bwram());
+        bus.write(0x00_2228, 0x00); // shrink protection so the write below succeeds
+        bus.write(0x00_2224, 0x01); // BMAPS: block 1 ($2000-$3FFF of BW-RAM)
+        bus.write(0x00_6000, 0x77);
+        // The same byte must be visible directly at BW-RAM offset $2000 (bank $40).
+        assert_eq!(bus.read(0x40_2000), 0x77);
+    }
+
+    #[test]
+    fn sa1_bwram_direct_banks_cover_the_full_range() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart_with_bwram());
+        bus.write(0x00_2228, 0x00); // shrink protection
+        bus.write(0x00_2226, 0x80); // and enable writes outright
+        bus.write(0x41_0000, 0x99); // bank $41 = BW-RAM offset $10000
+        assert_eq!(bus.read(0x41_0000), 0x99);
+    }
+
+    #[test]
+    fn sa1_rom_banking_hirom_quarter_always_honors_the_bank_select_field() {
+        let mut rom = vec![0u8; 0x20_0000]; // 2MB: room for ROM slots 0 and 1
+        write_sa1_header(&mut rom);
+        rom[0x10_0000..0x10_0003].copy_from_slice(&[0x11, 0x22, 0x33]); // ROM slot 1
+        let cartridge = Cartridge::from_bytes(&rom).expect("valid SA-1 ROM");
+        let mut bus = SnesSystemBus::new(cartridge);
+
+        bus.write(0x00_2220, 0x01); // CXB: slot 1 (bit 7 clear)
+        assert_eq!(bus.read(0xC0_0000), 0x11);
+        assert_eq!(bus.read(0xC0_0001), 0x22);
+    }
+
+    #[test]
+    fn sa1_rom_banking_lorom_quarter_remaps_once_bit7_is_set() {
+        let mut rom = vec![0u8; 0x20_0000]; // 2MB: room for ROM slots 0 and 1
+        write_sa1_header(&mut rom);
+        rom[0x10_0000] = 0xAB; // ROM slot 1, byte 0
+        let cartridge = Cartridge::from_bytes(&rom).expect("valid SA-1 ROM");
+        let mut bus = SnesSystemBus::new(cartridge);
+
+        bus.write(0x00_2220, 0x81); // CXB: slot 1, bit 7 set (remap LoROM too)
+        assert_eq!(bus.read(0x00_8000), 0xAB);
+    }
+
+    /// Writes a minimal valid SA-1 LoROM header into `rom` (64 KiB+, chipset `$35`), matching
+    /// the pattern in [`sa1_test_cart`] but as a free function so ROM-banking tests can build a
+    /// larger backing buffer (needed to address ROM slot 1 at file offset `$100000`).
+    fn write_sa1_header(rom: &mut [u8]) {
+        let base = 0x7FC0;
+        rom[base..base + 21].copy_from_slice(b"SYSTEM BUS TEST      ");
+        rom[base + 0x3C] = 0x00;
+        rom[base + 0x3D] = 0x80;
+        rom[base + 0x15] = 0x20;
+        rom[base + 0x16] = 0x35;
+        rom[base + 0x17] = 0x07;
+        rom[base + 0x18] = 0x00;
+        rom[base + 0x1C] = 0x34;
+        rom[base + 0x1D] = 0x12;
+        rom[base + 0x1E] = 0xCB;
+        rom[base + 0x1F] = 0xED;
+    }
+
+    #[test]
+    fn save_state_round_trips_sa1_memory_control_and_bwram() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart_with_bwram());
+        bus.write(0x00_2228, 0x00); // shrink BWPA protection
+        bus.write(0x00_2226, 0x80); // SBWE
+        bus.write(0x00_2224, 0x03); // BMAPS
+        bus.write(0x00_2220, 0x81); // CXB: slot 1, LoROM remap enabled
+        bus.write(0x00_6000, 0x5A); // BW-RAM byte via the (now block-3) window
+
+        let state = bus.capture_state();
+        let mut restored = SnesSystemBus::new(sa1_test_cart_with_bwram());
+        restored.restore_state(&state).expect("restore");
+
+        assert_eq!(restored.read(0x00_6000), 0x5A);
+        // Protection state must survive: still shrunk to 256 bytes, still write-enabled.
+        restored.write(0x00_6100, 0x11);
+        assert_eq!(restored.read(0x00_6100), 0x11);
     }
 }

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -405,14 +405,20 @@ impl SnesSystemBus {
         let Some(control) = &self.sa1_memory_control else {
             return;
         };
-        if control.borrow().is_bwram_write_protected(index) {
-            return;
-        }
         let mut sram = self.sram.borrow_mut();
         let len = sram.len();
-        if len != 0 {
-            sram[index % len] = value;
+        if len == 0 {
+            return;
         }
+        // Protection must be checked against the *wrapped* physical offset -- BW-RAM mirrors
+        // when the selected block/bank exceeds the physical size, so an unwrapped check could
+        // let a mirrored address (e.g. banks $44-$4F, or a large BMAP block) bypass protection
+        // on a byte that maps onto a protected physical address after wrapping.
+        let wrapped = index % len;
+        if control.borrow().is_bwram_write_protected(wrapped) {
+            return;
+        }
+        sram[wrapped] = value;
     }
 
     fn start_dma_transfer(&mut self, mdmaen: u8) {
@@ -2518,6 +2524,24 @@ mod tests {
         bus.write(0x00_6000, 0x77);
         // The same byte must be visible directly at BW-RAM offset $2000 (bank $40).
         assert_eq!(bus.read(0x40_2000), 0x77);
+    }
+
+    #[test]
+    fn sa1_bwram_write_protection_is_checked_against_the_wrapped_physical_offset() {
+        // 32KB BW-RAM = 4 blocks of 8KB (blocks 0-3). Block 4 wraps around to physical offset 0
+        // -- the exact byte BWPA protects below. A protection check against the *unwrapped*
+        // linear offset (4*0x2000 = 0x8000) would wrongly see it as outside the 256-byte
+        // protected region and let the write through onto a byte that block 0 (offset 0) would
+        // correctly protect.
+        let mut bus = SnesSystemBus::new(sa1_test_cart_with_bwram());
+        bus.write(0x00_2228, 0x00); // protect only the first 256 bytes
+        bus.write(0x00_2224, 0x04); // BMAPS: block 4 (wraps to physical offset 0 in 32KB BW-RAM)
+        bus.write(0x00_6000, 0x42);
+        assert_eq!(
+            bus.read(0x00_6000),
+            0x00,
+            "mirrored block must not bypass protection"
+        );
     }
 
     #[test]

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -40,6 +40,22 @@ fn default_sa1_bwpa() -> u8 {
     0xFF
 }
 
+/// `$2221`/`$2222`/`$2223` DXB/EXB/FXB's hardware reset values (fullsnes "Reset" table: ROM
+/// slots 1/2/3 in order). Used as `#[serde(default)]` fallbacks so a `SnesSa1State` saved before
+/// these fields existed (i.e. before #2959) deserializes to the same ROM mapping as power-on --
+/// plain `0` would incorrectly show ROM slot 0 in all three quarters instead.
+fn default_sa1_dxb() -> u8 {
+    0x01
+}
+
+fn default_sa1_exb() -> u8 {
+    0x02
+}
+
+fn default_sa1_fxb() -> u8 {
+    0x03
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SnesBlockMoveDirection {
     #[default]
@@ -151,11 +167,11 @@ pub struct SnesSa1State {
     pub iram_sa1_write_protect: u8,
     #[serde(default)]
     pub cxb: u8,
-    #[serde(default)]
+    #[serde(default = "default_sa1_dxb")]
     pub dxb: u8,
-    #[serde(default)]
+    #[serde(default = "default_sa1_exb")]
     pub exb: u8,
-    #[serde(default)]
+    #[serde(default = "default_sa1_fxb")]
     pub fxb: u8,
     #[serde(default)]
     pub bmaps: u8,
@@ -455,5 +471,26 @@ impl SnesSaveState {
         let state: Self = crate::platform::save_state::from_bytes(bytes)?;
         crate::platform::save_state::check_version(state.version, &[SNES_SAVESTATE_VERSION])?;
         Ok(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `SnesSa1State` predating #2959 (i.e. before CXB/DXB/EXB/FXB/BMAPS/BMAP/SBWE/CBWE/BWPA
+    /// existed) deserializes as an empty JSON object for those fields.
+    #[test]
+    fn sa1_state_missing_memory_control_fields_deserializes_to_hardware_reset_values() {
+        let state: SnesSa1State = serde_json::from_str("{}").expect("deserialize");
+        assert_eq!(state.cxb, 0x00);
+        assert_eq!(state.dxb, 0x01);
+        assert_eq!(state.exb, 0x02);
+        assert_eq!(state.fxb, 0x03);
+        assert_eq!(state.bmaps, 0x00);
+        assert_eq!(state.bmap, 0x00);
+        assert_eq!(state.sbwe, 0x00);
+        assert_eq!(state.cbwe, 0x00);
+        assert_eq!(state.bwpa, 0xFF);
     }
 }

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -33,6 +33,13 @@ fn default_dram_refresh_position() -> u16 {
     538
 }
 
+/// `$2228` BWPA's hardware reset value (fullsnes "Reset" table), used as the `#[serde(default)]`
+/// fallback so a `SnesSa1State` predating this field still deserializes to the fully-protected
+/// power-on state rather than `bwpa=$00` (protected-area size `256` bytes only).
+fn default_sa1_bwpa() -> u8 {
+    0xFF
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SnesBlockMoveDirection {
     #[default]
@@ -111,9 +118,11 @@ pub struct SnesDmaState {
 }
 
 /// SA-1 enhancement chip state: control/vector registers (`$2200-$220F`), I-RAM plus its two
-/// independent write-protection registers (`$2229`/`$222A`), and the second 65816 CPU core's
-/// own architectural state. `None`/absent on `SnesBusState` for non-SA-1 cartridges and for
-/// save states captured before SA-1 support existed.
+/// independent write-protection registers (`$2229`/`$222A`), Super MMC ROM banking and BW-RAM
+/// mapping/write-protection registers (`$2220-$2228`), and the second 65816 CPU core's own
+/// architectural state. `None`/absent on `SnesBusState` for non-SA-1 cartridges and for save
+/// states captured before SA-1 support existed. BW-RAM's own bytes are `SnesBusState::sram` --
+/// shared with the SNES CPU's cartridge RAM, not duplicated here.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SnesSa1State {
     #[serde(default)]
@@ -140,6 +149,24 @@ pub struct SnesSa1State {
     pub iram_snes_write_protect: u8,
     #[serde(default)]
     pub iram_sa1_write_protect: u8,
+    #[serde(default)]
+    pub cxb: u8,
+    #[serde(default)]
+    pub dxb: u8,
+    #[serde(default)]
+    pub exb: u8,
+    #[serde(default)]
+    pub fxb: u8,
+    #[serde(default)]
+    pub bmaps: u8,
+    #[serde(default)]
+    pub bmap: u8,
+    #[serde(default)]
+    pub sbwe: u8,
+    #[serde(default)]
+    pub cbwe: u8,
+    #[serde(default = "default_sa1_bwpa")]
+    pub bwpa: u8,
     #[serde(default)]
     pub cpu: SnesCpuState,
     #[serde(default)]

--- a/src/snes/integration_tests/mod.rs
+++ b/src/snes/integration_tests/mod.rs
@@ -10,5 +10,6 @@ mod processor_tests_65816;
 mod processor_tests_spc700;
 mod rom_runner;
 mod sa1_boot_tests;
+mod sa1_bwram_tests;
 mod sa1_iram_tests;
 mod undisbeliever_tests;

--- a/src/snes/integration_tests/sa1_bwram_tests.rs
+++ b/src/snes/integration_tests/sa1_bwram_tests.rs
@@ -1,0 +1,92 @@
+//! Black-box coverage for issue #2959 (SA-1 BW-RAM mapping and write protection): a hand-built
+//! SA-1-chipset ROM where the main CPU enables SNES-side BW-RAM writes (`$2226` SBWE), writes a
+//! marker byte into the mappable `$6000-$7FFF` window, releases SA-1, and the SA-1 CPU -- after
+//! enabling its own `$2227` CBWE -- reads that byte through its *own* `$6000-$7FFF` window (same
+//! physical BW-RAM, since both sides default to block 0) and writes a transformed copy back for
+//! the main CPU to observe.
+
+use crate::platform::app_context::AppContext;
+use crate::platform::emulator::Emulator;
+use crate::snes::console::Snes;
+
+const HEADER: usize = 0x7FC0;
+
+fn write_lorom_header(rom: &mut [u8], title: &[u8], chipset: u8, ram_size_field: u8) {
+    rom[HEADER..HEADER + 21].fill(b' ');
+    rom[HEADER..HEADER + title.len()].copy_from_slice(title);
+    rom[HEADER + 0x15] = 0x20; // Map mode: LoROM, slow.
+    rom[HEADER + 0x16] = chipset;
+    rom[HEADER + 0x17] = 0x07; // ROM size.
+    rom[HEADER + 0x18] = ram_size_field;
+    rom[HEADER + 0x1C] = 0x34; // Complement check (not validated by this codebase).
+    rom[HEADER + 0x1D] = 0x12;
+    rom[HEADER + 0x1E] = 0xCB; // Checksum (not validated by this codebase).
+    rom[HEADER + 0x1F] = 0xED;
+    rom[HEADER + 0x3C] = 0x00; // Main CPU reset vector low byte.
+    rom[HEADER + 0x3D] = 0x80; // Main CPU reset vector high byte -> $8000.
+}
+
+/// Builds a 64 KiB LoROM SA-1 ROM (chipset `$35`, 32KB BW-RAM) whose main-CPU program at bank
+/// `$00:$8000` enables SNES-side BW-RAM writes, stores a marker byte (`$77`) into BW-RAM via the
+/// `$6000-$7FFF` window, points the SA-1 reset vector at `$9000`, releases SA-1, then idles; and
+/// whose SA-1-side program at bank `$00:$9000` enables its own BW-RAM writes, reads the marker
+/// byte back through its own `$6000-$7FFF` window, increments it, stores the result at BW-RAM
+/// offset `$10`, then idles.
+fn build_sa1_bwram_roundtrip_rom() -> Vec<u8> {
+    let mut rom = vec![0u8; 0x1_0000];
+    write_lorom_header(&mut rom, b"SA1 BWRAM TEST", 0x35, 0x05);
+
+    // Main CPU program, bank $00:$8000 (file offset $0000).
+    #[rustfmt::skip]
+    let main_program: [u8; 28] = [
+        0xA9, 0x80,       // LDA #$80
+        0x8D, 0x26, 0x22, // STA $2226 (SBWE: SNES-side BW-RAM write enable)
+        0xA9, 0x77,       // LDA #$77
+        0x8D, 0x00, 0x60, // STA $6000 (marker byte into BW-RAM, block 0 default)
+        0xA9, 0x00,       // LDA #$00
+        0x8D, 0x03, 0x22, // STA $2203 (CRVL)
+        0xA9, 0x90,       // LDA #$90
+        0x8D, 0x04, 0x22, // STA $2204 (CRVH) -> SA-1 reset vector = $9000
+        0xA9, 0x00,       // LDA #$00
+        0x8D, 0x00, 0x22, // STA $2200 (CCNT) -> release SA-1 from reset
+        0x4C, 0x19, 0x80, // JMP $8019 (idle loop)
+    ];
+    rom[0x0000..main_program.len()].copy_from_slice(&main_program);
+
+    // SA-1 CPU program, bank $00:$9000 (file offset $1000).
+    #[rustfmt::skip]
+    let sa1_program: [u8; 15] = [
+        0xA9, 0x80,       // LDA #$80
+        0x8D, 0x27, 0x22, // STA $2227 (CBWE: SA-1-side BW-RAM write enable)
+        0xAD, 0x00, 0x60, // LDA $6000 (read the marker byte through SA-1's own window)
+        0x1A,             // INC A
+        0x8D, 0x10, 0x60, // STA $6010 (write the transformed byte, block 0, offset $10)
+        0x4C, 0x0C, 0x90, // JMP $900C (idle loop)
+    ];
+    rom[0x1000..0x1000 + sa1_program.len()].copy_from_slice(&sa1_program);
+
+    rom
+}
+
+#[test]
+fn sa1_and_main_cpu_exchange_data_through_shared_bwram() {
+    let rom = build_sa1_bwram_roundtrip_rom();
+    let mut snes = Snes::new(AppContext::default());
+    snes.load_rom(&rom, "sa1-bwram-roundtrip-test.sfc")
+        .expect("failed to load SA-1 BW-RAM roundtrip fixture ROM");
+
+    for _ in 0..4000 {
+        snes.run_tick();
+    }
+
+    assert_eq!(
+        snes.read_bus_for_debugger_for_tests(0x00_6000),
+        Some(0x77),
+        "main CPU's marker byte should still be readable through the BW-RAM window"
+    );
+    assert_eq!(
+        snes.read_bus_for_debugger_for_tests(0x00_6010),
+        Some(0x78),
+        "SA-1 should have read the marker byte and written back its increment"
+    );
+}

--- a/src/snes/sa1/memory_control.rs
+++ b/src/snes/sa1/memory_control.rs
@@ -1,0 +1,330 @@
+//! SA-1 Super MMC ROM banking (`$2220-$2223`) and BW-RAM mapping/write-protection
+//! (`$2224-$2228`).
+//!
+//! Scope (issue #2959): configurable ROM banking for both CPU sides, the mappable 8KB BW-RAM
+//! window (banks `$00-$3F`/`$80-$BF`:`$6000-$7FFF`) with independent per-side block selection,
+//! direct linear BW-RAM access (banks `$40-$4F`), and the shared write-protection rule. Register
+//! bit layouts, reset values, and the ROM-banking semantics are sourced from fullsnes ("SNES
+//! Cart SA-1 Memory Control" section); fullsnes's wording on the LoROM-range default/bit-7
+//! behavior is ambiguous on its own, so it's cross-checked against bsnes
+//! (`bsnes/sfc/coprocessor/sa1/rom.cpp` `readCPU`, `bwram.cpp` `writeCPU`/`writeLinear`), per the
+//! `snes-hardware-research` skill's escalation path.
+//!
+//! Deliberately out of scope: BW-RAM "bitmap" mode (`$223F` BBF, banks `$60-$6F`, 2bpp/4bpp pixel
+//! packing) -- not exercised by either absindx conformance ROM's RAM-protection focus. `$2225`
+//! BMAP's bit 7 (mode select) is stored but otherwise ignored; SA-1-side BW-RAM access always
+//! uses the linear (non-bitmap) 8KB-window interpretation of BMAP's low 7 bits.
+
+/// `$2220-$2228`: Super MMC ROM banking and BW-RAM mapping/write-protection registers.
+pub struct Sa1MemoryControl {
+    /// `$2220` CXB (SNES-writable): banks `$C0-$CF`/`$00-$1F` ROM banking.
+    cxb: u8,
+    /// `$2221` DXB (SNES-writable): banks `$D0-$DF`/`$20-$3F` ROM banking.
+    dxb: u8,
+    /// `$2222` EXB (SNES-writable): banks `$E0-$EF`/`$80-$9F` ROM banking.
+    exb: u8,
+    /// `$2223` FXB (SNES-writable): banks `$F0-$FF`/`$A0-$BF` ROM banking.
+    fxb: u8,
+    /// `$2224` BMAPS (SNES-writable): SNES-side BW-RAM block select for the `$6000-$7FFF` window.
+    bmaps: u8,
+    /// `$2225` BMAP (SA-1-writable): SA-1-side BW-RAM block select for the `$6000-$7FFF` window
+    /// (bits 0-6) plus the bitmap-mode select (bit 7, stored but not acted on -- see module doc).
+    bmap: u8,
+    /// `$2226` SBWE (SNES-writable): SNES-side BW-RAM write enable (bit 7).
+    sbwe: u8,
+    /// `$2227` CBWE (SA-1-writable): SA-1-side BW-RAM write enable (bit 7).
+    cbwe: u8,
+    /// `$2228` BWPA (SNES-writable): BW-RAM write-protected area size code (bits 0-3).
+    bwpa: u8,
+}
+
+impl Sa1MemoryControl {
+    /// Hardware reset values (fullsnes "Reset" table): `$2220-$2223`=`$00,$01,$02,$03` (ROM
+    /// slots 0-3 in order, bit 7 clear); `$2228`=`$FF` (protected-area code `$F`, i.e. 8MB --
+    /// larger than any real BW-RAM, so effectively "protect everything"); everything else `$00`
+    /// (BW-RAM write-disabled from both sides, combined with the `$FF` BWPA this fully
+    /// protects BW-RAM at power-on, mirroring I-RAM's own protect-by-default convention).
+    pub fn new() -> Self {
+        Self {
+            cxb: 0x00,
+            dxb: 0x01,
+            exb: 0x02,
+            fxb: 0x03,
+            bmaps: 0x00,
+            bmap: 0x00,
+            sbwe: 0x00,
+            cbwe: 0x00,
+            bwpa: 0xFF,
+        }
+    }
+
+    /// Dispatches a write to the raw `$2220-$2228` MMIO offset.
+    pub fn write(&mut self, port: u16, value: u8) {
+        match port {
+            0x2220 => self.cxb = value,
+            0x2221 => self.dxb = value,
+            0x2222 => self.exb = value,
+            0x2223 => self.fxb = value,
+            0x2224 => self.bmaps = value,
+            0x2225 => self.bmap = value,
+            0x2226 => self.sbwe = value,
+            0x2227 => self.cbwe = value,
+            0x2228 => self.bwpa = value,
+            _ => {}
+        }
+    }
+
+    pub(crate) fn cxb(&self) -> u8 {
+        self.cxb
+    }
+    pub(crate) fn dxb(&self) -> u8 {
+        self.dxb
+    }
+    pub(crate) fn exb(&self) -> u8 {
+        self.exb
+    }
+    pub(crate) fn fxb(&self) -> u8 {
+        self.fxb
+    }
+    pub(crate) fn bmaps(&self) -> u8 {
+        self.bmaps
+    }
+    pub(crate) fn bmap(&self) -> u8 {
+        self.bmap
+    }
+    pub(crate) fn sbwe(&self) -> u8 {
+        self.sbwe
+    }
+    pub(crate) fn cbwe(&self) -> u8 {
+        self.cbwe
+    }
+    pub(crate) fn bwpa(&self) -> u8 {
+        self.bwpa
+    }
+
+    /// Restores every register to an exact byte value, for save-state loading.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn restore_raw(
+        &mut self,
+        cxb: u8,
+        dxb: u8,
+        exb: u8,
+        fxb: u8,
+        bmaps: u8,
+        bmap: u8,
+        sbwe: u8,
+        cbwe: u8,
+        bwpa: u8,
+    ) {
+        self.cxb = cxb;
+        self.dxb = dxb;
+        self.exb = exb;
+        self.fxb = fxb;
+        self.bmaps = bmaps;
+        self.bmap = bmap;
+        self.sbwe = sbwe;
+        self.cbwe = cbwe;
+        self.bwpa = bwpa;
+    }
+
+    /// `$2224` BMAPS bits 0-4: SNES-side 8KB BW-RAM block select (0-31).
+    pub fn snes_bwram_block(&self) -> usize {
+        (self.bmaps & 0x1F) as usize
+    }
+
+    /// `$2225` BMAP bits 0-6: SA-1-side 8KB BW-RAM block select (0-127, linear mode).
+    pub fn sa1_bwram_block(&self) -> usize {
+        (self.bmap & 0x7F) as usize
+    }
+
+    /// `$2228` BWPA: size in bytes of the write-protected region, based at BW-RAM offset 0
+    /// (fullsnes: "Select size of Write-Protected Area (`256 SHL N` bytes)").
+    pub fn protected_bytes(&self) -> usize {
+        256usize << (self.bwpa & 0x0F)
+    }
+
+    /// Whether a write to the given *linear* BW-RAM offset is blocked.
+    ///
+    /// bsnes (`SA1::BWRAM::writeCPU`/`writeLinear`), confirming the absindx
+    /// `SA1RamProtectionTest` README's own note ("BW-RAM Protection will not be reflected unless
+    /// protection is enabled on both SNES and SA-1"): protection engages **only** when *both*
+    /// `$2226` SBWE and `$2227` CBWE have their write-enable bit clear; if either side has
+    /// enabled writes, `$2228` BWPA has no effect and the write always succeeds. This is a
+    /// single, shared rule -- not independent per-side protection like I-RAM's SIWP/CIWP.
+    pub fn is_bwram_write_protected(&self, linear_offset: usize) -> bool {
+        let snes_write_enabled = self.sbwe & 0x80 != 0;
+        let sa1_write_enabled = self.cbwe & 0x80 != 0;
+        !snes_write_enabled && !sa1_write_enabled && linear_offset < self.protected_bytes()
+    }
+}
+
+impl Default for Sa1MemoryControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decodes a cartridge ROM address into a byte offset per SA-1's Super MMC banking.
+///
+/// fullsnes: "The registers do affect both SNES and SA-1 mapping" -- this single decode is
+/// shared by both CPU sides. HiROM banks (`$C0-$FF`) always honor their quarter's bank-select
+/// field; LoROM banks (`$00-$3F`/`$80-$BF`:`$8000-$FFFF`) only do so if that quarter's bit 7 is
+/// set, otherwise they show a fixed, un-remapped 1MB slot (0/1/2/3 respectively) -- confirmed
+/// against bsnes's `SA1::ROM::readCPU` since fullsnes's own prose here is ambiguous in
+/// isolation. Each 1MB slot is `256 SHL 12` bytes; up to 8 slots (3-bit field) address up to 8MB.
+pub fn decode_rom_index(addr: u32, control: &Sa1MemoryControl) -> Option<usize> {
+    let addr = addr & 0xFF_FFFF;
+    let bank = ((addr >> 16) & 0xFF) as u8;
+    let offset = (addr & 0xFFFF) as u16;
+
+    if let Some((register, bank_in_quarter)) = match bank {
+        0xC0..=0xCF => Some((control.cxb(), bank & 0x0F)),
+        0xD0..=0xDF => Some((control.dxb(), bank & 0x0F)),
+        0xE0..=0xEF => Some((control.exb(), bank & 0x0F)),
+        0xF0..=0xFF => Some((control.fxb(), bank & 0x0F)),
+        _ => None,
+    } {
+        let slot = (register & 0x07) as usize;
+        return Some(slot * 0x10_0000 + bank_in_quarter as usize * 0x10000 + offset as usize);
+    }
+
+    if offset < 0x8000 {
+        return None;
+    }
+    let (register, fixed_slot, bank_in_quarter) = match bank {
+        0x00..=0x1F => (control.cxb(), 0u8, bank & 0x1F),
+        0x20..=0x3F => (control.dxb(), 1u8, bank & 0x1F),
+        0x80..=0x9F => (control.exb(), 2u8, bank & 0x1F),
+        0xA0..=0xBF => (control.fxb(), 3u8, bank & 0x1F),
+        _ => return None,
+    };
+    let remaps_lorom = register & 0x80 != 0;
+    let slot = if remaps_lorom {
+        (register & 0x07) as usize
+    } else {
+        fixed_slot as usize
+    };
+    Some(slot * 0x10_0000 + bank_in_quarter as usize * 0x8000 + (offset as usize - 0x8000))
+}
+
+/// Decodes an address into a BW-RAM window offset (`0..0x2000`) if it falls within the mappable
+/// `$6000-$7FFF` window (banks `$00-$3F`/`$80-$BF`). The 8KB block selected within BW-RAM is a
+/// per-side concern (`$2224` BMAPS or `$2225` BMAP) applied by the caller.
+pub fn decode_windowed_offset(addr: u32) -> Option<usize> {
+    let addr = addr & 0xFF_FFFF;
+    let bank = ((addr >> 16) & 0xFF) as u8;
+    let offset = (addr & 0xFFFF) as u16;
+    if matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && (0x6000..=0x7FFF).contains(&offset) {
+        Some((offset - 0x6000) as usize)
+    } else {
+        None
+    }
+}
+
+/// Decodes an address into a linear BW-RAM offset if it falls within the direct-access banks
+/// `$40-$4F` (fullsnes: "Entire 256Kbyte BW-RAM (mirrors in 44h-4Fh)" -- the mirroring itself is
+/// handled by the caller modulo-ing against the actual BW-RAM size).
+pub fn decode_direct_offset(addr: u32) -> Option<usize> {
+    let addr = addr & 0xFF_FFFF;
+    let bank = ((addr >> 16) & 0xFF) as u8;
+    let offset = (addr & 0xFFFF) as u16;
+    if (0x40..=0x4F).contains(&bank) {
+        Some((bank - 0x40) as usize * 0x10000 + offset as usize)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_resets_to_hardware_defaults() {
+        let control = Sa1MemoryControl::new();
+        assert_eq!(control.cxb(), 0x00);
+        assert_eq!(control.dxb(), 0x01);
+        assert_eq!(control.exb(), 0x02);
+        assert_eq!(control.fxb(), 0x03);
+        assert_eq!(control.bwpa(), 0xFF);
+        assert_eq!(control.protected_bytes(), 256 << 0xF);
+    }
+
+    #[test]
+    fn hirom_banks_always_honor_the_bank_select_field_regardless_of_bit7() {
+        let mut control = Sa1MemoryControl::new();
+        control.write(0x2220, 0x05); // CXB: slot 5, bit7 clear
+        assert_eq!(decode_rom_index(0x00C0_0000, &control), Some(5 * 0x10_0000));
+        assert_eq!(
+            decode_rom_index(0x00CF_FFFF, &control),
+            Some(5 * 0x10_0000 + 0x0F_FFFF)
+        );
+    }
+
+    #[test]
+    fn lorom_banks_show_a_fixed_slot_when_bit7_is_clear() {
+        let control = Sa1MemoryControl::new(); // cxb=$00, bit7 clear
+        // Bank $00 offset $8000 must show fixed slot 0, ignoring cxb's bank-select bits.
+        assert_eq!(decode_rom_index(0x00_8000, &control), Some(0));
+        // Bank $20 (DXB's quarter) offset $8000 must show fixed slot 1.
+        assert_eq!(decode_rom_index(0x20_8000, &control), Some(0x10_0000));
+    }
+
+    #[test]
+    fn lorom_banks_honor_the_bank_select_field_once_bit7_is_set() {
+        let mut control = Sa1MemoryControl::new();
+        control.write(0x2220, 0x87); // CXB: slot 7, bit7 set (remap LoROM too)
+        assert_eq!(decode_rom_index(0x00_8000, &control), Some(7 * 0x10_0000));
+    }
+
+    #[test]
+    fn lorom_offsets_below_8000_are_unmapped() {
+        let control = Sa1MemoryControl::new();
+        assert_eq!(decode_rom_index(0x00_0000, &control), None);
+    }
+
+    #[test]
+    fn unrelated_banks_are_unmapped() {
+        let control = Sa1MemoryControl::new();
+        assert_eq!(decode_rom_index(0x40_8000, &control), None);
+    }
+
+    #[test]
+    fn decode_windowed_offset_covers_6000_7fff_in_system_banks() {
+        assert_eq!(decode_windowed_offset(0x00_6000), Some(0x0000));
+        assert_eq!(decode_windowed_offset(0x80_7FFF), Some(0x1FFF));
+        assert_eq!(decode_windowed_offset(0x00_5FFF), None);
+        assert_eq!(decode_windowed_offset(0x40_6000), None);
+    }
+
+    #[test]
+    fn decode_direct_offset_covers_40_4f_banks() {
+        assert_eq!(decode_direct_offset(0x40_0000), Some(0));
+        assert_eq!(decode_direct_offset(0x4F_FFFF), Some(0x0F_FFFF));
+        assert_eq!(decode_direct_offset(0x3F_0000), None);
+        assert_eq!(decode_direct_offset(0x50_0000), None);
+    }
+
+    #[test]
+    fn write_protection_engages_only_when_both_sides_have_writes_disabled() {
+        let mut control = Sa1MemoryControl::new();
+        control.write(0x2228, 0x00); // protect only the first 256 bytes
+        assert!(control.is_bwram_write_protected(0));
+        assert!(!control.is_bwram_write_protected(256));
+
+        control.write(0x2226, 0x80); // SNES side enables writes
+        assert!(
+            !control.is_bwram_write_protected(0),
+            "either side enabling writes lifts BWPA"
+        );
+    }
+
+    #[test]
+    fn bwram_block_selects_are_independent_per_side() {
+        let mut control = Sa1MemoryControl::new();
+        control.write(0x2224, 0x05); // BMAPS
+        control.write(0x2225, 0x7F); // BMAP
+        assert_eq!(control.snes_bwram_block(), 5);
+        assert_eq!(control.sa1_bwram_block(), 0x7F);
+    }
+}

--- a/src/snes/sa1/mod.rs
+++ b/src/snes/sa1/mod.rs
@@ -1,18 +1,27 @@
-//! SA-1 enhancement chip: dual-CPU core, `$2200-$220F` control/vector registers, and I-RAM.
+//! SA-1 enhancement chip: dual-CPU core, `$2200-$220F` control/vector registers, I-RAM, Super
+//! MMC ROM banking, and BW-RAM.
 //!
-//! Scope so far (issues #2957, #2958): a second, independently-clocked 65816 CPU core for SA-1,
-//! reusing the existing generic [`Cpu`] unmodified, the SA-1 control/vector register block
-//! needed to boot it, and SA-1's 2KB I-RAM (see [`iram`]) with its per-CPU-side write
-//! protection. BW-RAM, the cross-CPU IRQ/status handshake, and the version-code/read-only
-//! register block are separate sub-issues of #2956 and land on top of this.
+//! Scope so far (issues #2957, #2958, #2959): a second, independently-clocked 65816 CPU core for
+//! SA-1, reusing the existing generic [`Cpu`] unmodified, the SA-1 control/vector register block
+//! needed to boot it, SA-1's 2KB I-RAM (see [`iram`]) with its per-CPU-side write protection,
+//! configurable ROM banking, and BW-RAM mapping/write-protection (see [`memory_control`]). The
+//! cross-CPU IRQ/status handshake and the version-code/read-only register block are separate
+//! sub-issues of #2956 and land on top of this.
 //!
 //! Register bit layouts and reset values are sourced from fullsnes ("SNES Cart SA-1 I/O Map" /
 //! "Interrupt/Control on SNES Side" / "Interrupt/Control on SA-1 Side" / "Memory Control"
-//! sections), per the `snes-hardware-research` skill's source priority.
+//! sections), per the `snes-hardware-research` skill's source priority; the ROM-banking default
+//! LoROM-range behavior is additionally cross-checked against bsnes since fullsnes's own prose
+//! there is ambiguous in isolation (see [`memory_control::decode_rom_index`]'s doc comment).
 
 mod iram;
+mod memory_control;
 
 pub use iram::{Sa1IRam, decode_mirror_offset};
+pub use memory_control::{
+    Sa1MemoryControl, decode_direct_offset as decode_bwram_direct_offset, decode_rom_index,
+    decode_windowed_offset as decode_bwram_windowed_offset,
+};
 
 use crate::platform::save_state::Stateful;
 use crate::snes::bus::SnesBus;
@@ -192,27 +201,34 @@ impl Default for Sa1ControlRegisters {
 
 /// SA-1-side bus: serves the SA-1 CPU's reset/NMI/IRQ vectors from the control registers
 /// instead of ROM, its 2KB I-RAM (direct `$0000-$07FF` and mirrored `$3000-$37FF`, gated by
-/// `$222A` CIWP on writes), and cartridge ROM through SA-1's default (pre-#2959) Super MMC
-/// mapping.
+/// `$222A` CIWP on writes), cartridge ROM through SA-1's configurable Super MMC mapping, and
+/// BW-RAM (windowed `$6000-$7FFF`, gated by its own `$2225` BMAP block select, and direct
+/// `$40-$4F`), gated by the shared write-protection rule (see [`memory_control`]).
 ///
-/// BW-RAM and the rest of the `$2200-$230E` register block are not yet readable/writable from
-/// the SA-1 side (#2959/#2961); all other reads return open bus (`0`) and writes are no-ops.
+/// The rest of the `$2200-$230E` register block is not yet readable/writable from the SA-1 side
+/// (#2961); all other reads return open bus (`0`) and writes are no-ops.
 pub struct Sa1Bus {
     registers: Rc<RefCell<Sa1ControlRegisters>>,
     iram: Rc<RefCell<Sa1IRam>>,
+    memory_control: Rc<RefCell<Sa1MemoryControl>>,
     rom: Rc<Vec<u8>>,
+    sram: Rc<RefCell<Vec<u8>>>,
 }
 
 impl Sa1Bus {
     pub fn new(
         registers: Rc<RefCell<Sa1ControlRegisters>>,
         iram: Rc<RefCell<Sa1IRam>>,
+        memory_control: Rc<RefCell<Sa1MemoryControl>>,
         rom: Rc<Vec<u8>>,
+        sram: Rc<RefCell<Vec<u8>>>,
     ) -> Self {
         Self {
             registers,
             iram,
+            memory_control,
             rom,
+            sram,
         }
     }
 
@@ -237,30 +253,23 @@ impl Sa1Bus {
         })
     }
 
-    /// Default (pre-#2959) Super MMC mapping: CXB/DXB/EXB/FXB left at their hardware reset
-    /// values (`$00/$01/$02/$03`, i.e. ROM slots 0-3 in order, fullsnes "Reset" table) with no
-    /// remapping -- equivalent to a plain LoROM decode for banks `$00-$3F`/`$80-$BF` at offset
-    /// `$8000-$FFFF` (fullsnes "Memory Map (SA-1 Side)": "Four mappable 1MByte LoROM blocks").
-    /// Configurable banking via `$2220-$2223` (including the HiROM-only vs LoROM+HiROM bit 7
-    /// distinction) lands in #2959.
-    fn decode_rom_index(addr: u32) -> Option<usize> {
-        let addr = addr & 0xFF_FFFF;
-        let bank = ((addr >> 16) & 0xFF) as u8;
-        let offset = (addr & 0xFFFF) as u16;
-        if matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && offset >= 0x8000 {
-            let bank_index = (bank & 0x7F) as usize;
-            Some(bank_index * 0x8000 + (offset as usize - 0x8000))
-        } else {
-            None
-        }
-    }
-
     /// True if `addr` is `system_offset` within a system bank (`$00-$3F`/`$80-$BF`), the same
     /// bank range the `$2200-$23FF` register block lives in.
     fn is_system_offset(addr: u32, system_offset: u16) -> bool {
         let bank = ((addr >> 16) & 0xFF) as u8;
         let offset = (addr & 0xFFFF) as u16;
         matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && offset == system_offset
+    }
+
+    /// BW-RAM linear offset from the SA-1 CPU's own perspective: its `$2225` BMAP block select
+    /// for the windowed `$6000-$7FFF` view, or the direct `$40-$4F` banks.
+    fn bwram_index(&self, addr: u32) -> Option<usize> {
+        let control = self.memory_control.borrow();
+        if let Some(window_offset) = memory_control::decode_windowed_offset(addr) {
+            Some(control.sa1_bwram_block() * 0x2000 + window_offset)
+        } else {
+            memory_control::decode_direct_offset(addr)
+        }
     }
 }
 
@@ -275,7 +284,15 @@ impl SnesBus for Sa1Bus {
         {
             return self.iram.borrow().read(offset);
         }
-        Self::decode_rom_index(addr)
+        if let Some(index) = self.bwram_index(addr) {
+            let sram = self.sram.borrow();
+            return if sram.is_empty() {
+                0
+            } else {
+                sram[index % sram.len()]
+            };
+        }
+        memory_control::decode_rom_index(addr, &self.memory_control.borrow())
             .and_then(|index| self.rom.get(index).copied())
             .unwrap_or(0)
     }
@@ -286,6 +303,26 @@ impl SnesBus for Sa1Bus {
             iram::decode_direct_offset(addr).or_else(|| iram::decode_mirror_offset(addr))
         {
             self.iram.borrow_mut().write_from_sa1(offset, value);
+            return;
+        }
+        if let Some(index) = self.bwram_index(addr) {
+            let mut sram = self.sram.borrow_mut();
+            let len = sram.len();
+            if len != 0 && !self.memory_control.borrow().is_bwram_write_protected(index) {
+                let wrapped = index % len;
+                sram[wrapped] = value;
+            }
+            return;
+        }
+        // $2225 BMAP and $2227 CBWE are SA-1-side-writable (fullsnes I/O map "Side" column); the
+        // SNES-side register block ($2220-$2224, $2226, $2228) is written from `SnesSystemBus`
+        // instead -- see the module doc comment.
+        if Self::is_system_offset(addr, 0x2225) {
+            self.memory_control.borrow_mut().write(0x2225, value);
+            return;
+        }
+        if Self::is_system_offset(addr, 0x2227) {
+            self.memory_control.borrow_mut().write(0x2227, value);
             return;
         }
         // $222A CIWP is SA-1-side-writable (fullsnes I/O map "Side" column); the SNES-side
@@ -331,9 +368,11 @@ impl Sa1Core {
     pub fn new(
         registers: Rc<RefCell<Sa1ControlRegisters>>,
         iram: Rc<RefCell<Sa1IRam>>,
+        memory_control: Rc<RefCell<Sa1MemoryControl>>,
         rom: Rc<Vec<u8>>,
+        sram: Rc<RefCell<Vec<u8>>>,
     ) -> Self {
-        let bus = Sa1Bus::new(Rc::clone(&registers), iram, rom);
+        let bus = Sa1Bus::new(Rc::clone(&registers), iram, memory_control, rom, sram);
         let mut cpu = Cpu::new(bus);
         cpu.set_fast_rom(true);
         Self {
@@ -423,6 +462,14 @@ mod tests {
         Rc::new(RefCell::new(Sa1IRam::new()))
     }
 
+    fn fresh_memory_control() -> Rc<RefCell<Sa1MemoryControl>> {
+        Rc::new(RefCell::new(Sa1MemoryControl::new()))
+    }
+
+    fn fresh_sram(size: usize) -> Rc<RefCell<Vec<u8>>> {
+        Rc::new(RefCell::new(vec![0u8; size]))
+    }
+
     #[test]
     fn new_control_registers_hold_sa1_in_reset_by_default() {
         let registers = Sa1ControlRegisters::new();
@@ -487,7 +534,13 @@ mod tests {
     fn bus_serves_reset_vector_instead_of_rom() {
         let registers = registers_with(|r| write_vector(r, 0x2203, 0x2204, 0x9000));
         let rom = Rc::new(vec![0u8; 0x8000]);
-        let bus = Sa1Bus::new(registers, fresh_iram(), rom);
+        let bus = Sa1Bus::new(
+            registers,
+            fresh_iram(),
+            fresh_memory_control(),
+            rom,
+            fresh_sram(0),
+        );
         assert_eq!(bus.read(0x00_FFFC), 0x00);
         assert_eq!(bus.read(0x00_FFFD), 0x90);
     }
@@ -499,7 +552,13 @@ mod tests {
             write_vector(r, 0x2207, 0x2208, 0x5678);
         });
         let rom = Rc::new(vec![0u8; 0x8000]);
-        let bus = Sa1Bus::new(registers, fresh_iram(), rom);
+        let bus = Sa1Bus::new(
+            registers,
+            fresh_iram(),
+            fresh_memory_control(),
+            rom,
+            fresh_sram(0),
+        );
         assert_eq!(bus.read(0x00_FFEA), 0x34);
         assert_eq!(bus.read(0x00_FFEB), 0x12);
         assert_eq!(bus.read(0x00_FFFA), 0x34);
@@ -511,12 +570,18 @@ mod tests {
     }
 
     #[test]
-    fn bus_reads_rom_through_default_lorom_shaped_mapping() {
+    fn bus_reads_rom_through_default_super_mmc_mapping() {
         let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
         let mut rom = vec![0u8; 0x8000];
         rom[0x0000] = 0xAA; // bank $00 offset $8000
         rom[0x1000] = 0xBB; // bank $00 offset $9000
-        let bus = Sa1Bus::new(registers, fresh_iram(), Rc::new(rom));
+        let bus = Sa1Bus::new(
+            registers,
+            fresh_iram(),
+            fresh_memory_control(),
+            Rc::new(rom),
+            fresh_sram(0),
+        );
         assert_eq!(bus.read(0x00_8000), 0xAA);
         assert_eq!(bus.read(0x00_9000), 0xBB);
     }
@@ -525,8 +590,14 @@ mod tests {
     fn bus_returns_open_bus_zero_outside_mapped_rom_and_vectors() {
         let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
         let rom = Rc::new(vec![0xFFu8; 0x8000]);
-        let bus = Sa1Bus::new(registers, fresh_iram(), rom);
-        // Bank $40 offset $0000 is not in the default LoROM-shaped window.
+        let bus = Sa1Bus::new(
+            registers,
+            fresh_iram(),
+            fresh_memory_control(),
+            rom,
+            fresh_sram(0),
+        );
+        // Bank $40 offset $0000 is not in the default Super MMC mapping, nor BW-RAM.
         assert_eq!(bus.read(0x40_0000), 0x00);
     }
 
@@ -537,7 +608,13 @@ mod tests {
         iram.borrow_mut().set_sa1_write_protect(0xFF);
         iram.borrow_mut().write_from_sa1(0x0010, 0x7E);
         let rom = Rc::new(vec![0u8; 0x8000]);
-        let bus = Sa1Bus::new(registers, Rc::clone(&iram), rom);
+        let bus = Sa1Bus::new(
+            registers,
+            Rc::clone(&iram),
+            fresh_memory_control(),
+            rom,
+            fresh_sram(0),
+        );
         assert_eq!(bus.read(0x00_0010), 0x7E); // direct window
         assert_eq!(bus.read(0x00_3010), 0x7E); // mirror window
     }
@@ -547,7 +624,13 @@ mod tests {
         let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
         let iram = fresh_iram();
         let rom = Rc::new(vec![0u8; 0x8000]);
-        let mut bus = Sa1Bus::new(registers, Rc::clone(&iram), rom);
+        let mut bus = Sa1Bus::new(
+            registers,
+            Rc::clone(&iram),
+            fresh_memory_control(),
+            rom,
+            fresh_sram(0),
+        );
         bus.write(0x00_0000, 0x99); // blocked: CIWP is $00 at reset
         assert_eq!(iram.borrow().read(0x0000), 0x00);
 
@@ -557,10 +640,68 @@ mod tests {
     }
 
     #[test]
+    fn bus_reads_and_writes_bwram_through_the_windowed_view_using_bmap() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let memory_control = fresh_memory_control();
+        memory_control.borrow_mut().write(0x2228, 0x00); // shrink BWPA protection
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let sram = fresh_sram(0x1_0000);
+        let mut bus = Sa1Bus::new(
+            registers,
+            fresh_iram(),
+            Rc::clone(&memory_control),
+            rom,
+            Rc::clone(&sram),
+        );
+
+        bus.write(0x2225, 0x02); // BMAP: block 2 (SA-1-writable, routed through Sa1Bus)
+        bus.write(0x00_6010, 0x5A);
+        assert_eq!(sram.borrow()[0x4010], 0x5A); // block 2 * 0x2000 + 0x10
+        assert_eq!(bus.read(0x00_6010), 0x5A);
+    }
+
+    #[test]
+    fn bus_reads_and_writes_bwram_through_the_direct_banks() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let memory_control = fresh_memory_control();
+        memory_control.borrow_mut().write(0x2227, 0x80); // CBWE: SA-1 side enables writes
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let sram = fresh_sram(0x2_0000);
+        let mut bus = Sa1Bus::new(registers, fresh_iram(), memory_control, rom, sram);
+
+        bus.write(0x41_0000, 0x33);
+        assert_eq!(bus.read(0x41_0000), 0x33);
+    }
+
+    #[test]
+    fn bus_bwram_write_honors_the_shared_protection_rule() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let memory_control = fresh_memory_control(); // BWPA=$FF, SBWE=CBWE=0 at reset: protected
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let sram = fresh_sram(0x1_0000);
+        let mut bus = Sa1Bus::new(
+            registers,
+            fresh_iram(),
+            memory_control,
+            rom,
+            Rc::clone(&sram),
+        );
+
+        bus.write(0x00_6000, 0x77);
+        assert_eq!(sram.borrow()[0], 0x00);
+    }
+
+    #[test]
     fn core_stays_halted_while_held_in_reset() {
         let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
         let rom = Rc::new(vec![0u8; 0x8000]);
-        let mut core = Sa1Core::new(Rc::clone(&registers), fresh_iram(), rom);
+        let mut core = Sa1Core::new(
+            Rc::clone(&registers),
+            fresh_iram(),
+            fresh_memory_control(),
+            rom,
+            fresh_sram(0),
+        );
         for _ in 0..1000 {
             core.tick_one_master_clock();
         }
@@ -581,7 +722,13 @@ mod tests {
             let mut regs = registers.borrow_mut();
             write_vector(&mut regs, 0x2203, 0x2204, 0x9000);
         }
-        let mut core = Sa1Core::new(Rc::clone(&registers), fresh_iram(), Rc::new(rom));
+        let mut core = Sa1Core::new(
+            Rc::clone(&registers),
+            fresh_iram(),
+            fresh_memory_control(),
+            Rc::new(rom),
+            fresh_sram(0),
+        );
         registers.borrow_mut().write(0x2200, 0x00); // release reset
 
         for _ in 0..100 {
@@ -604,7 +751,13 @@ mod tests {
             let mut regs = registers.borrow_mut();
             write_vector(&mut regs, 0x2203, 0x2204, 0x9000);
         }
-        let mut core = Sa1Core::new(Rc::clone(&registers), fresh_iram(), Rc::new(rom));
+        let mut core = Sa1Core::new(
+            Rc::clone(&registers),
+            fresh_iram(),
+            fresh_memory_control(),
+            Rc::new(rom),
+            fresh_sram(0),
+        );
         registers.borrow_mut().write(0x2200, 0x00);
         for _ in 0..50 {
             core.tick_one_master_clock();

--- a/src/snes/sa1/mod.rs
+++ b/src/snes/sa1/mod.rs
@@ -308,9 +308,17 @@ impl SnesBus for Sa1Bus {
         if let Some(index) = self.bwram_index(addr) {
             let mut sram = self.sram.borrow_mut();
             let len = sram.len();
-            if len != 0 && !self.memory_control.borrow().is_bwram_write_protected(index) {
+            if len != 0 {
+                // Protection must be checked against the *wrapped* physical offset -- see the
+                // matching comment on `SnesSystemBus::write_sa1_bwram`.
                 let wrapped = index % len;
-                sram[wrapped] = value;
+                if !self
+                    .memory_control
+                    .borrow()
+                    .is_bwram_write_protected(wrapped)
+                {
+                    sram[wrapped] = value;
+                }
             }
             return;
         }
@@ -689,6 +697,33 @@ mod tests {
 
         bus.write(0x00_6000, 0x77);
         assert_eq!(sram.borrow()[0], 0x00);
+    }
+
+    #[test]
+    fn bus_bwram_write_protection_is_checked_against_the_wrapped_physical_offset() {
+        // Same scenario as the SnesSystemBus-level regression test: an 8KB-per-block BW-RAM
+        // with only 0x8000 (32KB, blocks 0-3) of physical backing. Block 4 wraps to physical
+        // offset 0, which BWPA protects; an unwrapped protection check would miss this.
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let memory_control = fresh_memory_control();
+        memory_control.borrow_mut().write(0x2228, 0x00); // protect only the first 256 bytes
+        memory_control.borrow_mut().write(0x2225, 0x04); // BMAP: block 4
+        let rom = Rc::new(vec![0u8; 0x8000]);
+        let sram = fresh_sram(0x8000);
+        let mut bus = Sa1Bus::new(
+            registers,
+            fresh_iram(),
+            memory_control,
+            rom,
+            Rc::clone(&sram),
+        );
+
+        bus.write(0x00_6000, 0x42);
+        assert_eq!(
+            sram.borrow()[0],
+            0x00,
+            "mirrored block must not bypass protection"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Configurable Super MMC ROM banking** (\`\$2220-\$2223\` CXB/DXB/EXB/FXB), replacing #2957's fixed-default-only mapping on *both* CPU buses. fullsnes confirms these registers affect both SNES and SA-1 mapping; its own prose on the LoROM range's bit-7/default behavior was ambiguous in isolation, so the exact rule is cross-checked against bsnes (\`sfc/coprocessor/sa1/rom.cpp\` \`readCPU\`): HiROM banks (\`\$C0-\$FF\`) always honor their quarter's bank-select field; LoROM banks (\`\$00-\$3F\`/\`\$80-\$BF\`:\`\$8000-\$FFFF\`) only do so once that quarter's bit 7 is set, otherwise showing a fixed, un-remapped 1MB slot.
- **BW-RAM**: the mappable 8KB \`\$6000-\$7FFF\` window (independent block-select per CPU side via \`\$2224\` BMAPS / \`\$2225\` BMAP) and direct linear access at banks \`\$40-\$4F\`, sharing the same underlying bytes as the existing cartridge SRAM (\`sram\` is now \`Rc<RefCell<Vec<u8>>>\`, mirroring how ROM is already shared between the two buses).
- **Shared write-protection rule** (\`\$2226\` SBWE / \`\$2227\` CBWE / \`\$2228\` BWPA): confirmed against bsnes's \`BWRAM::writeLinear\` (including its Kirby's Dream Land 3 quirk comment) that protection engages only when *both* sides have writes disabled -- enabling either one lifts it entirely, unlike I-RAM's independent per-side SIWP/CIWP.
- Extends \`SnesSa1State\` (save-state) with the new registers immediately, following the same approach as #2958 rather than deferring the gap.

This is the third sub-issue of epic #2956 (SA-1 support). A new integration test proves the main CPU and SA-1 CPU can round-trip data through shared BW-RAM using a real running SA-1 program. **Neither vendored absindx ROM passes yet** -- BW-RAM/I-RAM protection round-trips now work, but the cross-CPU IRQ handshake (#2960) and version-code register (#2961) are still needed before #2962 can wire up the actual conformance ROMs.

Fixes #2959.

## Test plan

- [x] \`./scripts/test-dir.sh src/snes --skip-integration\` -- 1256 passed
- [x] \`cargo test --no-default-features --lib\` (full suite) -- 12192 passed, 0 failed
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` -- clean
- [x] \`cargo fmt\`
- [x] \`npm test\` -- 412 passed
- [x] Python test suites -- 378 passed
- [ ] \`wasm-pack test --headless --chrome\` -- not re-verified this round; the prior two PRs in this epic (#2963, #2964) confirmed the only failure mode seen locally is a pre-existing ChromeDriver/Chrome version mismatch unrelated to code changes, and CI's own \`wasm\`/\`web-integration\` jobs are the authoritative check here.
- [x] New unit tests in \`src/snes/sa1/memory_control.rs\` (ROM-banking HiROM/LoROM/bit-7 rules, BW-RAM window/direct decode, shared protection rule) and \`src/snes/sa1/mod.rs\` (\`Sa1Bus\` BW-RAM read/write through both windows, \$2225/\$2227 SA-1-side register routing).
- [x] New \`SnesSystemBus\`-level tests: BWPA/SBWE/CBWE interplay, BMAPS block selection, direct-bank range, ROM-banking HiROM/LoROM behavior, and an extended save-state round-trip covering the new registers.
- [x] New black-box integration test (\`src/snes/integration_tests/sa1_bwram_tests.rs\`): main CPU writes a marker byte into BW-RAM and releases SA-1; SA-1 reads it back through its own BW-RAM window, transforms it, and writes the result back for the main CPU to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)