### PR TITLE
feat(scripts): add SNES platform to the TheGamesDB metadata scraper

### DIFF
--- a/scripts/metadata-scraper/main.py
+++ b/scripts/metadata-scraper/main.py
@@ -19,6 +19,7 @@ from sync import Syncer
 
 PLATFORMS = {
     "nes":  {"id": 7,  "name": "Nintendo Entertainment System (NES)", "alias": "nintendo-entertainment-system-nes"},
+    "snes": {"id": 6,  "name": "Super Nintendo (SNES)",               "alias": "super-nintendo-snes"},
     "gb":   {"id": 4,  "name": "Nintendo Game Boy",                   "alias": "nintendo-gameboy"},
     "gbc":  {"id": 41, "name": "Nintendo Game Boy Color",             "alias": "nintendo-gameboy-color"},
     "gba":  {"id": 5,  "name": "Nintendo Game Boy Advance",           "alias": "nintendo-gameboy-advance"},

--- a/scripts/metadata-scraper/test_main.py
+++ b/scripts/metadata-scraper/test_main.py
@@ -41,6 +41,12 @@ class TestMainCliArgParsing(unittest.TestCase):
         call_kwargs = syncer.sync.call_args[1]
         self.assertEqual(call_kwargs["platform_id"], 7)
 
+    def test_sync_snes_calls_syncer_sync(self):
+        _, _, syncer, _ = self._run(["sync", "--platform", "snes", "--api-key", "testkey"])
+        syncer.sync.assert_called_once()
+        call_kwargs = syncer.sync.call_args[1]
+        self.assertEqual(call_kwargs["platform_id"], 6)
+
     def test_sync_force_full_passes_flag(self):
         _, _, syncer, _ = self._run(["sync", "--platform", "nes", "--force-full", "--api-key", "testkey"])
         call_kwargs = syncer.sync.call_args[1]
@@ -92,6 +98,12 @@ class TestMainCliArgParsing(unittest.TestCase):
         call_kwargs = db.list_games.call_args[1]
         self.assertEqual(call_kwargs["platform_id"], 7)
 
+    def test_list_platform_snes_filters_by_platform_id_6(self):
+        db, _, _, _ = self._run(["list", "--platform", "snes", "--api-key", "testkey"])
+        db.list_games.assert_called_once()
+        call_kwargs = db.list_games.call_args[1]
+        self.assertEqual(call_kwargs["platform_id"], 6)
+
     def test_list_game_id_filters_by_id(self):
         db, _, _, _ = self._run(["list", "--game-id", "135", "--api-key", "testkey"])
         db.list_games.assert_called_once()
@@ -140,13 +152,14 @@ class TestMainCliArgParsing(unittest.TestCase):
             output = captured.getvalue()
             self.assertIn("boxart/back/135-2.jpg", output)
 
-    def test_sync_all_platforms_syncs_nes_gb_gbc_gba(self):
+    def test_sync_all_platforms_syncs_nes_gb_gbc_gba_snes(self):
         _, _, syncer, _ = self._run(["sync", "--platform", "all", "--api-key", "testkey"])
         platform_ids = [c[1]["platform_id"] for c in syncer.sync.call_args_list]
         self.assertIn(7, platform_ids)   # NES
         self.assertIn(4, platform_ids)   # GB
         self.assertIn(41, platform_ids)  # GBC
         self.assertIn(5, platform_ids)   # GBA
+        self.assertIn(6, platform_ids)   # SNES
 
 
 class TestInfoCommand(unittest.TestCase):
@@ -183,6 +196,11 @@ class TestInfoCommand(unittest.TestCase):
         db, _ = self._run_info(["castlevania", "--platform", "nes"])
         call_kwargs = db.search_games.call_args[1]
         self.assertEqual(call_kwargs.get("platform_id"), 7)
+
+    def test_info_with_platform_snes_passes_platform_id_6(self):
+        db, _ = self._run_info(["mario", "--platform", "snes"])
+        call_kwargs = db.search_games.call_args[1]
+        self.assertEqual(call_kwargs.get("platform_id"), 6)
 
     def test_info_no_results_prints_not_found(self):
         _, output = self._run_info(["zeldaXXX"])


### PR DESCRIPTION
Closes #3029

## What

Adds SNES to the metadata scraper platform registry in scripts/metadata-scraper/main.py: slug snes, TheGamesDB platform id 6, name "Super Nintendo (SNES)", alias super-nintendo-snes (id and name verified against the thegamesdb.net platform page). SNES is now selectable in sync/list/info and included in sync --platform all; everything downstream (sync engine, DB schema, API client, images) was already platform-agnostic.

## Tests (TDD)

Four new CLI tests written first and shown failing (argparse rejected --platform snes; platform id 6 absent from the all-sync): sync dispatches platform id 6, all-platform sync includes 6, list and info filter by id 6. Full scraper suite: 108 passed.

## Validation

- Python unittest discovery (scripts, metadata-scraper, nes-rom-db-scraper): all pass
- npm test, cargo clippy -D warnings, cargo fmt: clean
- Full cargo test --lib and wasm-pack Chrome suites: running, results posted before merge (no Rust code changed on this branch)

## Note

During the session the tracked scripts/metadata-scraper/metadata.db was twice found rewritten (4.8 MB -> 9.3 MB) after test runs, but the rewrite is no longer reproducible (individual and full-suite runs now leave it untouched); most likely a stale SQLite WAL sidecar from an old real sync got checkpointed on open and is now gone. The file is restored to HEAD in this PR; flagged here in case it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
