### PR TITLE
Web and launcher gamepad support: db-driven browser pad layouts, replica pad fixes, focus-gated launcher input

### DIFF
--- a/gamecontrollerdb.txt
+++ b/gamecontrollerdb.txt
@@ -1168,7 +1168,7 @@ xinput,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,
 # Generic SNES USB replica pad (buttons enumerate as X,A,B,Y,Select,Start):
 # The d-pad reports as axes 0/1; mapped as left stick because gilrs half-axis
 # d-pad mappings (-a0/-a1) drop the negative directions (up/left).
-030000001f08000001e4000006010000,USB SNES gamepad,a:b2,b:b1,x:b3,y:b0,back:b8,start:b9,leftx:a0,lefty:a1,platform:Mac OS X,
+030000001f08000001e4000006010000,USB SNES gamepad,a:b2,b:b1,x:b3,y:b0,back:b8,start:b9,leftshoulder:b4,rightshoulder:b5,leftx:a0,lefty:a1,platform:Mac OS X,
 
 # Linux
 03000000c82d00001930000011010000,8BitDo 64,a:b0,b:b1,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b6,leftstick:b13,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b7,righttrigger:b9,rightx:a2,righty:a3,start:b11,platform:Linux,

--- a/scripts/build_web.sh
+++ b/scripts/build_web.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# Always run from the repository root: cargo would find the workspace from any
+# cwd, but the wasm-bindgen/web/pkg/vite paths below are root-relative.
+cd "$(dirname "$0")/.."
+
 # Only skip the WASM build when explicitly requested (e.g. in CI with pre-built artifacts)
 SKIP_WASM_BUILD_IF_ARTIFACTS_EXIST="${SKIP_WASM_BUILD_IF_ARTIFACTS_EXIST:-0}"
 if [ "$SKIP_WASM_BUILD_IF_ARTIFACTS_EXIST" = "1" ] && [ -f web/pkg/neser_bg.wasm ] && [ -f web/pkg/neser.js ]; then

--- a/src/frontends/native/gamepad.rs
+++ b/src/frontends/native/gamepad.rs
@@ -38,7 +38,10 @@ pub fn map_button_to_nes(button: gilrs::Button) -> Option<Button> {
         gilrs::Button::South => Some(Button::B),
         gilrs::Button::East => Some(Button::A),
         gilrs::Button::West => Some(Button::B),
-        gilrs::Button::North => Some(Button::A),
+        // North acts as B (not A): NES replica pads share the SNES
+        // replica's GUID, so their B button arrives as North through the
+        // shared SDL mapping.
+        gilrs::Button::North => Some(Button::B),
         gilrs::Button::Start | gilrs::Button::RightTrigger2 => Some(Button::Start),
         gilrs::Button::Select | gilrs::Button::LeftTrigger2 => Some(Button::Select),
         gilrs::Button::DPadUp => Some(Button::Up),
@@ -666,8 +669,11 @@ mod tests {
     }
 
     #[test]
-    fn nes_mapping_north_is_a_alternate() {
-        assert_eq!(map_button_to_nes(gilrs::Button::North), Some(Button::A));
+    fn nes_mapping_north_is_b_alternate() {
+        // NES replica pads share the SNES replica's GUID, so their B button
+        // arrives as North through the shared SDL mapping; North must act
+        // as NES B for those pads to work.
+        assert_eq!(map_button_to_nes(gilrs::Button::North), Some(Button::B));
     }
 
     #[test]

--- a/src/frontends/native/rom_browser/app/actions.rs
+++ b/src/frontends/native/rom_browser/app/actions.rs
@@ -264,9 +264,6 @@ impl RomBrowserApp {
                     self.open_search_panel();
                 }
                 BrowserAction::Favorite => self.toggle_favorite(),
-                BrowserAction::Detail => {
-                    self.open_detail_view();
-                }
             }
         }
     }

--- a/src/frontends/native/rom_browser/app/handler.rs
+++ b/src/frontends/native/rom_browser/app/handler.rs
@@ -272,12 +272,18 @@ impl ApplicationHandler for RomBrowserApp {
                 }
             }
 
+            WindowEvent::Focused(focused) => {
+                self.window_focused = focused;
+                if let Some(ref mut gl) = self.gl {
+                    let _ = gl.on_window_event(&event);
+                }
+            }
+
             WindowEvent::CursorMoved { .. }
             | WindowEvent::MouseInput { .. }
             | WindowEvent::MouseWheel { .. }
             | WindowEvent::Touch { .. }
             | WindowEvent::ScaleFactorChanged { .. }
-            | WindowEvent::Focused(_)
             | WindowEvent::Ime(_) => {
                 if let Some(ref mut gl) = self.gl {
                     let _ = gl.on_window_event(&event);
@@ -285,8 +291,10 @@ impl ApplicationHandler for RomBrowserApp {
             }
 
             WindowEvent::RedrawRequested => {
-                // Poll gamepad events and apply browser actions.
-                let actions = self.poll_gamepad();
+                // Poll gamepad events; apply them only while focused (gilrs
+                // sees the pad globally, so polling always drains the queue).
+                let actions =
+                    Self::filter_gamepad_actions(self.poll_gamepad(), self.window_focused);
                 for action in actions {
                     self.apply_action(action, event_loop);
                 }

--- a/src/frontends/native/rom_browser/app/handler.rs
+++ b/src/frontends/native/rom_browser/app/handler.rs
@@ -274,6 +274,13 @@ impl ApplicationHandler for RomBrowserApp {
 
             WindowEvent::Focused(focused) => {
                 self.window_focused = focused;
+                // Discard gamepad events queued while unfocused: redraws
+                // (which normally drain the queue) may pause when the window
+                // is hidden or minimized, and the backlog would otherwise
+                // apply all at once on refocus.
+                if focused && let Some(ref mut gilrs) = self.gilrs {
+                    while gilrs.next_event().is_some() {}
+                }
                 if let Some(ref mut gl) = self.gl {
                     let _ = gl.on_window_event(&event);
                 }

--- a/src/frontends/native/rom_browser/app/input.rs
+++ b/src/frontends/native/rom_browser/app/input.rs
@@ -90,6 +90,15 @@ impl RomBrowserApp {
     }
 
     /// Map a gilrs button to a browser action.
+    /// Drop gamepad actions while the browser window is unfocused, so pad
+    /// input pressed for another window (e.g. a running game) is ignored.
+    pub(super) fn filter_gamepad_actions(
+        actions: Vec<BrowserAction>,
+        window_focused: bool,
+    ) -> Vec<BrowserAction> {
+        if window_focused { actions } else { Vec::new() }
+    }
+
     pub(super) fn map_button(button: gilrs::Button) -> Option<BrowserAction> {
         match button {
             gilrs::Button::DPadUp => Some(BrowserAction::Up),

--- a/src/frontends/native/rom_browser/app/input.rs
+++ b/src/frontends/native/rom_browser/app/input.rs
@@ -90,7 +90,7 @@ impl RomBrowserApp {
     }
 
     /// Map a gilrs button to a browser action.
-    fn map_button(button: gilrs::Button) -> Option<BrowserAction> {
+    pub(super) fn map_button(button: gilrs::Button) -> Option<BrowserAction> {
         match button {
             gilrs::Button::DPadUp => Some(BrowserAction::Up),
             gilrs::Button::DPadDown => Some(BrowserAction::Down),
@@ -99,7 +99,10 @@ impl RomBrowserApp {
             gilrs::Button::East => Some(BrowserAction::Confirm), // Nintendo A button
             gilrs::Button::South => Some(BrowserAction::Back),   // Nintendo B button
             gilrs::Button::Start | gilrs::Button::RightTrigger2 => Some(BrowserAction::Search),
-            gilrs::Button::North => Some(BrowserAction::Detail), // Nintendo X button
+            // North also acts as Back: NES replica pads share the SNES
+            // replica's GUID, so their B button arrives as North. The detail
+            // view stays reachable via Confirm (A) in the gallery.
+            gilrs::Button::North => Some(BrowserAction::Back),
             gilrs::Button::West => Some(BrowserAction::Favorite), // Nintendo Y button
             gilrs::Button::Select | gilrs::Button::LeftTrigger2 => Some(BrowserAction::Favorite),
             _ => None,

--- a/src/frontends/native/rom_browser/app/mod.rs
+++ b/src/frontends/native/rom_browser/app/mod.rs
@@ -162,6 +162,9 @@ pub struct RomBrowserApp {
     catalog_state: CatalogState,
     /// Tracks current modifier key state.
     modifiers: winit::keyboard::ModifiersState,
+    /// Whether the browser window currently has focus. Gamepad input is
+    /// ignored while unfocused since gilrs sees the pad globally.
+    window_focused: bool,
     /// Gamepad input via gilrs.
     gilrs: Option<Gilrs>,
     /// Tracks analog stick state for digital D-pad conversion.
@@ -257,6 +260,7 @@ impl RomBrowserApp {
             show_favorites_only: false,
             catalog_state: CatalogState::Idle,
             modifiers: winit::keyboard::ModifiersState::empty(),
+            window_focused: true,
             gilrs: {
                 let mut builder = GilrsBuilder::new()
                     .with_default_filters(true)
@@ -297,6 +301,11 @@ impl RomBrowserApp {
         // Reset transient state for a fresh UI pass but keep catalog/textures.
         self.result = BrowserResult::Closed;
         self.gl = None;
+        // Discard gamepad events queued while the browser was dormant
+        // (e.g. everything pressed during an emulation session).
+        if let Some(ref mut gilrs) = self.gilrs {
+            while gilrs.next_event().is_some() {}
+        }
         event_loop
             .run_app_on_demand(self)
             .map_err(|e| format!("Browser event loop error: {e}"))?;

--- a/src/frontends/native/rom_browser/app/mod.rs
+++ b/src/frontends/native/rom_browser/app/mod.rs
@@ -89,6 +89,7 @@ struct GamepadRepeatState {
 }
 
 /// Actions that can be triggered by gamepad input.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 enum BrowserAction {
     Up,
     Down,
@@ -98,7 +99,6 @@ enum BrowserAction {
     Back,
     Search,
     Favorite,
-    Detail,
 }
 
 /// ROM browser winit application.

--- a/src/frontends/native/rom_browser/app/tests.rs
+++ b/src/frontends/native/rom_browser/app/tests.rs
@@ -505,6 +505,20 @@ fn legend_shows_controller_buttons_in_search_with_controller() {
 }
 
 #[test]
+fn gamepad_north_maps_to_back_for_nes_replica_pads() {
+    // NES replica pads share the SNES replica's GUID, so their B button
+    // arrives as North; it must go Back in the browser, like B does.
+    assert_eq!(
+        RomBrowserApp::map_button(gilrs::Button::North),
+        Some(BrowserAction::Back)
+    );
+    assert_eq!(
+        RomBrowserApp::map_button(gilrs::Button::South),
+        Some(BrowserAction::Back)
+    );
+}
+
+#[test]
 fn search_action_closes_search_but_back_does_not() {
     let mut app = test_browser(vec![make_entry("Zelda")]);
     app.search_active = true;

--- a/src/frontends/native/rom_browser/app/tests.rs
+++ b/src/frontends/native/rom_browser/app/tests.rs
@@ -79,6 +79,7 @@ fn test_browser(entries: Vec<RomEntry>) -> RomBrowserApp {
         show_favorites_only: false,
         catalog_state: CatalogState::Ready,
         modifiers: winit::keyboard::ModifiersState::empty(),
+        window_focused: true,
         gilrs: None, // No gamepad in tests
         gamepad_axis: GamepadAxisState::default(),
         gamepad_repeat: GamepadRepeatState::default(),
@@ -502,6 +503,18 @@ fn legend_shows_controller_buttons_in_search_with_controller() {
     // Start opened the search view, so Start closes it — not B.
     let items = RomBrowserApp::legend_items(true, false, false, true);
     assert_eq!(items, [("A", "Select"), ("Start", "Close")]);
+}
+
+#[test]
+fn gamepad_actions_are_discarded_while_window_unfocused() {
+    // gilrs sees the pad globally; the browser must only react to it when
+    // its window has focus (e.g. not while a game is being played).
+    let actions = vec![BrowserAction::Up, BrowserAction::Confirm];
+    assert_eq!(
+        RomBrowserApp::filter_gamepad_actions(actions.clone(), true),
+        actions
+    );
+    assert!(RomBrowserApp::filter_gamepad_actions(actions, false).is_empty());
 }
 
 #[test]

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -3316,12 +3316,16 @@ function applyGamepadState(state: GamepadButtonState, controller: number, lastSt
         }
     };
 
-    // Button mappings: [state key, SNES button ID, fallback NES button]
+    // Button mappings: [state key, SNES button ID, fallback NES button].
+    // NES fallbacks follow the native frontend's positional convention:
+    // south/west/north act as NES B and east as NES A. North-as-B also
+    // covers NES replica pads that share the SNES replica's ids, whose B
+    // button arrives as north through the shared SDL layout.
     const buttonMappings: Array<[keyof GamepadButtonState, number, number | undefined]> = [
-        ["a", SNES_LEGACY_BUTTON.B, 0],        // South -> SNES B, NES A
-        ["b", SNES_LEGACY_BUTTON.A, 1],        // East -> SNES A, NES B
-        ["y", SNES_LEGACY_BUTTON.Y, undefined], // West -> SNES Y
-        ["x", SNES_LEGACY_BUTTON.X, undefined], // North -> SNES X
+        ["a", SNES_LEGACY_BUTTON.B, 1],        // South -> SNES B, NES B
+        ["b", SNES_LEGACY_BUTTON.A, 0],        // East -> SNES A, NES A
+        ["y", SNES_LEGACY_BUTTON.Y, 1],        // West -> SNES Y, NES B
+        ["x", SNES_LEGACY_BUTTON.X, 1],        // North -> SNES X, NES B
         ["select", SNES_LEGACY_BUTTON.SELECT, 2],
         ["start", SNES_LEGACY_BUTTON.START, 3],
         ["up", SNES_LEGACY_BUTTON.UP, 4],

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -1,5 +1,10 @@
 import init, { WasmNes, WasmGb, WasmGba, WasmSnes, gamepad_init_toast_message } from "../pkg/neser";
-import { mapStandardGamepadState, selectGamepads } from "./input/gamepad";
+import { loadRawButtonLayoutsFromDb, mapStandardGamepadState, selectGamepads } from "./input/gamepad";
+
+// Load per-pad raw button layouts for browser-unmapped gamepads from the
+// bundled gamecontrollerdb.txt. Fire-and-forget: until (or without) the db,
+// built-in seeds and the standard layout apply.
+void loadRawButtonLayoutsFromDb();
 import {
     createRomSaveKey,
     hasState,

--- a/web/src/input/gamepad.test.ts
+++ b/web/src/input/gamepad.test.ts
@@ -98,6 +98,56 @@ it("prefers pressed if both d-pad and axes active", () => {
   expect(state.right).toBe(true);
 });
 
+it("remaps the generic SNES USB replica pad when the browser exposes it unmapped", () => {
+  // Chrome id format. Raw HID button order on this pad: 0=X, 1=A, 2=B, 3=Y,
+  // 8=Select, 9=Start — feeding it through the standard-layout reading made
+  // physical X act as SNES B.
+  const gamepad = {
+    id: "USB gamepad (Vendor: 081f Product: e401)",
+    mapping: "",
+    buttons: makeButtons([2]),
+    axes: [0, 0, 0, 0]
+  };
+
+  const state = mapStandardGamepadState(gamepad as unknown as Gamepad);
+
+  expect(state.a).toBe(true); // physical B = south position
+  expect(state.x).toBe(false);
+  expect(state.y).toBe(false);
+});
+
+it("maps the replica pad's physical X to the north position, not south", () => {
+  const gamepad = {
+    id: "081f-e401-USB gamepad", // Firefox id format
+    mapping: "",
+    buttons: makeButtons([0, 1, 3, 8, 9]),
+    axes: [0, 0, 0, 0]
+  };
+
+  const state = mapStandardGamepadState(gamepad as unknown as Gamepad);
+
+  expect(state.x).toBe(true); // physical X (raw 0) = north
+  expect(state.b).toBe(true); // physical A (raw 1) = east
+  expect(state.y).toBe(true); // physical Y (raw 3) = west
+  expect(state.a).toBe(false); // south (physical B, raw 2) not pressed
+  expect(state.select).toBe(true);
+  expect(state.start).toBe(true);
+});
+
+it("does not remap the replica pad when the browser already standard-maps it", () => {
+  const gamepad = {
+    id: "USB gamepad (STANDARD GAMEPAD Vendor: 081f Product: e401)",
+    mapping: "standard",
+    buttons: makeButtons([0]),
+    axes: [0, 0, 0, 0]
+  };
+
+  const state = mapStandardGamepadState(gamepad as unknown as Gamepad);
+
+  expect(state.a).toBe(true); // standard b0 = south
+  expect(state.x).toBe(false);
+});
+
 it("selects first connected gamepad", () => {
   const gamepads = [
     null,

--- a/web/src/input/gamepad.test.ts
+++ b/web/src/input/gamepad.test.ts
@@ -98,7 +98,17 @@ it("prefers pressed if both d-pad and axes active", () => {
   expect(state.right).toBe(true);
 });
 
-it("remaps the generic SNES USB replica pad when the browser exposes it unmapped", () => {
+const REPLICA_DB_LINE =
+  "030000001f08000001e4000006010000,USB SNES gamepad,a:b2,b:b1,x:b3,y:b0,back:b8,start:b9,leftshoulder:b4,rightshoulder:b5,leftx:a0,lefty:a1,platform:Mac OS X,";
+const MAC_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)";
+
+async function loadReplicaDb() {
+  const fetchStub = (async () => ({ ok: true, text: async () => REPLICA_DB_LINE })) as unknown as typeof fetch;
+  await loadRawButtonLayoutsFromDb(fetchStub, MAC_UA);
+}
+
+it("remaps the generic SNES USB replica pad when the browser exposes it unmapped", async () => {
+  await loadReplicaDb();
   // Chrome id format. Raw HID button order on this pad: 0=X, 1=A, 2=B, 3=Y,
   // 8=Select, 9=Start — feeding it through the standard-layout reading made
   // physical X act as SNES B.
@@ -116,11 +126,12 @@ it("remaps the generic SNES USB replica pad when the browser exposes it unmapped
   expect(state.y).toBe(false);
 });
 
-it("maps the replica pad's physical X to the north position, not south", () => {
+it("maps the replica pad's physical X to the north position, not south", async () => {
+  await loadReplicaDb();
   const gamepad = {
     id: "081f-e401-USB gamepad", // Firefox id format
     mapping: "",
-    buttons: makeButtons([0, 1, 3, 8, 9]),
+    buttons: makeButtons([0, 1, 3, 4, 5, 8, 9]),
     axes: [0, 0, 0, 0]
   };
 
@@ -132,6 +143,8 @@ it("maps the replica pad's physical X to the north position, not south", () => {
   expect(state.a).toBe(false); // south (physical B, raw 2) not pressed
   expect(state.select).toBe(true);
   expect(state.start).toBe(true);
+  expect(state.l).toBe(true); // verified on hardware: L is raw b4
+  expect(state.r).toBe(true); // verified on hardware: R is raw b5
 });
 
 it("does not remap the replica pad when the browser already standard-maps it", () => {
@@ -173,20 +186,17 @@ it("uses layouts loaded from gamecontrollerdb.txt for other unmapped pads", asyn
   expect(state.x).toBe(false);
 });
 
-it("keeps the built-in SNES replica layout after loading a db without it", async () => {
-  const fetchStub = (async () => ({ ok: true, text: async () => "" })) as unknown as typeof fetch;
-  await loadRawButtonLayoutsFromDb(fetchStub, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
-
+it("falls back to the standard layout for unmapped pads absent from the db", () => {
   const gamepad = {
-    id: "USB gamepad (Vendor: 081f Product: e401)",
+    id: "Mystery pad (Vendor: 1234 Product: abcd)",
     mapping: "",
-    buttons: makeButtons([2]),
+    buttons: makeButtons([0]),
     axes: [0, 0, 0, 0]
   };
 
   const state = mapStandardGamepadState(gamepad as unknown as Gamepad);
 
-  expect(state.a).toBe(true);
+  expect(state.a).toBe(true); // standard b0 = south
 });
 
 it("selects first connected gamepad", () => {

--- a/web/src/input/gamepad.test.ts
+++ b/web/src/input/gamepad.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "vitest";
 
-import { mapStandardGamepadState, selectPrimaryGamepad } from "./gamepad";
+import { loadRawButtonLayoutsFromDb, mapStandardGamepadState, selectPrimaryGamepad } from "./gamepad";
 
 function makeButtons(pressedIndexes: number[] = []) {
   const buttons = Array.from({ length: 16 }, () => ({ pressed: false }));
@@ -146,6 +146,47 @@ it("does not remap the replica pad when the browser already standard-maps it", (
 
   expect(state.a).toBe(true); // standard b0 = south
   expect(state.x).toBe(false);
+});
+
+it("uses layouts loaded from gamecontrollerdb.txt for other unmapped pads", async () => {
+  // Fake db entry for vendor 045e / product 028e with a scrambled layout.
+  const dbLine =
+    "030000005e0400008e02000000000000,Fake pad,a:b3,b:b2,x:b1,y:b0,back:b6,start:b7,platform:Mac OS X,";
+  const fetchStub = (async () => ({
+    ok: true,
+    text: async () => dbLine
+  })) as unknown as typeof fetch;
+
+  await loadRawButtonLayoutsFromDb(fetchStub, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+
+  const gamepad = {
+    id: "Fake pad (Vendor: 045e Product: 028e)",
+    mapping: "",
+    buttons: makeButtons([3, 6]),
+    axes: [0, 0, 0, 0]
+  };
+
+  const state = mapStandardGamepadState(gamepad as unknown as Gamepad);
+
+  expect(state.a).toBe(true); // db says south is raw b3
+  expect(state.select).toBe(true); // back -> raw b6
+  expect(state.x).toBe(false);
+});
+
+it("keeps the built-in SNES replica layout after loading a db without it", async () => {
+  const fetchStub = (async () => ({ ok: true, text: async () => "" })) as unknown as typeof fetch;
+  await loadRawButtonLayoutsFromDb(fetchStub, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+
+  const gamepad = {
+    id: "USB gamepad (Vendor: 081f Product: e401)",
+    mapping: "",
+    buttons: makeButtons([2]),
+    axes: [0, 0, 0, 0]
+  };
+
+  const state = mapStandardGamepadState(gamepad as unknown as Gamepad);
+
+  expect(state.a).toBe(true);
 });
 
 it("selects first connected gamepad", () => {

--- a/web/src/input/gamepad.ts
+++ b/web/src/input/gamepad.ts
@@ -1,31 +1,56 @@
+import gamecontrollerDbUrl from "../../../gamecontrollerdb.txt?url";
+
+import {
+    extractVendorProduct,
+    parseGameControllerDb,
+    sdlPlatformForUserAgent,
+    type RawButtonLayout,
+} from "./sdl_mapping";
+
 // Default analog stick axis threshold used to interpret directional input.
 // Callers can override this by passing a custom `axisThreshold` value.
 const DEFAULT_AXIS_THRESHOLD = 0.5;
 
-/**
- * Raw button indices for the returned positional fields (a=south, b=east,
- * y=west, x=north), used for pads the browser exposes without a "standard"
- * mapping. Values index directly into `gamepad.buttons`.
- */
-interface RawButtonLayout {
-    a: number;
-    b: number;
-    y: number;
-    x: number;
-    select: number;
-    start: number;
-    l: number;
-    r: number;
-}
-
 // The W3C standard gamepad layout.
 const STANDARD_LAYOUT: RawButtonLayout = { a: 0, b: 1, y: 2, x: 3, select: 8, start: 9, l: 4, r: 5 };
 
-// Generic SNES USB replica pads (vendor 081f, product e401) enumerate their
-// buttons in raw HID order X, A, B, Y, ..., Select, Start. Browsers expose
-// them without a standard mapping, so reading them positionally made
-// physical X act as the south button.
-const SNES_REPLICA_LAYOUT: RawButtonLayout = { a: 2, b: 1, y: 3, x: 0, select: 8, start: 9, l: 4, r: 5 };
+/**
+ * Raw layouts for pads the browser exposes without a "standard" mapping,
+ * keyed by "vendor:product". Seeded with the generic SNES USB replica pad
+ * (raw HID order X, A, B, Y, ..., Select, Start) so it works even before —
+ * or without — gamecontrollerdb.txt loading; loading merges over the seeds.
+ */
+const rawLayoutRegistry = new Map<string, RawButtonLayout>([
+    ["081f:e401", { a: 2, b: 1, y: 3, x: 0, select: 8, start: 9, l: 4, r: 5 }],
+]);
+
+/**
+ * Load raw button layouts for the current platform from the bundled SDL
+ * gamecontrollerdb.txt (the same file the native frontend uses). Failures
+ * leave the built-in seeds in place.
+ */
+export async function loadRawButtonLayoutsFromDb(
+    fetchFn: typeof fetch = fetch,
+    userAgent: string = typeof navigator !== "undefined" ? navigator.userAgent : ""
+): Promise<void> {
+    const platform = sdlPlatformForUserAgent(userAgent);
+    if (!platform) {
+        return;
+    }
+    try {
+        const response = await fetchFn(gamecontrollerDbUrl);
+        if (!response.ok) {
+            return;
+        }
+        const layouts = parseGameControllerDb(await response.text(), platform);
+        for (const [key, layout] of layouts) {
+            rawLayoutRegistry.set(key, layout);
+        }
+    } catch {
+        // Keep the built-in seeds; unmapped unknown pads fall back to the
+        // standard interpretation.
+    }
+}
 
 /**
  * Pick the raw button layout for a pad: known non-standard pads are matched
@@ -37,9 +62,12 @@ function rawButtonLayoutFor(gamepad: Gamepad | null): RawButtonLayout {
     if (!gamepad || gamepad.mapping === "standard") {
         return STANDARD_LAYOUT;
     }
-    const id = (gamepad.id ?? "").toLowerCase();
-    if (id.includes("081f") && id.includes("e401")) {
-        return SNES_REPLICA_LAYOUT;
+    const key = extractVendorProduct(gamepad.id ?? "");
+    if (key) {
+        const layout = rawLayoutRegistry.get(`${key.vendor}:${key.product}`);
+        if (layout) {
+            return layout;
+        }
     }
     return STANDARD_LAYOUT;
 }

--- a/web/src/input/gamepad.ts
+++ b/web/src/input/gamepad.ts
@@ -2,9 +2,52 @@
 // Callers can override this by passing a custom `axisThreshold` value.
 const DEFAULT_AXIS_THRESHOLD = 0.5;
 
+/**
+ * Raw button indices for the returned positional fields (a=south, b=east,
+ * y=west, x=north), used for pads the browser exposes without a "standard"
+ * mapping. Values index directly into `gamepad.buttons`.
+ */
+interface RawButtonLayout {
+    a: number;
+    b: number;
+    y: number;
+    x: number;
+    select: number;
+    start: number;
+    l: number;
+    r: number;
+}
+
+// The W3C standard gamepad layout.
+const STANDARD_LAYOUT: RawButtonLayout = { a: 0, b: 1, y: 2, x: 3, select: 8, start: 9, l: 4, r: 5 };
+
+// Generic SNES USB replica pads (vendor 081f, product e401) enumerate their
+// buttons in raw HID order X, A, B, Y, ..., Select, Start. Browsers expose
+// them without a standard mapping, so reading them positionally made
+// physical X act as the south button.
+const SNES_REPLICA_LAYOUT: RawButtonLayout = { a: 2, b: 1, y: 3, x: 0, select: 8, start: 9, l: 4, r: 5 };
+
+/**
+ * Pick the raw button layout for a pad: known non-standard pads are matched
+ * by the vendor/product ids browsers embed in `Gamepad.id`; anything the
+ * browser already standard-maps (or that we don't recognize) uses the
+ * standard layout.
+ */
+function rawButtonLayoutFor(gamepad: Gamepad | null): RawButtonLayout {
+    if (!gamepad || gamepad.mapping === "standard") {
+        return STANDARD_LAYOUT;
+    }
+    const id = (gamepad.id ?? "").toLowerCase();
+    if (id.includes("081f") && id.includes("e401")) {
+        return SNES_REPLICA_LAYOUT;
+    }
+    return STANDARD_LAYOUT;
+}
+
 export function mapStandardGamepadState(gamepad: Gamepad | null, axisThreshold = DEFAULT_AXIS_THRESHOLD) {
     const buttons = gamepad?.buttons ?? [];
     const axes = gamepad?.axes ?? [];
+    const layout = rawButtonLayoutFor(gamepad);
 
     const up = Boolean(buttons[12]?.pressed) || axes[1] < -axisThreshold;
     const down = Boolean(buttons[13]?.pressed) || axes[1] > axisThreshold;
@@ -12,18 +55,18 @@ export function mapStandardGamepadState(gamepad: Gamepad | null, axisThreshold =
     const right = Boolean(buttons[15]?.pressed) || axes[0] > axisThreshold;
 
     return {
-        a: Boolean(buttons[0]?.pressed),
-        b: Boolean(buttons[1]?.pressed),
-        y: Boolean(buttons[2]?.pressed),
-        x: Boolean(buttons[3]?.pressed),
-        select: Boolean(buttons[8]?.pressed),
-        start: Boolean(buttons[9]?.pressed),
+        a: Boolean(buttons[layout.a]?.pressed),
+        b: Boolean(buttons[layout.b]?.pressed),
+        y: Boolean(buttons[layout.y]?.pressed),
+        x: Boolean(buttons[layout.x]?.pressed),
+        select: Boolean(buttons[layout.select]?.pressed),
+        start: Boolean(buttons[layout.start]?.pressed),
         up,
         down,
         left,
         right,
-        l: Boolean(buttons[4]?.pressed),
-        r: Boolean(buttons[5]?.pressed)
+        l: Boolean(buttons[layout.l]?.pressed),
+        r: Boolean(buttons[layout.r]?.pressed)
     };
 }
 

--- a/web/src/input/gamepad.ts
+++ b/web/src/input/gamepad.ts
@@ -16,18 +16,16 @@ const STANDARD_LAYOUT: RawButtonLayout = { a: 0, b: 1, y: 2, x: 3, select: 8, st
 
 /**
  * Raw layouts for pads the browser exposes without a "standard" mapping,
- * keyed by "vendor:product". Seeded with the generic SNES USB replica pad
- * (raw HID order X, A, B, Y, ..., Select, Start) so it works even before —
- * or without — gamecontrollerdb.txt loading; loading merges over the seeds.
+ * keyed by "vendor:product". Populated from the bundled
+ * gamecontrollerdb.txt, which is the single source of truth for pad
+ * layouts (shared with the native frontend).
  */
-const rawLayoutRegistry = new Map<string, RawButtonLayout>([
-    ["081f:e401", { a: 2, b: 1, y: 3, x: 0, select: 8, start: 9, l: 4, r: 5 }],
-]);
+const rawLayoutRegistry = new Map<string, RawButtonLayout>();
 
 /**
  * Load raw button layouts for the current platform from the bundled SDL
- * gamecontrollerdb.txt (the same file the native frontend uses). Failures
- * leave the built-in seeds in place.
+ * gamecontrollerdb.txt (the same file the native frontend uses). On
+ * failure, unmapped pads fall back to the standard interpretation.
  */
 export async function loadRawButtonLayoutsFromDb(
     fetchFn: typeof fetch = fetch,
@@ -47,8 +45,8 @@ export async function loadRawButtonLayoutsFromDb(
             rawLayoutRegistry.set(key, layout);
         }
     } catch {
-        // Keep the built-in seeds; unmapped unknown pads fall back to the
-        // standard interpretation.
+        // Unmapped pads fall back to the standard interpretation until the
+        // db can be loaded.
     }
 }
 

--- a/web/src/input/sdl_mapping.test.ts
+++ b/web/src/input/sdl_mapping.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./sdl_mapping";
 
 const REPLICA_LINE =
-    "030000001f08000001e4000006010000,USB SNES gamepad,a:b2,b:b1,x:b3,y:b0,back:b8,start:b9,leftx:a0,lefty:a1,platform:Mac OS X,";
+    "030000001f08000001e4000006010000,USB SNES gamepad,a:b2,b:b1,x:b3,y:b0,back:b8,start:b9,leftshoulder:b4,rightshoulder:b5,leftx:a0,lefty:a1,platform:Mac OS X,";
 
 it("extracts vendor and product from an SDL GUID (little-endian fields)", () => {
     expect(vendorProductFromGuid("030000001f08000001e4000006010000")).toEqual({
@@ -52,7 +52,7 @@ it("parses the SNES replica line into a raw button layout", () => {
     const layout = layouts.get("081f:e401");
     // SDL a=south, b=east, x=west, y=north; our fields are a=south, b=east,
     // y=west, x=north.
-    expect(layout).toEqual({ a: 2, b: 1, y: 3, x: 0, select: 8, start: 9, l: -1, r: -1 });
+    expect(layout).toEqual({ a: 2, b: 1, y: 3, x: 0, select: 8, start: 9, l: 4, r: 5 });
 });
 
 it("skips lines for other platforms and comments", () => {

--- a/web/src/input/sdl_mapping.test.ts
+++ b/web/src/input/sdl_mapping.test.ts
@@ -47,6 +47,19 @@ it("detects the SDL platform from the user agent", () => {
     expect(sdlPlatformForUserAgent("Mozilla/5.0 (X11; Linux x86_64)")).toBe("Linux");
 });
 
+it("detects iOS despite the 'like Mac OS X' token in its user agents", () => {
+    expect(
+        sdlPlatformForUserAgent(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15"
+        )
+    ).toBe("iOS");
+    expect(
+        sdlPlatformForUserAgent(
+            "Mozilla/5.0 (iPad; CPU OS 16_6 like Mac OS X) AppleWebKit/605.1.15"
+        )
+    ).toBe("iOS");
+});
+
 it("parses the SNES replica line into a raw button layout", () => {
     const layouts = parseGameControllerDb(REPLICA_LINE, "Mac OS X");
     const layout = layouts.get("081f:e401");

--- a/web/src/input/sdl_mapping.test.ts
+++ b/web/src/input/sdl_mapping.test.ts
@@ -1,0 +1,99 @@
+import { expect, it } from "vitest";
+
+import {
+    extractVendorProduct,
+    parseGameControllerDb,
+    sdlPlatformForUserAgent,
+    vendorProductFromGuid,
+} from "./sdl_mapping";
+
+const REPLICA_LINE =
+    "030000001f08000001e4000006010000,USB SNES gamepad,a:b2,b:b1,x:b3,y:b0,back:b8,start:b9,leftx:a0,lefty:a1,platform:Mac OS X,";
+
+it("extracts vendor and product from an SDL GUID (little-endian fields)", () => {
+    expect(vendorProductFromGuid("030000001f08000001e4000006010000")).toEqual({
+        vendor: "081f",
+        product: "e401",
+    });
+});
+
+it("returns null for a malformed GUID", () => {
+    expect(vendorProductFromGuid("not-a-guid")).toBe(null);
+});
+
+it("extracts vendor and product from a Chrome gamepad id", () => {
+    expect(extractVendorProduct("USB gamepad (Vendor: 081f Product: e401)")).toEqual({
+        vendor: "081f",
+        product: "e401",
+    });
+});
+
+it("extracts vendor and product from a Firefox gamepad id", () => {
+    expect(extractVendorProduct("81f-e401-USB gamepad")).toEqual({
+        vendor: "081f",
+        product: "e401",
+    });
+});
+
+it("returns null when a gamepad id carries no vendor/product", () => {
+    expect(extractVendorProduct("Some Bluetooth Controller")).toBe(null);
+});
+
+it("detects the SDL platform from the user agent", () => {
+    expect(sdlPlatformForUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")).toBe(
+        "Mac OS X"
+    );
+    expect(sdlPlatformForUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")).toBe("Windows");
+    expect(sdlPlatformForUserAgent("Mozilla/5.0 (X11; Linux x86_64)")).toBe("Linux");
+});
+
+it("parses the SNES replica line into a raw button layout", () => {
+    const layouts = parseGameControllerDb(REPLICA_LINE, "Mac OS X");
+    const layout = layouts.get("081f:e401");
+    // SDL a=south, b=east, x=west, y=north; our fields are a=south, b=east,
+    // y=west, x=north.
+    expect(layout).toEqual({ a: 2, b: 1, y: 3, x: 0, select: 8, start: 9, l: -1, r: -1 });
+});
+
+it("skips lines for other platforms and comments", () => {
+    const text = [
+        "# a comment",
+        "030000001f08000001e4000010010000,Super Famicom Controller,a:b2,b:b1,x:b3,y:b0,back:b8,start:b9,platform:Linux,",
+        REPLICA_LINE,
+    ].join("\n");
+    const layouts = parseGameControllerDb(text, "Linux");
+    expect(layouts.size).toBe(1);
+    expect(layouts.get("081f:e401")?.a).toBe(2);
+});
+
+it("later lines override earlier lines for the same pad", () => {
+    const text = [
+        "030000001f08000001e4000006010000,First,a:b0,b:b1,platform:Mac OS X,",
+        "030000001f08000001e4000006010000,Second,a:b2,b:b1,platform:Mac OS X,",
+    ].join("\n");
+    const layouts = parseGameControllerDb(text, "Mac OS X");
+    expect(layouts.get("081f:e401")?.a).toBe(2);
+});
+
+it("tolerates SDL3-format lines with a crc field", () => {
+    const text =
+        "030000001f08000001e4000006010000,NES,platform:Mac OS X,crc:2a4d,a:b1,b:b0,back:b8,start:b9,";
+    const layouts = parseGameControllerDb(text, "Mac OS X");
+    expect(layouts.get("081f:e401")?.a).toBe(1);
+});
+
+it("marks face buttons mapped to axes or hats as absent", () => {
+    const text =
+        "030000001f08000001e4000006010000,Odd pad,a:b2,b:b1,x:+a3,y:h0.1,back:b8,start:b9,platform:Mac OS X,";
+    const layouts = parseGameControllerDb(text, "Mac OS X");
+    const layout = layouts.get("081f:e401");
+    expect(layout?.a).toBe(2);
+    expect(layout?.y).toBe(-1); // SDL x (west) is axis-valued
+    expect(layout?.x).toBe(-1); // SDL y (north) is hat-valued
+});
+
+it("skips lines whose south or east buttons are not plain buttons", () => {
+    const text = "030000001f08000001e4000006010000,Broken,a:+a1,b:b1,platform:Mac OS X,";
+    const layouts = parseGameControllerDb(text, "Mac OS X");
+    expect(layouts.size).toBe(0);
+});

--- a/web/src/input/sdl_mapping.ts
+++ b/web/src/input/sdl_mapping.ts
@@ -57,6 +57,10 @@ export function sdlPlatformForUserAgent(userAgent: string): string | null {
     if (/android/i.test(userAgent)) {
         return "Android";
     }
+    // iOS user agents contain "like Mac OS X", so check them first.
+    if (/iphone|ipad|ipod/i.test(userAgent)) {
+        return "iOS";
+    }
     if (/mac os x|macintosh/i.test(userAgent)) {
         return "Mac OS X";
     }

--- a/web/src/input/sdl_mapping.ts
+++ b/web/src/input/sdl_mapping.ts
@@ -1,0 +1,135 @@
+// Derive raw button layouts for browser-unmapped gamepads from the SDL
+// gamecontrollerdb.txt that the repo already ships for the native frontend.
+//
+// Browsers expose unknown pads with `mapping: ""` and raw driver button
+// order. The SDL db knows that order per pad and platform: its GUID encodes
+// the USB vendor/product ids (which browsers also embed in `Gamepad.id`),
+// and its a/b/x/y fields are positional (south/east/west/north).
+
+/**
+ * Raw indices into `gamepad.buttons` for the positional fields returned by
+ * the gamepad mapper (a=south, b=east, y=west, x=north). `-1` marks a button
+ * the pad does not have (or that is not a plain button in the SDL mapping).
+ */
+export interface RawButtonLayout {
+    a: number;
+    b: number;
+    y: number;
+    x: number;
+    select: number;
+    start: number;
+    l: number;
+    r: number;
+}
+
+/** Extract the USB vendor/product ids from an SDL GUID (little-endian). */
+export function vendorProductFromGuid(guid: string): { vendor: string; product: string } | null {
+    if (!/^[0-9a-fA-F]{32}$/.test(guid)) {
+        return null;
+    }
+    const lower = guid.toLowerCase();
+    const vendor = lower.slice(10, 12) + lower.slice(8, 10);
+    const product = lower.slice(18, 20) + lower.slice(16, 18);
+    return { vendor, product };
+}
+
+/**
+ * Extract the USB vendor/product ids from a browser `Gamepad.id`.
+ * Chrome: "USB gamepad (Vendor: 081f Product: e401)".
+ * Firefox: "81f-e401-USB gamepad".
+ */
+export function extractVendorProduct(id: string): { vendor: string; product: string } | null {
+    const pad = (hex: string) => hex.toLowerCase().padStart(4, "0");
+
+    const chrome = /vendor:?\s*([0-9a-fA-F]{1,4})\s+product:?\s*([0-9a-fA-F]{1,4})/i.exec(id);
+    if (chrome) {
+        return { vendor: pad(chrome[1]), product: pad(chrome[2]) };
+    }
+    const firefox = /^([0-9a-fA-F]{1,4})-([0-9a-fA-F]{1,4})-/.exec(id);
+    if (firefox) {
+        return { vendor: pad(firefox[1]), product: pad(firefox[2]) };
+    }
+    return null;
+}
+
+/** Map a browser user agent to the SDL db platform field value. */
+export function sdlPlatformForUserAgent(userAgent: string): string | null {
+    if (/android/i.test(userAgent)) {
+        return "Android";
+    }
+    if (/mac os x|macintosh/i.test(userAgent)) {
+        return "Mac OS X";
+    }
+    if (/windows/i.test(userAgent)) {
+        return "Windows";
+    }
+    if (/linux|cros/i.test(userAgent)) {
+        return "Linux";
+    }
+    return null;
+}
+
+/** Parse "bN" SDL button values; anything else (axes, hats) yields -1. */
+function buttonIndex(value: string | undefined): number {
+    if (value === undefined) {
+        return -1;
+    }
+    const match = /^b(\d+)$/.exec(value);
+    return match ? Number(match[1]) : -1;
+}
+
+/**
+ * Parse gamecontrollerdb.txt content into raw button layouts for one SDL
+ * platform, keyed by "vendor:product". Later lines override earlier ones.
+ * Lines whose south (a) or east (b) entries are not plain buttons are
+ * skipped — without those two the layout is useless.
+ */
+export function parseGameControllerDb(
+    text: string,
+    platform: string
+): Map<string, RawButtonLayout> {
+    const layouts = new Map<string, RawButtonLayout>();
+
+    for (const rawLine of text.split("\n")) {
+        const line = rawLine.trim();
+        if (line === "" || line.startsWith("#")) {
+            continue;
+        }
+        const fields = line.split(",");
+        const key = vendorProductFromGuid(fields[0]);
+        if (!key) {
+            continue;
+        }
+
+        const entries = new Map<string, string>();
+        for (const field of fields.slice(2)) {
+            const colon = field.indexOf(":");
+            if (colon > 0) {
+                entries.set(field.slice(0, colon), field.slice(colon + 1));
+            }
+        }
+        if (entries.get("platform") !== platform) {
+            continue;
+        }
+
+        const a = buttonIndex(entries.get("a"));
+        const b = buttonIndex(entries.get("b"));
+        if (a < 0 || b < 0) {
+            continue;
+        }
+
+        layouts.set(`${key.vendor}:${key.product}`, {
+            a,
+            b,
+            // SDL x is the west button and SDL y the north button.
+            y: buttonIndex(entries.get("x")),
+            x: buttonIndex(entries.get("y")),
+            select: buttonIndex(entries.get("back")),
+            start: buttonIndex(entries.get("start")),
+            l: buttonIndex(entries.get("leftshoulder")),
+            r: buttonIndex(entries.get("rightshoulder")),
+        });
+    }
+
+    return layouts;
+}

--- a/web/types/assets.d.ts
+++ b/web/types/assets.d.ts
@@ -1,0 +1,5 @@
+// Vite asset imports used by the web frontend.
+declare module "*.txt?url" {
+    const url: string;
+    export default url;
+}


### PR DESCRIPTION
## Summary

Seven commits from a session on web-frontend and controller behavior, developed with the navigator and verified against physical NES/SNES replica pads.

### Web frontend gamepads

- Fixed the generic SNES USB replica pad (vendor 081f, product e401) in the browser: it is exposed without a standard mapping, so its raw HID button order (X, A, B, Y) was read as the W3C standard layout — physical X acted as SNES B.
- Generalized the fix: the web frontend now derives raw button layouts for any browser-unmapped pad from the bundled SDL gamecontrollerdb.txt (the same file the native side uses). The SDL GUID encodes the USB vendor/product ids browsers embed in Gamepad.id; a/b/x/y fields are positional; platform lines are selected by user agent. The db ships as a lazily fetched, content-hashed Vite asset (46 kB gzipped), and the parser handles the SDL3 crc lines gilrs cannot. Roughly the whole community db becomes usable in the browser.
- The temporary hardcoded remap was then removed: gamecontrollerdb.txt is the single source of truth for both frontends. The replica pad's db line gained leftshoulder/rightshoulder (verified on hardware), which also makes L/R work in native games where they were silently unmapped.

### NES replica pad (shares the SNES replica's GUID)

The NES and SNES replica pads use the same USB chip and report identical GUID and name, so one SDL mapping must serve both and the SNES pad's needs determine it. Through that mapping the NES pad's B arrives as North. Fixes, verified with a probe on the physical pads:

- Emulation: North acts as NES B in the native mapping, and the web gamepad NES fallbacks adopt native's positional convention (south/west/north = B, east = A), which also removes a pre-existing web/native inconsistency for all pads. GB/GBA share the ids, so the alignment is uniform.
- Launcher: gamepad North now acts as Back like South; the redundant Detail action was removed (Confirm already opens the detail view).

### Launcher input focus

- The ROM browser no longer reacts to gamepad input while its window is unfocused, and it flushes the gilrs event queue when resuming after emulation — previously a whole game session's button presses replayed into the launcher on quit.

### Build

- scripts/build_web.sh now cds to the repository root, fixing the 'failed reading target/.../neser.wasm' error when invoked from inside scripts/.

## Validation

- cargo clippy --all-targets --all-features -D warnings: clean; cargo fmt: clean
- Full Rust suite: 12513 passed, 0 failed; native frontends suite: 390 passed
- Web unit tests: 429 passed (17 new, all written test-first); wasm-pack Chrome suite: passed
- SNES Playwright integration specs (frontend flow, save states): passed against a freshly built web bundle
- Python suites: all OK
- Hardware-verified with gilrs probes on both replica pads (face buttons, Select/Start, shoulders, d-pad axes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)