### PR TITLE
fix(snes): OBJ interlace (SETINI $2133 bit 1) halves sprite height with field-interleaved lines

### DIFF
--- a/.github/skills/snes-hardware-research/SKILL.md
+++ b/.github/skills/snes-hardware-research/SKILL.md
@@ -64,19 +64,17 @@ Use this skill whenever you need details about any part of Super Nintendo Entert
    - Treat ares/Mesen2 as implementation evidence, not as equal authority with written specifications.
    - When both agree on behavior not in specs, that's strong evidence; when they disagree, state both approaches.
 
-9. For visual verification, use a two-emulator cross-check.
-   - **Locating binaries**:
-     - Check if built from local source (e.g., `../ares/desktop-ui/ares`, `../Mesen2/bin/x64/Release/Mesen`)
-     - macOS: check `/Applications/ares.app`, `/Applications/Mesen2.app`
+9. For visual verification, cross-check against Mesen2 (the sole screenshot reference; navigator decision in #3000 — ares stays a source-code reference only, see step 8).
+   - **Locating the binary**:
+     - Check if built from local source (e.g., `../Mesen2/bin/x64/Release/Mesen`)
+     - macOS: check `/Applications/Mesen.app` (`/Applications/Mesen.app/Contents/MacOS/Mesen`)
      - Linux: check `~/Applications/`, `/usr/local/bin/`, `~/.local/bin/`
      - Windows: check `C:\Program Files\`, `C:\Program Files (x86)\`
      - If not found in standard locations, ask the user for the path
-   - **Always capture screenshots from both ares AND Mesen2 first.**
-   - If ares and Mesen2 produce identical output (pixel-perfect match), use that as the reference for NESER comparison.
-   - If ares and Mesen2 disagree, **stop and ask the user** how to proceed — don't pick one arbitrarily.
+   - Capture a Mesen2 screenshot at the same frame as NESER and pixel-diff programmatically; exact matches become the reference for NESER comparison.
+   - If NESER and Mesen2 disagree and the divergence is suspected to be a Mesen2 quirk, **ask the user** how to proceed rather than approving either side unilaterally.
    - Screenshot settings for comparable captures:
      - Mesen2: `--Video.VideoFilter=None --Video.AspectRatio=NoStretching --snes.disableFrameSkipping=true`
-     - ares: use default "None" video filter, no overscan cropping
    - Mesen2 headless mode: `Mesen --testRunner --enableStdout --timeout=N <rom> <script.lua>`
    - **`--snes.disableFrameSkipping=true` is mandatory for animated content** (found in #2990):
      headless testRunner emulation runs >100 fps, engaging `_skipRender` (SnesPpu.cpp) which
@@ -174,18 +172,20 @@ When writing code that targets or emulates SNES hardware, always verify against 
 
 When verifying SNES emulator accuracy:
 
-- **Two-emulator verification (mandatory for screenshots)**:
-  1. Capture screenshots from **both ares and Mesen2** for the same ROM/frame
-  2. Compare ares vs Mesen2 pixel-by-pixel first
-  3. If they match: use that as the reference for NESER comparison
-  4. If they differ: **ask the user** how to proceed — do not pick one arbitrarily
-  5. Document which emulator(s) NESER matches in test comments
+- **Mesen2 verification (mandatory for screenshots)**:
+  1. Capture a Mesen2 screenshot for the same ROM/frame (Mesen2 is the sole
+     screenshot reference; ares is source-code evidence only — navigator
+     decision in #3000)
+  2. Pixel-diff NESER vs Mesen2 programmatically; an exact match approves the
+     baseline
+  3. If they differ and Mesen2 itself is suspect: **ask the user** how to
+     proceed — do not approve either side arbitrarily
+  4. Document the Mesen2 approval (frame, diff result) in test comments
 - **Pixel-perfect comparison**: Use Python/PIL to compare screenshots pixel-by-pixel. Don't trust visual inspection — differences of 2-4% are invisible to the eye but indicate timing bugs.
 - **CRC-based integration tests**: Capture frame CRCs at known stable points (e.g., frame 600) and use as golden values for regression testing. Update test comments to reference GitHub issues for known differences.
 - **Screenshot settings for comparable captures**:
   - Mesen2: `--Video.VideoFilter=None --Video.AspectRatio=NoStretching --snes.disableFrameSkipping=true`
     (the frame-skip switch is mandatory for animated content; see step 9 of the Instructions)
-  - ares: default "None" video filter, no overscan cropping
   - Since the BG vertical-scroll display-line fix (issue #2945, PR #2981), NESER and
     Mesen2 frame-N captures align **byte-for-byte at zero row offset**. A previously
     documented "constant 1-scanline row offset vs NESER" was in fact a NESER BG bug,
@@ -502,53 +502,7 @@ kill $MESEN_PID
 - `emu.takeScreenshot()` returns PNG binary data as string
 - `emu.stop(0)` does not work in regular mode; use external process control instead
 
-#### ares (Manual/Semi-Automated)
-
-ares does not have Lua scripting like Mesen2, but supports hotkeys for frame advance and screenshots.
-
-**Hotkey Configuration Format:**
-
-Hotkeys in `settings.bml` use the format: `0xDEVICE_ID/GROUP_ID/INPUT_ID;;`
-- `0x1` = Keyboard device
-- `0` = Button group
-- `INPUT_ID` = Index in the key mapping array
-
-**Key Mapping** (from `ares/ruby/input/keyboard/quartz.cpp` on macOS):
-Keys are indexed in this order starting from 0:
-1. Escape (0)
-2. F1-F20 (1-20)
-3. Tilde, Num1-0, Dash, Equal, Delete (21-34)
-4. Erase, Home, End, PageUp, PageDown (35-39)
-5. A-Z (40-65)
-6. LeftBracket, RightBracket, Backslash, Semicolon, Apostrophe, Comma, Period, Slash (66-73)
-7. Keypad1-0, Clear, Equals, Divide, Multiply, Subtract, Add, Enter, Decimal (74-91)
-8. Up, Down, Left, Right (92-95)
-9. Tab (96), Return (97), Spacebar (98)
-10. Modifiers: Shift, Control, Alt, Super (99+)
-
-**Example configuration** (in `~/Library/Application Support/ares/settings.bml`):
-```
-Hotkey
-  FrameAdvance: 0x1/0/96;;        # Tab key (index 96)
-  CaptureScreenshot: 0x1/0/1;;    # F1 key (index 1)
-Paths
-  Screenshots: /path/to/output/directory
-```
-
-**Manual Capture Workflow:**
-1. Configure hotkeys in `settings.bml` or via ares GUI (Settings → Hotkeys)
-2. Set screenshot output path in `settings.bml` under `Paths/Screenshots`
-3. Launch ares with ROM: `/Applications/ares.app/Contents/MacOS/ares path/to/rom.sfc --system "Super Famicom"`
-4. Manually press Tab 120 times (or configured frame advance key)
-5. Press F1 (or configured screenshot key) to capture
-6. Screenshot saves to configured path with automatic naming
-
-**Automation Challenges:**
-- Hotkeys configured correctly in settings.bml may not respond to simulated keystrokes (AppleScript/Python automation)
-- ares may require interactive GUI session for hotkey processing
-- Frame advance via hotkey is manual and tedious for large frame counts
-
-**Recommended Approach:**
-For automated testing, prefer Mesen2 (fully scriptable). For ares, use manual capture or launch in GUI mode with user interaction for frame advance + screenshot at target frame.
+(ares is not used for screenshot capture — it has no scripting support and is
+a source-code reference only; see step 9 of the Instructions.)
 
 

--- a/README-SNES.md
+++ b/README-SNES.md
@@ -117,15 +117,15 @@ Test suites:
 - `undisbeliever_ppu_obj_tests.rs` -- the OBJ/sprite-limit dropout ROM built
   from the undisbeliever source mirror
   (`roms/snes/automated_tests/snes_test_roms/undisbeliever-ppu-obj/`).
-  Committed `#[ignore]`d: NESER enforces the 32-OBJ range-over limit but not
-  the 34-sliver time-over limit (#2999).
+  Automated with a Mesen2-approved golden since the #2999 OBJ eval/fetch
+  pipeline (34-sliver time-over limit) landed.
 - `byuu_test_oam_tests.rs` -- byuu's interactive `test_oam.smc` menu
   (`roms/snes/automated_tests/snes_test_roms/jonasquinn-test-roms/test_oam/`)
-  driven through `rom_runner`'s frame-stamped input scripting. 28 combos
-  (menu, all 8 OBSEL bases x both size bits, flips, char variants) carry
-  Mesen2-approved goldens; 6 SETINI combos are `#[ignore]`d -- OBJ interlace
-  diverges (#3000) and the screen-interlace/overscan capture dimensions
-  differ from Mesen2's (#3001).
+  driven through `rom_runner`'s frame-stamped input scripting. 30 combos
+  (menu, all 8 OBSEL bases x both size bits, flips, char variants, OBJ
+  interlace since #3000) carry Mesen2-approved goldens; 4 SETINI combos are
+  `#[ignore]`d -- the screen-interlace/overscan capture dimensions differ
+  from Mesen2's (#3001).
 - `neser_obj_tests.rs` -- NESER-authored OBJ feature ROMs written against
   the undisbeliever bass framework
   (`roms/snes/automated_tests/snes_test_roms/neser-obj-tests/`, sources

--- a/src/snes/integration_tests/byuu_test_oam_tests.rs
+++ b/src/snes/integration_tests/byuu_test_oam_tests.rs
@@ -30,10 +30,10 @@
 //!   window, both give 0-pixel diffs) but the raw frame dimensions differ,
 //!   so they stay `#[ignore]`d without goldens until #3001 settles the
 //!   capture convention.
-//! - `setini2_*` (OBJ interlace, $2133=2) diverges genuinely: Mesen2
-//!   renders the sprite half-height with interleaved lines, NESER ignores
-//!   the bit (issue #3000) -- those two tests are `#[ignore]`d with
-//!   NESER's current CRCs recorded for post-fix comparison.
+//! - `setini2_*` (OBJ interlace, $2133=2): the sprite renders half-height
+//!   with field-interleaved lines since issue #3000; both combos match
+//!   Mesen2 exactly at shift (0,0) (re-approved via the same replay
+//!   workflow, 0-pixel diffs) and carry approved goldens.
 
 use super::rom_runner::{InputEvent, RunConfig, RunOracle, run_rom_with_oracle};
 use crate::snes::input::SnesButton;
@@ -266,31 +266,9 @@ mod tests {
     test_oam_combo_ignored_3001!(setini4_small, "i4-s0", { setini: 4, size: 0 }, 0x5E52_C62B);
     test_oam_combo_ignored_3001!(setini4_large, "i4-s1", { setini: 4, size: 1 }, 0x78AE_B7C8);
 
-    /// NESER ignores OBJ interlace (SETINI bit 1), so these CRCs are
-    /// NESER's own output from when #3000 was filed, NOT Mesen2-approved
-    /// goldens (Mesen2 halves the sprite height). Re-probe and re-approve
-    /// once #3000 is fixed, then remove the ignore attributes.
-    #[test]
-    #[ignore = "NESER lacks OBJ interlace (SETINI $2133 bit 1); pending #3000"]
-    fn setini2_small() {
-        let combo = OamCombo {
-            setini: 2,
-            size: 0,
-            ..OamCombo::default_menu()
-        };
-        let (script, sample_frame) = build_combo_script(combo);
-        assert_test_oam_screen_crc("i2-s0", &script, sample_frame, 0xD1F7_F5C4);
-    }
-
-    #[test]
-    #[ignore = "NESER lacks OBJ interlace (SETINI $2133 bit 1); pending #3000"]
-    fn setini2_large() {
-        let combo = OamCombo {
-            setini: 2,
-            size: 1,
-            ..OamCombo::default_menu()
-        };
-        let (script, sample_frame) = build_combo_script(combo);
-        assert_test_oam_screen_crc("i2-s1", &script, sample_frame, 0xF5CF_D3FC);
-    }
+    // OBJ interlace ($2133=2, issue #3000): the sprite renders half-height
+    // with field-interleaved lines. Goldens re-approved against Mesen2
+    // headless replay (0-pixel diffs at shift (0,0)).
+    test_oam_combo!(setini2_small, "i2-s0", { setini: 2, size: 0 }, 0x7BE9_8B23);
+    test_oam_combo!(setini2_large, "i2-s1", { setini: 2, size: 1 }, 0xFE8D_F854);
 }

--- a/src/snes/ppu/sprites.rs
+++ b/src/snes/ppu/sprites.rs
@@ -23,17 +23,6 @@ pub(super) struct ObjPixel {
 }
 
 impl Ppu {
-    /// Convert framebuffer row `line` into the OBJ sampling line.
-    ///
-    /// With interlace+OBJ interlace enabled, OBJ fetches alternate source lines per field.
-    fn obj_source_line(&self, line: u16) -> u16 {
-        if self.interlace_enabled() && self.obj_interlace_enabled() {
-            line.saturating_mul(2) + self.interlace_field as u16
-        } else {
-            line
-        }
-    }
-
     /// Small-OBJ pixel size `(width, height)` selected by OBSEL bits 7-5.
     pub(super) fn obj_size_small(&self) -> (u8, u8) {
         obj_size_pair(self.obsel).0
@@ -101,12 +90,20 @@ impl Ppu {
         ((self.oam[0x200 + (index >> 2)] >> ((index & 3) * 2)) & 1) as u16
     }
 
-    /// Whether OBJ `index` is in range for OBJ source line `line`: it must intersect the line
+    /// Whether OBJ `index` is in range for display line `line`: it must intersect the line
     /// vertically (8-bit Y wrap) and not be fully off-screen horizontally. Exception: raw X=256
     /// (sign-extended -256) is always in range -- it consumes range/time budget without being
     /// drawn (Mesen2 `SpriteInfo::IsVisible`, ares `PPU::Object::onScanline`).
+    ///
+    /// With OBJ interlace (SETINI $2133 bit 1, independent of screen interlace) the sprite keeps
+    /// its OAM Y anchor but spans half its height on screen (Mesen2/ares: `height >> 1`).
     fn obj_in_range(&self, index: usize, line: u16) -> bool {
         let (width, height) = self.obj_size(index);
+        let height = if self.obj_interlace_enabled() {
+            height >> 1
+        } else {
+            height
+        };
         let y = self.oam[index * 4 + 1] as u16;
         let row = line.wrapping_sub(y) & 0xFF;
         if row >= height as u16 {
@@ -235,8 +232,7 @@ impl Ppu {
         }
         self.obj_pipeline.eval_cursor += 1;
         let index = (self.obj_pipeline.first_sprite as usize + cursor as usize) & 0x7F;
-        let source_line = self.obj_source_line(self.position.scanline);
-        if !self.obj_in_range(index, source_line) {
+        if !self.obj_in_range(index, self.position.scanline) {
             return;
         }
         let pipeline = &mut self.obj_pipeline;
@@ -295,8 +291,13 @@ impl Ppu {
         let vflip = attr & 0x80 != 0;
         let base_tile = self.oam[index * 4 + 2] as u16 | (((attr & 0x01) as u16) << 8);
         let y = self.oam[index * 4 + 1] as u16;
-        let source_line = self.obj_source_line(self.position.scanline);
-        let mut within_y = (source_line.wrapping_sub(y) & 0xFF) as i32;
+        let mut within_y = (self.position.scanline.wrapping_sub(y) & 0xFF) as i32;
+        // OBJ interlace: each field shows alternate source lines of the half-height sprite --
+        // double the line-within-sprite and OR in the field, then V-flip mirrors the doubled
+        // coordinate against the full height (Mesen2 `FetchSpriteAttributes`, ares equivalent).
+        if self.obj_interlace_enabled() {
+            within_y = (within_y << 1) | self.interlace_field as i32;
+        }
         if vflip {
             within_y = height - 1 - within_y;
         }
@@ -841,6 +842,187 @@ mod tests {
         // Field 0 samples source line 0 for display line 0; field 1 samples source line 1.
         assert_eq!(line_color_for_field(false), Some(0x001F));
         assert_eq!(line_color_for_field(true), Some(0x03E0));
+    }
+
+    #[test]
+    fn obj_interlace_halves_height_anchored_at_oam_y() {
+        // SETINI bit 1 alone (no screen interlace): the sprite stays anchored at OAM Y with
+        // halved on-screen height (Mesen2 `SpriteInfo::IsVisible`, ares `onScanline`).
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2101, 0x00); // 8x8
+        ppu.write_register(0x2133, 0x02); // OBJ interlace only
+        park_all_offscreen(&mut ppu);
+        set_obj_tile_solid(&mut ppu, 0, 3);
+        set_cgram(&mut ppu, 128 + 3, 0x1234);
+        set_obj(&mut ppu, 0, 50, 40, 0, 0, false);
+
+        present_line(&mut ppu, 20);
+        assert_eq!(obj_color_at(&ppu, 50, 20), None, "not anchored at Y/2");
+        present_line(&mut ppu, 39);
+        assert_eq!(obj_color_at(&ppu, 50, 39), None, "row above OAM Y");
+        present_line(&mut ppu, 40);
+        assert_eq!(
+            obj_color_at(&ppu, 50, 40),
+            Some(0x1234),
+            "anchored at OAM Y"
+        );
+        present_line(&mut ppu, 43);
+        assert_eq!(
+            obj_color_at(&ppu, 50, 43),
+            Some(0x1234),
+            "last halved-height row"
+        );
+        present_line(&mut ppu, 44);
+        assert_eq!(
+            obj_color_at(&ppu, 50, 44),
+            None,
+            "halved height: 4 rows for 8x8"
+        );
+    }
+
+    #[test]
+    fn obj_interlace_samples_doubled_source_line_plus_field() {
+        // Presented row `r` fetches sprite source line `(r - Y) * 2 + field`
+        // (Mesen2 `FetchSpriteAttributes`, ares `Object::fetch`).
+        let color_at_row = |row: u16, field: bool| {
+            let mut ppu = Ppu::new();
+            ppu.write_register(0x2101, 0x00); // 8x8
+            ppu.write_register(0x2133, 0x02); // OBJ interlace only
+            park_all_offscreen(&mut ppu);
+            for fy in 0..4usize {
+                set_obj_tile_pixel(&mut ppu, 0, 0, fy, fy as u8 + 1);
+                set_cgram(&mut ppu, 128 + fy as u8 + 1, 0x1000 + fy as u16);
+            }
+            set_obj(&mut ppu, 0, 50, 40, 0, 0, false);
+            ppu.interlace_field = field;
+            present_line(&mut ppu, row);
+            obj_color_at(&ppu, 50, row)
+        };
+
+        assert_eq!(
+            color_at_row(40, false),
+            Some(0x1000),
+            "row 40 field 0 -> line 0"
+        );
+        assert_eq!(
+            color_at_row(40, true),
+            Some(0x1001),
+            "row 40 field 1 -> line 1"
+        );
+        assert_eq!(
+            color_at_row(41, false),
+            Some(0x1002),
+            "row 41 field 0 -> line 2"
+        );
+        assert_eq!(
+            color_at_row(41, true),
+            Some(0x1003),
+            "row 41 field 1 -> line 3"
+        );
+    }
+
+    #[test]
+    fn obj_interlace_applies_vflip_to_the_doubled_source_line() {
+        // With V-flip, the mirror applies to the doubled coordinate against the full height:
+        // source line = height - 1 - ((r - Y) * 2 + field).
+        let color_at_row = |row: u16, field: bool| {
+            let mut ppu = Ppu::new();
+            ppu.write_register(0x2101, 0x00); // 8x8
+            ppu.write_register(0x2133, 0x02); // OBJ interlace only
+            park_all_offscreen(&mut ppu);
+            for fy in 0..8usize {
+                set_obj_tile_pixel(&mut ppu, 0, 0, fy, fy as u8 + 1);
+                set_cgram(&mut ppu, 128 + fy as u8 + 1, 0x1000 + fy as u16);
+            }
+            set_obj(&mut ppu, 0, 50, 40, 0, 0x80, false);
+            ppu.interlace_field = field;
+            present_line(&mut ppu, row);
+            obj_color_at(&ppu, 50, row)
+        };
+
+        assert_eq!(
+            color_at_row(40, false),
+            Some(0x1007),
+            "row 40 field 0 -> line 7"
+        );
+        assert_eq!(
+            color_at_row(40, true),
+            Some(0x1006),
+            "row 40 field 1 -> line 6"
+        );
+        assert_eq!(
+            color_at_row(41, false),
+            Some(0x1005),
+            "row 41 field 0 -> line 5"
+        );
+        assert_eq!(
+            color_at_row(43, true),
+            Some(0x1000),
+            "row 43 field 1 -> line 0"
+        );
+    }
+
+    #[test]
+    fn obj_interlace_range_accounting_uses_halved_height() {
+        // The range over-limit counts sprites in range of the halved height only.
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2101, 0x00); // 8x8
+        ppu.write_register(0x2133, 0x02); // OBJ interlace only
+        park_all_offscreen(&mut ppu);
+        for i in 0..33 {
+            set_obj(&mut ppu, i, 0, 40, 0, 0, false);
+        }
+
+        let eval = ppu.evaluate_line_objects(44);
+        assert!(
+            eval.indices().is_empty(),
+            "row 44 is past the halved height"
+        );
+        assert!(
+            !eval.range_over,
+            "out-of-range sprites consume no range budget"
+        );
+
+        let eval = ppu.evaluate_line_objects(40);
+        assert_eq!(eval.indices().len(), 32, "in-range rows keep the 32 budget");
+        assert!(eval.range_over, "33rd in-range OBJ still raises range over");
+    }
+
+    #[test]
+    fn obj_interlace_with_screen_interlace_keeps_oam_y_anchor() {
+        // Regression for the combined $2133=3 case: the doubled-line model previously anchored
+        // the sprite at Y/2; the reference model keeps OAM Y with halved height per field.
+        let color_at_row = |row: u16, field: bool| {
+            let mut ppu = Ppu::new();
+            ppu.write_register(0x2101, 0x00); // 8x8
+            ppu.write_register(0x2133, 0x03); // screen + OBJ interlace
+            park_all_offscreen(&mut ppu);
+            set_obj_tile_solid(&mut ppu, 0, 3);
+            set_obj_tile_pixel(&mut ppu, 0, 0, 0, 1); // source line 0 marker
+            set_cgram(&mut ppu, 128 + 3, 0x1234);
+            set_cgram(&mut ppu, 128 + 1, 0x0F0F);
+            set_obj(&mut ppu, 0, 50, 40, 0, 0, false);
+            ppu.interlace_field = field;
+            present_line(&mut ppu, row);
+            obj_color_at(&ppu, 50, row)
+        };
+
+        assert_eq!(color_at_row(20, false), None, "not anchored at Y/2");
+        assert_eq!(
+            color_at_row(40, false),
+            Some(0x0F0F),
+            "row 40 field 0 samples source line 0"
+        );
+        assert_eq!(
+            color_at_row(43, false),
+            Some(0x1234),
+            "last halved-height row"
+        );
+        assert_eq!(
+            color_at_row(44, false),
+            None,
+            "halved height: 4 rows for 8x8"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #3000

## What

Implements OBJ interlace (SETINI $2133 bit 1) in the SNES PPU sprite pipeline, adopting the model both Mesen2 and ares agree on:

- In-range test (obj_in_range): the sprite stays anchored at OAM Y with its height halved whenever bit 1 is set, independent of screen interlace (bit 0). Range/time over-limit accounting follows automatically.
- Tile fetch (obj_fetch_step): the line-within-sprite is doubled and the current field is OR'd in; V-flip then mirrors the doubled coordinate against the full height.
- Removes the old obj_source_line helper, which required both interlace bits and doubled the compare line instead - anchoring sprites at half their OAM Y (only correct at Y=0, which is all the old unit test covered).

## Failing behavior

With $2133=2 alone, sprites rendered full-height where Mesen2 shows them half-height with field-interleaved lines (found while baselining byuu's test_oam in #2879; combos i2-s0/i2-s1 were ignored with placeholder CRCs).

## Tests

- 5 new unit tests (TDD red first, all failing for the right reasons): halved-height OAM-Y anchor, doubled-source-line field parity, V-flip on the doubled coordinate, range-limit accounting, and a $2133=3 regression locking the intentional combined-mode geometry change.
- Re-enabled setini2_small / setini2_large with Mesen2-approved goldens: identical frame-stamped input schedules replayed in Mesen2 headless (testRunner + Lua setInput, VideoFilter=None, AspectRatio=NoStretching, disableFrameSkipping=true), pixel-diffed at the sample frames (202 / 210): 0 differing pixels at shift 0 for both. A b0-s0 control replay reproduced its already-approved golden exactly, validating the replay pipeline. The 4 remaining ignored SETINI combos are #3001 (capture-dimension convention), untouched.

## Also in this PR

- snes-hardware-research skill: screenshot verification is now Mesen2-only (navigator decision during planning); ares remains a source-code/spec-evidence reference. The manual ares hotkey-capture appendix is removed.
- README-SNES.md: refreshed the stale test_oam entry (now 30 approved combos / 4 ignored) and the undisbeliever-obj entry (stale since #2999).

## Validation

- cargo clippy --all-targets --all-features -D warnings: clean
- cargo fmt: clean
- ./scripts/test-dir.sh src/snes: 1682 passed, 0 failed
- cargo test --no-default-features --lib: 12478 passed, 0 failed
- wasm-pack test --headless --chrome: all suites pass (exit 0)
- Python unittest discovery (scripts, metadata-scraper, nes-rom-db-scraper): OK
- npm test: 412 passed

## Review notes

An 8-angle adversarial review ran on the diff; two findings survived verification: the README staleness (fixed here) and a pre-existing, exotic mid-scanline OAM/SETINI rewrite race between the eval and fetch windows (wrong pixels only, never a crash, hardware behavior unverified) - tracked as follow-up #3026, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
