### PR TITLE
Document INIDISP brightness timing as known limitation (#2973)

### DIFF
--- a/src/snes/integration_tests/undisbeliever_tests.rs
+++ b/src/snes/integration_tests/undisbeliever_tests.rs
@@ -228,7 +228,29 @@ mod tests {
         0x7EDB_74D1
     );
 
-    // Tests HDMA-driven INIDISP changes. Same known minor visual differences.
+    // Tests mid-scanline INIDISP (brightness) changes: an H-IRQ at dot 309
+    // writes INIDISP directly (no HDMA involved, despite this ROM's name
+    // implying otherwise) to step the master brightness up/down on specific
+    // scanlines. NESER latches INIDISP once per scanline at
+    // `VISIBLE_DOT_START` (`Ppu::render_dot`/`line_inidisp` in
+    // `framebuffer.rs`), applying the whole row's brightness at once, while
+    // real hardware has some (undocumented) pixel-level delay between the
+    // write and the visible change. This produces a 4.45% pixel diff vs
+    // Mesen2 concentrated at brightness band edges (issue #2973).
+    //
+    // Investigated and left as a documented known limitation rather than a
+    // bug fix: fullsnes itself is explicitly unsure of the exact delay
+    // ("Forced blank doesn't apply immediately... so one must wait whatever
+    // (maybe a scanline)... or is it only vice-versa... shows garbage
+    // pixels?"), and no cycle-accurate real-hardware measurement is
+    // documented anywhere -- undisbeliever's `inidisp_brightness_delay.asm`
+    // source (designed to visualize the effect via real-hardware photos)
+    // asserts no specific delay value either. Any "fix" here would just
+    // mean picking one undocumented emulator's model over another, not
+    // matching a known-correct reference -- same shared-limitation
+    // reasoning as the `inidisp_hammer_*` glitch tests above (#2949) and
+    // related low-severity timing issues #2967/#2971. The golden CRC is
+    // unchanged; no behavior/timing code was modified for this issue.
     undisbeliever_rom_test!(
         inidisp_brightness_delay_matches_mesen2,
         "inidisp_brightness_delay.sfc",


### PR DESCRIPTION
## Summary

Documents the INIDISP mid-scanline brightness timing difference vs Mesen2 (`inidisp_brightness_delay.sfc`, 4.45% pixel diff at brightness band edges) as a known, low-severity, hardware-underspecified timing limitation, rather than attempting a behavior fix.

## Why no code fix

- fullsnes itself is explicitly unsure of the exact mid-scanline INIDISP delay: *"Forced blank doesn't apply immediately... so one must wait whatever (maybe a scanline)... or is it only vice-versa... shows garbage pixels?"*
- No cycle-accurate real-hardware measurement is documented anywhere reachable.
- undisbeliever's `inidisp_brightness_delay.asm` test ROM source (designed to visualize the effect via real-hardware photos) asserts no specific expected delay value.
- Any code change here would mean picking one undocumented emulator's model (e.g. Mesen2's) over another, not matching a known-correct reference. This matches the existing shared-limitation precedent for the `inidisp_hammer_*` glitch tests (#2949) and related low-severity timing issues #2967/#2971.

## Changes

- Updates the `inidisp_brightness_delay_matches_mesen2` test comment in `src/snes/integration_tests/undisbeliever_tests.rs`:
  - Fixes an inaccurate "HDMA-driven" description — the ROM actually uses an H-IRQ (dot 309) writing INIDISP directly, no HDMA is involved.
  - Documents the root cause (per-scanline vs per-pixel INIDISP latch) and the research findings above.
- No behavior/timing code changed. Golden CRC (`0xA6F2AED7`) is unchanged.

## Verification

- `cargo test --no-default-features --lib inidisp_brightness_delay_matches_mesen2` → passes, same CRC
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo fmt` → no changes needed
- `cargo test --no-default-features --lib` → 12798 passed, 0 failed
- `wasm-pack test --headless --chrome --no-default-features --features wasm` → 94 passed
- Python test suites (scripts, metadata-scraper, nes-rom-db-scraper) → all pass
- `npm test` → 430 passed

Closes #2973

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>