### PR TITLE
feat(snes): SA-1 cross-CPU IRQ and status registers

### DIFF
--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -291,11 +291,48 @@ impl SnesSystemBus {
         }
     }
 
+    /// SNES-side optional NMI/IRQ vector-override interception: reads of `$00FFEA`/`$00FFEB`
+    /// return `$220C`/`$220D` SNV instead of ROM when `$2209` SCNT bit 4 is set; reads of
+    /// `$00FFEE`/`$00FFEF` return `$220E`/`$220F` SIV instead when SCNT bit 6 is set (confirmed
+    /// against bsnes's `SA1::ROM::readCPU`, since fullsnes documents the switch bits but not
+    /// this exact interception mechanism). fullsnes notes real games rarely use this for actual
+    /// vector redirection ("used only by Jumpin Derby") -- the absindx RAM protection test
+    /// instead repurposes the IRQ pair as a data side-channel: its own IRQ handler, entered via
+    /// the ROM's ordinary fixed IRQ vector, deliberately re-reads `$00FFEE` as *data* to recover
+    /// a byte SA-1 stashed in SIV (see `Sa1ControlRegisters::snes_irq_vector`'s doc comment).
+    /// `None` for non-SA-1 cartridges or when the matching override switch is off.
+    fn sa1_snes_vector_override_byte(&self, addr: u32) -> Option<u8> {
+        let registers = self.sa1_registers.as_ref()?.borrow();
+        let (vector, low_byte) = match addr & 0xFF_FFFF {
+            0x00_FFEA if registers.snes_nmi_vector_override_enabled() => {
+                (registers.snes_nmi_vector(), true)
+            }
+            0x00_FFEB if registers.snes_nmi_vector_override_enabled() => {
+                (registers.snes_nmi_vector(), false)
+            }
+            0x00_FFEE if registers.snes_irq_vector_override_enabled() => {
+                (registers.snes_irq_vector(), true)
+            }
+            0x00_FFEF if registers.snes_irq_vector_override_enabled() => {
+                (registers.snes_irq_vector(), false)
+            }
+            _ => return None,
+        };
+        Some(if low_byte {
+            (vector & 0xFF) as u8
+        } else {
+            (vector >> 8) as u8
+        })
+    }
+
     fn dma_read_a_bus_impl(&self, addr: u32, open_bus: u8) -> u8 {
         if Self::is_dma_a_bus_mmio(addr) {
             return open_bus;
         }
 
+        if let Some(byte) = self.sa1_snes_vector_override_byte(addr) {
+            return byte;
+        }
         if let Some(index) = Self::decode_wram_index(addr) {
             return self.wram[index];
         }
@@ -331,6 +368,10 @@ impl SnesSystemBus {
     }
 
     fn read_for_debugger_impl(&self, addr: u32) -> u8 {
+        if let Some(byte) = self.sa1_snes_vector_override_byte(addr) {
+            return byte;
+        }
+
         if let Some(index) = Self::decode_wram_index(addr) {
             return self.wram[index];
         }
@@ -670,6 +711,9 @@ impl SnesSystemBus {
             cpu: core.cpu_state(),
             booted: core.booted(),
             master_clock_debt: core.master_clock_debt(),
+            sa1_irq_pending: registers.sa1_irq_pending(),
+            sa1_nmi_pending: registers.sa1_nmi_pending(),
+            snes_irq_pending: registers.snes_irq_pending(),
         })
     }
 
@@ -748,6 +792,9 @@ impl SnesSystemBus {
             state.cie,
             state.snes_nmi_vector,
             state.snes_irq_vector,
+            state.sa1_irq_pending,
+            state.sa1_nmi_pending,
+            state.snes_irq_pending,
         );
         iram.borrow_mut().restore_raw(
             &state.iram,
@@ -813,6 +860,16 @@ impl SnesSystemBus {
         self.sa1_core.as_ref().map(|core| core.cpu().read_a())
     }
 
+    /// Simulates the SA-1 CPU itself writing one of its side-writable registers (e.g. `$2209`
+    /// SCNT, `$220A` CIE, `$220B` CIC), without needing a running fixture program. No-op for
+    /// non-SA-1 cartridges.
+    #[cfg(test)]
+    pub(crate) fn write_sa1_side_register_for_tests(&self, port: u16, value: u8) {
+        if let Some(registers) = &self.sa1_registers {
+            registers.borrow_mut().write(port, value);
+        }
+    }
+
     fn read_mmio(&self, addr: u32) -> Option<u8> {
         let offset = Self::decode_system_offset(addr)?;
         let open_bus = self.mdr.get();
@@ -856,6 +913,10 @@ impl SnesSystemBus {
             0x4016 => self.input.borrow_mut().read_joya(open_bus),
             0x4017 => self.input.borrow_mut().read_joyb(open_bus),
             0x4218..=0x421F => self.input.borrow().read_joy_register(offset)?,
+            // $2300 SFR: SNES-side status flag read (message from SA-1, vector-override
+            // switches, IRQ-from-SA-1 pending). `None` for non-SA-1 cartridges, matching every
+            // other SA-1 register's fall-through-to-open-bus behavior.
+            0x2300 => self.sa1_registers.as_ref()?.borrow().sfr(),
             0x4300..=0x437F => self.dma.read_register(offset)?,
             _ => return None,
         };
@@ -961,10 +1022,11 @@ impl SnesSystemBus {
                 self.ppu.borrow_mut().write_register(offset, value);
                 true
             }
-            // SA-1 control/vector registers are write-only on real hardware (fullsnes lists
-            // them under "Write Only Registers"), so there is no matching read_mmio arm --
-            // reads of this range correctly fall through to open bus.
-            0x2200..=0x220F => match &self.sa1_registers {
+            // $2200-$2208 are the SNES-side-writable subset of the control/vector register
+            // block; $2209-$220F (SCNT/CIE/CIC/SNV/SIV) are SA-1-side-writable instead (handled
+            // by `Sa1Bus`). All are write-only (fullsnes "Write Only Registers"), so no
+            // read_mmio arm -- $2300 SFR is the separate read-only status register.
+            0x2200..=0x2208 => match &self.sa1_registers {
                 Some(registers) => {
                     registers.borrow_mut().write(offset, value);
                     true
@@ -1057,6 +1119,11 @@ impl SnesBus for SnesSystemBus {
         if let Some(value) = self.read_mmio(addr) {
             self.mdr.set(value);
             return value;
+        }
+
+        if let Some(byte) = self.sa1_snes_vector_override_byte(addr) {
+            self.mdr.set(byte);
+            return byte;
         }
 
         if let Some(index) = Self::decode_wram_index(addr) {
@@ -1167,8 +1234,14 @@ impl SnesBus for SnesSystemBus {
 
     fn poll_irq(&self) -> bool {
         // CPU-dispatch-visible signal (one-dot delayed vs. the raw PPU line) -- see
-        // `Ppu::poll_irq_dispatch` and the `SnesBus::poll_irq` trait doc.
+        // `Ppu::poll_irq_dispatch` and the `SnesBus::poll_irq` trait doc. OR'd with SA-1's own
+        // cross-CPU IRQ line (SCNT bit 7 pending && SIE bit 7 enabled), which has no equivalent
+        // dispatch-pipeline delay to model.
         self.ppu.borrow().poll_irq_dispatch()
+            || self
+                .sa1_registers
+                .as_ref()
+                .is_some_and(|registers| registers.borrow().snes_irq_line())
     }
 
     fn screen_dimensions(&self) -> (u32, u32) {
@@ -2578,6 +2651,60 @@ mod tests {
         assert_eq!(bus.read(0x00_8000), 0xAB);
     }
 
+    #[test]
+    fn sa1_irq_vector_override_redirects_00ffee_ffef_to_siv() {
+        let bus = SnesSystemBus::new(sa1_test_cart());
+        // Before the override switch (SCNT bit 6) is set, $00FFEE/FFEF read real ROM (zeroed).
+        assert_eq!(bus.read(0x00_FFEE), 0x00);
+
+        bus.write_sa1_side_register_for_tests(0x220E, 0x34); // SIV low
+        bus.write_sa1_side_register_for_tests(0x220F, 0x12); // SIV high
+        bus.write_sa1_side_register_for_tests(0x2209, 0x40); // SCNT bit 6: enable IRQ vector override
+        assert_eq!(bus.read(0x00_FFEE), 0x34);
+        assert_eq!(bus.read(0x00_FFEF), 0x12);
+        assert_eq!(
+            bus.read_for_debugger(0x00_FFEE),
+            0x34,
+            "debugger path sees the same override"
+        );
+    }
+
+    #[test]
+    fn sa1_nmi_vector_override_redirects_00ffea_ffeb_to_snv() {
+        let bus = SnesSystemBus::new(sa1_test_cart());
+        bus.write_sa1_side_register_for_tests(0x220C, 0x78); // SNV low
+        bus.write_sa1_side_register_for_tests(0x220D, 0x56); // SNV high
+        bus.write_sa1_side_register_for_tests(0x2209, 0x10); // SCNT bit 4: enable NMI vector override
+        assert_eq!(bus.read(0x00_FFEA), 0x78);
+        assert_eq!(bus.read(0x00_FFEB), 0x56);
+    }
+
+    #[test]
+    fn sa1_vector_override_does_not_affect_non_sa1_cartridges() {
+        let bus = SnesSystemBus::new(lorom_test_cart());
+        assert_eq!(bus.read(0x00_FFEE), 0x00);
+    }
+
+    #[test]
+    fn sa1_irq_from_sa1_asserts_main_bus_poll_irq_once_enabled() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart());
+        bus.write_sa1_side_register_for_tests(0x2209, 0x80); // SCNT: SA-1 raises IRQ
+        assert!(!bus.poll_irq(), "SIE not yet enabled");
+
+        bus.write(0x00_2201, 0x80); // SIE: SNES side enables IRQ-from-SA-1
+        assert!(bus.poll_irq());
+
+        bus.write(0x00_2202, 0x80); // SIC: acknowledge
+        assert!(!bus.poll_irq());
+    }
+
+    #[test]
+    fn sa1_sfr_reflects_message_and_pending_from_scnt() {
+        let bus = SnesSystemBus::new(sa1_test_cart());
+        bus.write_sa1_side_register_for_tests(0x2209, 0x87); // message=7, IRQ trigger
+        assert_eq!(bus.read(0x00_2300), 0x87);
+    }
+
     /// Writes a minimal valid SA-1 LoROM header into `rom` (64 KiB+, chipset `$35`), matching
     /// the pattern in [`sa1_test_cart`] but as a free function so ROM-banking tests can build a
     /// larger backing buffer (needed to address ROM slot 1 at file offset `$100000`).
@@ -2613,5 +2740,25 @@ mod tests {
         // Protection state must survive: still shrunk to 256 bytes, still write-enabled.
         restored.write(0x00_6100, 0x11);
         assert_eq!(restored.read(0x00_6100), 0x11);
+    }
+
+    #[test]
+    fn save_state_round_trips_sa1_cross_cpu_interrupt_pending_flags() {
+        let mut bus = SnesSystemBus::new(sa1_test_cart());
+        bus.write(0x00_2200, 0x90); // CCNT: latch sa1_irq_pending and sa1_nmi_pending
+        bus.write_sa1_side_register_for_tests(0x2209, 0x80); // SCNT: latch snes_irq_pending
+
+        let state = bus.capture_state();
+        let mut restored = SnesSystemBus::new(sa1_test_cart());
+        restored.restore_state(&state).expect("restore");
+
+        let registers = restored
+            .sa1_registers
+            .as_ref()
+            .expect("SA-1 cart should have control registers")
+            .borrow();
+        assert!(registers.sa1_irq_pending());
+        assert!(registers.sa1_nmi_pending());
+        assert!(registers.snes_irq_pending());
     }
 }

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -189,6 +189,16 @@ pub struct SnesSa1State {
     pub booted: bool,
     #[serde(default)]
     pub master_clock_debt: i64,
+    /// CFR bit 7 (SA-1-side IRQ-from-SNES pending). Not re-derivable from `ccnt` alone, since
+    /// its message nibble may have been overwritten since the flag latched.
+    #[serde(default)]
+    pub sa1_irq_pending: bool,
+    /// CFR bit 4 (SA-1-side NMI-from-SNES pending). See `sa1_irq_pending`.
+    #[serde(default)]
+    pub sa1_nmi_pending: bool,
+    /// SFR bit 7 (SNES-side IRQ-from-SA-1 pending). See `sa1_irq_pending`.
+    #[serde(default)]
+    pub snes_irq_pending: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
@@ -492,5 +502,17 @@ mod tests {
         assert_eq!(state.sbwe, 0x00);
         assert_eq!(state.cbwe, 0x00);
         assert_eq!(state.bwpa, 0xFF);
+    }
+
+    /// A `SnesSa1State` predating #2960 (i.e. before the cross-CPU IRQ pending flags existed)
+    /// deserializes with all three flags clear -- the correct "nothing pending" hardware
+    /// power-on state, and also what a pre-#2960 save state's SA-1 would actually have been in
+    /// (since the interrupt lines didn't exist to have anything pending).
+    #[test]
+    fn sa1_state_missing_irq_pending_fields_deserializes_to_nothing_pending() {
+        let state: SnesSa1State = serde_json::from_str("{}").expect("deserialize");
+        assert!(!state.sa1_irq_pending);
+        assert!(!state.sa1_nmi_pending);
+        assert!(!state.snes_irq_pending);
     }
 }

--- a/src/snes/integration_tests/mod.rs
+++ b/src/snes/integration_tests/mod.rs
@@ -12,4 +12,5 @@ mod rom_runner;
 mod sa1_boot_tests;
 mod sa1_bwram_tests;
 mod sa1_iram_tests;
+mod sa1_irq_tests;
 mod undisbeliever_tests;

--- a/src/snes/integration_tests/sa1_irq_tests.rs
+++ b/src/snes/integration_tests/sa1_irq_tests.rs
@@ -1,0 +1,114 @@
+//! Black-box coverage for issue #2960 (SA-1 cross-CPU IRQ and status registers): a hand-built
+//! SA-1-chipset ROM that exercises the same SA-1-raises-IRQ / main-CPU-responds handshake
+//! `SA1RamProtectionTest.sfc`'s `SendSA1MessageAcc` macro uses (see
+//! `TestRoutines.asm`), simplified to a single round-trip:
+//!
+//! 1. The main CPU boots, enables `$2201` SIE (IRQ-from-SA-1), releases SA-1 from reset, and
+//!    idles with interrupts unmasked (`CLI`).
+//! 2. SA-1 boots and raises an IRQ via `$2209` SCNT, embedding a 4-bit message.
+//! 3. The main CPU's real (fixed, emulation-mode) IRQ handler fires, reads the message back via
+//!    `$2300` SFR, stashes it into WRAM, acknowledges via `$2202` SIC, and writes a response
+//!    message into `$2200` CCNT.
+//! 4. SA-1, busy-polling `$2301` CFR (exactly like the real ROM), observes the response and
+//!    idles.
+
+use crate::platform::app_context::AppContext;
+use crate::platform::emulator::Emulator;
+use crate::snes::console::Snes;
+
+const HEADER: usize = 0x7FC0;
+
+fn write_lorom_header(rom: &mut [u8], title: &[u8], chipset: u8) {
+    rom[HEADER..HEADER + 21].fill(b' ');
+    rom[HEADER..HEADER + title.len()].copy_from_slice(title);
+    rom[HEADER + 0x15] = 0x20; // Map mode: LoROM, slow.
+    rom[HEADER + 0x16] = chipset;
+    rom[HEADER + 0x17] = 0x07; // ROM size.
+    rom[HEADER + 0x18] = 0x00; // RAM size.
+    rom[HEADER + 0x1C] = 0x34; // Complement check (not validated by this codebase).
+    rom[HEADER + 0x1D] = 0x12;
+    rom[HEADER + 0x1E] = 0xCB; // Checksum (not validated by this codebase).
+    rom[HEADER + 0x1F] = 0xED;
+    rom[HEADER + 0x3C] = 0x00; // Main CPU reset vector low byte.
+    rom[HEADER + 0x3D] = 0x80; // Main CPU reset vector high byte -> $8000.
+    rom[HEADER + 0x3E] = 0x00; // Main CPU emulation-mode IRQ/BRK vector low byte.
+    rom[HEADER + 0x3F] = 0x81; // ... high byte -> $8100 (the CPU never switches to native mode).
+}
+
+/// Builds a 64 KiB LoROM SA-1 ROM whose main-CPU program at bank `$00:$8000` enables `$2201`
+/// SIE, releases SA-1, unmasks interrupts, and idles; whose fixed IRQ handler at `$00:$8100`
+/// reads `$2300` SFR, stashes the message at WRAM `$0000`, acknowledges via `$2202` SIC, and
+/// replies via `$2200` CCNT; and whose SA-1-side program at `$00:$9000` raises an IRQ with
+/// message `$7` via `$2209` SCNT, then busy-polls `$2301` CFR for the message-`$5` reply.
+fn build_sa1_irq_roundtrip_rom() -> Vec<u8> {
+    let mut rom = vec![0u8; 0x1_0000];
+    write_lorom_header(&mut rom, b"SA1 IRQ TEST", 0x35);
+
+    // Main CPU boot, bank $00:$8000 (file offset $0000).
+    #[rustfmt::skip]
+    let main_boot: [u8; 24] = [
+        0xA9, 0x00,       // LDA #$00
+        0x8D, 0x03, 0x22, // STA $2203 (CRVL)
+        0xA9, 0x90,       // LDA #$90
+        0x8D, 0x04, 0x22, // STA $2204 (CRVH) -> SA-1 reset vector = $9000
+        0xA9, 0x80,       // LDA #$80
+        0x8D, 0x01, 0x22, // STA $2201 (SIE) -> enable IRQ-from-SA-1
+        0xA9, 0x00,       // LDA #$00
+        0x8D, 0x00, 0x22, // STA $2200 (CCNT) -> release SA-1 from reset
+        0x58,             // CLI
+        0x4C, 0x15, 0x80, // JMP $8015 (idle loop)
+    ];
+    rom[0x0000..main_boot.len()].copy_from_slice(&main_boot);
+
+    // Main CPU IRQ handler, bank $00:$8100 (file offset $0100).
+    #[rustfmt::skip]
+    let main_irq_handler: [u8; 19] = [
+        0xAD, 0x00, 0x23, // LDA $2300 (SFR)
+        0x29, 0x0F,       // AND #$0F
+        0x8D, 0x00, 0x00, // STA $0000 (stash the message)
+        0xA9, 0x80,       // LDA #$80
+        0x8D, 0x02, 0x22, // STA $2202 (SIC) -> acknowledge
+        0xA9, 0x05,       // LDA #$05
+        0x8D, 0x00, 0x22, // STA $2200 (CCNT) -> reply with message $5
+        0x40,             // RTI
+    ];
+    rom[0x0100..0x0100 + main_irq_handler.len()].copy_from_slice(&main_irq_handler);
+
+    // SA-1 CPU program, bank $00:$9000 (file offset $1000).
+    #[rustfmt::skip]
+    let sa1_program: [u8; 17] = [
+        0xA9, 0x87,       // LDA #$87
+        0x8D, 0x09, 0x22, // STA $2209 (SCNT) -> raise IRQ, message = $7
+        0xAD, 0x01, 0x23, // LDA $2301 (CFR)
+        0x29, 0x0F,       // AND #$0F
+        0xC9, 0x05,       // CMP #$05
+        0xD0, 0xF7,       // BNE -9 (poll)
+        0x4C, 0x0E, 0x90, // JMP $900E (idle loop)
+    ];
+    rom[0x1000..0x1000 + sa1_program.len()].copy_from_slice(&sa1_program);
+
+    rom
+}
+
+#[test]
+fn sa1_irq_round_trips_a_message_through_the_main_cpus_real_irq_handler() {
+    let rom = build_sa1_irq_roundtrip_rom();
+    let mut snes = Snes::new(AppContext::default());
+    snes.load_rom(&rom, "sa1-irq-roundtrip-test.sfc")
+        .expect("failed to load SA-1 IRQ roundtrip fixture ROM");
+
+    for _ in 0..6000 {
+        snes.run_tick();
+    }
+
+    assert_eq!(
+        snes.read_bus_for_debugger_for_tests(0x00_0000),
+        Some(0x07),
+        "main CPU's real IRQ handler should have read SA-1's message via SFR"
+    );
+    assert_eq!(
+        snes.sa1_cpu_pc_for_tests(),
+        Some(0x900E),
+        "SA-1 should have observed the $5 reply via CFR and reached its idle loop"
+    );
+}

--- a/src/snes/sa1/mod.rs
+++ b/src/snes/sa1/mod.rs
@@ -199,9 +199,14 @@ impl Sa1ControlRegisters {
     }
 
     /// Consumes the edge-triggered SA-1-side NMI dispatch signal (see the struct doc comment).
-    /// Does not affect the separately-tracked, CIC-acknowledged `sa1_nmi_pending` flag CFR
-    /// exposes.
+    /// Does nothing while SA-1-side NMI is disabled (CIE bit 4) -- the edge stays latched so
+    /// enabling NMI afterward still dispatches it, and a masked edge is never delivered to the
+    /// SA-1 CPU. Does not affect the separately-tracked, CIC-acknowledged `sa1_nmi_pending` flag
+    /// CFR exposes.
     pub(crate) fn take_sa1_nmi_edge(&mut self) -> bool {
+        if !self.sa1_nmi_enabled {
+            return false;
+        }
         std::mem::take(&mut self.sa1_nmi_edge)
     }
 
@@ -763,6 +768,7 @@ mod tests {
     #[test]
     fn ccnt_nmi_trigger_sets_edge_and_persistent_pending_independently() {
         let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x220A, 0x10); // CIE bit 4: enable SA-1-side NMI
         registers.write(0x2200, 0x10); // NMI trigger bit
         assert!(registers.sa1_nmi_pending());
         assert!(registers.take_sa1_nmi_edge(), "edge consumed once");
@@ -773,6 +779,23 @@ mod tests {
         // The CFR-visible pending flag survives the edge being consumed -- it's cleared only by
         // CIC, matching real 65816 NMI hardware (edge dispatch, level-persistent status flag).
         assert!(registers.sa1_nmi_pending());
+    }
+
+    #[test]
+    fn take_sa1_nmi_edge_stays_latched_while_nmi_is_disabled_then_fires_once_enabled() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0x10); // NMI trigger bit, CIE bit 4 not yet set
+        assert!(
+            !registers.take_sa1_nmi_edge(),
+            "masked NMI must not be delivered to the SA-1 CPU"
+        );
+
+        registers.write(0x220A, 0x10); // CIE bit 4: enable SA-1-side NMI
+        assert!(
+            registers.take_sa1_nmi_edge(),
+            "the edge must still be latched once NMI is enabled"
+        );
+        assert!(!registers.take_sa1_nmi_edge(), "edge consumed once");
     }
 
     #[test]

--- a/src/snes/sa1/mod.rs
+++ b/src/snes/sa1/mod.rs
@@ -35,14 +35,29 @@ use std::rc::Rc;
 /// All of these are write-only on real hardware (fullsnes lists them under "SA-1 I/O Map (Write
 /// Only Registers)"), so there is deliberately no read path here -- reads of this range fall
 /// through to open bus in [`crate::snes::bus::system_bus::SnesSystemBus`].
+///
+/// Interrupt pending/enable semantics (bits confirmed unambiguous by fullsnes but the write-time
+/// *behavior* -- when a pending flag latches, when it's cleared, whether writing 0 to a trigger
+/// bit is a no-op -- is only clearly specified by bsnes's `SA1::writeIOCPU`/`writeIOSA1`
+/// (`sfc/coprocessor/sa1/io.cpp`), since fullsnes marks some of this "(0=No Change?)"):
+/// - Writing a trigger bit as 1 (CCNT bit 4 NMI / bit 7 IRQ; SCNT bit 7 IRQ) always latches the
+///   corresponding pending flag, regardless of the matching enable bit -- fullsnes: "When
+///   interrupts are disabled (in CIE/SIE), then it sounds as if the interrupt flags still do get
+///   set". Writing 0 to a trigger bit does *not* clear it; only the matching CIC/SIC bit does.
+/// - IRQ is level-triggered: `pending && enabled` is asserted for as long as both hold, exactly
+///   like the existing PPU IRQ line this bus already models via `poll_irq()`.
+/// - NMI is edge-triggered like real 65816 hardware: the SA-1 CPU's actual dispatch happens once
+///   per rising edge (a *new* CCNT bit 4 write, not "still set from before"), consumed via
+///   `poll_nmi()` exactly like the existing PPU NMI edge -- independently of the CFR-visible
+///   pending flag, which persists until CIC acknowledges it.
 #[derive(Debug, Clone)]
 pub struct Sa1ControlRegisters {
     /// `$2200` CCNT (SNES-writable). Bits 0-3: message SNES->SA-1. Bit 4: NMI SNES->SA-1. Bit
     /// 5: hold SA-1 in reset (1=reset, matches the `$20` power-on default). Bit 6: wait (freeze
     /// the SA-1 CPU). Bit 7: IRQ SNES->SA-1.
     ccnt: u8,
-    /// `$2201` SIE (SNES-writable): SNES CPU interrupt enable bits. Stored verbatim; behavior
-    /// lands with the cross-CPU IRQ handshake (#2960).
+    /// `$2201` SIE (SNES-writable): SNES CPU interrupt enable bits. Bit 7 (IRQ from SA-1) is
+    /// acted on; bit 5 (character-conversion DMA IRQ) is stored verbatim (DMA is out of scope).
     sie: u8,
     /// `$2203`/`$2204` CRV: SA-1 CPU reset vector. Fullsnes: "Exception Vectors on SA-1 side
     /// (these are ALWAYS replacing the normal vectors in ROM)".
@@ -51,17 +66,39 @@ pub struct Sa1ControlRegisters {
     nmi_vector: u16,
     /// `$2207`/`$2208` CIV: SA-1 CPU IRQ vector (always replaces the ROM vector).
     irq_vector: u16,
-    /// `$2209` SCNT (SA-1-writable): SNES CPU control. Stored verbatim; behavior lands with #2960.
+    /// `$2209` SCNT (SA-1-writable): SNES CPU control. Bit 7 (IRQ from SA-1) is acted on; bits
+    /// 4/6 (NMI/IRQ vector-override switches) are acted on by `SnesSystemBus`'s vector
+    /// interception, not here.
     scnt: u8,
-    /// `$220A` CIE (SA-1-writable): SA-1 CPU interrupt enable bits. Stored verbatim; behavior
-    /// lands with #2960.
+    /// `$220A` CIE (SA-1-writable): SA-1 CPU interrupt enable bits. Bits 4/7 (NMI/IRQ from
+    /// SNES) are acted on; bits 5/6 (DMA/timer IRQ) are stored verbatim (out of scope).
     cie: u8,
-    /// `$220C`/`$220D` SNV: SNES CPU NMI vector override (optional, gated by `scnt` bit 4 per
-    /// fullsnes; the gating itself is #2960's job). Stored verbatim here.
+    /// `$220C`/`$220D` SNV: SNES CPU NMI vector override (optional, gated by `scnt` bit 4).
     snes_nmi_vector: u16,
-    /// `$220E`/`$220F` SIV: SNES CPU IRQ vector override (optional, gated by `scnt` bit 6).
-    /// Stored verbatim here.
+    /// `$220E`/`$220F` SIV: SNES CPU IRQ vector override (optional, gated by `scnt` bit 6). The
+    /// absindx RAM protection test repurposes this as a data side-channel: it writes an
+    /// arbitrary byte here (not a real address) and relies on the main CPU's own IRQ handler
+    /// reading `$00FFEE` (redirected here by the override) to retrieve it.
     snes_irq_vector: u16,
+    /// SA-1-side IRQ-from-SNES pending flag (CFR bit 7), latched on CCNT bit 7 = 1, cleared on
+    /// CIC bit 7 = 1.
+    sa1_irq_pending: bool,
+    /// `$220A` CIE bit 7: SA-1-side IRQ-from-SNES enable.
+    sa1_irq_enabled: bool,
+    /// SA-1-side NMI-from-SNES pending flag (CFR bit 4), latched on CCNT bit 4 = 1, cleared on
+    /// CIC bit 4 = 1. Independent of the edge-consumed dispatch signal below.
+    sa1_nmi_pending: bool,
+    /// `$220A` CIE bit 4: SA-1-side NMI-from-SNES enable.
+    sa1_nmi_enabled: bool,
+    /// Edge-triggered NMI dispatch signal, consumed once by `Sa1Bus::poll_nmi()`. Set on every
+    /// CCNT bit 4 = 1 write (a new edge), regardless of `sa1_nmi_enabled` -- matches real 65816
+    /// NMI hardware, which latches the edge even while masked, then dispatches once unmasked.
+    sa1_nmi_edge: bool,
+    /// SNES-side IRQ-from-SA-1 pending flag (SFR bit 7), latched on SCNT bit 7 = 1, cleared on
+    /// SIC bit 7 = 1.
+    snes_irq_pending: bool,
+    /// `$2201` SIE bit 7: SNES-side IRQ-from-SA-1 enable.
+    snes_irq_enabled: bool,
 }
 
 impl Sa1ControlRegisters {
@@ -80,27 +117,65 @@ impl Sa1ControlRegisters {
             cie: 0x00,
             snes_nmi_vector: 0x0000,
             snes_irq_vector: 0x0000,
+            sa1_irq_pending: false,
+            sa1_irq_enabled: false,
+            sa1_nmi_pending: false,
+            sa1_nmi_enabled: false,
+            sa1_nmi_edge: false,
+            snes_irq_pending: false,
+            snes_irq_enabled: false,
         }
     }
 
     /// Dispatches a write to the raw `$2200-$220F` MMIO offset.
     pub fn write(&mut self, port: u16, value: u8) {
         match port {
-            0x2200 => self.ccnt = value,
-            0x2201 => self.sie = value,
-            // $2202 SIC: SNES CPU interrupt-acknowledge strobe. No persistent state of its own;
-            // applying its clear effect to pending-IRQ status lands with #2960.
-            0x2202 => {}
+            0x2200 => {
+                self.ccnt = value;
+                if value & 0x80 != 0 {
+                    self.sa1_irq_pending = true;
+                }
+                if value & 0x10 != 0 {
+                    self.sa1_nmi_pending = true;
+                    self.sa1_nmi_edge = true;
+                }
+            }
+            0x2201 => {
+                self.sie = value;
+                self.snes_irq_enabled = value & 0x80 != 0;
+            }
+            // $2202 SIC: SNES CPU interrupt-acknowledge strobe.
+            0x2202 => {
+                if value & 0x80 != 0 {
+                    self.snes_irq_pending = false;
+                }
+            }
             0x2203 => self.reset_vector = (self.reset_vector & 0xFF00) | u16::from(value),
             0x2204 => self.reset_vector = (self.reset_vector & 0x00FF) | (u16::from(value) << 8),
             0x2205 => self.nmi_vector = (self.nmi_vector & 0xFF00) | u16::from(value),
             0x2206 => self.nmi_vector = (self.nmi_vector & 0x00FF) | (u16::from(value) << 8),
             0x2207 => self.irq_vector = (self.irq_vector & 0xFF00) | u16::from(value),
             0x2208 => self.irq_vector = (self.irq_vector & 0x00FF) | (u16::from(value) << 8),
-            0x2209 => self.scnt = value,
-            0x220A => self.cie = value,
-            // $220B CIC: SA-1 CPU interrupt-acknowledge strobe; same as $2202 above.
-            0x220B => {}
+            0x2209 => {
+                self.scnt = value;
+                if value & 0x80 != 0 {
+                    self.snes_irq_pending = true;
+                }
+            }
+            0x220A => {
+                self.cie = value;
+                self.sa1_irq_enabled = value & 0x80 != 0;
+                self.sa1_nmi_enabled = value & 0x10 != 0;
+            }
+            // $220B CIC: SA-1 CPU interrupt-acknowledge strobe.
+            0x220B => {
+                if value & 0x80 != 0 {
+                    self.sa1_irq_pending = false;
+                }
+                if value & 0x10 != 0 {
+                    self.sa1_nmi_pending = false;
+                }
+            }
             0x220C => {
                 self.snes_nmi_vector = (self.snes_nmi_vector & 0xFF00) | u16::from(value);
             }
@@ -115,6 +190,66 @@ impl Sa1ControlRegisters {
             }
             _ => {}
         }
+    }
+
+    /// SA-1-side IRQ line (`pending && enabled`), polled every master clock like the existing
+    /// PPU IRQ line.
+    pub(crate) fn sa1_irq_line(&self) -> bool {
+        self.sa1_irq_pending && self.sa1_irq_enabled
+    }
+
+    /// Consumes the edge-triggered SA-1-side NMI dispatch signal (see the struct doc comment).
+    /// Does not affect the separately-tracked, CIC-acknowledged `sa1_nmi_pending` flag CFR
+    /// exposes.
+    pub(crate) fn take_sa1_nmi_edge(&mut self) -> bool {
+        std::mem::take(&mut self.sa1_nmi_edge)
+    }
+
+    /// SNES-side IRQ line (`pending && enabled`).
+    pub(crate) fn snes_irq_line(&self) -> bool {
+        self.snes_irq_pending && self.snes_irq_enabled
+    }
+
+    /// `$2301` CFR: SA-1 CPU flag read. Bits 5/6 (DMA/timer IRQ) always read 0 -- neither is
+    /// implemented (out of scope; see the module doc comment).
+    pub(crate) fn cfr(&self) -> u8 {
+        let mut value = self.ccnt & 0x0F; // message SNES->SA-1
+        if self.sa1_nmi_pending {
+            value |= 0x10;
+        }
+        if self.sa1_irq_pending {
+            value |= 0x80;
+        }
+        value
+    }
+
+    /// `$2300` SFR: SNES CPU flag read. Bit 5 (character-conversion DMA IRQ) always reads 0 --
+    /// not implemented (out of scope).
+    pub(crate) fn sfr(&self) -> u8 {
+        let mut value = self.scnt & 0x0F; // message SA-1->SNES
+        if self.scnt & 0x10 != 0 {
+            value |= 0x10; // cpu_nvsw (NMI vector override switch), mirrors SCNT bit 4
+        }
+        if self.scnt & 0x40 != 0 {
+            value |= 0x40; // cpu_ivsw (IRQ vector override switch), mirrors SCNT bit 6
+        }
+        if self.snes_irq_pending {
+            value |= 0x80;
+        }
+        value
+    }
+
+    /// `$2209` SCNT bit 4: NMI vector override switch (fullsnes: "NMI Vector for SNES (0=ROM
+    /// FFEAh, 1=Port 220Ch)").
+    pub(crate) fn snes_nmi_vector_override_enabled(&self) -> bool {
+        self.scnt & 0x10 != 0
+    }
+
+    /// `$2209` SCNT bit 6: IRQ vector override switch (fullsnes: "IRQ Vector for SNES (0=ROM
+    /// FFEEh, 1=Port 220Eh)"). The absindx RAM protection test relies on this to smuggle a data
+    /// byte to the main CPU (see `snes_irq_vector`'s doc comment).
+    pub(crate) fn snes_irq_vector_override_enabled(&self) -> bool {
+        self.scnt & 0x40 != 0
     }
 
     /// CCNT bit 5: SA-1 CPU is held in reset (fullsnes: "Reset from SNES to SA-1 (0=No Reset,
@@ -165,9 +300,23 @@ impl Sa1ControlRegisters {
         self.snes_irq_vector
     }
 
-    /// Restores every register to an exact byte value, for save-state loading. Unlike
-    /// [`Self::write`], this bypasses per-port dispatch semantics (there's no "message" or
-    /// "strobe" to interpret -- just raw state to reinstate).
+    pub(crate) fn sa1_irq_pending(&self) -> bool {
+        self.sa1_irq_pending
+    }
+
+    pub(crate) fn sa1_nmi_pending(&self) -> bool {
+        self.sa1_nmi_pending
+    }
+
+    pub(crate) fn snes_irq_pending(&self) -> bool {
+        self.snes_irq_pending
+    }
+
+    /// Restores every register and latched interrupt-line state to an exact value, for
+    /// save-state loading. Unlike [`Self::write`], this bypasses per-port dispatch semantics
+    /// (there's no "message" or "strobe" to interpret, and the pending/enabled flags can't be
+    /// re-derived from the raw register bytes alone -- e.g. `ccnt`'s message nibble may have
+    /// been overwritten since a still-pending IRQ trigger).
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn restore_raw(
         &mut self,
@@ -180,6 +329,9 @@ impl Sa1ControlRegisters {
         cie: u8,
         snes_nmi_vector: u16,
         snes_irq_vector: u16,
+        sa1_irq_pending: bool,
+        sa1_nmi_pending: bool,
+        snes_irq_pending: bool,
     ) {
         self.ccnt = ccnt;
         self.sie = sie;
@@ -190,6 +342,13 @@ impl Sa1ControlRegisters {
         self.cie = cie;
         self.snes_nmi_vector = snes_nmi_vector;
         self.snes_irq_vector = snes_irq_vector;
+        self.sa1_irq_pending = sa1_irq_pending;
+        self.sa1_irq_enabled = cie & 0x80 != 0;
+        self.sa1_nmi_pending = sa1_nmi_pending;
+        self.sa1_nmi_enabled = cie & 0x10 != 0;
+        self.sa1_nmi_edge = false; // transient dispatch signal; never persisted
+        self.snes_irq_pending = snes_irq_pending;
+        self.snes_irq_enabled = sie & 0x80 != 0;
     }
 }
 
@@ -261,6 +420,17 @@ impl Sa1Bus {
         matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && offset == system_offset
     }
 
+    /// Like [`Self::is_system_offset`], but for a range of offsets; returns the matched offset.
+    fn system_offset_in(addr: u32, range: std::ops::RangeInclusive<u16>) -> Option<u16> {
+        let bank = ((addr >> 16) & 0xFF) as u8;
+        let offset = (addr & 0xFFFF) as u16;
+        if matches!(bank, 0x00..=0x3F | 0x80..=0xBF) && range.contains(&offset) {
+            Some(offset)
+        } else {
+            None
+        }
+    }
+
     /// BW-RAM linear offset from the SA-1 CPU's own perspective: its `$2225` BMAP block select
     /// for the windowed `$6000-$7FFF` view, or the direct `$40-$4F` banks.
     fn bwram_index(&self, addr: u32) -> Option<usize> {
@@ -292,6 +462,11 @@ impl SnesBus for Sa1Bus {
                 sram[index % sram.len()]
             };
         }
+        // $2301 CFR is SA-1-side-readable (fullsnes I/O map "Side" column); the SNES-side $2300
+        // SFR is read from `SnesSystemBus` instead.
+        if Self::is_system_offset(addr, 0x2301) {
+            return self.registers.borrow().cfr();
+        }
         memory_control::decode_rom_index(addr, &self.memory_control.borrow())
             .and_then(|index| self.rom.get(index).copied())
             .unwrap_or(0)
@@ -322,6 +497,13 @@ impl SnesBus for Sa1Bus {
             }
             return;
         }
+        // $2209-$220F (SCNT, CIE, CIC, SNV, SIV) are SA-1-side-writable (fullsnes I/O map "Side"
+        // column); the SNES-side register block ($2200-$2208) is written from `SnesSystemBus`
+        // instead -- see the module doc comment.
+        if let Some(offset) = Self::system_offset_in(addr, 0x2209..=0x220F) {
+            self.registers.borrow_mut().write(offset, value);
+            return;
+        }
         // $2225 BMAP and $2227 CBWE are SA-1-side-writable (fullsnes I/O map "Side" column); the
         // SNES-side register block ($2220-$2224, $2226, $2228) is written from `SnesSystemBus`
         // instead -- see the module doc comment.
@@ -334,8 +516,8 @@ impl SnesBus for Sa1Bus {
             return;
         }
         // $222A CIWP is SA-1-side-writable (fullsnes I/O map "Side" column); the SNES-side
-        // register block ($2200-$220F, $2229 SIWP) is written from `SnesSystemBus` instead --
-        // see the module doc comment.
+        // register block ($2229 SIWP) is written from `SnesSystemBus` instead -- see the module
+        // doc comment.
         if Self::is_system_offset(addr, 0x222A) {
             self.iram.borrow_mut().set_sa1_write_protect(value);
         }
@@ -346,6 +528,20 @@ impl SnesBus for Sa1Bus {
         // SA-1's own clock-domain bookkeeping lives on `Sa1Core`, not the bus (see the
         // module-level clock note): unlike `SnesSystemBus`, this bus has no PPU/APU/input of
         // its own to advance per tick.
+    }
+
+    /// Edge-triggered: consumes the SNES->SA-1 NMI dispatch signal set by a CCNT bit 4 = 1
+    /// write. See [`Sa1ControlRegisters`]'s doc comment for why this is edge-based (real 65816
+    /// NMI hardware) rather than the level-based `sa1_nmi_pending` flag CFR exposes.
+    fn poll_nmi(&mut self) -> bool {
+        self.registers.borrow_mut().take_sa1_nmi_edge()
+    }
+
+    /// Level-triggered: the SNES->SA-1 IRQ line stays asserted for as long as CCNT's IRQ-pending
+    /// bit and CIE's IRQ-enable bit are both set (fullsnes/bsnes-confirmed; see
+    /// [`Sa1ControlRegisters`]'s doc comment).
+    fn poll_irq(&self) -> bool {
+        self.registers.borrow().sa1_irq_line()
     }
 }
 
@@ -536,6 +732,99 @@ mod tests {
         // unchanged.
         assert!(registers.is_held_in_reset());
         assert!(!registers.is_waiting());
+    }
+
+    #[test]
+    fn ccnt_irq_trigger_latches_pending_regardless_of_enable() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0x80); // IRQ trigger bit, CIE not yet enabled
+        assert!(registers.sa1_irq_pending());
+        assert!(!registers.sa1_irq_line(), "not enabled yet");
+
+        registers.write(0x220A, 0x80); // CIE: enable SA-1-side IRQ
+        assert!(
+            registers.sa1_irq_line(),
+            "pending flag persists across the enable write"
+        );
+    }
+
+    #[test]
+    fn cic_clears_sa1_irq_pending() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0x80);
+        registers.write(0x220A, 0x80);
+        assert!(registers.sa1_irq_line());
+
+        registers.write(0x220B, 0x80); // CIC bit 7: acknowledge
+        assert!(!registers.sa1_irq_line());
+        assert!(!registers.sa1_irq_pending());
+    }
+
+    #[test]
+    fn ccnt_nmi_trigger_sets_edge_and_persistent_pending_independently() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0x10); // NMI trigger bit
+        assert!(registers.sa1_nmi_pending());
+        assert!(registers.take_sa1_nmi_edge(), "edge consumed once");
+        assert!(
+            !registers.take_sa1_nmi_edge(),
+            "edge does not re-fire without a new write"
+        );
+        // The CFR-visible pending flag survives the edge being consumed -- it's cleared only by
+        // CIC, matching real 65816 NMI hardware (edge dispatch, level-persistent status flag).
+        assert!(registers.sa1_nmi_pending());
+    }
+
+    #[test]
+    fn cic_clears_sa1_nmi_pending_without_affecting_the_edge_signal() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0x10);
+        registers.write(0x220B, 0x10); // CIC bit 4: acknowledge NMI
+        assert!(!registers.sa1_nmi_pending());
+    }
+
+    #[test]
+    fn writing_ccnt_message_only_does_not_retrigger_irq_or_nmi() {
+        // Mirrors the real ROM's `SetSnesStatus` (AND #$0F; STA CCNT): updates only the message
+        // nibble, must not spuriously latch a new IRQ/NMI trigger.
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0x05);
+        assert!(!registers.sa1_irq_pending());
+        assert!(!registers.sa1_nmi_pending());
+        assert_eq!(registers.cfr() & 0x0F, 0x05);
+    }
+
+    #[test]
+    fn scnt_irq_trigger_latches_snes_side_pending_gated_by_sie() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2209, 0x80); // SCNT IRQ trigger, SIE not yet enabled
+        assert!(registers.snes_irq_pending());
+        assert!(!registers.snes_irq_line());
+
+        registers.write(0x2201, 0x80); // SIE: enable SNES-side IRQ
+        assert!(registers.snes_irq_line());
+
+        registers.write(0x2202, 0x80); // SIC: acknowledge
+        assert!(!registers.snes_irq_line());
+        assert!(!registers.snes_irq_pending());
+    }
+
+    #[test]
+    fn cfr_reports_message_and_both_pending_bits() {
+        let mut registers = Sa1ControlRegisters::new();
+        registers.write(0x2200, 0x90 | 0x0A); // NMI + IRQ triggers, message = $A
+        assert_eq!(registers.cfr(), 0x90 | 0x0A);
+    }
+
+    #[test]
+    fn sfr_reports_message_override_switches_and_pending() {
+        let mut registers = Sa1ControlRegisters::new();
+        // Bit 7 (IRQ trigger), bit 6 (IRQ vector override), bit 4 (NMI vector override),
+        // message = 3.
+        registers.write(0x2209, 0b1101_0011);
+        assert_eq!(registers.sfr(), 0b1101_0011);
+        assert!(registers.snes_nmi_vector_override_enabled());
+        assert!(registers.snes_irq_vector_override_enabled());
     }
 
     #[test]
@@ -809,5 +1098,56 @@ mod tests {
         // This fixture has no leading SEI (unlike the boot test above), so its 2-byte
         // `LDA #imm` + 2-byte `BRA -2` settle the infinite self-loop at $9002, not $9003.
         assert_eq!(core.cpu().read_pc(), 0x9002);
+    }
+
+    #[test]
+    fn core_dispatches_an_nmi_from_snes_once_enabled() {
+        let registers = Rc::new(RefCell::new(Sa1ControlRegisters::new()));
+        let mut rom = vec![0u8; 0x8000];
+        // SA-1 boot at $9000: unlock I-RAM (its own stack lives there and is write-protected by
+        // default -- see $222A CIWP's `$00` reset value), unmask interrupts (CLI), then idle.
+        rom[0x1000] = 0xA9; // LDA #$FF
+        rom[0x1001] = 0xFF;
+        rom[0x1002] = 0x8D; // STA $222A (CIWP: unlock all I-RAM chunks)
+        rom[0x1003] = 0x2A;
+        rom[0x1004] = 0x22;
+        rom[0x1005] = 0x58; // CLI
+        rom[0x1006] = 0x4C; // JMP $9006 (self)
+        rom[0x1007] = 0x06;
+        rom[0x1008] = 0x90;
+        // NMI handler at $9100: LDA #$99; RTI.
+        rom[0x1100] = 0xA9;
+        rom[0x1101] = 0x99;
+        rom[0x1102] = 0x40; // RTI
+        {
+            let mut regs = registers.borrow_mut();
+            write_vector(&mut regs, 0x2203, 0x2204, 0x9000); // CRV
+            write_vector(&mut regs, 0x2205, 0x2206, 0x9100); // CNV
+        }
+        let mut core = Sa1Core::new(
+            Rc::clone(&registers),
+            fresh_iram(),
+            fresh_memory_control(),
+            Rc::new(rom),
+            fresh_sram(0),
+        );
+        registers.borrow_mut().write(0x220A, 0x10); // CIE: enable SA-1-side NMI
+        registers.borrow_mut().write(0x2200, 0x00); // release reset
+        for _ in 0..50 {
+            core.tick_one_master_clock();
+        }
+        assert_eq!(core.cpu().read_pc(), 0x9006, "idling, waiting for the NMI");
+
+        registers.borrow_mut().write(0x2200, 0x10); // CCNT: NMI trigger
+        for _ in 0..300 {
+            core.tick_one_master_clock();
+        }
+
+        assert_eq!(
+            core.cpu().read_a() & 0xFF,
+            0x99,
+            "NMI handler must have run"
+        );
+        assert_eq!(core.cpu().read_pc(), 0x9006, "RTI returns to the idle loop");
     }
 }


### PR DESCRIPTION
## Summary

- Implements the $2200-$220F cross-CPU interrupt handshake for SA-1:
  - Level-triggered IRQ in both directions (SNES->SA-1 via CCNT/CIE/CIC, SA-1->SNES via SCNT/SIE/SIC).
  - Edge-triggered NMI-from-SNES (CCNT bit4), consumed once per edge like the existing PPU NMI line, distinct from the persistent CFR-visible pending bit which is cleared separately via CIC.
  - New $2300 SFR / $2301 CFR read-only status registers exposing each side's message nibble, vector-override switches, and pending bits.
- Wires the SNV/SIV vector-override interception at $00FFEA/$00FFEB and $00FFEE/$00FFEF (gated by SCNT bits 4/6), verified against bsnes's `SA1::ROM::readCPU` since fullsnes documents the switch bits but not the exact interception mechanism. The absindx RAM protection test's fixed IRQ handler relies on this as a data side-channel (re-reading its own vector fetch address as data) to recover SA-1's message byte.
- Fixes a #2957-era bug: SA-1-side-writable registers ($2209-$220F) were incorrectly reachable from the main bus's `write_mmio` (narrowed the main-bus arm to `0x2200..=0x2208`).
- Extends save-state coverage (`SnesSa1State`) with the three new pending-flag fields, with `#[serde(default)]` backward compatibility for pre-#2960 states (all default to "nothing pending", matching hardware power-on).
- New integration test (`sa1_irq_tests.rs`): a full round-trip through the main CPU's *real* IRQ handler -- SA-1 raises an IRQ with a message, the main CPU's fixed handler reads SFR, acks via SIC, and replies via CCNT, and SA-1 busy-polls CFR for the reply.

Part of epic #2956. Fixes #2960.

## Test plan

- [x] New unit tests in `src/snes/sa1/mod.rs` for CCNT/SCNT/CIE/CIC pending-latch semantics, SFR/CFR reporting
- [x] New unit tests in `src/snes/bus/system_bus.rs` for vector-override interception, poll_irq wiring, and save-state round-trips (including the new pending flags)
- [x] New integration test `src/snes/integration_tests/sa1_irq_tests.rs` (full round-trip through real IRQ handler code)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`
- [x] `./scripts/test-dir.sh src/snes --skip-integration`
- [x] `cargo test --no-default-features --lib` (full suite, 12212 passed)
- [x] Python test suites
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)