### PR TITLE
SNES: align interlace/overscan capture dimensions with Mesen2 (#3001)

### DIFF
--- a/src/snes/integration_tests/byuu_test_oam_tests.rs
+++ b/src/snes/integration_tests/byuu_test_oam_tests.rs
@@ -23,13 +23,13 @@
 //! - The menu screen, all 16 OBSEL base x size-bit combos, all flip combos
 //!   and all character-number variants match Mesen2 exactly at shift (0,0)
 //!   and carry approved goldens.
-//! - `setini1_*` (screen interlace, $2133=1) and `setini4_*` (239-line
-//!   overscan, $2133=4) are content-verified against Mesen2 (halving
-//!   Mesen2's column-doubled 512x448 interlace frame, resp. comparing
-//!   NESER rows 7..231 of the 239-line frame with Mesen2's 224-line
-//!   window, both give 0-pixel diffs) but the raw frame dimensions differ,
-//!   so they stay `#[ignore]`d without goldens until #3001 settles the
-//!   capture convention.
+//! - `setini1_*` (screen interlace, $2133=1): NESER now emits 512×448 by
+//!   column-doubling each pixel (matching Mesen2's convention); both combos
+//!   approved against Mesen2 headless replay at 0-pixel diff (#3001).
+//! - `setini4_*` (239-line overscan, $2133=4): NESER now clips the 239-line
+//!   frame to the Mesen2-compatible 224-line window (rows 7..231,
+//!   Rust-exclusive); both combos approved against Mesen2 at 0-pixel diff
+//!   (#3001).
 //! - `setini2_*` (OBJ interlace, $2133=2): the sprite renders half-height
 //!   with field-interleaved lines since issue #3000; both combos match
 //!   Mesen2 exactly at shift (0,0) (re-approved via the same replay
@@ -231,32 +231,15 @@ mod tests {
     test_oam_combo!(char255_small, "c255-s0", { chr: 255, size: 0 }, 0x90EB_9069);
     test_oam_combo!(char255_large, "c255-s1", { chr: 255, size: 1 }, 0x37C6_490A);
 
-    // $2133 (SETINI) display modes. Screen interlace and 239-line overscan
-    // are content-verified against Mesen2 (see module docs) but the raw
-    // frame dimensions differ (NESER 256x448 vs Mesen2 512x448; NESER
-    // 256x239 vs Mesen2's 224-line window), so per the #2879 approval
-    // policy they carry no golden until #3001 settles the capture
-    // convention. The recorded CRCs are NESER's current output for
-    // post-fix comparison.
-    macro_rules! test_oam_combo_ignored_3001 {
-        ($name:ident, $label:expr, { $($field:ident : $value:expr),* $(,)? }, $crc:expr) => {
-            #[test]
-            #[ignore = "capture dimensions differ from Mesen2 in this display mode; pending #3001"]
-            fn $name() {
-                let combo = OamCombo {
-                    $($field: $value,)*
-                    ..OamCombo::default_menu()
-                };
-                let (script, sample_frame) = build_combo_script(combo);
-                assert_test_oam_screen_crc($label, &script, sample_frame, $crc);
-            }
-        };
-    }
-
-    test_oam_combo_ignored_3001!(setini1_small, "i1-s0", { setini: 1, size: 0 }, 0xD750_B115);
-    test_oam_combo_ignored_3001!(setini1_large, "i1-s1", { setini: 1, size: 1 }, 0xDA0C_5377);
-    test_oam_combo_ignored_3001!(setini4_small, "i4-s0", { setini: 4, size: 0 }, 0x5E52_C62B);
-    test_oam_combo_ignored_3001!(setini4_large, "i4-s1", { setini: 4, size: 1 }, 0x78AE_B7C8);
+    // $2133 (SETINI) display modes: screen interlace and 239-line overscan.
+    // NESER now emits Mesen2-compatible dimensions for both modes (#3001):
+    // screen interlace → 512×448 (column-doubled), overscan → 256×224
+    // (cropped to rows 7..231, Rust-exclusive).  All four combos carry
+    // Mesen2-approved goldens verified at 0-pixel diff via testRunner replay.
+    test_oam_combo!(setini1_small, "i1-s0", { setini: 1, size: 0 }, 0xF3AB_FC7C);
+    test_oam_combo!(setini1_large, "i1-s1", { setini: 1, size: 1 }, 0xD678_64B6);
+    test_oam_combo!(setini4_small, "i4-s0", { setini: 4, size: 0 }, 0xFD9E_A997);
+    test_oam_combo!(setini4_large, "i4-s1", { setini: 4, size: 1 }, 0x2476_20AA);
 
     // OBJ interlace ($2133=2, issue #3000): the sprite renders half-height
     // with field-interleaved lines. Goldens re-approved against Mesen2

--- a/src/snes/integration_tests/neser_pal_tests.rs
+++ b/src/snes/integration_tests/neser_pal_tests.rs
@@ -469,16 +469,17 @@ mod tests {
         );
     }
 
-    /// SETINI bit 2 selects the 239-line tall screen. It is a PPU mode, not a
-    /// region property: both consoles grow the active area to 239 lines and
-    /// take their extra lines out of blanking.
+    /// SETINI bit 2 selects the 239-line tall screen.  It is a PPU mode, not a
+    /// region property: both consoles grow the active area to 239 lines.  The
+    /// Mesen2-compatible snapshot clips the output to the standard 224-line
+    /// window (#3001) so both regions report 256×224.
     #[test]
-    fn overscan_output_is_239_lines_in_both_regions() {
+    fn overscan_output_is_224_lines_mesen2_compat_in_both_regions() {
         let ntsc = render_banded_screen(0x04, SnesHardware::Ntsc);
         let pal = render_banded_screen(0x04, SnesHardware::Pal);
 
-        assert_eq!(ntsc.screen_dimensions, (256, 239));
-        assert_eq!(pal.screen_dimensions, (256, 239));
+        assert_eq!(ntsc.screen_dimensions, (256, 224));
+        assert_eq!(pal.screen_dimensions, (256, 224));
         assert_eq!(
             ntsc.screen_crc32, pal.screen_crc32,
             "overscan output must match across regions (ntsc=0x{:08X} pal=0x{:08X})",

--- a/src/snes/ppu/framebuffer.rs
+++ b/src/snes/ppu/framebuffer.rs
@@ -308,14 +308,16 @@ mod tests {
         use super::super::{DOTS_PER_SCANLINE, MASTER_CYCLES_PER_DOT};
         let ticks_per_line = u32::from(DOTS_PER_SCANLINE) * MASTER_CYCLES_PER_DOT;
 
-        // Rows 0..6: blue backdrop.
+        // Rendered rows 0..6 (scanlines 1..7) must be blue.  Scanline 0 is not
+        // visible (VISIBLE_LINE_START = 1), so we must tick 8 scanlines (0..7)
+        // to cause scanlines 1..7 to be rendered, giving us 7 blue rows.
         set_backdrop(&mut ppu, 0x7C00); // full blue
-        for _ in 0..(ticks_per_line * 7) {
+        for _ in 0..(ticks_per_line * 8) {
             ppu.tick();
         }
         // Rows 7..238: red backdrop.
         set_backdrop(&mut ppu, 0x001F); // full red
-        let remaining = NTSC_SCANLINES_PER_FRAME as u32 - 7;
+        let remaining = NTSC_SCANLINES_PER_FRAME as u32 - 8;
         for _ in 0..(ticks_per_line * remaining) {
             ppu.tick();
         }

--- a/src/snes/ppu/framebuffer.rs
+++ b/src/snes/ppu/framebuffer.rs
@@ -5,7 +5,7 @@
 //! [`Ppu::screen_snapshot_rgb`] applies INIDISP forced-blank and master brightness at output,
 //! converting to packed RGB888.
 
-use super::{Ppu, SCREEN_WIDTH, VISIBLE_DOT_START, VISIBLE_LINE_START};
+use super::{OVERSCAN_CROP_TOP, Ppu, SCREEN_WIDTH, VISIBLE_DOT_START, VISIBLE_LINE_START};
 
 impl Ppu {
     /// Render the pixel at the current dot (called once per dot from the timing loop).
@@ -71,6 +71,10 @@ impl Ppu {
 
     /// Snapshot the visible framebuffer as packed RGB888, applying INIDISP forced-blank and
     /// master brightness. Forced blank or brightness 0 yields a black screen.
+    ///
+    /// The output dimensions match [`Self::frame_dimensions`]:
+    /// - Screen interlace (non-hires): each pixel is column-doubled to 512 wide (Mesen2 convention, #3001).
+    /// - 239-line overscan: clipped to the 224-line Mesen2 window starting at internal row 7 (#3001).
     pub fn screen_snapshot_rgb(&self) -> Vec<u8> {
         let (width, height) = self.frame_dimensions();
         let width = width as usize;
@@ -78,15 +82,32 @@ impl Ppu {
         let mut out = vec![0u8; width * height * 3];
 
         let stride = self.framebuffer_stride();
+
+        // Overscan: the Mesen2-compatible window starts 7 lines into the rendered
+        // 239-line frame.  In interlace mode each source line occupies two framebuffer
+        // rows, so the framebuffer offset is doubled.
+        let interlace_mult = if self.interlace_enabled() { 2 } else { 1 };
+        let y_fb_offset = if self.overscan_239_enabled() {
+            OVERSCAN_CROP_TOP * interlace_mult
+        } else {
+            0
+        };
+
+        // Non-hires screen interlace: pixels were written at columns 0..255 but the
+        // output is 512 wide (column-doubled), matching Mesen2.
+        let col_double = self.interlace_enabled() && !self.hires_output_enabled();
+
         for y in 0..height {
-            let line_inidisp = self.line_inidisp[y];
+            let fb_y = y + y_fb_offset;
+            let line_inidisp = self.line_inidisp[fb_y];
             let forced_blank = line_inidisp & 0x80 != 0;
             let brightness = (line_inidisp & 0x0F) as u32;
             if forced_blank || brightness == 0 {
                 continue; // row already all-black
             }
             for x in 0..width {
-                let pixel = self.framebuffer[y * stride + x];
+                let fb_x = if col_double { x / 2 } else { x };
+                let pixel = self.framebuffer[fb_y * stride + fb_x];
                 let (r, g, b) = bgr555_to_rgb888(pixel, brightness);
                 let idx = (y * width + x) * 3;
                 out[idx] = r;
@@ -243,7 +264,10 @@ mod tests {
     }
 
     #[test]
-    fn overscan_239_mode_renders_a_239_line_snapshot() {
+    fn overscan_239_mode_outputs_mesen2_compatible_224_line_snapshot() {
+        // Internal rendering still covers 239 lines, but the Mesen2-compatible
+        // snapshot is clipped to the 224-line window starting at rendered row 7
+        // (#3001: rows 7..231, Rust-exclusive = 224 rows).
         let mut ppu = Ppu::new();
         set_backdrop(&mut ppu, 0x001F); // full red
         ppu.write_register(0x2100, 0x0F);
@@ -251,10 +275,61 @@ mod tests {
         render_full_frame(&mut ppu);
 
         let rgb = ppu.screen_snapshot_rgb();
-        assert_eq!(rgb.len(), 256 * 239 * 3);
-        assert_eq!(&rgb[0..3], &[255, 0, 0], "top-left pixel is rendered");
-        let last = (256 * 239 - 1) * 3;
-        assert_eq!(&rgb[last..last + 3], &[255, 0, 0], "line 239 is rendered");
+        assert_eq!(
+            rgb.len(),
+            256 * 224 * 3,
+            "output is 256×224 (Mesen2-compatible)"
+        );
+        assert_eq!(
+            &rgb[0..3],
+            &[255, 0, 0],
+            "top output row is red (rendered row 7)"
+        );
+        let last = (256 * 224 - 1) * 3;
+        assert_eq!(
+            &rgb[last..last + 3],
+            &[255, 0, 0],
+            "bottom output row is red (rendered row 230)"
+        );
+    }
+
+    #[test]
+    fn overscan_snapshot_skips_top_7_rendered_rows() {
+        // Sets rendered rows 0..6 to blue, rows 7..238 to red.  The output
+        // window starts at row 7, so the snapshot must be fully red (no blue).
+        let mut ppu = Ppu::new();
+        ppu.write_register(0x2100, 0x0F);
+        ppu.write_register(0x2133, 0x04); // overscan
+
+        // Render a frame: the backdrop color changes mid-frame by writing CGRAM
+        // at the start of lines 0 and 7 via a simple tick-step approach.
+        // Because changing the backdrop mid-frame is done indirectly, we use the
+        // lower-level API: render lines manually with two different colors.
+        use super::super::{DOTS_PER_SCANLINE, MASTER_CYCLES_PER_DOT};
+        let ticks_per_line = u32::from(DOTS_PER_SCANLINE) * MASTER_CYCLES_PER_DOT;
+
+        // Rows 0..6: blue backdrop.
+        set_backdrop(&mut ppu, 0x7C00); // full blue
+        for _ in 0..(ticks_per_line * 7) {
+            ppu.tick();
+        }
+        // Rows 7..238: red backdrop.
+        set_backdrop(&mut ppu, 0x001F); // full red
+        let remaining = NTSC_SCANLINES_PER_FRAME as u32 - 7;
+        for _ in 0..(ticks_per_line * remaining) {
+            ppu.tick();
+        }
+
+        let rgb = ppu.screen_snapshot_rgb();
+        assert_eq!(rgb.len(), 256 * 224 * 3);
+        // Every pixel in the output must be red (none of the blue rows 0..6 leaked in).
+        for chunk in rgb.chunks_exact(3) {
+            assert_eq!(
+                chunk,
+                &[255, 0, 0],
+                "overscan output must start at rendered row 7"
+            );
+        }
     }
 
     #[test]

--- a/src/snes/ppu/mod.rs
+++ b/src/snes/ppu/mod.rs
@@ -36,6 +36,11 @@ pub(super) const SCREEN_HEIGHT_TALL: usize = 239;
 pub(super) const SCREEN_WIDTH_MAX: usize = 512;
 /// Maximum framebuffer height supported by the SNES PPU.
 pub(super) const SCREEN_HEIGHT_MAX: usize = 478;
+/// Lines cropped from the top of a 239-line overscan frame to produce the
+/// Mesen2-compatible 224-line output window (NESER rows 7..231, Rust-exclusive).
+/// Mesen2 centres the 224-line window inside the 239-line region, cutting 7 lines
+/// from the top and 8 from the bottom (#3001, verified in #2879).
+pub(super) const OVERSCAN_CROP_TOP: usize = 7;
 /// First visible dot within a scanline (active display is dots 22..=277).
 pub(super) const VISIBLE_DOT_START: u16 = 22;
 /// First visible scanline (active display is lines 1..=224).
@@ -647,16 +652,20 @@ impl Ppu {
 
     /// Active output geometry for the current frame.
     pub fn frame_dimensions(&self) -> (u32, u32) {
-        let width = if self.hires_output_enabled() {
+        // Screen interlace ($2133 bit 0) column-doubles to 512 px wide in Mesen2
+        // even when no hires mode is active; NESER matches that convention (#3001).
+        let width = if self.hires_output_enabled() || self.interlace_enabled() {
             SCREEN_WIDTH_MAX
         } else {
             SCREEN_WIDTH
         };
-        let active_height = self.active_screen_height();
+        // 239-line overscan is cropped to the standard 224-line window to match
+        // Mesen2's output geometry (#3001).  Internal rendering still covers all
+        // 239 lines; only the snapshot clips.
         let height = if self.interlace_enabled() {
-            active_height * 2
+            SCREEN_HEIGHT * 2
         } else {
-            active_height
+            SCREEN_HEIGHT
         };
         (width as u32, height as u32)
     }
@@ -855,10 +864,15 @@ mod tests {
 
         assert_eq!(ppu.frame_dimensions(), (256, 224));
 
+        // Mode 5 (hires) + screen interlace: already 512 wide from hires.
         ppu.write_register(0x2105, 0x05);
         ppu.write_register(0x2133, 0x01);
-
         assert_eq!(ppu.frame_dimensions(), (512, 448));
+
+        // Non-hires screen interlace: column-doubled to 512 wide to match Mesen2 (#3001).
+        let mut ppu2 = Ppu::new();
+        ppu2.write_register(0x2133, 0x01);
+        assert_eq!(ppu2.frame_dimensions(), (512, 448));
     }
 
     #[test]
@@ -871,15 +885,19 @@ mod tests {
     }
 
     #[test]
-    fn setini_overscan_mode_enables_239_line_output_height() {
+    fn setini_overscan_mode_clips_output_to_224_lines_to_match_mesen2() {
+        // Internal rendering still covers 239 lines, but the snapshot is clipped
+        // to the Mesen2-compatible 224-line window (#3001).
         let mut ppu = Ppu::new();
         assert_eq!(ppu.frame_dimensions(), (256, 224));
 
+        // Overscan only: clipped to 256×224.
         ppu.write_register(0x2133, 0x04);
-        assert_eq!(ppu.frame_dimensions(), (256, 239));
+        assert_eq!(ppu.frame_dimensions(), (256, 224));
 
+        // Overscan + screen interlace: both normalizations applied → 512×448.
         ppu.write_register(0x2133, 0x05);
-        assert_eq!(ppu.frame_dimensions(), (256, 478));
+        assert_eq!(ppu.frame_dimensions(), (512, 448));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #3001.

NESER's `screen_snapshot_rgb` output now matches Mesen2's frame geometry for screen-interlace and 239-line overscan modes, enabling byte-for-byte CRC comparison for the four previously-`#[ignore]`d `byuu_test_oam_tests` SETINI combos.

## Changes

### `src/snes/ppu/mod.rs`
- `frame_dimensions()`: width is now 512 when `hires_output_enabled() || interlace_enabled()` (was 512 only for hires); height is always based on `SCREEN_HEIGHT = 224` (×2 if interlace), dropping the overscan influence on output height.
- Added `pub(super) const OVERSCAN_CROP_TOP: usize = 7`.
- Updated `frame_dimensions_reflect_hires_and_interlace_settings` test to also cover non-hires interlace.
- Renamed/updated `setini_overscan_mode_enables_239_line_output_height` → `setini_overscan_mode_clips_output_to_224_lines_to_match_mesen2`.

### `src/snes/ppu/framebuffer.rs`
- `screen_snapshot_rgb()`:
  - Overscan: reads framebuffer starting at row `y + OVERSCAN_CROP_TOP` (= row 7), clipping to the Mesen2-compatible 224-line window.
  - Non-hires screen interlace: maps output column `x` to framebuffer column `x/2` (column-doubling to 512 wide).
  - Combined: both applied independently (→ 512×448).
- Updated `overscan_239_mode_renders_a_239_line_snapshot` → `overscan_239_mode_outputs_mesen2_compatible_224_line_snapshot`.
- Added `overscan_snapshot_skips_top_7_rendered_rows` test.

### `src/snes/integration_tests/byuu_test_oam_tests.rs`
- Replaced the four `test_oam_combo_ignored_3001!` invocations with `test_oam_combo!` using Mesen2-approved CRC goldens.
- Updated module doc to reflect the completed #3001 approval.

### `src/snes/integration_tests/neser_pal_tests.rs`
- Updated `overscan_output_is_239_lines_in_both_regions` → `overscan_output_is_224_lines_mesen2_compat_in_both_regions`.

## Mesen2 approval

Control golden (setini2_small, already approved): 0-pixel diff confirmed. ✓

| Combo | NESER new CRC | Mesen2 CRC | Result |
|-------|--------------|-----------|--------|
| setini1_small | 0xF3ABFC7C | 0xF3ABFC7C | ✓ exact match |
| setini1_large | 0xD67864B6 | 0xD67864B6 | ✓ exact match |
| setini4_small | 0xFD9EA997 | 0xFD9EA997 | ✓ exact match |
| setini4_large | 0x247620AA | 0x247620AA | ✓ exact match |

Verified via `--testRunner --enableStdout` with the same frame-stamped input schedule used by the Rust test (Lua `inputPolled` replay, `--snes.disableFrameSkipping=true`). PNG decoded to RGB888, CRC32 computed identically to NESER's `crc32::crc32`.

## Test results

`cargo test --no-default-features --lib`: **12790 passed, 0 failed, 33 ignored** (the remaining 33 are from other open issues).