### PR TITLE
Fix SNES BG vertical scroll off-by-one; automate all 10 scpu-a-dma-bug ROMs

### DIFF
--- a/src/snes/integration_tests/blargg_apu_tests.rs
+++ b/src/snes/integration_tests/blargg_apu_tests.rs
@@ -57,44 +57,44 @@ mod tests {
         blargg_1_test_exec_from_io_passes,
         "1-test_exec_from_io.smc",
         600,
-        0x7EEE_5E15
+        0x31D3_DB73
     );
 
     blargg_rom_test!(
         blargg_2_test_single_instr_passes,
         "2-test_single_instr.smc",
         600,
-        0x2B42_CE76
+        0x880D_ED35
     );
 
     blargg_rom_test!(
         blargg_3_test_write_disable_passes,
         "3-test_write_disable.smc",
         600,
-        0xC3DE_3F4F
+        0xF638_BAD0
     );
 
     blargg_rom_test!(
         blargg_4_test_ram_disable_passes,
         "4-test_ram_disable.smc",
         600,
-        0x85F1_D154
+        0x9BC6_1B79
     );
 
     blargg_rom_test!(
         blargg_test_ram_disable_ipl_passes,
         "test_ram_disable_ipl.smc",
         600,
-        0xD001_765E
+        0x5623_82B1
     );
 
-    blargg_rom_test!(blargg_spc_smp_passes, "spc_smp.sfc", 2200, 0xEFD1_3576);
+    blargg_rom_test!(blargg_spc_smp_passes, "spc_smp.sfc", 2200, 0x5D6F_C4EA);
 
     blargg_rom_test!(
         blargg_spc_mem_access_times_passes,
         "spc_mem_access_times.sfc",
         600,
-        0x3AC3_E30F
+        0x1B4A_C6BA
     );
 
     // Full suite (KON, Misc, Order, Random and Timing batteries) ends with
@@ -104,16 +104,16 @@ mod tests {
         blargg_spc_dsp6_passes,
         "spc_dsp6.sfc",
         9100,
-        0x05CD_5DA7,
+        0xD52F_0829,
         RunConfig::new(600_000_000, 0)
     );
 
-    blargg_rom_test!(blargg_spc_timer_passes, "spc_timer.sfc", 600, 0x2497_38B2);
+    blargg_rom_test!(blargg_spc_timer_passes, "spc_timer.sfc", 600, 0xAA7E_CF03);
 
     // Golden re-approved for #2938: with trampoline micro-ops cycle-scripted
     // and the stepper charging TEST wait states, every row now matches Mesen
     // exactly (fast 252/251, waited 126 and 26).
-    blargg_rom_test!(blargg_test_speed_passes, "test_speed.smc", 600, 0xFAE4_99DA);
+    blargg_rom_test!(blargg_test_speed_passes, "test_speed.smc", 600, 0x7BA3_BF97);
 
     // Golden re-approved for #2914 (cycle-stepped port polling, the hardware
     // 32040 Hz SPC rate + CPU->SPC write latch, then the exact Mesen
@@ -123,7 +123,7 @@ mod tests {
         blargg_test_timer_speed_passes,
         "test_timer_speed.smc",
         600,
-        0xA4D0_ACB0
+        0x2B6A_56F0
     );
 
     // Same re-approval as test_timer_speed (identical output screen).
@@ -131,7 +131,7 @@ mod tests {
         blargg_test_timer_speed2_passes,
         "test_timer_speed2.smc",
         600,
-        0xA4D0_ACB0
+        0x2B6A_56F0
     );
 
     // Golden re-approved for #2914 (see test_timer_speed note); measured
@@ -140,7 +140,7 @@ mod tests {
         blargg_test_timer_speed_2_passes,
         "test_timer_speed_2.smc",
         600,
-        0xCAF1_E3BC
+        0x6E5A_EFDF
     );
 
     // Golden re-approved for #2914 (see test_timer_speed_2 note); "Done"
@@ -149,21 +149,21 @@ mod tests {
         blargg_test_timer_speed3_passes,
         "test_timer_speed3.smc",
         600,
-        0x367A_08A5
+        0x2A5A_79CF
     );
 
     blargg_rom_test!(
         blargg_test_timer_stop_passes,
         "test_timer_stop.smc",
         600,
-        0x7CC2_B76B
+        0x7DFB_5542
     );
 
     blargg_rom_test!(
         blargg_test_timer_stop2_passes,
         "test_timer_stop2.smc",
         600,
-        0xB2CC_2986
+        0xA33B_ED78
     );
 
     // The ROM jumps to $0000 mid-test to request a soft reset; model it with
@@ -172,7 +172,7 @@ mod tests {
         blargg_timer_at_power_reset_passes,
         "timer_at_power_reset.smc",
         600,
-        0x9A3B_5FC3,
+        0x84EA_9009,
         RunConfig::new(400_000_000, 0).with_reset_on_pc_trap(0x0000)
     );
 
@@ -180,6 +180,6 @@ mod tests {
         blargg_speed_2_freezes2_passes,
         "speed_2_freezes2.smc",
         600,
-        0x6E1B_F905
+        0x6F17_26D2
     );
 }

--- a/src/snes/integration_tests/gilyon_cpu_tests.rs
+++ b/src/snes/integration_tests/gilyon_cpu_tests.rs
@@ -25,7 +25,7 @@ mod tests {
             "cputest.sfc",
             "gilyon_cpu_tests",
             2000,
-            0xB7EB_715E,
+            0xAE83_60F7,
             RunConfig::new(400_000_000, 0),
         );
     }

--- a/src/snes/integration_tests/gilyon_spc_tests.rs
+++ b/src/snes/integration_tests/gilyon_spc_tests.rs
@@ -20,7 +20,7 @@ mod tests {
             "spctest.sfc",
             "gilyon_spc_tests",
             2000,
-            0x35A5_C1B0,
+            0xE10F_EB9D,
             RunConfig::new(400_000_000, 0),
         );
     }

--- a/src/snes/integration_tests/hblank_dma_vram_tests.rs
+++ b/src/snes/integration_tests/hblank_dma_vram_tests.rs
@@ -125,7 +125,7 @@ mod tests {
         hvdma_matches_mesen2_and_hardware,
         "hvdma.sfc",
         600,
-        0x2E57_9FF7
+        0x8D23_B418
     );
 
     // Confirmed hardware-accurate: NESER's frame-600 capture is a

--- a/src/snes/integration_tests/peterlemon_cpu_tests.rs
+++ b/src/snes/integration_tests/peterlemon_cpu_tests.rs
@@ -28,79 +28,79 @@ mod tests {
     #[test]
     fn cpu_adc_passes_all_modes() {
         // Settles at frame 34 on the ADC (sr,S),Y page with all rows PASS.
-        run_cputest_screen_crc("ADC/CPUADC.sfc", 94, 0x4BEE_DE02);
+        run_cputest_screen_crc("ADC/CPUADC.sfc", 94, 0x6BF9_6B41);
     }
 
     #[test]
     fn cpu_and_passes_all_modes() {
         // Settles at frame 30 on the AND (sr,S),Y page with all rows PASS.
-        run_cputest_screen_crc("AND/CPUAND.sfc", 90, 0xA8A0_A1C4);
+        run_cputest_screen_crc("AND/CPUAND.sfc", 90, 0x2112_519A);
     }
 
     #[test]
     fn cpu_asl_passes_all_modes() {
         // Settles at frame 10 on the ASL dp,X page with all rows PASS.
-        run_cputest_screen_crc("ASL/CPUASL.sfc", 70, 0xC583_F94E);
+        run_cputest_screen_crc("ASL/CPUASL.sfc", 70, 0x4073_9A9D);
     }
 
     #[test]
     fn cpu_bit_passes_all_modes() {
         // Settles at frame 18 on the TSB dp page with all rows PASS.
-        run_cputest_screen_crc("BIT/CPUBIT.sfc", 78, 0xDE68_86CC);
+        run_cputest_screen_crc("BIT/CPUBIT.sfc", 78, 0x6CE9_EB3F);
     }
 
     #[test]
     fn cpu_bra_passes_all_branches() {
         // Settles at frame 2 with every branch opcode (BCC..BRL) PASS.
-        run_cputest_screen_crc("BRA/CPUBRA.sfc", 62, 0x8AA7_A0D1);
+        run_cputest_screen_crc("BRA/CPUBRA.sfc", 62, 0x4A8C_01B5);
     }
 
     #[test]
     fn cpu_cmp_passes_all_modes() {
         // Settles at frame 42 on the CPY dp page with all rows PASS.
-        run_cputest_screen_crc("CMP/CPUCMP.sfc", 102, 0x9D3E_4BFF);
+        run_cputest_screen_crc("CMP/CPUCMP.sfc", 102, 0x26A1_36A3);
     }
 
     #[test]
     fn cpu_dec_passes_all_modes() {
         // Settles at frame 14 on the DEY page with all rows PASS.
-        run_cputest_screen_crc("DEC/CPUDEC.sfc", 74, 0xD52C_E94E);
+        run_cputest_screen_crc("DEC/CPUDEC.sfc", 74, 0x07AB_8290);
     }
 
     #[test]
     fn cpu_eor_passes_all_modes() {
         // Settles at frame 30 on the EOR (sr,S),Y page with all rows PASS.
-        run_cputest_screen_crc("EOR/CPUEOR.sfc", 90, 0xAE77_FD05);
+        run_cputest_screen_crc("EOR/CPUEOR.sfc", 90, 0x81E6_684A);
     }
 
     #[test]
     fn cpu_inc_passes_all_modes() {
         // Settles at frame 14 on the INY page with all rows PASS.
-        run_cputest_screen_crc("INC/CPUINC.sfc", 74, 0xE2D7_9190);
+        run_cputest_screen_crc("INC/CPUINC.sfc", 74, 0x6CB7_0894);
     }
 
     #[test]
     fn cpu_jmp_passes_all_jumps() {
         // Settles at frame 2 with every JMP/JML/JSR/JSL variant PASS.
-        run_cputest_screen_crc("JMP/CPUJMP.sfc", 62, 0xE740_3CEF);
+        run_cputest_screen_crc("JMP/CPUJMP.sfc", 62, 0x144B_2E9B);
     }
 
     #[test]
     fn cpu_ldr_passes_all_modes() {
         // Settles at frame 50 on the LDY dp,X page with all rows PASS.
-        run_cputest_screen_crc("LDR/CPULDR.sfc", 110, 0x4AD8_56A6);
+        run_cputest_screen_crc("LDR/CPULDR.sfc", 110, 0xAB8C_539C);
     }
 
     #[test]
     fn cpu_lsr_passes_all_modes() {
         // Settles at frame 10 on the LSR dp,X page with all rows PASS.
-        run_cputest_screen_crc("LSR/CPULSR.sfc", 70, 0xEE12_D392);
+        run_cputest_screen_crc("LSR/CPULSR.sfc", 70, 0x7512_54E8);
     }
 
     #[test]
     fn cpu_mov_passes_block_moves() {
         // Settles at frame 6 with the MVP block-move result PASS.
-        run_cputest_screen_crc("MOV/CPUMOV.sfc", 66, 0xF87B_4CA6);
+        run_cputest_screen_crc("MOV/CPUMOV.sfc", 66, 0x81B5_1227);
     }
 
     #[test]
@@ -108,13 +108,13 @@ mod tests {
         // Settles at frame 3 with NOP/WDM/BRK/COP/WAI/STP all PASS. The ROM
         // also prints "** Please Reset To PASS STP **" (a hardware prompt),
         // but the settled screen already reports STP as PASS without a reset.
-        run_cputest_screen_crc("MSC/CPUMSC.sfc", 63, 0xAB40_776C);
+        run_cputest_screen_crc("MSC/CPUMSC.sfc", 63, 0x7E06_1BD2);
     }
 
     #[test]
     fn cpu_ora_passes_all_modes() {
         // Settles at frame 30 on the ORA (sr,S),Y page with all rows PASS.
-        run_cputest_screen_crc("ORA/CPUORA.sfc", 90, 0xCE37_E028);
+        run_cputest_screen_crc("ORA/CPUORA.sfc", 90, 0x4174_C6F4);
     }
 
     #[test]
@@ -122,48 +122,48 @@ mod tests {
         // Settles at frame 32 on the PLY page with all rows PASS. Previously
         // failed on the PLP page because RDNMI ($4210) bits 6-4 didn't return
         // CPU open bus, leaving V=0 after WaitNMI's `bit.w $4210` (#2975).
-        run_cputest_screen_crc("PHL/CPUPHL.sfc", 92, 0xC208_E97B);
+        run_cputest_screen_crc("PHL/CPUPHL.sfc", 92, 0x5115_ABA3);
     }
 
     #[test]
     fn cpu_psr_passes_all_flag_opcodes() {
         // Settles at frame 2 with CLC/CLD/CLI/CLV/REP/SEC/SED/SEI/SEP PASS.
-        run_cputest_screen_crc("PSR/CPUPSR.sfc", 62, 0x0826_2AF4);
+        run_cputest_screen_crc("PSR/CPUPSR.sfc", 62, 0xB38D_AC72);
     }
 
     #[test]
     fn cpu_ret_passes_all_returns() {
         // Settles at frame 2 with RTI/RTL/RTS all PASS.
-        run_cputest_screen_crc("RET/CPURET.sfc", 62, 0x021D_9680);
+        run_cputest_screen_crc("RET/CPURET.sfc", 62, 0x1CE2_2329);
     }
 
     #[test]
     fn cpu_rol_passes_all_modes() {
         // Settles at frame 10 on the ROL dp,X page with all rows PASS.
-        run_cputest_screen_crc("ROL/CPUROL.sfc", 70, 0xE888_CD0D);
+        run_cputest_screen_crc("ROL/CPUROL.sfc", 70, 0x8915_928C);
     }
 
     #[test]
     fn cpu_ror_passes_all_modes() {
         // Settles at frame 10 on the ROR dp,X page with all rows PASS.
-        run_cputest_screen_crc("ROR/CPUROR.sfc", 70, 0xF0E4_1FA6);
+        run_cputest_screen_crc("ROR/CPUROR.sfc", 70, 0x2774_35F7);
     }
 
     #[test]
     fn cpu_sbc_passes_all_modes() {
         // Settles at frame 34 on the SBC (sr,S),Y page with all rows PASS.
-        run_cputest_screen_crc("SBC/CPUSBC.sfc", 94, 0x6CEF_FFAB);
+        run_cputest_screen_crc("SBC/CPUSBC.sfc", 94, 0xEF44_3E4A);
     }
 
     #[test]
     fn cpu_str_passes_all_modes() {
         // Settles at frame 48 on the STZ dp,X page with all rows PASS.
-        run_cputest_screen_crc("STR/CPUSTR.sfc", 108, 0x1FA5_5810);
+        run_cputest_screen_crc("STR/CPUSTR.sfc", 108, 0x467E_881B);
     }
 
     #[test]
     fn cpu_trn_passes_all_transfers() {
         // Settles at frame 28 on the XCE page with all rows PASS.
-        run_cputest_screen_crc("TRN/CPUTRN.sfc", 88, 0x7068_651F);
+        run_cputest_screen_crc("TRN/CPUTRN.sfc", 88, 0x78B3_13EF);
     }
 }

--- a/src/snes/integration_tests/peterlemon_spc_tests.rs
+++ b/src/snes/integration_tests/peterlemon_spc_tests.rs
@@ -31,42 +31,42 @@ mod tests {
     #[test]
     fn spc700_adc_passes_all_modes() {
         // Settles at frame 1579 on the ADW dp page with all rows PASS.
-        run_spctest_screen_crc("ADC/SPC700ADC.sfc", 1639, 0x50B3_9FB7);
+        run_spctest_screen_crc("ADC/SPC700ADC.sfc", 1639, 0x794D_0629);
     }
 
     #[test]
     fn spc700_and_passes_all_modes() {
         // Settles at frame 1702 on the AND !addr:bit page with all rows PASS.
-        run_spctest_screen_crc("AND/SPC700AND.sfc", 1762, 0x4AE7_9C51);
+        run_spctest_screen_crc("AND/SPC700AND.sfc", 1762, 0xD41B_379C);
     }
 
     #[test]
     fn spc700_dec_passes_all_modes() {
         // Settles at frame 840 on the DEW dp page with all rows PASS.
-        run_spctest_screen_crc("DEC/SPC700DEC.sfc", 900, 0xCEC8_EF6D);
+        run_spctest_screen_crc("DEC/SPC700DEC.sfc", 900, 0x5B09_3146);
     }
 
     #[test]
     fn spc700_eor_passes_all_modes() {
         // Settles at frame 1579 on the EOR addr:bit page with all rows PASS.
-        run_spctest_screen_crc("EOR/SPC700EOR.sfc", 1639, 0xBB06_56CF);
+        run_spctest_screen_crc("EOR/SPC700EOR.sfc", 1639, 0x8A56_FC0D);
     }
 
     #[test]
     fn spc700_inc_passes_all_modes() {
         // Settles at frame 840 on the INW dp page with all rows PASS.
-        run_spctest_screen_crc("INC/SPC700INC.sfc", 900, 0x63DB_5A44);
+        run_spctest_screen_crc("INC/SPC700INC.sfc", 900, 0x907F_E928);
     }
 
     #[test]
     fn spc700_ora_passes_all_modes() {
         // Settles at frame 1702 on the ORC !addr:bit page with all rows PASS.
-        run_spctest_screen_crc("ORA/SPC700ORA.sfc", 1762, 0xE28B_E5EE);
+        run_spctest_screen_crc("ORA/SPC700ORA.sfc", 1762, 0x41E1_5C34);
     }
 
     #[test]
     fn spc700_sbc_passes_all_modes() {
         // Settles at frame 1579 on the SBW dp page with all rows PASS.
-        run_spctest_screen_crc("SBC/SPC700SBC.sfc", 1639, 0x1B1F_68AB);
+        run_spctest_screen_crc("SBC/SPC700SBC.sfc", 1639, 0x85DA_3CA3);
     }
 }

--- a/src/snes/integration_tests/sa1_absindx_tests.rs
+++ b/src/snes/integration_tests/sa1_absindx_tests.rs
@@ -32,7 +32,7 @@ fn sa1_ram_protection_test_passes() {
         "SA1RamProtectionTest.sfc",
         "sa1_absindx_tests",
         150,
-        0xF34C_0611,
+        0xD652_1ACE,
         RunConfig::new(400_000_000, 0),
     );
 }
@@ -44,7 +44,7 @@ fn sa1_version_code_test_matches_approved_register_dump() {
         "SA1VersionCodeTest.sfc",
         "sa1_absindx_tests",
         150,
-        0x9693_6ACB,
+        0x4184_C2B6,
         RunConfig::new(400_000_000, 0),
     );
 }

--- a/src/snes/integration_tests/undisbeliever_tests.rs
+++ b/src/snes/integration_tests/undisbeliever_tests.rs
@@ -1,4 +1,4 @@
-//! Automates 15 of the 29 vendored undisbeliever/snes-test-roms hardware
+//! Automates 25 of the 29 vendored undisbeliever/snes-test-roms hardware
 //! ROMs (`roms/snes/automated_tests/snes_test_roms/undisbeliever-inidisp/`)
 //! that visually match Mesen2.
 //!
@@ -18,8 +18,9 @@
 //! deterministically with no bus-residual modeling at all (see #2949). So
 //! each golden here is a **stability snapshot** cross-checked against
 //! Mesen2 (using `--Video.VideoFilter=None --Video.AspectRatio=NoStretching`
-//! for a comparable capture, and allowing for a harmless constant 1-scanline
-//! row offset between the two emulators' screenshot conventions): for the 2
+//! for a comparable capture; since the BG vertical-scroll display-line fix
+//! in #2945 the two emulators' captures align byte-for-byte with no row
+//! offset): for the 2
 //! ROMs the source confirms never glitch on real hardware
 //! (`hdma_21ff_glitch_matches_mesen2`, `inidisp_hammer_0f0f_matches_mesen2`,
 //! marked below) this genuinely *is* proof of hardware accuracy; for the
@@ -27,13 +28,12 @@
 //! checked reference emulator, not hardware accuracy -- see #2949 before
 //! treating a mismatch here as a regression.
 //!
-//! The other 14 ROMs are deliberately left un-automated: cross-checking
+//! The other 4 ROMs are deliberately left un-automated: cross-checking
 //! against Mesen2 exposed real NESER divergences, tracked as follow-up bugs
 //! rather than papered over with a golden that bakes in known-wrong
 //! behavior (see README-SNES.md for the full breakdown):
 //! - `hdma-2100-glitch-2ch-{0a,81}.sfc`, `hdma-21ff-2100-glitch.sfc` -- #2943
 //! - `inidisp_forgot_to_force_blank.sfc` -- #2944
-//! - all 10 `scpu-a-dma-bug-*.sfc` -- #2945
 
 use super::rom_runner::{RunConfig, RunOracle, run_rom_with_oracle};
 use std::fs;
@@ -45,7 +45,7 @@ const UNDISBELIEVER_ROOT: &str = "roms/snes/automated_tests/snes_test_roms/undis
 mod tests {
     use super::*;
 
-    /// All 11 ROMs here settle into their steady-state rendering well
+    /// All 25 ROMs here settle into their steady-state rendering well
     /// before frame 600 (matching the default budget used throughout
     /// blargg_apu_tests.rs / gilyon_*_tests.rs) and hold it indefinitely.
     ///
@@ -94,7 +94,7 @@ mod tests {
     undisbeliever_rom_test!(
         hdma_2100_glitch_matches_mesen2,
         "hdma-2100-glitch.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Glitches on real hardware via an FXPak firmware bug (a different cause
@@ -103,7 +103,7 @@ mod tests {
     undisbeliever_rom_test!(
         hdma_21ff_2100_0f_glitch_matches_mesen2,
         "hdma-21ff-2100-0f-glitch.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Confirmed by the source to never glitch on real hardware -- this
@@ -112,7 +112,7 @@ mod tests {
     undisbeliever_rom_test!(
         hdma_21ff_glitch_matches_mesen2,
         "hdma-21ff-glitch.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Real hardware reliably shows a sprite glitch here (`ldx.w #$0f80 ;
@@ -121,7 +121,7 @@ mod tests {
     undisbeliever_rom_test!(
         inidisp_d7_glitch_test_matches_mesen2,
         "inidisp_d7_glitch_test.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Real hardware reliably shows a brightness glitch here (`lda.b #$0f ;
@@ -130,7 +130,7 @@ mod tests {
     undisbeliever_rom_test!(
         inidisp_hammer_0f_matches_mesen2,
         "inidisp_hammer_0f.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Real hardware reliably shows a brightness glitch here (`ldx.w #$0f00 ;
@@ -139,7 +139,7 @@ mod tests {
     undisbeliever_rom_test!(
         inidisp_hammer_0f00_matches_mesen2,
         "inidisp_hammer_0f00.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Confirmed by the source to never glitch on real hardware -- this
@@ -148,7 +148,7 @@ mod tests {
     undisbeliever_rom_test!(
         inidisp_hammer_0f0f_matches_mesen2,
         "inidisp_hammer_0f0f.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Real hardware reliably shows the "inverse" glitch here (briefly
@@ -157,7 +157,7 @@ mod tests {
     undisbeliever_rom_test!(
         inidisp_hammer_0f8f_matches_mesen2,
         "inidisp_hammer_0f8f.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Same inverse glitch as inidisp_hammer_0f8f.sfc at a faster hammer
@@ -166,7 +166,7 @@ mod tests {
     undisbeliever_rom_test!(
         inidisp_hammer_0f8f_fast_matches_mesen2,
         "inidisp_hammer_0f8f_fast.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // Real hardware reliably shows a sprite glitch here (`lda.b #$0f ;
@@ -175,7 +175,7 @@ mod tests {
     undisbeliever_rom_test!(
         inidisp_hammer_0f_long_matches_mesen2,
         "inidisp_hammer_0f_long.sfc",
-        0x4844_ECF2
+        0x3B89_56D6
     );
 
     // The only exact byte-for-byte match against Mesen2 (both stay in
@@ -196,7 +196,7 @@ mod tests {
     undisbeliever_rom_test!(
         inidisp_enable_display_mid_frame_matches_mesen2,
         "inidisp_enable_display_mid_frame.sfc",
-        0x3B0F_939D
+        0xD3AE_551F
     );
 
     // Fixed by mid-scanline HDMA activation (#2943): ROMs write to HDMAEN mid-scanline
@@ -225,5 +225,33 @@ mod tests {
         inidisp_brightness_delay_matches_mesen2,
         "inidisp_brightness_delay.sfc",
         0xA6F2_AED7
+    );
+
+    // The 10 scpu-a-dma-bug-* ROMs (issue #2945) share one harness
+    // (`dma-test.inc`): an HTIME H-IRQ per visible scanline drives an MDMA
+    // byte to WMDATA while HDMA writes INIDISP on the previous scanline,
+    // rendering green squares with alternating dark/bright scanline
+    // banding on pass; a crash traps into the break/COP handler
+    // (flat half-brightness screen). They differ only in their appended
+    // HDMA table. Rendering these correctly required the DMA-to-WMDATA
+    // B-bus fix, the brightness formula fix (PR #2948), and the BG
+    // vertical-scroll display-line fix (all #2945).
+    undisbeliever_rom_test!(scpu_a_dma_bug_1, "scpu-a-dma-bug-1.sfc", 0x1E6F_71A7);
+    undisbeliever_rom_test!(scpu_a_dma_bug_2, "scpu-a-dma-bug-2.sfc", 0x8FF8_6612);
+    undisbeliever_rom_test!(scpu_a_dma_bug_3, "scpu-a-dma-bug-3.sfc", 0x8902_A5AE);
+    undisbeliever_rom_test!(scpu_a_dma_bug_5, "scpu-a-dma-bug-5.sfc", 0x2B1E_9001);
+    undisbeliever_rom_test!(scpu_a_dma_bug_ch0, "scpu-a-dma-bug-ch0.sfc", 0x8FF8_6612);
+    undisbeliever_rom_test!(scpu_a_dma_bug_fix, "scpu-a-dma-bug-fix.sfc", 0x8FF8_6612);
+    undisbeliever_rom_test!(scpu_a_dma_bug_fix2, "scpu-a-dma-bug-fix2.sfc", 0x8FF8_6612);
+    undisbeliever_rom_test!(scpu_a_dma_bug_r2, "scpu-a-dma-bug-r2.sfc", 0x1E6F_71A7);
+    undisbeliever_rom_test!(
+        scpu_a_dma_bug_strange,
+        "scpu-a-dma-bug-strange.sfc",
+        0x1E6F_71A7
+    );
+    undisbeliever_rom_test!(
+        scpu_a_dma_bug_two_regs,
+        "scpu-a-dma-bug-two-regs.sfc",
+        0x8FF8_6612
     );
 }

--- a/src/snes/integration_tests/undisbeliever_tests.rs
+++ b/src/snes/integration_tests/undisbeliever_tests.rs
@@ -3,7 +3,7 @@
 //! that visually match Mesen2.
 //!
 //! Unlike blargg/gilyon ROMs, these do not print a PASS/FAIL text screen.
-//! Most of them (9 of the 15 automated here) demonstrate a real, documented
+//! Nine of the 25 automated here demonstrate a real, documented
 //! SNES hardware bug -- the "INIDISP D7 glitch" -- where writing `$2100`
 //! shortly after the CPU/HDMA data bus held a byte with bit 7 set can
 //! corrupt sprite rendering or briefly flip force-blank, on real 3-chip/
@@ -16,8 +16,8 @@
 //! (`Core/SNES/SnesPpu.cpp`), ares (`ares/sfc/ppu/io.cpp`, Near's own
 //! current emulator), and Snes9x (`ppu.cpp`) -- all three write `$2100`
 //! deterministically with no bus-residual modeling at all (see #2949). So
-//! each golden here is a **stability snapshot** cross-checked against
-//! Mesen2 (using `--Video.VideoFilter=None --Video.AspectRatio=NoStretching`
+//! each golden in that glitch family is a **stability snapshot** cross-checked
+//! against Mesen2 (using `--Video.VideoFilter=None --Video.AspectRatio=NoStretching`
 //! for a comparable capture; since the BG vertical-scroll display-line fix
 //! in #2945 the two emulators' captures align byte-for-byte with no row
 //! offset): for the 2

--- a/src/snes/ppu/background.rs
+++ b/src/snes/ppu/background.rs
@@ -464,8 +464,12 @@ impl Ppu {
         } else {
             self.bg_vofs[bg]
         } & 0x03FF;
+        // Framebuffer row `y` shows display line `y + 1` (line 0 is never rendered), and the BG
+        // fetch adds BGnVOFS to the raw display line (ares fetchNameTable: vcounter() + vscroll;
+        // Mesen2: realY = _scanline). Same convention as Mode 7's screen_y (mode7.rs).
+        let screen_y = y.wrapping_add(1);
         let mut hoffset = x.wrapping_add(hscroll);
-        let mut voffset = y.wrapping_add(vscroll);
+        let mut voffset = screen_y.wrapping_add(vscroll);
 
         if matches!(self.bg_mode, 2 | 4 | 6) && bg < 2 {
             let tile_width = if self.bg_tile_size_16[bg] { 4 } else { 3 };
@@ -484,7 +488,7 @@ impl Ppu {
                             hoffset = offset_x.wrapping_add(hlookup & 0x03F8);
                         } else {
                             // V offset: full 10-bit field.
-                            voffset = y.wrapping_add(hlookup & 0x03FF);
+                            voffset = screen_y.wrapping_add(hlookup & 0x03FF);
                         }
                     }
                 } else {
@@ -493,7 +497,7 @@ impl Ppu {
                         hoffset = offset_x.wrapping_add(hlookup & 0x03F8);
                     }
                     if vlookup & valid_bit != 0 {
-                        voffset = y.wrapping_add(vlookup & 0x03FF);
+                        voffset = screen_y.wrapping_add(vlookup & 0x03FF);
                     }
                 }
             }
@@ -759,17 +763,25 @@ mod tests {
         // Tile 1: only the top-left pixel (row 0, col 0) is color 1.
         let base = 16; // char 1 at char_base 0: word 8 -> byte 16
         ppu.vram[base] = 0x80; // plane0 row 0, bit7 (left-most) set
-        // entry -> char 1 with H-flip + V-flip (bits 14,15).
-        set_vram_word(&mut ppu, 0, 1 | 0x4000 | 0x8000);
+        // Tilemap at word 0x400 (away from the char data): entry -> char 1 with H-flip + V-flip
+        // (bits 14,15).
+        set_vram_word(&mut ppu, 0x400, 1 | 0x4000 | 0x8000);
 
         ppu.write_register(0x2105, 0x00);
+        ppu.write_register(0x2107, 0x04); // BG1SC: map base word 0x400
         ppu.write_register(0x212C, 0x01);
         ppu.write_register(0x2100, 0x0F);
         render_frame(&mut ppu);
 
         let rgb = ppu.screen_snapshot_rgb();
-        // With both flips, the lit pixel moves to the bottom-right of the tile (7,7).
-        assert_eq!(pixel(&rgb, 7, 7), [255, 255, 255], "flipped pixel at (7,7)");
+        // With both flips, the lit pixel moves to the bottom-right of the tile: BG (7,7). Row 0
+        // shows BG line 1, so BG line 7 lands on framebuffer row 6.
+        assert_eq!(pixel(&rgb, 7, 6), [255, 255, 255], "flipped pixel at (7,6)");
+        assert_eq!(
+            pixel(&rgb, 7, 7),
+            [0, 0, 0],
+            "row 7 shows the next tile row"
+        );
         assert_eq!(pixel(&rgb, 0, 0), [0, 0, 0], "top-left now transparent");
     }
 
@@ -792,6 +804,60 @@ mod tests {
 
         let rgb = ppu.screen_snapshot_rgb();
         assert_eq!(pixel(&rgb, 0, 0), [255, 255, 255], "scrolled tile at x=0");
+    }
+
+    #[test]
+    fn vertical_scroll_samples_display_line_y_plus_1() {
+        // The first visible framebuffer row is display line 1 (line 0 is never rendered), and the
+        // BG fetch adds BGnVOFS to the raw display line: row `y` samples BG line `y + 1 + VOFS`
+        // (ares `background.cpp` fetchNameTable, Mesen2 `SnesPpu.cpp` realY = _scanline). This is
+        // why games write VOFS = -1 to pixel-align a BG with the top of the screen.
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x7FFF);
+        // Tile 1: only the pixel at (fine_x=0, fine_y=1) is lit.
+        set_vram_word(&mut ppu, 0, 1);
+        set_2bpp_tile_pixel(&mut ppu, 0, 1, 0, 1, 1);
+
+        ppu.write_register(0x2105, 0x00);
+        ppu.write_register(0x212C, 0x01);
+        ppu.write_register(0x2100, 0x0F);
+        render_frame(&mut ppu);
+
+        let rgb = ppu.screen_snapshot_rgb();
+        // With VOFS = 0, framebuffer row 0 shows BG line 1: the lit pixel lands on row 0.
+        assert_eq!(
+            pixel(&rgb, 0, 0),
+            [255, 255, 255],
+            "BG line 1 appears on framebuffer row 0"
+        );
+        assert_eq!(pixel(&rgb, 0, 1), [0, 0, 0], "BG line 2 on row 1 is dark");
+    }
+
+    #[test]
+    fn vertical_scroll_of_minus_one_pixel_aligns_the_bg() {
+        // VOFS = -1 (0x3FF) cancels the +1: framebuffer row 0 shows BG line 0. This is the
+        // convention used by the undisbeliever scpu-a-dma-bug ROMs (issue #2945).
+        let mut ppu = Ppu::new();
+        set_cgram(&mut ppu, 0, 0x0000);
+        set_cgram(&mut ppu, 1, 0x7FFF);
+        // Tile 1: only the pixel at (fine_x=0, fine_y=0) is lit.
+        set_vram_word(&mut ppu, 0, 1);
+        set_2bpp_tile_pixel(&mut ppu, 0, 1, 0, 0, 1);
+
+        ppu.write_register(0x2105, 0x00);
+        ppu.write_register(0x212C, 0x01);
+        ppu.write_register(0x2100, 0x0F);
+        ppu.write_register(0x210E, 0xFF); // BG1VOFS low
+        ppu.write_register(0x210E, 0xFF); // BG1VOFS high -> vofs = 0x3FF = -1
+        render_frame(&mut ppu);
+
+        let rgb = ppu.screen_snapshot_rgb();
+        assert_eq!(
+            pixel(&rgb, 0, 0),
+            [255, 255, 255],
+            "VOFS -1 puts BG line 0 on framebuffer row 0"
+        );
     }
 
     /// Configure BGnSC for layer `bg` with a 32x32 tilemap at `base` words.
@@ -1665,19 +1731,19 @@ mod tests {
 
     #[test]
     fn vertical_mosaic_replicates_top_row_of_each_block() {
-        // Tile 1: only row 0 (fine_y=0) is white; all other rows are black.
-        // With mosaic block_size=4 and no scroll: scanlines 0-3 (vcount=0,1,2,3) all look at
-        // effective_y=0 (the top row), so they all show white. Scanlines 4-7 look at effective_y=4
-        // which is row 4 of the tile (black).
+        // Tile 1: only row 1 (fine_y=1) is white; all other rows are black.
+        // Framebuffer row 0 is display line 1, and with VOFS=0 it samples BG line 1. With mosaic
+        // block_size=4: rows 0-3 (block index 0,1,2,3) all replicate the block's first sampled
+        // line (BG line 1, white). Rows 4-7 replicate BG line 5 (black).
         let mut ppu = Ppu::new();
         set_cgram(&mut ppu, 0, 0x0000);
         set_cgram(&mut ppu, 1, 0x7FFF);
 
         // Tilemap: all entries char 1.
         set_vram_word(&mut ppu, 0, 1);
-        // Tile 1: only fine_y=0 is white for all columns.
+        // Tile 1: only fine_y=1 is white for all columns.
         for fine_x in 0..8 {
-            set_2bpp_tile_pixel(&mut ppu, 0, 1, fine_x, 0, 1); // row 0 = white
+            set_2bpp_tile_pixel(&mut ppu, 0, 1, fine_x, 1, 1); // row 1 = white
         }
 
         setup_bg1_mode0(&mut ppu);
@@ -1686,37 +1752,37 @@ mod tests {
         render_frame(&mut ppu);
         let rgb = ppu.screen_snapshot_rgb();
 
-        // Scanlines 0-3: top of block (vcount=0,1,2,3 all map effective_y=0 → white row).
+        // Rows 0-3: block index 0,1,2,3 all replicate the block's first line (BG line 1, white).
         assert_eq!(
             pixel(&rgb, 0, 0),
             [255, 255, 255],
-            "scanline 0: effective_y=0, white"
+            "row 0: block start, BG line 1, white"
         );
         assert_eq!(
             pixel(&rgb, 0, 1),
             [255, 255, 255],
-            "scanline 1: vcount=1 → effective_y=0"
+            "row 1: block index 1 → BG line 1"
         );
         assert_eq!(
             pixel(&rgb, 0, 2),
             [255, 255, 255],
-            "scanline 2: vcount=2 → effective_y=0"
+            "row 2: block index 2 → BG line 1"
         );
         assert_eq!(
             pixel(&rgb, 0, 3),
             [255, 255, 255],
-            "scanline 3: vcount=3 → effective_y=0"
+            "row 3: block index 3 → BG line 1"
         );
-        // Scanline 4: new block (vcount=0), effective_y=4 → black row.
+        // Row 4: new block, replicates BG line 5 → black.
         assert_eq!(
             pixel(&rgb, 0, 4),
             [0, 0, 0],
-            "scanline 4: new block, effective_y=4, black"
+            "row 4: new block, BG line 5, black"
         );
         assert_eq!(
             pixel(&rgb, 0, 5),
             [0, 0, 0],
-            "scanline 5: vcount=1 → effective_y=4"
+            "row 5: block index 1 → BG line 5"
         );
     }
 


### PR DESCRIPTION
Fixes #2945.

## Root cause

The tile-BG renderer added BGnVOFS to the 0-based framebuffer row, but hardware adds it to the raw display line: the first visible line is vcounter 1 (line 0 is never rendered), so framebuffer row y samples BG line y + 1 + VOFS. This is exactly why games (including the scpu-a-dma-bug harness) write VOFS = -1 to pixel-align a BG with the top of the screen.

Confirmed against both reference implementations:
- ares background.cpp fetchNameTable: voffset = vcounter() + vscroll, early-returns at vcounter 0
- Mesen2 SnesPpu.cpp: realY = _scanline (renders scanlines 1..224), row = (realY + vScroll) >> 3

NESER's Mode 7 already applied this +1 (mode7.rs screen_y with the same rationale documented); effective_offsets in background.rs now does the same for the main vscroll add and both offset-per-tile voffset paths. Written TDD red-first: two new unit tests encode the vcounter-based sampling (VOFS=0 shows BG line 1 on row 0; VOFS=-1 pixel-aligns). Two existing tests that had baked in the old convention were updated - one of them (applies_horizontal_and_vertical_flip) had also only been passing through a VRAM tilemap/char-data aliasing accident and is now robust.

## scpu-a-dma-bug automation (the #2945 deliverable)

All 10 scpu-a-dma-bug-*.sfc ROMs now render pixel-identical to Mesen2 at frame 600 - zero differing pixels at zero row offset, verified programmatically per ROM - and are automated as screen-CRC tests in undisbeliever_tests.rs (25 of the 29 vendored undisbeliever ROMs now automated; the remaining 4 stay tracked under #2943/#2944).

## Golden regeneration (74 CRCs)

The fix shifts every BG up one row, so every screen-CRC golden with visible BG content changed. Verification was layered:

1. Pre-fix main was built in a worktree and its full integration suite confirmed green (183/183), with captures taken.
2. Every changed static-screen golden (blargg 18, PeterLemon CPU 23 / SPC 7, gilyon 2, SA-1 absindx 2) was programmatically verified to be an exact 1-row shift of its previously approved capture - no other pixel changed, so prior PASS-row approvals carry over.
3. Fresh Mesen2 captures for samples from every affected suite now align byte-for-byte at zero row offset. The previously documented "harmless constant 1-scanline capture offset" between NESER and Mesen2 was this bug, not a screenshot convention; the undisbeliever suite doc was updated accordingly.
4. The two non-exact Mesen2 samples - hvdma.sfc (1.52%) and inidisp_enable_display_mid_frame.sfc (0.42%, rows 88-89 only) - both existed pre-fix (1.70% / 1.67%) and improved with this change; residuals are the known INIDISP-transition/timing classes (#2967, #2973).

Note for review: the two navigator-approved SA-1 absindx goldens (SA1RamProtectionTest, SA1VersionCodeTest) are among the regenerated CRCs; both verified as exact 1-row shifts of the approved screens (item 2), so the screens' content is unchanged.

## Pre-merge checkpoints

- cargo clippy --all-targets --all-features -D warnings: clean
- cargo fmt: applied
- ./scripts/test-dir.sh src/snes --skip-integration: 1291 passed
- cargo test --no-default-features --lib: 12280 passed, 0 failed
- wasm-pack test --headless --chrome: 94 passed
- Python unittest suites (scripts, metadata-scraper, nes-rom-db-scraper): OK
- npm test: 412 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)