### PR TITLE
Gate PPU VRAM/CGRAM/OAM writes by display state and advance the bus during DMA (#2944)

### DIFF
--- a/src/snes/bus/dma.rs
+++ b/src/snes/bus/dma.rs
@@ -7,6 +7,12 @@ pub trait DmaABus {
     fn dma_read_a_bus(&mut self, addr: u32, open_bus: u8) -> u8;
     fn dma_write_a_bus(&mut self, addr: u32, value: u8);
     fn dma_write_b_bus(&mut self, addr: u8, value: u8);
+    /// Advance the rest of the system (PPU/APU/input) by `master_clocks` while the DMA
+    /// controller owns the bus. Real hardware keeps rendering during a general-purpose DMA
+    /// (Mesen2 `SnesDmaController` advances the master clock per transferred byte), so B-bus
+    /// writes must land at the scan position they really occur at. Default no-op for test
+    /// doubles that don't model time.
+    fn dma_tick(&mut self, _master_clocks: u64) {}
 }
 
 #[derive(Clone)]
@@ -99,6 +105,7 @@ impl DmaController {
         }
 
         let mut ticks = 16u64;
+        abus.dma_tick(16);
         let mut open_bus = seed_open_bus;
 
         for channel in 0u8..8 {
@@ -107,6 +114,7 @@ impl DmaController {
             }
 
             ticks += 8;
+            abus.dma_tick(8);
             ticks += self.run_channel(channel, abus, &mut open_bus);
         }
 
@@ -254,6 +262,10 @@ impl DmaController {
             let a_addr = ((bank as u32) << 16) | ((a_high as u32) << 8) | (a_low as u32);
             let b_addr = bbad.wrapping_add(pattern[i % pattern.len()]);
 
+            // Each byte occupies an 8-master-clock bus slot: the read fills the first
+            // half, the write lands at the slot's midpoint (Mesen2 `CopyDmaByte`, where
+            // ReadDma/WriteDma each advance 4 clocks).
+            abus.dma_tick(4);
             if direction_b_to_a {
                 let value = self.read_b_bus(b_addr);
                 *open_bus = value;
@@ -264,6 +276,7 @@ impl DmaController {
                 self.write_b_bus(b_addr, value);
                 abus.dma_write_b_bus(b_addr, value);
             }
+            abus.dma_tick(4);
 
             ticks += 8;
             count = count.wrapping_sub(1);

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -1138,10 +1138,13 @@ impl DmaABus for SnesSystemBus {
 
     fn dma_tick(&mut self, master_clocks: u64) {
         // Advance the PPU/APU/input while the DMA controller owns the bus. HDMA
-        // triggers and the DRAM-refresh stall are deliberately not processed here:
-        // `self.dma` is `mem::take`n during a transfer, so `check_hdma_triggers`
-        // would operate on an empty controller; a refresh point crossed during DMA
-        // is picked up by the first normal `tick()` afterwards.
+        // triggers are deliberately not processed here: `self.dma` is `mem::take`n
+        // during a transfer, so `check_hdma_triggers` would operate on an empty
+        // controller (HDMA-during-DMA remains unmodeled, as before). The DRAM-refresh
+        // stall is also not paid here yet: Mesen2 does process it mid-transfer (its
+        // DMA clocks through `Exec()`), but enabling it shifts SNES<->SA-1 phase
+        // alignment in a way that trips a latent handshake bug (absindx
+        // SA1RamProtectionTest TEST ID 160 regresses from Passed) -- deferred to #2985.
         for _ in 0..master_clocks {
             self.tick_one_master_clock();
         }

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -470,10 +470,11 @@ impl SnesSystemBus {
 
     fn start_dma_transfer(&mut self, mdmaen: u8) {
         let mut dma = std::mem::take(&mut self.dma);
-        let (consumed_ticks, dma_open_bus) = dma.start_dma(mdmaen, self, self.mdr.get());
+        // `start_dma` advances the system live via `dma_tick` (which increments
+        // `self.ticks` one clock at a time), so the returned tick total must not be
+        // added again here.
+        let (_consumed_ticks, dma_open_bus) = dma.start_dma(mdmaen, self, self.mdr.get());
 
-        self.ticks
-            .set(self.ticks.get().wrapping_add(consumed_ticks));
         self.mdr.set(dma_open_bus);
         self.dma = dma;
     }
@@ -1135,6 +1136,17 @@ impl DmaABus for SnesSystemBus {
         self.dma_write_a_bus_impl(addr, value);
     }
 
+    fn dma_tick(&mut self, master_clocks: u64) {
+        // Advance the PPU/APU/input while the DMA controller owns the bus. HDMA
+        // triggers and the DRAM-refresh stall are deliberately not processed here:
+        // `self.dma` is `mem::take`n during a transfer, so `check_hdma_triggers`
+        // would operate on an empty controller; a refresh point crossed during DMA
+        // is picked up by the first normal `tick()` afterwards.
+        for _ in 0..master_clocks {
+            self.tick_one_master_clock();
+        }
+    }
+
     fn dma_write_b_bus(&mut self, addr: u8, value: u8) {
         match addr {
             0x00..=0x3F => self
@@ -1750,6 +1762,26 @@ mod tests {
 
         // 8/byte + 8/channel + fixed 16 global transfer overhead.
         assert_eq!(ticks_after - ticks_before, 16 + 2 * 8 + 2 * 8);
+    }
+
+    #[test]
+    fn general_purpose_dma_advances_the_ppu_during_the_transfer() {
+        let mut bus = SnesSystemBus::new(lorom_test_cart());
+        // 1024 bytes at 8 master clocks each (plus 16 + 8 overhead) is 8216 clocks,
+        // about 6 scanlines: the PPU must keep running while DMA owns the bus, so
+        // that writes land at the scan position they really occur at (hardware
+        // keeps rendering during DMA; Mesen2 `SnesDmaController` advances the
+        // master clock per transferred byte). See #2944.
+        write_dma_channel(&mut bus, 0, 0x00, 0x80, 0x7E0100, 1024);
+        let scanline_before = bus.ppu.borrow().position().scanline;
+        bus.write(0x00420B, 0x01);
+        let scanline_after = bus.ppu.borrow().position().scanline;
+
+        assert_eq!(scanline_before, 0);
+        assert!(
+            (5..=7).contains(&scanline_after),
+            "PPU should advance ~6 scanlines during a 1KB DMA, got scanline {scanline_after}"
+        );
     }
 
     #[test]

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -295,6 +295,10 @@ pub struct SnesPpuState {
     pub cgram_address: u16,
     #[serde(default)]
     pub cgram_latch: u8,
+    /// Renderer's current CGRAM fetch cursor (mid-render CGRAM writes land here).
+    /// Defaults to 0 for states saved before it existed.
+    #[serde(default)]
+    pub cgram_render_index: u8,
     #[serde(default)]
     pub oam_address: u16,
     #[serde(default)]

--- a/src/snes/integration_tests/sa1_absindx_tests.rs
+++ b/src/snes/integration_tests/sa1_absindx_tests.rs
@@ -39,12 +39,17 @@ fn sa1_ram_protection_test_passes() {
 
 #[test]
 fn sa1_version_code_test_matches_approved_register_dump() {
+    // Golden re-approved for #2944: general-purpose DMA now advances the bus per
+    // transferred byte, so the ROM's SA-1 H/V counter latch happens at a later,
+    // hardware-plausible scan position. Only the HCRL/HCRH/VCRL rows of the dump
+    // changed (H $00A2 -> $0145, V $3B -> $09); every other register value is
+    // identical to the previously approved capture.
     assert_rom_screen_crc(
         ROOT,
         "SA1VersionCodeTest.sfc",
         "sa1_absindx_tests",
         150,
-        0x9693_6ACB,
+        0x019C_64BB,
         RunConfig::new(400_000_000, 0),
     );
 }

--- a/src/snes/integration_tests/undisbeliever_tests.rs
+++ b/src/snes/integration_tests/undisbeliever_tests.rs
@@ -27,12 +27,11 @@
 //! checked reference emulator, not hardware accuracy -- see #2949 before
 //! treating a mismatch here as a regression.
 //!
-//! The other 14 ROMs are deliberately left un-automated: cross-checking
+//! The other 13 ROMs are deliberately left un-automated: cross-checking
 //! against Mesen2 exposed real NESER divergences, tracked as follow-up bugs
 //! rather than papered over with a golden that bakes in known-wrong
 //! behavior (see README-SNES.md for the full breakdown):
 //! - `hdma-2100-glitch-2ch-{0a,81}.sfc`, `hdma-21ff-2100-glitch.sfc` -- #2943
-//! - `inidisp_forgot_to_force_blank.sfc` -- #2944
 //! - all 10 `scpu-a-dma-bug-*.sfc` -- #2945
 
 use super::rom_runner::{RunConfig, RunOracle, run_rom_with_oracle};
@@ -225,5 +224,18 @@ mod tests {
         inidisp_brightness_delay_matches_mesen2,
         "inidisp_brightness_delay.sfc",
         0xA6F2_AED7
+    );
+
+    // Demonstrates forgetting to force-blank before uploading to the PPU (#2944):
+    // VRAM writes outside VBlank/forced blank are dropped, OAM writes are
+    // redirected into the high table, and CGRAM writes land at the renderer's
+    // current palette fetch (entry 0 here -- the yellow), so the "clean" uploads
+    // never land and the initial VRAM garbage fill stays on screen as the noisy
+    // striped pattern. Pixel-diffs 0.10% against Mesen2 at the usual 1-scanline
+    // capture offset -- an exact match up to anti-aliasing-level noise.
+    undisbeliever_rom_test!(
+        inidisp_forgot_to_force_blank_matches_mesen2,
+        "inidisp_forgot_to_force_blank.sfc",
+        0x104E_0736
     );
 }

--- a/src/snes/ppu/background.rs
+++ b/src/snes/ppu/background.rs
@@ -565,7 +565,12 @@ impl Ppu {
     }
 
     /// Read a CGRAM color (BGR555) by palette index.
+    ///
+    /// Also records the index as the renderer's current palette-fetch address, which is
+    /// where CPU/DMA CGRAM writes land when they happen during active rendering (see the
+    /// $2122 handler in `registers.rs`).
     pub(super) fn cgram_color(&self, index: u8) -> u16 {
+        self.cgram_render_index.set(index);
         let byte = (index as usize) << 1;
         (self.cgram[byte & (CGRAM_SIZE - 1)] as u16
             | ((self.cgram[(byte + 1) & (CGRAM_SIZE - 1)] as u16) << 8))

--- a/src/snes/ppu/framebuffer.rs
+++ b/src/snes/ppu/framebuffer.rs
@@ -45,10 +45,23 @@ impl Ppu {
         } else {
             self.framebuffer[base] = self.compute_pixel(x as u16, y as u16);
         }
+        // Mesen2's render pipeline ends every pixel chunk with `RenderBgColor`, which
+        // fetches the backdrop for any pixel the sub screen doesn't cover. With no
+        // sub-screen layers enabled that is every pixel, so the CGRAM render cursor
+        // ([`Ppu::cgram_render_index`]) parks on palette entry 0 after each dot. (With
+        // sub-screen layers enabled the cursor keeps the last real fetch instead --
+        // a per-pixel sub-coverage check isn't modeled here.)
+        if self.ts & 0x1F == 0 {
+            self.cgram_render_index.set(0);
+        }
     }
 
     /// The backdrop color (CGRAM entry 0) as a 15-bit BGR555 word.
+    ///
+    /// Records palette word 0 as the renderer's current fetch address, mirroring Mesen2's
+    /// `RenderBgColor` (backdrop pixels reset `InternalCgramAddress` to 0).
     pub(super) fn backdrop_color(&self) -> u16 {
+        self.cgram_render_index.set(0);
         let low = self.cgram[0] as u16;
         let high = self.cgram[1] as u16;
         (low | (high << 8)) & 0x7FFF

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -173,6 +173,10 @@ pub struct Ppu {
     vram_prefetch: u16,
     cgram_address: u16,
     cgram_latch: u8,
+    /// Palette word index of the renderer's most recent CGRAM fetch. CPU/DMA CGRAM writes
+    /// during active rendering land here instead of at the CPU-facing address (Mesen2's
+    /// `InternalCgramAddress`). A `Cell` because color fetches happen on `&self` render paths.
+    cgram_render_index: std::cell::Cell<u8>,
     oam_address: u16,
     oam_latch: u8,
     /// Latched horizontal counter (OPHCT, $213C).
@@ -342,7 +346,10 @@ impl Ppu {
             dram_refresh_position: DRAM_REFRESH_BASE_POSITION,
             hdma_init_position: HDMA_INIT_BASE_POSITION,
             line_timing_profile: PpuLineTimingProfile::Normal,
-            inidisp: 0,
+            // Power-on state is force-blanked (Mesen2 `SnesPpu::PowerOn` and ares
+            // `PPU::power` both start with forced blank set); this also keeps VRAM/CGRAM/OAM
+            // CPU-writable from reset until a game clears INIDISP.7.
+            inidisp: 0x80,
             nmi_enable: false,
             nmi_flag: false,
             vblank_active: false,
@@ -354,6 +361,7 @@ impl Ppu {
             vram_prefetch: 0,
             cgram_address: 0,
             cgram_latch: 0,
+            cgram_render_index: std::cell::Cell::new(0),
             oam_address: 0,
             oam_latch: 0,
             ophct_latch: 0,

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -5,7 +5,10 @@
 //! `$4212` HVBJOY). The bus passes the bare offset to [`Ppu::write_register`] /
 //! [`Ppu::read_register`].
 
-use super::{CGRAM_SIZE, CPU_VERSION, PPU1_VERSION, PPU2_VERSION, Ppu, VRAM_SIZE};
+use super::{
+    CGRAM_SIZE, CPU_VERSION, HBLANK_START_DOT, PPU1_VERSION, PPU2_VERSION, Ppu, VISIBLE_DOT_START,
+    VRAM_SIZE,
+};
 use crate::platform::debugging::ppu_trace_level;
 use crate::trace_ppu;
 
@@ -171,16 +174,23 @@ impl Ppu {
                 self.vram_prefetch = self.read_vram_word(self.vram_address);
             }
             // VMDATAL / VMDATAH: VRAM data write (low/high byte of the addressed word).
+            // Outside VBlank/forced blank the data is silently dropped (fullsnes: "All video
+            // memory can be accessed only during V-Blank, or Forced Blank"), but the VRAM
+            // address still increments (Mesen2 `SnesPpu.cpp` $2118/$2119).
             0x2118 => {
-                let index = self.vram_index();
-                self.vram[index] = value;
+                if self.vram_cpu_access_allowed() {
+                    let index = self.vram_index();
+                    self.vram[index] = value;
+                }
                 if !self.vram_increment_after_high {
                     self.increment_vram_address();
                 }
             }
             0x2119 => {
-                let index = self.vram_index() | 1;
-                self.vram[index] = value;
+                if self.vram_cpu_access_allowed() {
+                    let index = self.vram_index() | 1;
+                    self.vram[index] = value;
+                }
                 if self.vram_increment_after_high {
                     self.increment_vram_address();
                 }
@@ -189,13 +199,23 @@ impl Ppu {
             0x2121 => self.cgram_address = (value as u16) << 1,
             // CGDATA: CGRAM data write. Even byte latches the low byte; the odd byte commits the
             // 15-bit word (high byte keeps only bits 0-6). The address increments after each write.
+            // Outside its access window (VBlank, forced blank, scanline 0, or HBlank) the
+            // commit is redirected to the palette entry the renderer is currently fetching
+            // ([`Ppu::cgram_render_index`]), corrupting the on-screen palette instead of
+            // landing at the CPU address (Mesen2 `SnesPpu.cpp` $2122, `InternalCgramAddress`).
+            // The latch and address increment happen either way.
             0x2122 => {
                 let index = self.cgram_index();
                 if index & 1 == 0 {
                     self.cgram_latch = value;
                 } else {
-                    self.cgram[index - 1] = self.cgram_latch;
-                    self.cgram[index] = value & 0x7F;
+                    let commit = if self.cgram_cpu_access_allowed() {
+                        index
+                    } else {
+                        (((self.cgram_render_index.get() as usize) << 1) | 1) & (CGRAM_SIZE - 1)
+                    };
+                    self.cgram[commit - 1] = self.cgram_latch;
+                    self.cgram[commit] = value & 0x7F;
                 }
                 self.increment_cgram_address();
             }
@@ -217,9 +237,19 @@ impl Ppu {
             // OAMDATA: OAM data write. In the low table ($000-$1FF) an even byte latches and the
             // odd byte commits the word; the high table ($200-$21F) writes each byte directly.
             // The address increments after each write.
+            // During active rendering the sprite unit's internal read cursor overrides the
+            // CPU-facing address and the write is redirected into the high table at
+            // 0x200 | ((addr & 0x1F0) >> 4) (Mesen2 `SnesPpu.cpp` $2104, needed for
+            // Uniracers). Mesen2 derives the cursor from its per-dot sprite evaluation; we
+            // approximate with the CPU-facing address, which reproduces the essential
+            // behavior: the low table is protected and the high table gets corrupted.
             0x2104 => {
                 let addr = (self.oam_address as usize) & 0x03FF;
-                if addr < 0x200 {
+                if self.oam_rendering_active() {
+                    let redirected = 0x200 | ((addr & 0x1F0) >> 4);
+                    self.oam_latch = value;
+                    self.oam[redirected] = value;
+                } else if addr < 0x200 {
                     if addr & 1 == 0 {
                         self.oam_latch = value;
                     } else {
@@ -399,6 +429,35 @@ impl Ppu {
             );
         }
         value
+    }
+
+    /// True when INIDISP ($2100) bit 7 force-blanks the display.
+    fn forced_blank_enabled(&self) -> bool {
+        self.inidisp & 0x80 != 0
+    }
+
+    /// CPU writes to VRAM are honored only during VBlank or forced blank (fullsnes: "All
+    /// video memory can be accessed only during V-Blank, or Forced Blank"; Mesen2
+    /// `SnesPpu::CanAccessVram`).
+    fn vram_cpu_access_allowed(&self) -> bool {
+        self.position.scanline >= self.vblank_start_line() || self.forced_blank_enabled()
+    }
+
+    /// CGRAM is more permissive than VRAM: also writable on scanline 0 and during the
+    /// current scanline's HBlank, i.e. outside the active-fetch dots 22..274 (Mesen2
+    /// `SnesPpu::CanAccessCgram`, hclock < 88 || >= 1096; fullsnes notes CGRAM writes work
+    /// "during certain timespots in the Hblank-period").
+    fn cgram_cpu_access_allowed(&self) -> bool {
+        self.vram_cpu_access_allowed()
+            || self.position.scanline == 0
+            || self.position.dot < VISIBLE_DOT_START
+            || self.position.dot >= HBLANK_START_DOT
+    }
+
+    /// True while the sprite unit owns OAM: display enabled and before the first VBlank
+    /// scanline (Mesen2 `SnesPpu.cpp` $2104 redirect condition).
+    fn oam_rendering_active(&self) -> bool {
+        !self.forced_blank_enabled() && self.position.scanline < self.vblank_start_line()
     }
 
     fn vram_index(&self) -> usize {
@@ -618,6 +677,202 @@ mod tests {
         ppu.write_register(0x2104, 0x56);
 
         assert_eq!(ppu.oam_byte(0x200), 0x56);
+    }
+
+    #[test]
+    fn ppu_powers_on_with_forced_blank_enabled() {
+        // Real hardware powers on force-blanked (both Mesen2 `SnesPpu::PowerOn` and ares
+        // `PPU::power` set forced blank at init); games must clear INIDISP.7 themselves.
+        let ppu = Ppu::new();
+        assert_eq!(ppu.inidisp & 0x80, 0x80);
+    }
+
+    #[test]
+    fn vram_writes_during_active_display_are_dropped_but_address_still_increments() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F); // display enabled, full brightness
+        ppu.position.scanline = 40;
+        ppu.position.dot = 100;
+
+        ppu.write_register(0x2115, 0x80);
+        ppu.write_register(0x2116, 0x00);
+        ppu.write_register(0x2117, 0x10);
+        ppu.write_register(0x2118, 0xAA);
+        ppu.write_register(0x2119, 0xBB);
+
+        // The data is silently dropped...
+        assert_eq!(ppu.vram_byte(0x2000), 0x00);
+        assert_eq!(ppu.vram_byte(0x2001), 0x00);
+
+        // ...but the VRAM address still increments: re-entering forced blank, the
+        // next word write lands one word past the dropped one.
+        ppu.write_register(0x2100, 0x80);
+        ppu.write_register(0x2118, 0x11);
+        ppu.write_register(0x2119, 0x22);
+        assert_eq!(ppu.vram_byte(0x2002), 0x11);
+        assert_eq!(ppu.vram_byte(0x2003), 0x22);
+    }
+
+    #[test]
+    fn vram_writes_during_vblank_are_stored_with_display_enabled() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F);
+        ppu.position.scanline = 225; // first VBlank scanline (224-line mode)
+        ppu.position.dot = 100;
+
+        ppu.write_register(0x2115, 0x80);
+        ppu.write_register(0x2116, 0x00);
+        ppu.write_register(0x2117, 0x10);
+        ppu.write_register(0x2118, 0xAA);
+        ppu.write_register(0x2119, 0xBB);
+
+        assert_eq!(ppu.vram_byte(0x2000), 0xAA);
+        assert_eq!(ppu.vram_byte(0x2001), 0xBB);
+    }
+
+    #[test]
+    fn vram_writes_on_scanline_zero_are_dropped_when_display_enabled() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F);
+        ppu.position.scanline = 0;
+        ppu.position.dot = 100;
+
+        ppu.write_register(0x2115, 0x80);
+        ppu.write_register(0x2116, 0x00);
+        ppu.write_register(0x2117, 0x10);
+        ppu.write_register(0x2118, 0xAA);
+        ppu.write_register(0x2119, 0xBB);
+
+        assert_eq!(ppu.vram_byte(0x2000), 0x00);
+        assert_eq!(ppu.vram_byte(0x2001), 0x00);
+    }
+
+    #[test]
+    fn cgram_writes_during_active_rendering_land_at_the_renderer_fetch_address() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F);
+        ppu.position.scanline = 40;
+        ppu.position.dot = 100; // inside the active-fetch window (dots 22..274)
+        ppu.cgram_render_index.set(0x05); // renderer last fetched palette word 5
+
+        ppu.write_register(0x2121, 0x10);
+        ppu.write_register(0x2122, 0x34);
+        ppu.write_register(0x2122, 0x12);
+
+        // The CPU-addressed word is untouched; the commit is redirected to the
+        // palette entry the renderer is currently reading (word 5, bytes 0x0A/0x0B).
+        assert_eq!(ppu.cgram_byte(0x20), 0x00);
+        assert_eq!(ppu.cgram_byte(0x21), 0x00);
+        assert_eq!(ppu.cgram_byte(0x0A), 0x34);
+        assert_eq!(ppu.cgram_byte(0x0B), 0x12);
+    }
+
+    #[test]
+    fn cgram_render_index_tracks_the_last_palette_fetch() {
+        let ppu = Ppu::new();
+        ppu.cgram_render_index.set(0x00);
+        let _ = ppu.cgram_color(0x42);
+        assert_eq!(ppu.cgram_render_index.get(), 0x42);
+    }
+
+    #[test]
+    fn cgram_render_index_parks_on_the_backdrop_when_the_sub_screen_is_empty() {
+        // Mesen2 ends every rendered pixel chunk with `RenderBgColor`, which fetches
+        // the backdrop for sub-screen-empty pixels; with no sub-screen layers enabled
+        // the render cursor therefore always parks on palette entry 0.
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F); // display on
+        ppu.write_register(0x212D, 0x00); // no sub-screen layers
+        ppu.cgram_render_index.set(0x42);
+
+        // Tick through one visible dot so render_dot runs.
+        ppu.position.scanline = 40;
+        ppu.position.dot = 100;
+        for _ in 0..4 {
+            ppu.tick();
+        }
+
+        assert_eq!(ppu.cgram_render_index.get(), 0x00);
+    }
+
+    #[test]
+    fn cgram_writes_during_hblank_are_stored() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F);
+        ppu.position.scanline = 40;
+        ppu.position.dot = 280; // HBlank (>= dot 274)
+
+        ppu.write_register(0x2121, 0x10);
+        ppu.write_register(0x2122, 0x34);
+        ppu.write_register(0x2122, 0x12);
+
+        assert_eq!(ppu.cgram_byte(0x20), 0x34);
+        assert_eq!(ppu.cgram_byte(0x21), 0x12);
+    }
+
+    #[test]
+    fn cgram_writes_before_the_active_fetch_window_are_stored() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F);
+        ppu.position.scanline = 40;
+        ppu.position.dot = 10; // before the active-fetch window (< dot 22)
+
+        ppu.write_register(0x2121, 0x10);
+        ppu.write_register(0x2122, 0x34);
+        ppu.write_register(0x2122, 0x12);
+
+        assert_eq!(ppu.cgram_byte(0x20), 0x34);
+        assert_eq!(ppu.cgram_byte(0x21), 0x12);
+    }
+
+    #[test]
+    fn cgram_writes_on_scanline_zero_are_stored() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F);
+        ppu.position.scanline = 0;
+        ppu.position.dot = 100;
+
+        ppu.write_register(0x2121, 0x10);
+        ppu.write_register(0x2122, 0x34);
+        ppu.write_register(0x2122, 0x12);
+
+        assert_eq!(ppu.cgram_byte(0x20), 0x34);
+        assert_eq!(ppu.cgram_byte(0x21), 0x12);
+    }
+
+    #[test]
+    fn oam_writes_during_active_rendering_are_redirected_to_the_high_table() {
+        let mut ppu = Ppu::new();
+        // CPU-facing OAM address: word 0x20 -> byte address 0x40.
+        ppu.write_register(0x2102, 0x20);
+        ppu.write_register(0x2103, 0x00);
+        ppu.write_register(0x2100, 0x0F);
+        ppu.position.scanline = 40;
+        ppu.position.dot = 100;
+
+        ppu.write_register(0x2104, 0x9A);
+
+        // The low table is untouched; the write lands in the high table at
+        // 0x200 | ((0x40 & 0x1F0) >> 4) = 0x204.
+        assert_eq!(ppu.oam_byte(0x40), 0x00);
+        assert_eq!(ppu.oam_byte(0x41), 0x00);
+        assert_eq!(ppu.oam_byte(0x204), 0x9A);
+    }
+
+    #[test]
+    fn oam_writes_during_vblank_commit_normally_with_display_enabled() {
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2102, 0x20);
+        ppu.write_register(0x2103, 0x00);
+        ppu.write_register(0x2100, 0x0F);
+        ppu.position.scanline = 225;
+        ppu.position.dot = 100;
+
+        ppu.write_register(0x2104, 0x9A);
+        ppu.write_register(0x2104, 0xBC);
+
+        assert_eq!(ppu.oam_byte(0x40), 0x9A);
+        assert_eq!(ppu.oam_byte(0x41), 0xBC);
     }
 
     #[test]

--- a/src/snes/ppu/save_state.rs
+++ b/src/snes/ppu/save_state.rs
@@ -36,6 +36,7 @@ impl Ppu {
             vram_prefetch: self.vram_prefetch,
             cgram_address: self.cgram_address,
             cgram_latch: self.cgram_latch,
+            cgram_render_index: self.cgram_render_index.get(),
             oam_address: self.oam_address,
             oam_latch: self.oam_latch,
             ophct_latch: self.ophct_latch,
@@ -131,6 +132,7 @@ impl Ppu {
         self.vram_prefetch = state.vram_prefetch;
         self.cgram_address = state.cgram_address;
         self.cgram_latch = state.cgram_latch;
+        self.cgram_render_index.set(state.cgram_render_index);
         self.oam_address = state.oam_address;
         self.oam_latch = state.oam_latch;
         self.ophct_latch = state.ophct_latch;
@@ -242,6 +244,19 @@ fn restore_memory(dst: &mut [u8], src: &[u8], expected: usize, name: &str) -> Re
 #[cfg(test)]
 mod tests {
     use super::super::{Ppu, PpuLineTimingProfile};
+
+    #[test]
+    fn save_state_round_trips_the_cgram_render_index() {
+        // The CGRAM render cursor decides where mid-render CGRAM writes land, so a
+        // state saved mid-frame must restore it for deterministic resume.
+        let ppu = Ppu::new();
+        ppu.cgram_render_index.set(0x42);
+        let snapshot = ppu.capture_state();
+
+        let mut restored = Ppu::new();
+        restored.restore_state(&snapshot).expect("restore");
+        assert_eq!(restored.cgram_render_index.get(), 0x42);
+    }
 
     #[test]
     fn capture_restore_round_trips_ppu_state() {

--- a/src/snes/ppu/sprites.rs
+++ b/src/snes/ppu/sprites.rs
@@ -890,6 +890,7 @@ mod tests {
     fn range_over_flag_is_raised_at_oam_index_times_two_dot() {
         let mut ppu = Ppu::new();
         fill_in_range(&mut ppu, 40, 50); // 40 in range on line 50 -> 33rd is OBJ #32, dot 64
+        ppu.write_register(0x2100, 0x0F); // display on (evaluation skips forced blank)
         tick_dots(&mut ppu, 50 * 341 + 63); // scanline 50, dot 63 (just before)
         assert_eq!(
             stat77(&mut ppu) & 0x40,
@@ -904,6 +905,7 @@ mod tests {
     fn range_over_flag_stays_clear_with_32_or_fewer_objects() {
         let mut ppu = Ppu::new();
         fill_in_range(&mut ppu, 32, 50);
+        ppu.write_register(0x2100, 0x0F); // display on (evaluation skips forced blank)
         tick_dots(&mut ppu, 51 * 341);
         assert_eq!(
             stat77(&mut ppu) & 0x40,
@@ -920,6 +922,7 @@ mod tests {
             let y = if i < 5 { 50 } else { 224 }; // park at 224 (32px tall, no wrap into visible)
             set_obj(&mut ppu, i, 0, y, 0, 0, i < 5); // 5 large -> 40 tiles > 34
         }
+        ppu.write_register(0x2100, 0x0F); // display on (evaluation skips forced blank)
         // Time over for line 50 is applied at the start of display scanline 51 (H=0).
         tick_dots(&mut ppu, 50 * 341 + 200);
         assert_eq!(
@@ -939,6 +942,7 @@ mod tests {
     fn over_limit_flags_clear_at_end_of_vblank() {
         let mut ppu = Ppu::new();
         fill_in_range(&mut ppu, 40, 50);
+        ppu.write_register(0x2100, 0x0F); // display on (evaluation skips forced blank)
         tick_dots(&mut ppu, 50 * 341 + 100); // raise range over
         assert_eq!(stat77(&mut ppu) & 0x40, 0x40);
         // Advance to scanline 0 of the next frame (end of VBlank) -> flags cleared.
@@ -955,6 +959,7 @@ mod tests {
     fn over_limit_flags_are_not_cleared_during_forced_blank() {
         let mut ppu = Ppu::new();
         fill_in_range(&mut ppu, 40, 50);
+        ppu.write_register(0x2100, 0x0F); // display on (evaluation skips forced blank)
         tick_dots(&mut ppu, 50 * 341 + 100);
         assert_eq!(stat77(&mut ppu) & 0x40, 0x40);
         ppu.write_register(0x2100, 0x80); // forced blank
@@ -1014,11 +1019,16 @@ mod tests {
         // Enter visible line 0 and render through x=4.
         tick_dots(&mut ppu, 341 + 26);
 
-        // Mid-scanline OAMDATA write: move OBJ0 from x=0 to x=40.
+        // Mid-scanline OAMDATA write: move OBJ0 from x=0 to x=40. During active display
+        // OAM low-table writes are redirected to the high table, so briefly enter forced
+        // blank around the write, the way real games do (Mario Kart changes OAM mid-screen
+        // via forced blank).
+        ppu.write_register(0x2100, 0x80);
         ppu.write_register(0x2102, 0x00);
         ppu.write_register(0x2103, 0x00);
         ppu.write_register(0x2104, 40);
         ppu.write_register(0x2104, 0);
+        ppu.write_register(0x2100, 0x0F);
 
         // Render past x=40 on the same scanline.
         tick_dots(&mut ppu, 40);


### PR DESCRIPTION
Fixes #2944.

## What

NESER's PPU accepted VRAM/CGRAM/OAM writes unconditionally, so inidisp_forgot_to_force_blank.sfc rendered a clean screen where real hardware (and Mesen2) shows heavy corruption. Three mechanisms were missing, all now implemented per fullsnes ("All video memory can be accessed only during V-Blank, or Forced Blank") and Mesen2's SnesPpu.cpp as the reference:

- VRAM ($2118/$2119): writes outside VBlank/forced blank are silently dropped; the VRAM address still increments (Mesen2 CanAccessVram).
- CGRAM ($2122): more permissive window (also scanline 0 and HBlank, dots < 22 or >= 274, matching Mesen2's hclock < 88 || >= 1096). Outside it, the commit is redirected to the palette entry the renderer is currently fetching -- a new cgram_render_index cursor mirroring Mesen2's InternalCgramAddress, including the RenderBgColor tail behavior of parking on entry 0 whenever the sub screen is empty.
- OAM ($2104): writes during active rendering are redirected into the high table at 0x200 | ((addr & 0x1F0) >> 4) (Mesen2's Uniracers-compatibility behavior), approximating the sprite unit's cursor with the CPU-facing address.
- Power-on: INIDISP now defaults to 0x80 (forced blank), matching both Mesen2 and ares. This keeps power-on uploads (and all existing unit tests) working with the new gating.

Additionally, general-purpose DMA now advances the whole system per transferred byte (8 master clocks per byte plus the existing 16 + 8/channel overheads) via a new DmaABus::dma_tick hook. Previously an entire multi-scanline DMA executed at one frozen (scanline, dot), which made the gating all-or-nothing; hardware keeps rendering during DMA, and the corrupted output depends on which bytes land in blank windows. HDMA keeps its existing lump-sum tick accounting (unchanged scope).

## Verification

- TDD throughout: new unit tests for every gating rule, the OAM redirect, the CGRAM render-cursor redirect, the power-on default, and the PPU advancing ~6 scanlines during a 1KB DMA.
- inidisp_forgot_to_force_blank.sfc is now automated with golden CRC 0x104E0736. Frame-600 capture pixel-diffs 0.10% (57 of 57,088 pixels) against a Mesen2 headless capture at the known constant 1-scanline offset -- effectively an exact match of the yellow/black striped corruption.
- Full local checkpoint battery passes: clippy -D warnings, cargo fmt, full lib suite (12,274 tests), wasm-pack Chrome suite (94), python unittest suites, npm/Vitest (412).

## Navigator re-approval needed

SA1VersionCodeTest.sfc's approved register-dump golden changed (0x96936ACB -> 0x019C64BB) because DMA now consumes real bus time. I pixel-diffed old vs new captures: only the HCRL/HCRH/VCRL rows differ (SA-1 H/V counter latch, H $00A2 -> $0145, V $3B -> $09); every other register value is identical. This looks like the expected, hardware-plausible consequence of the timing fix, but per the suite's methodology the new capture is a navigator-approved golden -- please confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)