### PR TITLE
Testing: gate golden-fixture regeneration behind NESER_REGENERATE_FIXTURES (#3107)

### DIFF
--- a/src/gb/console/save_state.rs
+++ b/src/gb/console/save_state.rs
@@ -536,12 +536,21 @@ mod tests {
     }
 
     /// Regenerates the committed golden save-state fixture used by
-    /// `test_golden_save_state_v6_loads`. Run manually only after an
-    /// intentional, reviewed change to the save-state format:
-    /// `cargo test --no-default-features --lib \
+    /// `test_golden_save_state_v6_loads`.
+    ///
+    /// Appropriate only when `GB_SAVESTATE_VERSION` is bumped -- at which point
+    /// the old fixture fails that test's version assertion anyway. Regenerating
+    /// at an unchanged version is destructive: the fixture's whole value is that
+    /// an *older* build wrote it, so replacing it with current output leaves a
+    /// file that still claims the same version while containing today's schema,
+    /// and the load test then proves nothing.
+    ///
+    /// Writing is therefore opt-in, so `cargo test -- --include-ignored` cannot
+    /// clobber the fixture (#3107):
+    /// `NESER_REGENERATE_FIXTURES=1 cargo test --no-default-features --lib \
     ///   gb::console::save_state::tests::regenerate_golden_save_state_fixture -- --ignored`
     #[test]
-    #[ignore = "regenerates a committed fixture; run manually"]
+    #[ignore = "regenerates a committed fixture; run manually with NESER_REGENERATE_FIXTURES=1"]
     fn regenerate_golden_save_state_fixture() {
         let mut gb = make_dmg();
         for _ in 0..1000 {
@@ -549,6 +558,9 @@ mod tests {
         }
         let bytes = gb.save_state().to_bytes().expect("serialize save state");
         let compressed = crate::platform::save_state::gzip_compress(&bytes);
+        if !crate::platform::save_state::fixture_regeneration_enabled() {
+            return;
+        }
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/gb/console/testdata");
         std::fs::create_dir_all(&dir).expect("create testdata dir");
         std::fs::write(dir.join("savestate_golden_v6.json.gz"), compressed).expect("write fixture");
@@ -558,7 +570,8 @@ mod tests {
     fn test_golden_save_state_v6_loads() {
         // A save-state captured from a previous build must still load, proving
         // the on-disk format stayed backward-compatible across the
-        // shared-helper refactor.
+        // shared-helper refactor. Do not regenerate the fixture to "refresh"
+        // it: it is meaningful precisely because an older build produced it.
         let compressed = include_bytes!("testdata/savestate_golden_v6.json.gz");
         let bytes = crate::platform::save_state::gzip_decompress(compressed);
         let state = GbSaveState::from_bytes(&bytes).expect("golden save state should deserialize");

--- a/src/gba/console/save_state.rs
+++ b/src/gba/console/save_state.rs
@@ -464,12 +464,21 @@ mod tests {
     }
 
     /// Regenerates the committed golden save-state fixture used by
-    /// `test_golden_save_state_v7_loads`. Run manually only after an
-    /// intentional, reviewed change to the save-state format:
-    /// `cargo test --no-default-features --lib \
+    /// `test_golden_save_state_v7_loads`.
+    ///
+    /// Appropriate only when `GBA_SAVESTATE_VERSION` is bumped -- at which point
+    /// the old fixture fails that test's version assertion anyway. Regenerating
+    /// at an unchanged version is destructive: the fixture's whole value is that
+    /// an *older* build wrote it, so replacing it with current output leaves a
+    /// file that still claims the same version while containing today's schema,
+    /// and the load test then proves nothing.
+    ///
+    /// Writing is therefore opt-in, so `cargo test -- --include-ignored` cannot
+    /// clobber the fixture (#3107):
+    /// `NESER_REGENERATE_FIXTURES=1 cargo test --no-default-features --lib \
     ///   gba::console::save_state::tests::regenerate_golden_save_state_fixture -- --ignored`
     #[test]
-    #[ignore = "regenerates a committed fixture; run manually"]
+    #[ignore = "regenerates a committed fixture; run manually with NESER_REGENERATE_FIXTURES=1"]
     fn regenerate_golden_save_state_fixture() {
         let mut gba = make_gba();
         for _ in 0..1000 {
@@ -477,6 +486,9 @@ mod tests {
         }
         let bytes = gba.save_state().to_bytes().expect("serialize save state");
         let compressed = crate::platform::save_state::gzip_compress(&bytes);
+        if !crate::platform::save_state::fixture_regeneration_enabled() {
+            return;
+        }
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/gba/console/testdata");
         std::fs::create_dir_all(&dir).expect("create testdata dir");
         std::fs::write(dir.join("savestate_golden_v7.json.gz"), compressed).expect("write fixture");
@@ -486,7 +498,8 @@ mod tests {
     fn test_golden_save_state_v7_loads() {
         // A save-state captured from a previous build must still load, proving
         // the on-disk format stayed backward-compatible across the
-        // shared-helper refactor.
+        // shared-helper refactor. Do not regenerate the fixture to "refresh"
+        // it: it is meaningful precisely because an older build produced it.
         let compressed = include_bytes!("testdata/savestate_golden_v7.json.gz");
         let bytes = crate::platform::save_state::gzip_decompress(compressed);
         let state = GbaSaveState::from_bytes(&bytes).expect("golden save state should deserialize");

--- a/src/nes/console/nes.rs
+++ b/src/nes/console/nes.rs
@@ -2437,18 +2437,37 @@ mod tests {
         }
     }
 
+    /// Fixed RAM seed for the golden fixture, so regenerating produces a
+    /// reviewable diff instead of fresh noise. `Config::default()` uses
+    /// `RamInitMode::Random` off wasm, which made every regeneration differ in
+    /// its RAM contents and hid whether the *format* had actually changed --
+    /// unhelpful when the diff is an opaque `.gz` (#3107).
+    const GOLDEN_FIXTURE_RAM_SEED: u64 = 0x3107;
+
     /// Regenerates the committed golden save-state fixture used by
-    /// `test_golden_save_state_v8_loads`. Run manually only after an
-    /// intentional, reviewed change to the save-state format:
-    /// `cargo test --no-default-features --lib \
+    /// `test_golden_save_state_v8_loads`.
+    ///
+    /// Appropriate only when `SAVESTATE_VERSION` is bumped -- at which point the
+    /// old fixture fails that test's version assertion anyway. Regenerating at
+    /// an unchanged version is destructive: the fixture's whole value is that an
+    /// *older* build wrote it, so replacing it with current output leaves a file
+    /// that still claims the same version while containing today's schema, and
+    /// the load test then proves nothing.
+    ///
+    /// Writing is therefore opt-in, so `cargo test -- --include-ignored` cannot
+    /// clobber the fixture (#3107):
+    /// `NESER_REGENERATE_FIXTURES=1 cargo test --no-default-features --lib \
     ///   nes::console::nes::tests::regenerate_golden_save_state_fixture -- --ignored`
     #[test]
-    #[ignore = "regenerates a committed fixture; run manually"]
+    #[ignore = "regenerates a committed fixture; run manually with NESER_REGENERATE_FIXTURES=1"]
     fn regenerate_golden_save_state_fixture() {
         let rom_data = create_minimal_nrom_rom();
         let cartridge = load_test_cartridge(&rom_data);
+        let mut config = Config::default();
+        config.frontend.ram_init_mode =
+            crate::platform::config::RamInitMode::SeededRandom(GOLDEN_FIXTURE_RAM_SEED);
         let mut nes = Nes::new(crate::platform::app_context::AppContext::new_with_config(
-            Config::default(),
+            config,
         ));
         nes.insert_cartridge(cartridge);
         nes.reset(false);
@@ -2457,6 +2476,9 @@ mod tests {
         }
         let bytes = nes.save_state().to_bytes().expect("serialize save state");
         let compressed = crate::platform::save_state::gzip_compress(&bytes);
+        if !crate::platform::save_state::fixture_regeneration_enabled() {
+            return;
+        }
         let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/nes/console/testdata");
         std::fs::create_dir_all(&dir).expect("create testdata dir");
         std::fs::write(dir.join("savestate_golden_v8.json.gz"), compressed).expect("write fixture");
@@ -2466,7 +2488,8 @@ mod tests {
     fn test_golden_save_state_v8_loads() {
         // A save-state captured from a previous build must still load, proving
         // the on-disk format stayed backward-compatible across the
-        // shared-helper refactor.
+        // shared-helper refactor. Do not regenerate the fixture to "refresh"
+        // it: it is meaningful precisely because an older build produced it.
         let compressed = include_bytes!("testdata/savestate_golden_v8.json.gz");
         let bytes = crate::platform::save_state::gzip_decompress(compressed);
         let state = SaveState::from_bytes(&bytes).expect("golden save state should deserialize");

--- a/src/platform/save_state.rs
+++ b/src/platform/save_state.rs
@@ -134,6 +134,22 @@ pub(crate) fn gzip_compress(bytes: &[u8]) -> Vec<u8> {
         .expect("gzip finalize should not fail on an in-memory buffer")
 }
 
+/// Whether the golden-fixture regeneration tests may write to the repository.
+///
+/// The four `regenerate_golden_save_state_fixture` tests are `#[ignore]`d, but
+/// `cargo test -- --include-ignored` runs them anyway, and they overwrite
+/// committed fixtures. That is destructive rather than merely untidy: each
+/// fixture's value comes from having been written by an *older* build (see the
+/// `test_golden_save_state_v*_loads` tests), so regenerating one silently turns
+/// a compatibility test into a round-trip test, in an opaque `.gz` diff.
+///
+/// Gating the write on an explicit opt-in keeps any ordinary test run
+/// non-destructive. Presence-based, matching `NESER_CAPTURE_SCREEN`.
+#[cfg(test)]
+pub(crate) fn fixture_regeneration_enabled() -> bool {
+    std::env::var_os("NESER_REGENERATE_FIXTURES").is_some()
+}
+
 /// Gzip-decompress bytes produced by [`gzip_compress`].
 ///
 /// Test-only helper used by the per-console golden-fixture loading tests.

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -1382,12 +1382,24 @@ mod tests {
     }
 
     /// Regenerates the committed golden save-state fixture used by
-    /// `test_golden_save_state_v2_loads`. Run manually only after an
-    /// intentional, reviewed change to the save-state format:
-    /// `cargo test --no-default-features --lib \
+    /// `test_golden_save_state_v2_loads`.
+    ///
+    /// Appropriate only when `SNES_SAVESTATE_VERSION` is bumped -- at which
+    /// point the old fixture fails that test's version assertion anyway.
+    /// Regenerating at an unchanged version is destructive, and this fixture is
+    /// the clearest example in the repo: the committed file predates the
+    /// `nmi_arm_counter` / `irq_line_shadow` / `waiting` / `irq_lock_step` /
+    /// `irq_i_shadow` CPU fields added by #2985, #3049 and #3081, all of which
+    /// arrived without a version bump. It is the only fixture still proving
+    /// that a genuinely older v2 file loads. Overwrite it and that evidence is
+    /// gone, behind an opaque `.gz` diff.
+    ///
+    /// Writing is therefore opt-in, so `cargo test -- --include-ignored` cannot
+    /// clobber the fixture (#3107):
+    /// `NESER_REGENERATE_FIXTURES=1 cargo test --no-default-features --lib \
     ///   snes::console::snes::tests::regenerate_golden_save_state_fixture -- --ignored`
     #[test]
-    #[ignore = "regenerates a committed fixture; run manually"]
+    #[ignore = "regenerates a committed fixture; run manually with NESER_REGENERATE_FIXTURES=1"]
     fn regenerate_golden_save_state_fixture() {
         let rom = lorom_rom_with_battery_sram(0x05);
         let mut snes = make_snes();
@@ -1400,6 +1412,9 @@ mod tests {
             .to_bytes()
             .expect("serialize save state");
         let compressed = crate::platform::save_state::gzip_compress(&bytes);
+        if !crate::platform::save_state::fixture_regeneration_enabled() {
+            return;
+        }
         let dir =
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/snes/console/testdata");
         std::fs::create_dir_all(&dir).expect("create testdata dir");
@@ -1410,7 +1425,9 @@ mod tests {
     fn test_golden_save_state_v2_loads() {
         // A save-state captured from a previous build must still load, proving
         // the on-disk format stayed backward-compatible across the
-        // shared-helper refactor.
+        // shared-helper refactor. Do not regenerate the fixture to "refresh"
+        // it: it is meaningful precisely because an older build produced it,
+        // predating several CPU fields that current code emits.
         let compressed = include_bytes!("testdata/savestate_golden_v2.json.gz");
         let bytes = crate::platform::save_state::gzip_decompress(compressed);
         let state =


### PR DESCRIPTION
Closes #3107.

## Problem

The four `regenerate_golden_save_state_fixture` tests are `#[ignore]`d, but `cargo test -- --include-ignored` runs them and they `fs::write` into the tracked tree. Found when the #3092 ignored-test audit dirtied two fixtures without warning.

That is destructive, not untidy. Each fixture is paired with a `test_golden_save_state_v<N>_loads` asserting `state.version == CURRENT`, so a fixture can only ever be a same-version file written by an **older build** - which is precisely what makes it a compatibility test. Regenerating leaves a file still claiming the same version while carrying today's schema: the test keeps passing while proving nothing, behind an opaque `.gz` diff that is easy to wave through in review.

The SNES fixture is the clearest case. It predates the `nmi_arm_counter`, `irq_line_shadow`, `waiting`, `irq_lock_step` and `irq_i_shadow` CPU fields added by #2985, #3049 and #3081 without a version bump, and is the only fixture still proving a genuinely older v2 file loads.

## Change

Writes now require `NESER_REGENERATE_FIXTURES`. The tests still build, serialise and gzip, so their pass is not hollow - only the write is skipped. One shared helper in `src/platform/save_state.rs` keeps the variable name in one place, beside `gzip_compress`/`gzip_decompress` which all four regenerators already use.

Doc comments on both the regenerator and its loader now state the missing point: refreshing a fixture destroys the property that makes it a test, and regeneration is appropriate only when the version constant is bumped.

Also seeds the NES regenerator (`RamInitMode::SeededRandom`), since `Config::default()` is `RamInitMode::Random` off wasm and every regeneration previously differed in RAM contents - hiding whether the *format* had changed. The committed fixture is deliberately **not** regenerated; the load test checks deserialisation and version, not bytes.

## No new unit test, deliberately

The gate is `var(..).is_some()`, so a unit test would assert `Option::is_some()` rather than any behaviour of ours (navigator's call during planning). Verified behaviourally instead, which exercises the real call sites and the real environment:

| Check | Result |
| --- | --- |
| `--include-ignored` (the command that caused this) | tree clean, no testdata writes |
| Regeneration with the variable set | all four write |
| NES determinism | identical md5 across two runs (previously differed every run) |
| gb/gba/snes regeneration | byte-identical, as before |
| **Mutation: gate inverted** | fixtures dirtied again - gate is load-bearing |
| Fixtures afterwards | md5-identical to committed |

Full suite 12817 passed / 0 failed / 31 ignored (count unchanged); clippy `--all-targets --all-features -D warnings` and `cargo fmt --check` clean; wasm-pack 94 passed; python 250; npm 430.

## Follow-up filed: #3109

Measuring each fixture during verification confirmed a deeper weakness that this PR deliberately does not address: gb (v6) and gba (v7) regenerate **byte-identically** to current output, so their load tests are already round-trip tests rather than compatibility tests, and NES was effectively the same. Only SNES carries real evidence. Because the load test asserts `version == CURRENT`, historical-version fixtures can never be retained, so the decay is structural. #3109 also raises that "version 2" currently denotes two different SNES shapes.

Rebased onto b6f2c025 after #3102 and #3108 landed mid-implementation; submodule pin verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
