### PR TITLE
SNES: localise the hvdma row-107 residual -- a renderer model gap, not DMA (#3042)

### DIFF
--- a/.github/skills/snes-hardware-research/SKILL.md
+++ b/.github/skills/snes-hardware-research/SKILL.md
@@ -723,9 +723,47 @@ scratch:
 
 - **Diff**: `python -m scripts.diff_bus_traces <neser.log> <mesen.log>`.
 
+Two traps when tracing DMA specifically, both hit in issue 3042:
+
+- **Mesen2's DMA traffic does not go through `Read`/`Write`.** `CopyDmaByte` uses
+  `_memoryManager->ReadDma`/`WriteDma`, which the original hook did not cover, so a
+  window spanning a transfer logged *nothing but `idle`* -- easy to misread as "the CPU
+  is halted and there is nothing to see" when in fact the entire burst was invisible.
+  `NeserBusLog::LogDma` now covers both; it also logs the value, because clocks alone
+  cannot tell two adjacent VMDATA bytes apart when comparing against NESER's
+  `write 2118=03` PPU trace.
+- **Rebuilding `make core` is not enough.** The app extracts its embedded copy of
+  `MesenCore.dylib` into `~/Library/Application Support/Mesen2/` on every start and
+  *overwrites* whatever is there, so a hand-copied dylib is silently reverted. Run
+  `make ui` (which re-embeds the freshly built core) and use the binary under
+  `bin/osx-arm64/Release/osx-arm64/publish/`. To confirm which copy is live:
+  `DYLD_PRINT_LIBRARIES=1 <mesen> ... 2>&1 | grep -i mesencore`, and check the new code
+  is really in it with `strings <dylib> | grep '<your new format string>'`.
+
+Anchors line up better than expected: over 214 million master clocks both emulators were
+within a few hundred of each other on the same ROM, so a window derived from NESER's
+clocks can be reused verbatim on the Mesen2 side.
+
 Stamp both sides at the *same point within the cycle* or every line is offset
 by the access speed. NESER's reads are stamped `speed - 4` clocks into the
 cycle and writes at its end, matching Mesen2's `_execRead`/`_execWrite` split.
+
+### An exact bus-clock match does not imply matching pixels (from 3042)
+
+A trace diff answers "do both emulators put the same values on the bus at the same
+clocks". It says nothing about when each one *consumes* them. Issue 3042 was filed
+against HDMA B-bus write-clock jitter and survived three rounds of DMA work; the trace
+finally showed all 24 writes of the relevant burst identical in register, value **and**
+master clock, while the frame still differed by 16 px. The cause was downstream: NESER
+samples VRAM per dot inside `bg_pixel`, whereas Mesen2 pre-fetches tilemap and CHR into
+`_layerData` in chunks bounded by H=263 and skips fetching while forced blank is set. On
+a row the beam is drawing while a burst rewrites it, those two models disagree.
+
+So when a pixel divergence outlives an exact bus match, stop looking at the producer and
+go and read the consumer. The corollary is worth stating too: a residual's *name* can be
+wrong for a long time. Three separate re-approvals attributed this one to write-clock
+jitter because it moved whenever DMA or CPU timing changed -- moving with a change proves
+sensitivity, not causation.
 
 ### Distinguish a transient divergence from a persistent one (from #3050)
 

--- a/src/snes/integration_tests/hblank_dma_vram_tests.rs
+++ b/src/snes/integration_tests/hblank_dma_vram_tests.rs
@@ -137,8 +137,31 @@ mod tests {
     // essentially all of the per-byte write-clock jitter that #3042 tracks.
     // Re-approved again for #3049 (per-CPU-cycle NMI/H-V-IRQ dispatch
     // precision): still confined to row 107, now 16 px (was 4) vs a fresh
-    // Mesen2 capture -- the same CPU-side clock-skew category #3050 already
-    // tracks, just a different exact skew now that dispatch timing moved.
+    // Mesen2 capture.
+    //
+    // Issue 3042 localised that remaining 16 px, and it is NOT a DMA timing
+    // problem -- which is what that issue was originally filed against. Both
+    // emulators' bus traces were compared over the burst that immediately
+    // precedes the divergent row (the ROM force-blanks at scanline 107 dot 284,
+    // sets VMADD, bursts VMDATA, unblanks at dot 330). All 24 B-bus writes are
+    // identical: same registers, same values, same master clocks. The HDMA
+    // envelope is exact.
+    //
+    // What is left is a renderer model difference. NESER has no BG tile
+    // pre-fetch stage -- `bg_pixel` indexes VRAM at the dot being rendered --
+    // whereas Mesen2 pre-fetches tilemap and CHR into `_layerData` in chunks
+    // bounded by H=263 and skips fetching entirely while forced blank is set.
+    // On the transition row, where the burst is still rewriting the tiles the
+    // beam is about to draw, the two models disagree about which tiles carry
+    // old versus new data. Both emulators show a partial-update artifact there;
+    // they place it at different columns (NESER at 42-55, Mesen2 at 242-255).
+    //
+    // Closing that gap means giving NESER a fetch stage, which is a renderer
+    // change far larger than this residual justifies, so it is recorded rather
+    // than chased. The mechanism is pinned by
+    // `snes::ppu::background::tests::a_vram_write_mid_scanline_changes_the_pixels_to_its_right_on_the_same_line`
+    // -- that test explains the model and will fail if a fetch stage is added,
+    // which is the moment to re-measure this golden.
     hblank_dma_vram_rom_test!(
         hvdma_matches_mesen2_and_hardware,
         "hvdma.sfc",

--- a/src/snes/ppu/background.rs
+++ b/src/snes/ppu/background.rs
@@ -3286,6 +3286,74 @@ mod tests {
     const WHITE: [u8; 3] = [255, 255, 255];
     const BLACK: [u8; 3] = [0, 0, 0];
 
+    /// NESER has **no BG tile pre-fetch stage**: `bg_pixel` indexes `self.vram` at the
+    /// dot being rendered, so a VRAM write landing mid-scanline is visible to every dot
+    /// after it on that same line. Mesen2 instead pre-fetches tilemap and CHR into
+    /// `_layerData` in chunks bounded by H=263 (`SnesPpu::FetchTileData`), and skips
+    /// fetching altogether while forced blank is set -- so there, the same write reaches
+    /// a tile only if it precedes that tile's fetch.
+    ///
+    /// This model difference is what is left of issue 3042. The HDMA B-bus write clocks
+    /// it was filed against are **not** the cause: over the burst preceding the divergent
+    /// row, both emulators issue the identical 24 B-bus writes -- same registers, same
+    /// values, same master clocks. What differs is when each one SAMPLES what was written.
+    ///
+    /// This is a characterisation test, not a correctness claim. Real hardware fetches
+    /// ahead of the beam, which is closer to Mesen2's model than to NESER's. It is pinned
+    /// so that introducing a fetch stage trips a named test that explains itself, instead
+    /// of silently moving a screen-CRC golden.
+    #[test]
+    fn a_vram_write_mid_scanline_changes_the_pixels_to_its_right_on_the_same_line() {
+        let render_row0_with_midline_vram_write = |write_at: Option<u16>| {
+            let mut ppu = Ppu::new();
+            setup_white_bg1(&mut ppu);
+            if let Some(column) = write_at {
+                tick_to_column(&mut ppu, column);
+                // VRAM is CPU-writable only in VBlank or forced blank, so take the same
+                // route the hvdma ROM does: force-blank, then burst. The row still
+                // renders, because INIDISP is latched once per scanline at its first
+                // visible dot and this write lands after that (the #2973 limitation).
+                ppu.write_register(0x2100, 0x8F);
+                // Blank char 1 so its pixels fall through to the backdrop. A 2bpp char is
+                // 8 words, so char 1 starts at word 8.
+                ppu.write_register(0x2115, 0x80); // VMAIN: increment after high byte
+                ppu.write_register(0x2116, 0x08);
+                ppu.write_register(0x2117, 0x00);
+                for _ in 0..8 {
+                    ppu.write_register(0x2118, 0x00);
+                    ppu.write_register(0x2119, 0x00);
+                }
+            }
+            render_lines(&mut ppu, 1);
+            let rgb = ppu.screen_snapshot_rgb();
+            (0..256).map(|x| pixel(&rgb, x, 0)).collect::<Vec<_>>()
+        };
+
+        // Control: no mid-line write, so the whole row keeps the original tile.
+        let control = render_row0_with_midline_vram_write(None);
+        assert!(
+            control.iter().all(|&px| px == WHITE),
+            "control row must be uniformly white, or the split below proves nothing"
+        );
+
+        // Two split points, so the boundary is shown to track the write rather than
+        // landing at one column by coincidence.
+        for column in [60u16, 120] {
+            let split = render_row0_with_midline_vram_write(Some(column));
+            let boundary = usize::from(column);
+            assert!(
+                split[..=boundary].iter().all(|&px| px == WHITE),
+                "write at {column}: columns rendered before it keep the tile data they \
+                 were drawn with"
+            );
+            assert!(
+                split[boundary + 1..].iter().all(|&px| px == BLACK),
+                "write at {column}: columns rendered after it already see the new VRAM \
+                 contents -- NESER samples VRAM per dot, with no fetch stage in between"
+            );
+        }
+    }
+
     #[test]
     fn window_mask_settings_decode_enable_from_the_high_bit_of_each_pair() {
         // W12SEL/W34SEL/WOBJSEL nibbles are `EIei`: within each 2-bit pair the


### PR DESCRIPTION
Closes #3042.

## Outcome: localised and recorded, not fixed

The planned stopping rule for this issue was "localise first, fix only if clean; if the trace shows a structural mismatch a local fix cannot bridge, record a reproducible witness instead". The trace produced the second outcome, and it also **refuted the issue's premise**.

## The issue was chasing the wrong thing

#3042 was filed against HDMA B-bus write-clock jitter and carried that name through three re-approvals, because the residual moved whenever DMA or CPU timing changed. Moving with a change proves sensitivity, not causation.

Two of its three named residuals were already gone before this branch (`hdmaen_latch_test_2` and StarWars are both 0 px since #3021/#3050), and its described mechanism -- the "trigger + 34, then +8/byte" deadline queue -- no longer exists. The body and title were re-scoped to the one surviving residual before any work.

## What the trace shows

Over the burst that immediately precedes the divergent row -- the ROM force-blanks at scanline 107 dot 284, sets VMADD, bursts VMDATA, unblanks at dot 330 -- both emulators issue **all 24 B-bus writes identically: same registers, same values, same master clocks.** Diffed programmatically, not by eye. The HDMA envelope is exact.

## What it actually is

A renderer model difference, downstream of the bus:

- **NESER** has no BG tile pre-fetch stage. `bg_pixel` indexes VRAM at the dot being rendered, so a write landing mid-scanline is visible to every dot after it on that line.
- **Mesen2** pre-fetches tilemap and CHR into `_layerData` in chunks bounded by H=263 (`SnesPpu::FetchTileData`), and returns early without fetching while forced blank is set.

On the transition row the burst is still rewriting the very tiles the beam is about to draw, so the models disagree about which tiles carry old versus new data. Both emulators show a partial-update artifact; they place it at different columns -- NESER at 42-55, Mesen2 at 242-255 -- which is why neither side reads as simply early or late.

Closing that gap means giving NESER a fetch stage: a renderer change touching every BG mode, mosaic, offset-per-tile and hires, to buy 16 px on one row of one test ROM. Not a trade worth making, and deliberately not smuggled in here.

## What lands

- A characterisation test pinning the mechanism, with a control and **two** split points so the boundary is shown to track the write rather than landing somewhere by coincidence. Adding a fetch stage fails it by name -- the signal to re-measure the hvdma golden.
- The `hvdma` test comment carries the finding, replacing the write-clock attribution, for whoever next re-approves that CRC.
- `snes-hardware-research` gains the general lesson (an exact bus-clock match does not imply matching pixels -- go read the consumer) and two tracing traps that cost real time here:
  - Mesen2's DMA goes through `ReadDma`/`WriteDma`, which the #3050 hook did not cover, so a window spanning a burst logged **nothing but `idle`** -- easy to misread as "nothing to see".
  - `make core` is not enough: the app re-extracts its embedded `MesenCore.dylib` into `~/Library/Application Support/Mesen2/` on every start, silently reverting a hand-copied rebuild. `make ui` is required.

The Mesen2-side hook was extended locally (`NeserBusLog::LogDma`) to make DMA traffic visible at all; that is in the Mesen2 checkout, not this repo, consistent with the existing non-upstream hook.

No behaviour change. No golden moved.

## Checkpoints

`cargo clippy` clean, `cargo fmt` applied, `cargo test --no-default-features --lib` 12825 passed / 0 failed, `wasm-pack` 94 passed, Python 250+113+44 OK, `npm test` 430 passed.

Also closed #3099 as superseded by #3092/#3096 while working through this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
