### PR TITLE
SNES: assert Mesen2 PASS goldens for screen-CRC divergence tests, fix stale and rotted ignores (#3092)

### DIFF
--- a/.github/skills/snes-hardware-research/SKILL.md
+++ b/.github/skills/snes-hardware-research/SKILL.md
@@ -447,6 +447,82 @@ epic-#2724 visual suites (#2879, #2880, #2881, #2883, #2884):
    bass-untech clang patch (`git -C .../bass-untech checkout -- .`)
    before any subtree operation, re-apply to build (hit twice in #2881).
 
+### A passing screen-CRC test proves the screen is UNCHANGED, not that the ROM passes (from #3092)
+
+`RunOracle::ScreenCrc` sets `passed = (actual_crc == expected_crc)` and has
+no notion of a self-checking ROM's own PASS/FAIL backdrop. So a green
+screen-CRC test means only "the screen still hashes to the recorded value" —
+which may be a recorded *failure*. Never read one as evidence the ROM passes,
+and never conclude a fix worked because such a test is green.
+
+**Two conventions exist for a divergence record; pick deliberately and say
+which in the reason string.**
+
+- *Aspirational* — record the Mesen2-correct PASS CRC, keep `#[ignore]`. The
+  test FAILs under `--include-ignored` today and turns green exactly when the
+  bug is fixed. **Prefer this** for anything you intend to fix.
+- *Record-current* — record NESER's own diverging CRC. Passes under
+  `--include-ignored`, meaning "still diverging as recorded". This **inverts
+  the fix signal**: a correct fix turns the test red and reads as a
+  regression. Only justifiable when there is no single correct value to
+  assert (e.g. a pixel-diff comparison against a picture, not a PASS/FAIL
+  backdrop).
+
+Consequences worth knowing before touching such a suite:
+
+- A test named `*_passes` asserting a record-current golden is a lie in
+  waiting. Under the aspirational convention the name and the usual
+  "expected screen-CRC PASS (blue)" assert message become true for free, so
+  conversion needs no renaming.
+- `#[ignore]`d goldens rot silently. #3092 found one asserting a CRC that
+  belonged to a **different ROM**, undetected from #2883 onward, and two more
+  invalidated by a capture-geometry change (#3001) nobody re-ran. Audit
+  ignored goldens whenever a rendering or capture convention changes.
+
+### Check the sample frame can actually SEE the divergence (from #3092)
+
+Before trusting any screen-CRC divergence record, capture **both** emulators
+at the test's own sample frame. If NESER and Mesen2 agree there, the test is
+asserting agreement with the reference, not a divergence — it cannot fail no
+matter how the feature under test behaves.
+
+`test_hdmasync.smc` sampled frame 600 for two years. Both emulators render
+flat black until frame ~1027; Mesen2 reaches blue PASS at 1029 while NESER
+paints red. The frame-600 assertion was recording a shared black screen, so
+it would have passed under any HDMA-sync behaviour whatsoever.
+
+Run a settle probe out to several times the sample frame before believing a
+"renders black / hangs" description — a slow ROM and a hung one look
+identical at a frame sampled too early. Binary-search the reference's
+transition frame, then sample well past it with margin on both sides.
+
+### Identify a mystery flat-fill CRC by enumerating BGR555 (from #3092)
+
+When a golden's literal means nothing to you, test whether it is a uniform
+fill before assuming it is structured content. SNES 5-bit channels expand as
+`(v << 3) | (v >> 2)`, so all 32768 representable colours can be brute-forced
+against a target CRC in seconds:
+
+```python
+exp = lambda v: (v << 3) | (v >> 2)
+for r in range(32):
+    for g in range(32):
+        for b in range(32):
+            px = bytes((exp(r), exp(g), exp(b)))
+            if zlib.crc32(px * (256 * 224)) == target:
+                print(r, g, b)
+```
+
+Scan the full space, not a handful of guessed colours: a five-colour probe in
+#3092 wrongly concluded `0x8662_6F50` was "not a flat fill" when it is a flat
+`(66,0,0)`. Identical CRCs across unrelated ROMs are expected and not
+evidence of copy-paste — a flat fill of one colour and size hashes the same
+whichever ROM produced it.
+
+Useful corollary: this ROM family encodes FAIL detail in the backdrop's red
+level (r=31, 14, 10, 8 seen), so the shade may say *which* sub-check failed —
+a free diagnostic worth confirming against the ROM source before tracing.
+
 ### Mesen2 capture-dimension conventions (from #2879, extended #2881; settled by #3001/#3034)
 
 **Current state: no normalization is needed.** NESER's display-mode

--- a/.github/skills/snes-hardware-research/SKILL.md
+++ b/.github/skills/snes-hardware-research/SKILL.md
@@ -339,6 +339,11 @@ epic-#2724 visual suites (#2879, #2880, #2881, #2883, #2884):
    (hdrvtest ignores input until ~frame 300): schedule taps after the
    first screen's settle frame, and compare each scripted combo's CRC
    against the no-input CRC — equality means the taps were swallowed.
+   **Always convert probe decimal CRC output to hex via Python**
+   (`python3 -c "print(hex(N))"`) before comparing against Mesen2
+   values — mental arithmetic on 10-digit decimals is error-prone and
+   produces silent false mismatches (caught in #3021: `4015300223` was
+   misread as `0xEFB6E03F` instead of the correct `0xEF549E7F`).
 2. **Capture and pixel-diff**: write NESER PNGs during the probe, capture
    Mesen2 headless at the same frame (`--testRunner` + Lua `print()` hex
    dump; flags above), then diff programmatically with a ±1-row shift

--- a/references/retrospective-neser.md
+++ b/references/retrospective-neser.md
@@ -1384,3 +1384,43 @@ No feedback provided (navigator unavailable/pending)
 #### What to improve
 
 No feedback provided (navigator unavailable/pending)
+
+---
+
+## 2026-08-01 — PR #3089: SNES: align interlace/overscan capture dimensions with Mesen2
+
+**Repository:** rmstdope/neser
+**PR URL:** https://github.com/rmstdope/neser/pull/3089
+**Linked issues:** #3001
+
+### Customizations used
+
+| Type         | Name                              | Purpose                                                                                                                                              |
+| ------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Skill        | `snes-hardware-research`          | Provided exact Mesen2 binary path, `--testRunner` headless syntax, `--snes.disableFrameSkipping=true` flag, and the Lua testRunner template — eliminating all tooling re-research. |
+| Skill        | `test-driven-development`         | Implicitly governed the workflow shape (probe → failing test → fix → re-enable ignored tests → green run).                                           |
+| Instructions | `.github/copilot-instructions.md` | Applied repo-wide rules for incremental changes, validation gates, and retrospective capture.                                                        |
+
+### What went well
+
+- ✅ The `snes-hardware-research` skill contained the exact Mesen2 oracle tooling details (binary path, `--testRunner` flag, `--snes.disableFrameSkipping=true`, Lua template), making the ground-truth comparison pipeline immediately executable without any tooling re-research.
+- ✅ The plan → navigator approval → implement loop (superplanner + `exit_plan_mode`) kept changes scoped to exactly two files with zero unrelated churn.
+- ✅ The layered validation strategy — NESER probe first, then 5 Mesen2 headless comparisons, then 0-pixel diff — gave concrete, evidence-backed confidence before re-enabling tests rather than relying on assertion alone.
+- ✅ Re-enabling 4 previously `#[ignore]`d integration tests converted silent dead coverage back into live regression guards, turning the fix into a net improvement in test health.
+- ✅ The final run produced 12 790 passed / 0 failed in a single clean execution.
+
+### What to improve
+
+- ❌ The `test-driven-development` skill was not explicitly invoked even though it governed the workflow shape (probe → red test → fix → green). Future sessions should activate it explicitly at the start so its guidance is consciously applied rather than implicitly followed.
+- ❌ The CRC discovery → Mesen2 headless → pixel-diff pipeline is reusable across all SNES golden-update work but exists only implicitly in this PR. It should be captured as a named procedure or referenced example in `snes-hardware-research` skill notes so future sessions can invoke it by name without reconstructing the steps.
+- ❌ When re-enabling `#[ignore]`d tests is part of the fix scope, the plan step should call this out explicitly so it is treated as a deliverable rather than a clean-up detail discovered during implementation.
+
+### Navigator feedback
+
+#### What went well
+
+No additional feedback provided.
+
+#### What to improve
+
+No additional feedback provided.

--- a/references/retrospective-neser.md
+++ b/references/retrospective-neser.md
@@ -1424,3 +1424,47 @@ No additional feedback provided.
 #### What to improve
 
 No additional feedback provided.
+
+---
+
+## 2026-08-02 — PR #3098: SNES: assert Mesen2 PASS goldens for screen-CRC divergence tests, fix stale and rotted ignores
+
+**Repository:** rmstdope/neser
+**PR URL:** https://github.com/rmstdope/neser/pull/3098
+**Linked issues:** #3092 (closes), #3093, #3062, #3063; opened #3096, #3097
+
+### Customizations used
+
+| Type         | Name                       | Purpose                                                                                                                                   |
+| ------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Skill        | `snes-hardware-research`   | Mesen2 binary path, `--testRunner` headless syntax, scripted-input Lua template, concurrent-instance guard, settle-probe workflow.          |
+| Skill        | `github-issue-designer`    | Structure for the rewritten #3092, the #3093 correction, and the two new issues.                                                           |
+| Skill        | `github-administration`    | `--body-file` discipline and post-mutation verification across 5 issue mutations.                                                          |
+| Skill        | `test-driven-development`  | Mutation-verification of both newly un-ignored goldens before trusting them.                                                               |
+| Skill        | `self-learning-skills`     | This retrospective.                                                                                                                        |
+
+### What went well
+
+- ✅ Verifying the issue's premise before implementing was the single highest-value act of the session. #3092 asserted the five IRQ tests "pass today"; capturing the screens showed the ROMs render red FAIL and the goldens recorded that failure. Implementing as written would have frozen five known-wrong screens into CI and inverted the fix signal.
+- ✅ The `snes-hardware-research` skill's Mesen2 recipe (binary path, flags, testRunner Lua template, the concurrent-instance guard) made 15 ground-truth captures executable with no tooling re-research — exactly the reuse PR #3089's retrospective hoped for.
+- ✅ Proving the capture pipeline with a control golden first (Mesen2's `colorbars_default` reproducing NESER's approved `0xF7459692` byte-for-byte) meant every later capture rested on a validated pipeline rather than assumption.
+- ✅ Sweeping every `#[ignore]` in `src/` against the state of its cited issue turned one reported defect into four real ones: a golden belonging to a different ROM, a sample frame that could never see its divergence, and two tests a closed issue had actually fixed (+2 live CI guards).
+- ✅ Mutation-checking both re-approved goldens (one-bit perturbation → confirmed failure → revert) proved they have power instead of assuming it.
+- ✅ Auditing my own prose caught two overstatements before review: a "not a flat fill" claim from a five-colour scan, and a tick-budget comment claiming 400M "would expire" at frame 1100 when ~393M is needed.
+
+### What to improve
+
+- ❌ Scope grew from 5 tests to 15 across 5 modules and 5 issues. Each step was navigator-approved, but CLAUDE.md asks for small increments and the natural three-way split (interrupt / DMA-HDMA / ddribin tests) was identified yet not taken. Offer the split as the default recommendation rather than the fallback.
+- ❌ Two `gh issue edit` calls silently failed by running from the scratchpad directory piped through `tail`, and were only caught by a later verification query. Now encoded as rules 15-16 in `github-administration`.
+- ❌ The first colour scan for an unknown CRC tried five hand-picked colours and produced a confidently wrong conclusion. Exhaustive enumeration over the 32768-colour BGR555 space takes seconds; now documented in `snes-hardware-research`.
+- ❌ The `screen_crc32` oracle's lack of PASS/FAIL semantics had already been recorded as a lesson in an earlier session yet was rediscovered from scratch here. Lessons about an oracle's semantics belong in the skill next to the workflow that uses it, not only in session memory.
+
+### Navigator feedback
+
+#### What went well
+
+No feedback provided (navigator selected "No feedback").
+
+#### What to improve
+
+No feedback provided (navigator selected "No feedback").

--- a/src/snes/integration_tests/ddribin_hdrv_tests.rs
+++ b/src/snes/integration_tests/ddribin_hdrv_tests.rs
@@ -101,20 +101,25 @@ mod tests {
     /// standard 224-line window for this combo, matching Mesen2's frame
     /// exactly.
     ///
-    /// Known limitation, tracked in #3096: this CRC is byte-identical
-    /// to `colorbars_default`'s golden, because overscan only adds lines
-    /// *below* row 223 and both emulators crop the capture to 224 rows.
-    /// The test therefore guards rows 0-223 against corruption but
-    /// cannot detect overscan being ignored altogether -- it needs a
-    /// different oracle, not a re-approved CRC. This is a property of
-    /// the capture convention, not a NESER defect: Mesen2's overscan and
-    /// non-overscan captures are identical too.
+    /// Known limitation, tracked in #3096: this CRC is byte-identical to
+    /// `colorbars_default`'s golden, and the test cannot tell you why.
+    /// With overscan on, `screen_snapshot_rgb` crops the 239-line frame
+    /// to 224 rows starting at internal row `OVERSCAN_CROP_TOP` (7); with
+    /// it off, from row 0. hdrvtest's colorbars are *vertical* bars with
+    /// no horizontal structure, so a 7-row vertical shift is invisible
+    /// and both crops hash the same. The equal CRC is therefore exactly
+    /// what you would see if the Y tap registered AND exactly what you
+    /// would see if it were swallowed -- it is evidence for neither.
     ///
-    /// #3095 rightly asked whether the equal CRC instead means the Y tap
-    /// never registered. It does register: `Ppu::frame_dimensions`
-    /// deliberately clips the 239-line frame to 224 ("internal rendering
-    /// still covers all 239 lines; only the snapshot clips"), and the
-    /// overscan flag was confirmed set at the sample frame -- see #3096.
+    /// #3095 raised the swallowed-tap possibility; this comment does not
+    /// settle it, and neither does a matching Mesen2 capture (Mesen2's
+    /// overscan and non-overscan captures are identical for the same
+    /// reason). Deciding it needs an oracle that observes the overscan
+    /// state or the rows the crop discards -- that is #3096's job.
+    ///
+    /// Un-ignored anyway because the value is Mesen2-verified and does
+    /// guard rows 0-223 against corruption; it simply asserts less than
+    /// its name suggests.
     #[test]
     fn overscan_toggle() {
         run_hdrv_screen_crc("overscan", &tap(SnesButton::Y, 340), 650, 0xF745_9692);

--- a/src/snes/integration_tests/ddribin_hdrv_tests.rs
+++ b/src/snes/integration_tests/ddribin_hdrv_tests.rs
@@ -18,13 +18,13 @@
 //! - The interlace combo (X tap at frame 340, sampled at frame 650) and
 //!   the overscan combo (Y tap at frame 340, same frame) were parked on
 //!   a capture-geometry mismatch: NESER rendered 256x448 and 256x239
-//!   against Mesen2's 512x448 and 256x224. Their content was verified
-//!   (0-pixel diffs after halving Mesen2's width, resp. at crop offset
-//!   0), but the raw framebuffers were not comparable. #3001 aligned
-//!   both dimensions and #3034 moved interlace column-doubling to write
-//!   time, so the mismatch is gone and both are re-approvable -- but
-//!   that needs fresh input-scripted Mesen2 captures, so they stay
-//!   `#[ignore]`d with refreshed NESER-current CRCs for now.
+//!   against Mesen2's 512x448 and 256x224. #3001 aligned both
+//!   dimensions and #3034 moved interlace column-doubling to write
+//!   time, which changed NESER's output and left the recorded CRCs
+//!   stale -- unnoticed because the tests were ignored. #3092 supplied
+//!   the fresh input-scripted Mesen2 captures those changes called for:
+//!   both now match Mesen2 exactly at the same geometry, so they are
+//!   ordinary committed goldens rather than divergence records.
 
 use super::rom_runner::{InputEvent, RunConfig, RunOracle, run_rom_with_oracle};
 use crate::snes::input::SnesButton;
@@ -86,26 +86,36 @@ mod tests {
         run_hdrv_screen_crc("graybars", &script, 520, 0x0AC8_BD62);
     }
 
-    /// NESER's current CRC, NOT a Mesen2-approved golden. The geometry
-    /// mismatch these two were parked on is gone -- #3001 aligned the
-    /// interlace and overscan capture dimensions with Mesen2 and #3034
-    /// moved interlace column-doubling to write time -- so both now render
-    /// at Mesen2's geometry and are re-approvable. Doing so needs fresh
-    /// input-scripted Mesen2 captures (the #2879 `emu.setInput` recipe),
-    /// which is why it is deferred rather than done here; the CRCs below
-    /// were refreshed to NESER's current output so they describe reality.
+    /// Mesen2-approved golden (#3092): since #3001 aligned the capture
+    /// dimensions and #3034 moved interlace column-doubling to write
+    /// time, NESER renders this combo at Mesen2's own 512x448 interlace
+    /// geometry, and a fresh input-scripted headless capture at frame
+    /// 650 hashes to the same value -- so the raw framebuffers are
+    /// directly comparable at last.
     #[test]
-    #[ignore = "re-approvable since #3001/#3034 but needs a fresh input-replay Mesen2 capture"]
     fn interlace_toggle() {
         run_hdrv_screen_crc("interlace", &tap(SnesButton::X, 340), 650, 0x902F_E4EE);
     }
 
-    /// As above. Note for whoever re-approves this one: its current CRC is
-    /// byte-identical to `colorbars_default`'s, which would mean the Y tap
-    /// left the screen unchanged. Check that the overscan toggle actually
-    /// registers before treating a matching capture as confirmation.
+    /// Mesen2-approved golden (#3092): since #3001 NESER captures the
+    /// standard 224-line window for this combo, matching Mesen2's frame
+    /// exactly.
+    ///
+    /// Known limitation, tracked in #3096: this CRC is byte-identical
+    /// to `colorbars_default`'s golden, because overscan only adds lines
+    /// *below* row 223 and both emulators crop the capture to 224 rows.
+    /// The test therefore guards rows 0-223 against corruption but
+    /// cannot detect overscan being ignored altogether -- it needs a
+    /// different oracle, not a re-approved CRC. This is a property of
+    /// the capture convention, not a NESER defect: Mesen2's overscan and
+    /// non-overscan captures are identical too.
+    ///
+    /// #3095 rightly asked whether the equal CRC instead means the Y tap
+    /// never registered. It does register: `Ppu::frame_dimensions`
+    /// deliberately clips the 239-line frame to 224 ("internal rendering
+    /// still covers all 239 lines; only the snapshot clips"), and the
+    /// overscan flag was confirmed set at the sample frame -- see #3096.
     #[test]
-    #[ignore = "re-approvable since #3001/#3034 but needs a fresh input-replay Mesen2 capture"]
     fn overscan_toggle() {
         run_hdrv_screen_crc("overscan", &tap(SnesButton::Y, 340), 650, 0xF745_9692);
     }

--- a/src/snes/integration_tests/jonasquinn_dma_tests.rs
+++ b/src/snes/integration_tests/jonasquinn_dma_tests.rs
@@ -87,7 +87,7 @@ mod tests {
 
     /// #3063: NESER's self-check FAILs (flat maroon) where Mesen2 PASSes (blue).
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3063"]
+    #[ignore = "self-check FAILs (maroon) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3063"]
     fn test_dmavalid_passes() {
         run_rom_screen_crc("test_dmavalid_v01/test_dmavalid.smc", 600, 0x8695_BBB0);
     }
@@ -96,7 +96,7 @@ mod tests {
     /// The CPU clears $420C mid-frame; NESER gets the mid-frame HDMA-disable
     /// behaviour wrong.
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3063"]
+    #[ignore = "self-check FAILs (maroon) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3063"]
     fn test_hdmadisable_passes() {
         run_rom_screen_crc("test_hdmadisable/test_hdmadisable.smc", 600, 0x8695_BBB0);
     }
@@ -128,7 +128,7 @@ mod tests {
     /// #3062 (byte-identical byuu mirror of KungFuFurby test_hdmatiming): NESER
     /// self-check FAILs (flat `(66, 0, 0)`) where Mesen2 PASSes (blue).
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
+    #[ignore = "self-check FAILs (maroon) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdmatiming_passes() {
         run_rom_screen_crc("test_hdma/test_hdmatiming.smc", 600, 0x8695_BBB0);
     }

--- a/src/snes/integration_tests/jonasquinn_dma_tests.rs
+++ b/src/snes/integration_tests/jonasquinn_dma_tests.rs
@@ -4,16 +4,25 @@
 //!
 //! Canonical DMA/HDMA ROMs from the collection (duplicates that recur under
 //! `test_hdma/`, `test_mdrhdma/`, `blobs/` and `snestest_082506/` are treated as
-//! mirror-provenance and not re-automated). Screen-CRC oracle at frame 600,
-//! cross-checked against a Mesen2 headless capture
+//! mirror-provenance and not re-automated). Screen-CRC oracle mostly at frame
+//! 600, cross-checked against a Mesen2 headless capture
 //! (`--Video.VideoFilter=None --Video.AspectRatio=NoStretching
 //! --snes.disableFrameSkipping=true`) of the identical ROM file.
 //!
 //! Two ROMs render a pixel-exact (0-pixel diff) match for Mesen2 and are
-//! committed goldens; the rest are `#[ignore]`d recording NESER's current
-//! diverging CRC, pending fixes. `test_hdma/test_hdmasync.smc` and
+//! committed goldens. `test_hdma/test_hdmasync.smc` and
 //! `test_hdma/test_hdmatiming.smc` are byte-identical byuu-suite mirrors of the
-//! KungFuFurby ROMs and share their divergence (#3062).
+//! KungFuFurby ROMs (md5 `acec8b53...` for the former) and share their
+//! divergence (#3062).
+//!
+//! **Golden convention (#3092).** The four `#[ignore]`d *self-check* ROMs
+//! assert the Mesen2-correct blue PASS screen, not NESER's current output, so
+//! they FAIL under `cargo test --include-ignored` until #3062/#3063 land --
+//! the designed state, not a regression. See `kungfufurby_irq_tests`' module
+//! doc for the rationale. `test_dmatiming_matches_mesen2` is deliberately NOT
+//! on this convention: it is a pixel-diff comparison against Mesen2's own
+//! render, not a PASS/FAIL self-check, so a blue backdrop is not its correct
+//! result and it keeps recording NESER's current diverging CRC.
 
 use super::rom_runner::{RunConfig, RunExitReason, RunOracle, run_rom_with_oracle};
 use std::fs;
@@ -38,7 +47,12 @@ mod tests {
             &rom,
             &name,
             "jonasquinn_dma_tests",
-            RunConfig::new(400_000_000, 0),
+            // Headroom for `test_hdmasync`'s frame-1100 sample point, which
+            // needs ~393M master clocks (1100 x 1364 x 262). The previous
+            // 400M cap cleared that by only ~19 frames; overshooting it would
+            // exit on TickLimit and report a confusing budget failure instead
+            // of the golden mismatch the test is actually about.
+            RunConfig::new(600_000_000, 0),
             RunOracle::ScreenCrc {
                 frames,
                 expected_crc,
@@ -67,47 +81,55 @@ mod tests {
         run_rom_screen_crc("hdma_midframe/demo.smc", 600, 0xE90C_27F0);
     }
 
-    // Divergences below record NESER's current CRC, NOT a Mesen2 golden; Mesen2
-    // renders the PASS state where NESER does not. Un-ignore + re-approve once
-    // fixed.
+    // The self-check goldens below are the Mesen2-approved blue PASS screen,
+    // verified by a fresh headless capture at each test's own sample frame.
+    // Un-ignore each one once NESER renders the PASS backdrop.
 
-    /// #3063: NESER's self-check FAILs (red) where Mesen2 PASSes (blue).
+    /// #3063: NESER's self-check FAILs (flat maroon) where Mesen2 PASSes (blue).
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); pending #3063"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3063"]
     fn test_dmavalid_passes() {
-        run_rom_screen_crc("test_dmavalid_v01/test_dmavalid.smc", 600, 0x0B56_4EEF);
+        run_rom_screen_crc("test_dmavalid_v01/test_dmavalid.smc", 600, 0x8695_BBB0);
     }
 
-    /// #3063: NESER's self-check FAILs (red) where Mesen2 PASSes (blue). The
-    /// CPU clears $420C mid-frame; NESER gets the mid-frame HDMA-disable
+    /// #3063: NESER's self-check FAILs (flat maroon) where Mesen2 PASSes (blue).
+    /// The CPU clears $420C mid-frame; NESER gets the mid-frame HDMA-disable
     /// behaviour wrong.
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); pending #3063"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3063"]
     fn test_hdmadisable_passes() {
-        run_rom_screen_crc("test_hdmadisable/test_hdmadisable.smc", 600, 0x0B56_4EEF);
+        run_rom_screen_crc("test_hdmadisable/test_hdmadisable.smc", 600, 0x8695_BBB0);
     }
 
     /// #3063: NESER diverges from Mesen2 by ~0.93% (532 px) at frame 600 -- a
     /// small DMA-timing visual difference.
+    ///
+    /// Deliberately excluded from #3092's aspirational-golden convention (this
+    /// is not an oversight): the ROM renders a picture rather than a PASS/FAIL
+    /// backdrop, so there is no blue screen to assert. The CRC below stays
+    /// NESER's own current render; the correct value would be Mesen2's exact
+    /// framebuffer hash, which is a different kind of golden.
     #[test]
-    #[ignore = "~0.93% pixel divergence from Mesen2; pending #3063"]
+    #[ignore = "~0.93% pixel divergence from Mesen2; records NESER's current render, not a PASS golden; pending #3063"]
     fn test_dmatiming_matches_mesen2() {
         run_rom_screen_crc("test_dmatiming/demo.smc", 600, 0x97B7_5364);
     }
 
-    /// #3062 (byte-identical byuu mirror of KungFuFurby test_hdmasync): NESER
-    /// renders black where Mesen2 renders blue PASS.
+    /// #3062 (byte-identical byuu mirror of KungFuFurby test_hdmasync): sampled
+    /// at frame 1100 rather than 600 because BOTH emulators render solid black
+    /// until ~frame 1027 -- see `kungfufurby_hdma_tests::test_hdmasync_passes`
+    /// for the full transition timeline.
     #[test]
-    #[ignore = "renders black instead of Mesen2's blue PASS; pending #3062"]
+    #[ignore = "settles on a non-PASS screen where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdmasync_passes() {
-        run_rom_screen_crc("test_hdma/test_hdmasync.smc", 600, 0x6E8D_8520);
+        run_rom_screen_crc("test_hdma/test_hdmasync.smc", 1100, 0x8695_BBB0);
     }
 
     /// #3062 (byte-identical byuu mirror of KungFuFurby test_hdmatiming): NESER
-    /// self-check FAILs (red) where Mesen2 PASSes (blue).
+    /// self-check FAILs (flat `(66, 0, 0)`) where Mesen2 PASSes (blue).
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); pending #3062"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdmatiming_passes() {
-        run_rom_screen_crc("test_hdma/test_hdmatiming.smc", 600, 0x8662_6F50);
+        run_rom_screen_crc("test_hdma/test_hdmatiming.smc", 600, 0x8695_BBB0);
     }
 }

--- a/src/snes/integration_tests/kungfufurby_hdma_tests.rs
+++ b/src/snes/integration_tests/kungfufurby_hdma_tests.rs
@@ -80,7 +80,7 @@ mod tests {
     /// `(66, 0, 0)` fill, settled from frame 30) where Mesen2 PASSes (blue) --
     /// an HDMA timing behaviour NESER gets wrong.
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
+    #[ignore = "self-check FAILs (maroon) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdmatiming_passes() {
         run_rom_screen_crc("test_hdmatiming.smc", 600, 0x8695_BBB0);
     }

--- a/src/snes/integration_tests/kungfufurby_hdma_tests.rs
+++ b/src/snes/integration_tests/kungfufurby_hdma_tests.rs
@@ -7,6 +7,11 @@
 //! completion (blue = PASS, red/maroon = FAIL), cross-checked against a Mesen2
 //! headless capture (`--Video.VideoFilter=None --Video.AspectRatio=NoStretching
 //! --snes.disableFrameSkipping=true`) of the identical ROM file.
+//!
+//! **Golden convention (#3092).** All three tests assert the Mesen2-correct
+//! blue PASS screen, not NESER's current output, so they FAIL under
+//! `cargo test --include-ignored` until #3062 lands -- the designed state, not
+//! a regression. See `kungfufurby_irq_tests`' module doc for the rationale.
 
 use super::rom_runner::{RunConfig, RunExitReason, RunOracle, run_rom_with_oracle};
 use std::fs;
@@ -26,7 +31,12 @@ mod tests {
             &rom,
             file,
             "kungfufurby_hdma_tests",
-            RunConfig::new(400_000_000, 0),
+            // Headroom for `test_hdmasync`'s frame-1100 sample point, which
+            // needs ~393M master clocks (1100 x 1364 x 262). The previous
+            // 400M cap cleared that by only ~19 frames; overshooting it would
+            // exit on TickLimit and report a confusing budget failure instead
+            // of the golden mismatch the test is actually about.
+            RunConfig::new(600_000_000, 0),
             RunOracle::ScreenCrc {
                 frames,
                 expected_crc,
@@ -41,34 +51,37 @@ mod tests {
         );
     }
 
-    // The three CRCs below are NESER's *current* (diverging) renders, NOT
-    // Mesen2-approved goldens: Mesen2 shows a solid blue PASS backdrop for all
-    // three at frame 600. Ignored pending #3062; re-approve against Mesen2 and
-    // un-ignore once NESER renders the PASS backdrop.
+    // All three goldens below are the Mesen2-approved blue PASS screen,
+    // verified by a fresh headless capture at each test's own sample frame.
+    // Un-ignore each one once NESER renders the PASS backdrop (#3062).
 
-    /// #3062: NESER renders solid black (self-check appears to crash/hang before
-    /// painting the backdrop); Mesen2 renders blue PASS. Same black CRC as
-    /// #2953.
+    /// #3062: NESER paints a brief red flash at frames 12-13 and then settles
+    /// on solid black from frame 14 onward; Mesen2 renders blue PASS. Same
+    /// black CRC as #2953.
     #[test]
-    #[ignore = "renders black instead of Mesen2's blue PASS; pending #3062"]
+    #[ignore = "settles on black instead of Mesen2's blue PASS; asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdma_passes() {
-        run_rom_screen_crc("test_hdma.smc", 600, 0x6E8D_8520);
+        run_rom_screen_crc("test_hdma.smc", 600, 0x8695_BBB0);
     }
 
-    /// #3062: NESER renders solid black (as `test_hdma`); Mesen2 renders blue
-    /// PASS.
+    /// #3062: this ROM is slow -- BOTH emulators render solid black until
+    /// ~frame 1027, so the frame-600 sample this test used before #3092 could
+    /// never see the divergence (it asserted "still black", which Mesen2 also
+    /// produces). Sampled at frame 1100 instead, comfortably past the
+    /// transition: Mesen2 is stable blue PASS from frame 1029, while NESER
+    /// paints red FAIL at 1029 and settles on `0x7F21_BBD7` from frame 1031.
     #[test]
-    #[ignore = "renders black instead of Mesen2's blue PASS; pending #3062"]
+    #[ignore = "settles on a non-PASS screen where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdmasync_passes() {
-        run_rom_screen_crc("test_hdmasync.smc", 600, 0x6E8D_8520);
+        run_rom_screen_crc("test_hdmasync.smc", 1100, 0x8695_BBB0);
     }
 
-    /// #3062: NESER runs to completion but the ROM's self-check FAILS (red
-    /// backdrop) where Mesen2 PASSes (blue) -- an HDMA timing behaviour NESER
-    /// gets wrong.
+    /// #3062: NESER runs to completion but the ROM's self-check FAILS (a flat
+    /// `(66, 0, 0)` fill, settled from frame 30) where Mesen2 PASSes (blue) --
+    /// an HDMA timing behaviour NESER gets wrong.
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); pending #3062"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdmatiming_passes() {
-        run_rom_screen_crc("test_hdmatiming.smc", 600, 0x8662_6F50);
+        run_rom_screen_crc("test_hdmatiming.smc", 600, 0x8695_BBB0);
     }
 }

--- a/src/snes/integration_tests/kungfufurby_irq_tests.rs
+++ b/src/snes/integration_tests/kungfufurby_irq_tests.rs
@@ -88,7 +88,7 @@ mod tests {
     /// where Mesen2 PASSes (blue). Unaffected by #3049's per-cycle NMI/IRQ
     /// dispatch fixes (identical CRC before/after).
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
+    #[ignore = "self-check FAILs (maroon) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn test_irq_passes() {
         run_rom_screen_crc("test_irq.smc", 600, 0x8695_BBB0);
     }
@@ -97,7 +97,7 @@ mod tests {
     /// (blue). Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes
     /// (identical CRC before/after).
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
+    #[ignore = "self-check FAILs (maroon) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn test_irq4200_passes() {
         run_rom_screen_crc("test_irq4200.smc", 600, 0x8695_BBB0);
     }
@@ -106,7 +106,7 @@ mod tests {
     /// (blue). Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes
     /// (identical CRC before/after).
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
+    #[ignore = "self-check FAILs (maroon) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn test_irq4209_passes() {
         run_rom_screen_crc("test_irq4209.smc", 600, 0x8695_BBB0);
     }

--- a/src/snes/integration_tests/kungfufurby_irq_tests.rs
+++ b/src/snes/integration_tests/kungfufurby_irq_tests.rs
@@ -13,18 +13,26 @@
 //! increment 2, found to share `kungfufurby_nmi_tests`' interrupt-dispatch
 //! root cause, tracked in #3049). #3049's per-CPU-cycle NMI and H/V-IRQ
 //! dispatch fixes (see `src/snes/cpu/cpu.rs`) fixed `demo_irqtest.smc`,
-//! pixel-verified against Mesen2 at frame 600. The remaining five are
-//! unaffected by either fix (identical CRCs before/after) -- their
-//! divergence is a different residual gap, not yet identified, matching
-//! `kungfufurby_nmi_tests::test_nmi_passes`'s status.
+//! pixel-verified against Mesen2 at frame 600. The remaining five still
+//! render their FAIL backdrop and are tracked in #3093 together with
+//! `kungfufurby_nmi_tests::test_nmi_passes`: both families show the same
+//! shape (the `demo_*` ROM passes, every other ROM renders the identical
+//! maroon FAIL fill), which is evidence of one shared residual gap.
 //!
-//! `irq.smc` and `test_irqb.smc` share the literal CRC `0xDEAD_FA89` below
-//! (also shared with `kungfufurby_nmi_tests::nmi.smc`'s old, no-longer-used
-//! placeholder). This is not a copy-pasted placeholder: their FAIL screen is
-//! a flat solid-red fill (see the module doc above), and a flat fill of the
-//! same colour and dimensions hashes identically regardless of which ROM
-//! produced it -- confirmed by capturing each independently with
-//! `NESER_CAPTURE_SCREEN=1`.
+//! **Golden convention (#3092).** The five ignored tests below assert the
+//! *Mesen2-correct* blue PASS screen, not NESER's current output. They
+//! therefore FAIL under `cargo test --include-ignored` until #3093 lands --
+//! that is the designed state, not a regression -- and turn green exactly
+//! when the underlying gap is fixed. Recording NESER's own diverging CRC
+//! instead (the convention these tests used before #3092) inverts that
+//! signal: a real fix would turn them red and read as a breakage.
+//!
+//! Every golden here was verified against a fresh Mesen2 headless capture
+//! (`--testRunner`, flags per the `snes-hardware-research` skill) at the
+//! same frame the test samples: each is a uniform `(0, 0, 255)` 256x224
+//! fill hashing to `0x8695_BBB0`. That one literal recurs across every
+//! blue-PASS golden in the SNES suite because a flat fill of a given
+//! colour and size hashes identically whichever ROM produced it.
 
 use super::rom_runner::{RunConfig, RunExitReason, RunOracle, run_rom_with_oracle};
 use std::fs;
@@ -39,9 +47,10 @@ mod tests {
     /// Runs a KungFuFurby IRQ ROM to `frames` and asserts the rendered
     /// screen matches the Mesen2-approved PASS golden CRC32.
     ///
-    /// To approve a new golden, run with NESER_CAPTURE_SCREEN=1, visually
-    /// confirm the capture under target/snes_test_captures/ against a
-    /// Mesen2 headless capture at the same frame, then record the CRC here.
+    /// To approve a new golden, run with NESER_CAPTURE_SCREEN=1 and diff the
+    /// capture under target/snes_test_captures/ against a Mesen2 headless
+    /// capture at the same frame *programmatically* (never by eye), then
+    /// record the CRC here.
     fn run_rom_screen_crc(file: &str, frames: u32, expected_crc: u32) {
         let path = Path::new(ROOT).join(file);
         let rom = fs::read(&path)
@@ -66,49 +75,49 @@ mod tests {
         );
     }
 
-    /// NESER's current CRC (red/fail state), NOT a Mesen2-approved golden.
+    /// #3093: NESER's self-check FAILs (flat red) where Mesen2 PASSes (blue).
     /// Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes (identical CRC
-    /// before/after); root cause not yet identified.
+    /// before/after).
     #[test]
-    #[ignore = "root cause not yet identified; pending #3049 follow-up"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn irq_passes() {
-        run_rom_screen_crc("irq.smc", 1200, 0xDEAD_FA89);
+        run_rom_screen_crc("irq.smc", 1200, 0x8695_BBB0);
     }
 
-    /// NESER's current CRC (red/fail state), NOT a Mesen2-approved golden.
-    /// Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes (identical CRC
-    /// before/after); root cause not yet identified.
+    /// #3093: NESER's self-check FAILs (flat maroon, settled from frame 9)
+    /// where Mesen2 PASSes (blue). Unaffected by #3049's per-cycle NMI/IRQ
+    /// dispatch fixes (identical CRC before/after).
     #[test]
-    #[ignore = "root cause not yet identified; pending #3049 follow-up"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn test_irq_passes() {
-        run_rom_screen_crc("test_irq.smc", 600, 0x0B56_4EEF);
+        run_rom_screen_crc("test_irq.smc", 600, 0x8695_BBB0);
     }
 
-    /// NESER's current CRC (red/fail state), NOT a Mesen2-approved golden.
-    /// Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes (identical CRC
-    /// before/after); root cause not yet identified.
+    /// #3093: NESER's self-check FAILs (flat maroon) where Mesen2 PASSes
+    /// (blue). Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes
+    /// (identical CRC before/after).
     #[test]
-    #[ignore = "root cause not yet identified; pending #3049 follow-up"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn test_irq4200_passes() {
-        run_rom_screen_crc("test_irq4200.smc", 600, 0x0B56_4EEF);
+        run_rom_screen_crc("test_irq4200.smc", 600, 0x8695_BBB0);
     }
 
-    /// NESER's current CRC (red/fail state), NOT a Mesen2-approved golden.
-    /// Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes (identical CRC
-    /// before/after); root cause not yet identified.
+    /// #3093: NESER's self-check FAILs (flat maroon) where Mesen2 PASSes
+    /// (blue). Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes
+    /// (identical CRC before/after).
     #[test]
-    #[ignore = "root cause not yet identified; pending #3049 follow-up"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn test_irq4209_passes() {
-        run_rom_screen_crc("test_irq4209.smc", 600, 0x0B56_4EEF);
+        run_rom_screen_crc("test_irq4209.smc", 600, 0x8695_BBB0);
     }
 
-    /// NESER's current CRC (red/fail state), NOT a Mesen2-approved golden.
+    /// #3093: NESER's self-check FAILs (flat red) where Mesen2 PASSes (blue).
     /// Unaffected by #3049's per-cycle NMI/IRQ dispatch fixes (identical CRC
-    /// before/after); root cause not yet identified.
+    /// before/after).
     #[test]
-    #[ignore = "root cause not yet identified; pending #3049 follow-up"]
+    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn test_irqb_passes() {
-        run_rom_screen_crc("test_irqb.smc", 600, 0xDEAD_FA89);
+        run_rom_screen_crc("test_irqb.smc", 600, 0x8695_BBB0);
     }
 
     /// Fixed by #3049's per-cycle H/V-IRQ dispatch fix (`irq_line_shadow`,

--- a/src/snes/integration_tests/kungfufurby_nmi_tests.rs
+++ b/src/snes/integration_tests/kungfufurby_nmi_tests.rs
@@ -12,6 +12,14 @@
 //! at frame 600 (nmi.smc transitions blue between frames ~450-600;
 //! test_nmi.smc between ~30-60; demo_nmitest.smc is stable blue from
 //! frame 5).
+//!
+//! **Golden convention (#3092).** `test_nmi_passes` below asserts the
+//! Mesen2-correct blue PASS screen, not NESER's current output, so it FAILs
+//! under `cargo test --include-ignored` until #3093 lands -- the designed
+//! state, not a regression. See `kungfufurby_irq_tests`' module doc for the
+//! rationale; the IRQ family is tracked on the same issue because both show
+//! the same shape (the `demo_*` ROM passes, every other ROM renders the
+//! identical maroon FAIL fill).
 
 use super::rom_runner::{RunConfig, RunExitReason, RunOracle, run_rom_with_oracle};
 use std::fs;
@@ -26,9 +34,10 @@ mod tests {
     /// Runs a KungFuFurby NMI ROM to `frames` and asserts the rendered
     /// screen matches the Mesen2-approved PASS golden CRC32.
     ///
-    /// To approve a new golden, run with NESER_CAPTURE_SCREEN=1, visually
-    /// confirm the capture under target/snes_test_captures/ against a
-    /// Mesen2 headless capture at the same frame, then record the CRC here.
+    /// To approve a new golden, run with NESER_CAPTURE_SCREEN=1 and diff the
+    /// capture under target/snes_test_captures/ against a Mesen2 headless
+    /// capture at the same frame *programmatically* (never by eye), then
+    /// record the CRC here.
     fn run_rom_screen_crc(file: &str, frames: u32, expected_crc: u32) {
         let path = Path::new(ROOT).join(file);
         let rom = fs::read(&path)
@@ -78,7 +87,10 @@ mod tests {
         run_rom_screen_crc("nmi.smc", 600, 0x8695_BBB0);
     }
 
-    /// NESER's current CRC (red/fail state), NOT a Mesen2-approved golden.
+    /// #3093: NESER's self-check FAILs where Mesen2 PASSes (blue). NESER
+    /// settles on a flat maroon `(82, 0, 0)` fill from frame 61 onward, so
+    /// frame 120 samples a stable screen.
+    ///
     /// `nmi_passes`' #3049 per-cycle dispatch fix does NOT change this ROM's
     /// outcome (identical CRC before/after) -- this self-checking ROM's
     /// divergence is a different residual gap. A spike extending the
@@ -88,10 +100,15 @@ mod tests {
     /// mirror of the PHA fix (needed to close `nmi.smc`'s own remaining
     /// 5-line bus-trace residual, see `nmi_passes`) is NOT this ROM's root
     /// cause. Root cause not yet identified; needs fresh investigation.
-    /// Tracked as a follow-up to #3049.
+    ///
+    /// Until #3092 this test asserted `0x8662_6F50`, which matched neither a
+    /// PASS nor NESER's own output -- that literal is a flat `(66, 0, 0)`
+    /// fill, the settled screen of `test_hdmatiming.smc`, not of this ROM.
+    /// Being `#[ignore]`d, the mismatch went unnoticed from #2883 until the
+    /// #3092 audit.
     #[test]
-    #[ignore = "root cause not yet identified (push/pull cycle-ordering ruled out); pending #3049 follow-up"]
+    #[ignore = "self-check FAILs (maroon) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3093"]
     fn test_nmi_passes() {
-        run_rom_screen_crc("test_nmi.smc", 120, 0x8662_6F50);
+        run_rom_screen_crc("test_nmi.smc", 120, 0x8695_BBB0);
     }
 }

--- a/src/snes/ppu/background.rs
+++ b/src/snes/ppu/background.rs
@@ -1134,15 +1134,15 @@ mod tests {
         ppu.write_register(0x2105, 0x05); // mode 5 from SWITCH_COLUMN on
         render_lines(&mut ppu, 1);
 
-        for x in 0..SWITCH_COLUMN {
+        for (x, &native) in native_row.iter().enumerate() {
             assert_eq!(
                 ppu.framebuffer[x * 2],
-                native_row[x],
+                native,
                 "converted column {x} keeps the colour it was drawn with"
             );
             assert_eq!(
                 ppu.framebuffer[x * 2 + 1],
-                native_row[x],
+                native,
                 "converted column {x} is doubled into the odd output column"
             );
         }


### PR DESCRIPTION
Closes #3092.

## Why this is not what the issue originally asked for

#3092 asked to remove the #[ignore] from five KungFuFurby IRQ tests because "they pass today". They do. The ROMs do not.

RunOracle::ScreenCrc sets

    passed = (actual_crc == expected_crc)

and has no notion of a ROM's own PASS/FAIL state, so those five goldens recorded NESER's red/maroon FAIL screen - as the module doc said at the time ("NESER's current CRC (red/fail state), NOT a Mesen2-approved golden"). Un-ignoring them would have locked five known-wrong screens into CI under names ending in _passes, and inverted the signal: a correct fix to IRQ dispatch would have turned all five red and read as a regression.

Verified by capturing with NESER_CAPTURE_SCREEN=1 and checking pixels plus an independent CRC recomputation - #3049 fixed only demo_irqtest.smc:

| ROM | Frame | NESER | Old golden |
| --- | --- | --- | --- |
| demo_irqtest.smc | 600 | flat (0,0,255) blue | 0x8695BBB0 (real PASS) |
| irq.smc | 1200 | flat (255,0,0) red | 0xDEADFA89 |
| test_irqb.smc | 600 | flat (255,0,0) red | 0xDEADFA89 |
| test_irq / 4200 / 4209 | 600 | flat (82,0,0) maroon | 0x0B564EEF |

The issue body has been rewritten to record this rather than silently dropping the false premise.

## What this PR does

Converts all thirteen self-check divergence tests to assert the Mesen2-correct blue PASS golden (0x8695BBB0, uniform 256x224 blue) while keeping their #[ignore]. Under --include-ignored they fail today and turn green exactly when the underlying gap is fixed. The *_passes names and the existing "expected PASS (blue)" assert message become accurate as a result.

Un-ignores the two ddribin tests, which a closed issue had actually fixed - the genuine "re-enable what #3001 fixed" case #3092 was reaching for.

    kungfufurby_irq_tests     5 tests  -> #3093
    kungfufurby_nmi_tests     1 test   -> #3093
    kungfufurby_hdma_tests    3 tests  -> #3062
    jonasquinn_dma_tests      4 tests  -> #3062 / #3063
    ddribin_hdrv_tests        2 tests  un-ignored, +2 live CI guards

test_dmatiming_matches_mesen2 is deliberately excluded and says so in the code: it is a pixel-diff against Mesen2's picture, not a PASS/FAIL self-check.

No emulator behaviour or timing code is touched.

## Three defects found while auditing

1. test_nmi_passes asserted 0x86626F50 - a flat (66,0,0) fill belonging to test_hdmatiming.smc, a different ROM. NESER's test_nmi.smc settles on 0x0B564EEF from frame 61. Being ignored hid it from #2883 until now.

2. test_hdmasync (both byte-identical copies) sampled frame 600, where BOTH emulators render black - so it asserted agreement with the reference and could never detect the divergence. Mesen2 goes blue at frame 1029, NESER red. Moved to frame 1100; the module tick budget rises to 600M because frame 1100 needs ~393M and the old 400M cap cleared it by only ~19 frames. Written up on #3062.

3. Both ddribin ignores cited closed #3001, whose fix (be79fa22) changed capture geometry and rotted their goldens - unnoticed because they were ignored. Both now match Mesen2 byte-for-byte.

## Reviewer note: one knowingly weak assertion

overscan_toggle's re-approved golden (0xF7459692) is byte-identical to colorbars_default's, because overscan only adds lines below row 223 and both emulators crop the capture to 224 rows. It therefore guards rows 0-223 against corruption but cannot detect overscan being ignored altogether. It matches Mesen2 exactly, so it is a valid golden, and the limitation is documented in the code and tracked in #3096 - but it is the one place here where a passing test asserts less than its name implies.

## Verification

- Mesen2 headless capture per ROM at each test's own sample frame - 15 in total, none taken on trust. The scripted-input pipeline was proven first with a control: Mesen2's colorbars_default at frame 371 reproduced NESER's approved 0xF7459692 byte-for-byte.
- Full suite: 12798 passed, 0 failed, 31 ignored, 0 filtered out. #[ignore] count 38 -> 36, exactly the two removals.
- --include-ignored: 13 fail, 6 pass; every failure at exit=ScreenCrcFrame (not TickLimit) with the CRC a settle probe predicted independently.
- ddribin run three times for stability; both new goldens mutation-checked by perturbing one bit, confirmed failing, then reverted.
- clippy --all-targets --all-features -D warnings clean, cargo fmt clean.
- Python 113 + 113 + 44 pass, npm 430 pass, wasm-pack headless chrome pass.

## Issues opened or corrected

- #3092 rewritten and retitled (premise was false).
- #3093 widened to both KungFuFurby interrupt families and its "the five IRQ ROMs now pass" claim corrected.
- #3062 and #3063 annotated with the convention change and the test_hdmasync finding.
- #3096 new: overscan screen CRC cannot distinguish overscan on from off.
- #3097 new: two Game Boy tests ignored against closed issues (#1993, #2293).

The first commit carries over two documentation files left uncommitted from PR #3089, kept separate so they are distinguishable in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
