### PR TITLE
fix(rom-browser): build empty-state ROM hint from cartridge-search-paths (#3031)

### DIFF
--- a/src/frontends/native/rom_browser/app/mod.rs
+++ b/src/frontends/native/rom_browser/app/mod.rs
@@ -181,18 +181,21 @@ pub struct RomBrowserApp {
     texture_pending: Vec<i64>,
     /// Fast lookup from game_id to boxart path (built when catalog is set).
     boxart_by_game_id: std::collections::HashMap<i64, PathBuf>,
+    /// Message shown when the catalog is empty, listing the ROM search paths.
+    no_roms_hint: String,
 }
 
 impl RomBrowserApp {
     /// Create a new ROM browser application.
     pub fn new(app_context: SharedAppContext) -> Self {
-        let (default_height, fullscreen, favorites_path) = {
+        let (default_height, fullscreen, favorites_path, no_roms_hint) = {
             let ctx = app_context.borrow();
             let config = ctx.config();
             (
                 config.frontend.window_height,
                 config.frontend.fullscreen,
                 config.frontend.resolved_favorites_path(),
+                Self::no_roms_hint(&config.frontend.cartridge_search_paths),
             )
         };
         // Default browser window: use configured height with 16:9 ratio.
@@ -276,6 +279,21 @@ impl RomBrowserApp {
             texture_result_rx: result_rx,
             texture_pending: Vec::new(),
             boxart_by_game_id: std::collections::HashMap::new(),
+            no_roms_hint,
+        }
+    }
+
+    /// Build the empty-catalog message from the configured cartridge search
+    /// paths, mirroring the fallback used by the catalog scan: when no paths
+    /// are configured, ROMs are read from ~/.neser/roms/.
+    fn no_roms_hint(search_paths: &[String]) -> String {
+        if search_paths.is_empty() {
+            "No ROMs found. Add ROM files to ~/.neser/roms/".to_string()
+        } else {
+            format!(
+                "No ROMs found. Add ROM files to {}",
+                search_paths.join(", ")
+            )
         }
     }
 

--- a/src/frontends/native/rom_browser/app/render/grid.rs
+++ b/src/frontends/native/rom_browser/app/render/grid.rs
@@ -13,13 +13,14 @@ impl RomBrowserApp {
         selected: usize,
         scroll_offset: f32,
         search_query: &str,
+        no_roms_hint: &str,
     ) {
         if entries.is_empty() {
             ui.vertical_centered(|ui| {
                 ui.add_space(40.0);
                 if search_query.is_empty() {
                     ui.label(
-                        egui::RichText::new("No ROMs found. Add ROM files to ~/.neser/roms/")
+                        egui::RichText::new(no_roms_hint)
                             .color(theme::DIM_TEXT)
                             .size(13.0),
                     );

--- a/src/frontends/native/rom_browser/app/render/mod.rs
+++ b/src/frontends/native/rom_browser/app/render/mod.rs
@@ -75,6 +75,7 @@ impl RomBrowserApp {
 
         let search_active = self.search_active;
         let search_query = self.search_query.clone();
+        let no_roms_hint = self.no_roms_hint.clone();
         let genre_filter_active = self.genre_filter_active;
         let filter_panel_active = self.filter_panel_active;
         let filter_panel_cursor = self.filter_panel_cursor;
@@ -288,6 +289,7 @@ impl RomBrowserApp {
                         selected,
                         scroll_offset,
                         &search_query,
+                        &no_roms_hint,
                     );
                 });
 

--- a/src/frontends/native/rom_browser/app/tests.rs
+++ b/src/frontends/native/rom_browser/app/tests.rs
@@ -94,6 +94,7 @@ fn test_browser(entries: Vec<RomEntry>) -> RomBrowserApp {
         },
         texture_pending: Vec::new(),
         boxart_by_game_id: std::collections::HashMap::new(),
+        no_roms_hint: RomBrowserApp::no_roms_hint(&[]),
     };
     app.set_catalog(entries);
     app
@@ -129,6 +130,29 @@ fn rebuild_filtered_empty_result() {
     app.search_query = "castlevania".to_string();
     app.rebuild_filtered();
     assert!(app.filtered_indices.is_empty());
+}
+
+#[test]
+fn no_roms_hint_defaults_to_home_roms_dir_when_no_search_paths() {
+    let hint = RomBrowserApp::no_roms_hint(&[]);
+    assert_eq!(hint, "No ROMs found. Add ROM files to ~/.neser/roms/");
+}
+
+#[test]
+fn no_roms_hint_lists_single_configured_search_path() {
+    let paths = vec!["/mnt/roms".to_string()];
+    let hint = RomBrowserApp::no_roms_hint(&paths);
+    assert_eq!(hint, "No ROMs found. Add ROM files to /mnt/roms");
+}
+
+#[test]
+fn no_roms_hint_lists_multiple_configured_search_paths() {
+    let paths = vec!["/mnt/roms".to_string(), "/home/user/games".to_string()];
+    let hint = RomBrowserApp::no_roms_hint(&paths);
+    assert_eq!(
+        hint,
+        "No ROMs found. Add ROM files to /mnt/roms, /home/user/games"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #3031

## Failing behavior

The ROM browser's empty-catalog message always said 'No ROMs found. Add ROM files to ~/.neser/roms/', even when cartridge-search-paths was configured (config file or --cartridge-search-paths). The hardcoded path pointed users at a directory the browser was not actually scanning.

## Fix

Added RomBrowserApp::no_roms_hint(), which builds the message from the configured cartridge_search_paths and falls back to ~/.neser/roms/ only when the list is empty — the same resolution used by the catalog scan in src/platform/catalog/mod.rs. The hint is computed once from config in RomBrowserApp::new() and passed into render_grid_egui() instead of the hardcoded string.

## Tests added

- no_roms_hint_defaults_to_home_roms_dir_when_no_search_paths
- no_roms_hint_lists_single_configured_search_path
- no_roms_hint_lists_multiple_configured_search_paths

Written first (TDD red/green): they failed to compile before the fix and pass after.

## Validation

- cargo clippy --all-targets --all-features -- -D warnings: clean
- cargo fmt: no changes
- rom_browser suite (--features native): 45 passed
- cargo test --no-default-features --lib: 12478 passed, 0 failed
- wasm-pack test --headless --chrome: 94 passed
- Python suites: 230 + 108 + 44 passed
- npm test: 412 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)