### PR TITLE
GB: reach OAM row 19 on the line after LCD enable (closes #3104)

### DIFF
--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -1551,15 +1551,16 @@ mod tests {
         [0, 1, 2, 3].map(|i| u16::from_le_bytes([oam[base + i * 2], oam[base + i * 2 + 1]]))
     }
 
+    /// Enable the LCD and stop at OAM-scan `row` of scan 1 (dot `4 * row`).
+    ///
+    /// Scan 0 is 452 dots = 113 M-cycles and has no OAM scan, so after that many
+    /// ticks the PPU sits at dot 0 of scan 1.  Mode 2 then walks one OAM row per
+    /// M-cycle from dot 0, so `row` more ticks land on `row`.  Rows 1..=19 are
+    /// observable; row 0 lives in the 4-dot "fake" HBlank that opens scan 1 and
+    /// is immune to corruption anyway.
     fn enable_lcd_and_tick_to_row(bus: &mut DmgBus, row: usize) {
         bus.write(0xFF40, 0x91); // enable LCD → timing resets
-        // Skip scan 0 (452 dots = 113 M-cycles) plus the 4T Mode 0 gap at the start
-        // of scan 1 (1 M-cycle) → lands at dot=4 of scan 1, which is OamScan row 0.
-        for _ in 0..114 {
-            bus.tick(1);
-        }
-        // Now at dot=4 of scan 1 (OamScan row 0); tick to the desired row.
-        for _ in 0..row {
+        for _ in 0..113 + row {
             bus.tick(1); // 1 M-cycle = 4 dots = 1 OAM row
         }
     }
@@ -1635,8 +1636,7 @@ mod tests {
 
     #[test]
     fn test_notify_idu_glitch_applies_corruption_at_row_18() {
-        // Given: PPU at OamScan row 18 (dot=76 of scan 1; last valid row — OamScan [4,80)).
-        // Row 18 = dot 76: (76-4)/4 = 18.
+        // Given: PPU at OamScan row 18 (dot=72).
         // row 17: b=0x0002, w1=0x0003, c=0x0004, w3=0x0005
         // row 18: a=0x0001
         // write formula: ((0x0001^0x0004)&(0x0002^0x0004))^0x0004 = 0x0000
@@ -1644,7 +1644,7 @@ mod tests {
         let mut bus = make_bus();
         set_row_words(&mut bus.ppu.oam, 17, [0x0002, 0x0003, 0x0004, 0x0005]);
         set_row_words(&mut bus.ppu.oam, 18, [0x0001, 0x00AA, 0x00BB, 0x00CC]);
-        enable_lcd_and_tick_to_row(&mut bus, 18); // dot=76, OamScan, row 18 (last on scan 1)
+        enable_lcd_and_tick_to_row(&mut bus, 18);
         bus.begin_instruction(); // pre-instruction snapshot (row 18)
         bus.notify_idu_glitch(0xFE00);
         let row18 = get_row_words(&bus.ppu.oam, 18);
@@ -1652,6 +1652,75 @@ mod tests {
             row18,
             [0x0000, 0x0003, 0x0004, 0x0005],
             "notify_idu_glitch at OamScan row 18 must apply write corruption"
+        );
+    }
+
+    /// Row 19 is the last of the 20 rows Mode 2 walks, and it must be reachable
+    /// on the line right after LCD enable — which is the line blargg's oam_bug
+    /// `7-timing_effect` sweeps.  Under the old scan-1 `(dot - 4) / 4` numbering
+    /// this row could never be reached, because scan 1's Mode 2 ends at dot 80.
+    #[test]
+    fn test_notify_idu_glitch_applies_corruption_at_row_19() {
+        use crate::gb::bus::GbBus;
+        let mut bus = make_bus();
+        set_row_words(&mut bus.ppu.oam, 18, [0x0002, 0x0003, 0x0004, 0x0005]);
+        set_row_words(&mut bus.ppu.oam, 19, [0x0001, 0x00AA, 0x00BB, 0x00CC]);
+        enable_lcd_and_tick_to_row(&mut bus, 19); // dot=76, last OAM row
+        bus.begin_instruction();
+        bus.notify_idu_glitch(0xFE00);
+        assert_eq!(
+            get_row_words(&bus.ppu.oam, 19),
+            [0x0000, 0x0003, 0x0004, 0x0005],
+            "notify_idu_glitch at OamScan row 19 must apply write corruption"
+        );
+    }
+
+    /// The sweep blargg's `7-timing_effect` performs: `INC DE` with `DE = $FE00`
+    /// at every M-cycle offset after `LCDC = $81`, over more than a full
+    /// scanline.  Mode 2 walks 20 OAM rows one per M-cycle and row 0 is immune,
+    /// so exactly 19 consecutive offsets must corrupt, stepping through rows
+    /// 1..=19 in order.  Asserting the whole progression rather than a count
+    /// keeps a wrong row from passing as a right total.
+    #[test]
+    fn test_oam_bug_corrupts_nineteen_consecutive_rows_after_lcd_enable() {
+        use crate::gb::bus::GbBus;
+        let mut corrupting: Vec<(u32, usize)> = Vec::new();
+        // Scan 0 (452 dots = 113 M-cycles) has no OAM scan, and scan 1 is a full
+        // 456-dot line, so sweeping 227 offsets spans exactly one Mode 2 window.
+        for offset in 0u32..113 + 114 {
+            let mut bus = make_bus();
+            bus.write(0xFF40, 0x00); // LCD off: OAM freely writable
+            for i in 0..0xA0u16 {
+                bus.write(0xFE00 + i, i as u8);
+            }
+            let before = bus.ppu.oam;
+            bus.write(0xFF40, 0x81); // LCD on, as corrupt_oam does
+            for _ in 0..offset {
+                bus.tick(1);
+            }
+            bus.begin_instruction();
+            bus.notify_idu_glitch(0xFE00);
+            if bus.ppu.oam != before {
+                let row = (0..0xA0usize)
+                    .find(|&i| bus.ppu.oam[i] != before[i])
+                    .expect("OAM differs, so some byte differs")
+                    / 8;
+                corrupting.push((offset, row));
+            }
+        }
+
+        let rows: Vec<usize> = corrupting.iter().map(|&(_, row)| row).collect();
+        assert_eq!(
+            rows,
+            (1..=19).collect::<Vec<_>>(),
+            "Mode 2 must walk rows 1..=19, one per M-cycle; got {corrupting:?}"
+        );
+        let offsets: Vec<u32> = corrupting.iter().map(|&(offset, _)| offset).collect();
+        let first = offsets[0];
+        assert_eq!(
+            offsets,
+            (first..first + 19).collect::<Vec<_>>(),
+            "the corrupting offsets must be consecutive M-cycles; got {offsets:?}"
         );
     }
 

--- a/src/gb/bus/dmg_bus.rs
+++ b/src/gb/bus/dmg_bus.rs
@@ -1554,10 +1554,13 @@ mod tests {
     /// Enable the LCD and stop at OAM-scan `row` of scan 1 (dot `4 * row`).
     ///
     /// Scan 0 is 452 dots = 113 M-cycles and has no OAM scan, so after that many
-    /// ticks the PPU sits at dot 0 of scan 1.  Mode 2 then walks one OAM row per
-    /// M-cycle from dot 0, so `row` more ticks land on `row`.  Rows 1..=19 are
-    /// observable; row 0 lives in the 4-dot "fake" HBlank that opens scan 1 and
-    /// is immune to corruption anyway.
+    /// ticks the PPU sits at dot 0 of scan 1.  The physical OAM scan runs from
+    /// dot 0 there — `Timing::is_oam_blocked` blocks OAM from dot 0 on scan 1 —
+    /// and walks one row per M-cycle, so `row` further ticks land on row `row`.
+    ///
+    /// Only rows 1..=19 are observable through `current_oam_row`: `Timing::mode`
+    /// reports scan 1's first four dots as HBlank, hiding row 0, which is immune
+    /// to corruption anyway.
     fn enable_lcd_and_tick_to_row(bus: &mut DmgBus, row: usize) {
         bus.write(0xFF40, 0x91); // enable LCD → timing resets
         for _ in 0..113 + row {
@@ -1567,7 +1570,7 @@ mod tests {
 
     #[test]
     fn test_notify_idu_glitch_applies_write_corruption_in_mode_2() {
-        // Given: PPU at row 2 (dot 12 of scan 1, where OamScan starts at dot=4);
+        // Given: PPU at OAM-scan row 2 (dot 8 of scan 1, one row per M-cycle);
         // OAM rows 1 and 2 have known values.
         // row 1: b=0x0002, w1=0x0003, c=0x0004, w3=0x0005
         // row 2: a=0x0001

--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -45,13 +45,7 @@ fn run_blargg_rom(gb: &mut Gb<DmgBus>) -> String {
 /// `$A000 == 0`, but by then the ROM has already printed at least `"\nPassed"`.
 /// We therefore reject `status == 0 AND text.is_empty()` as the init window.
 fn read_cart_ram_output(gb: &mut Gb<DmgBus>) -> Option<String> {
-    const SIGNATURE: [u8; 3] = [0xDE, 0xB0, 0x61];
-    let sig = [
-        gb.cpu.bus.read(0xA001),
-        gb.cpu.bus.read(0xA002),
-        gb.cpu.bus.read(0xA003),
-    ];
-    if sig != SIGNATURE {
+    if !cart_ram_signature_present(gb) {
         return None;
     }
     let status = gb.cpu.bus.read(0xA000);
@@ -59,19 +53,7 @@ fn read_cart_ram_output(gb: &mut Gb<DmgBus>) -> Option<String> {
         // Test still running.
         return None;
     }
-    let mut text = Vec::new();
-    let mut addr: u16 = 0xA004;
-    loop {
-        let b = gb.cpu.bus.read(addr);
-        if b == 0 {
-            break;
-        }
-        text.push(b);
-        addr = addr.wrapping_add(1);
-        if addr > 0xAFFF {
-            break;
-        }
-    }
+    let text = cart_ram_text(gb);
     // Guard against the init_text_out timing window where the three signature
     // bytes have been written but $A000 hasn't been set to $80 yet (cart RAM
     // is still all-zero from initialisation).  In that window status == 0 and
@@ -80,7 +62,41 @@ fn read_cart_ram_output(gb: &mut Gb<DmgBus>) -> Option<String> {
     if status == 0 && text.is_empty() {
         return None;
     }
-    Some(String::from_utf8_lossy(&text).into_owned())
+    Some(text)
+}
+
+/// First and last address of the ROM's zero-terminated text buffer.
+///
+/// `init_text_out` sets the write pointer to `$A004` and the ROMs that use this
+/// channel are built with 8 KB of cartridge RAM, so the buffer runs all the way
+/// to `$BFFF`: 8188 addresses, holding up to 8187 characters plus the
+/// terminator.  Stopping the scan earlier silently truncates the output, which
+/// for a long-running ROM would drop the trailing "Passed".
+const CART_RAM_TEXT_START: u16 = 0xA004;
+const CART_RAM_TEXT_END: u16 = 0xBFFF;
+
+/// True when the `$DE $B0 $61` signature is present at `$A001`–`$A003`.
+fn cart_ram_signature_present(gb: &mut Gb<DmgBus>) -> bool {
+    const SIGNATURE: [u8; 3] = [0xDE, 0xB0, 0x61];
+    [
+        gb.cpu.bus.read(0xA001),
+        gb.cpu.bus.read(0xA002),
+        gb.cpu.bus.read(0xA003),
+    ] == SIGNATURE
+}
+
+/// Read the zero-terminated text the ROM has written so far, regardless of
+/// whether it has finished.  Scans `$A004..=$BFFF`, stopping at the terminator.
+fn cart_ram_text(gb: &mut Gb<DmgBus>) -> String {
+    let mut text = Vec::new();
+    for addr in CART_RAM_TEXT_START..=CART_RAM_TEXT_END {
+        let b = gb.cpu.bus.read(addr);
+        if b == 0 {
+            break;
+        }
+        text.push(b);
+    }
+    String::from_utf8_lossy(&text).into_owned()
 }
 
 /// Step `gb` until the cartridge-RAM output (mem_timing-2 style) signals
@@ -89,6 +105,26 @@ fn read_cart_ram_output(gb: &mut Gb<DmgBus>) -> Option<String> {
 /// Also accepts serial output ending with "Passed\n" / "Failed\n" as a
 /// fallback so the function works for serial-based ROMs as well.
 fn run_blargg_rom_cart_ram(gb: &mut Gb<DmgBus>) -> String {
+    run_blargg_rom_cart_ram_with_limit(gb, BLARGG_CYCLE_LIMIT)
+}
+
+/// Prefix marking a result the ROM never actually reported.
+const TIMEOUT_PREFIX: &str = "[timed out, partial output] ";
+
+/// As [`run_blargg_rom_cart_ram`], with an explicit M-cycle budget.
+///
+/// On timeout the ROM has not written a status byte, so the completion
+/// protocol yields nothing.  Rather than returning an empty string — which
+/// says only "no result" and hides how far the ROM got — return whatever text
+/// it has printed so far, behind [`TIMEOUT_PREFIX`] so it can never be mistaken
+/// for a completed run.
+///
+/// Callers assert on `contains("Passed")`, so a run that times out in the few
+/// instructions between the ROM printing its verdict and writing the status
+/// byte now passes where it previously failed.  That window is a handful of
+/// instructions out of the whole budget, and a ROM that printed "Passed" did
+/// pass — the marker keeps the timeout visible either way.
+fn run_blargg_rom_cart_ram_with_limit(gb: &mut Gb<DmgBus>, cycle_limit: u64) -> String {
     let start = gb.cycles();
     loop {
         // Check serial output on the raw byte slice — no allocation.
@@ -99,12 +135,17 @@ fn run_blargg_rom_cart_ram(gb: &mut Gb<DmgBus>) -> String {
         if let Some(text) = read_cart_ram_output(gb) {
             return text;
         }
-        if gb.cycles().saturating_sub(start) >= BLARGG_CYCLE_LIMIT {
+        if gb.cycles().saturating_sub(start) >= cycle_limit {
             // Return whatever we have collected so far.
             if let Some(text) = read_cart_ram_output(gb) {
                 return text;
             }
-            return String::from_utf8_lossy(gb.cpu.bus.serial_output()).into_owned();
+            let partial = if cart_ram_signature_present(gb) {
+                cart_ram_text(gb)
+            } else {
+                String::from_utf8_lossy(gb.cpu.bus.serial_output()).into_owned()
+            };
+            return format!("{TIMEOUT_PREFIX}{partial}");
         }
         gb.step();
     }
@@ -739,8 +780,24 @@ fn test_oam_bug_6_timing_no_bug() {
     );
 }
 
+/// `7-timing_effect` cannot report a result through the cartridge-RAM channel.
+///
+/// For every sweep timing that corrupts, the ROM prints a 525-byte block — the
+/// sweep index, then a full 521-byte OAM dump — and a correct DMG corrupts on 19
+/// of them (Mode 2 walks 20 OAM rows, one per M-cycle, and row 0 is immune).
+/// That is `17 + 19×525 + 8 = 10 000` bytes of text against the 8188 available
+/// at `$A004..$BFFF`.
+/// `write_text_out` (`oam_bug/source/common/shell.s`) has no bounds check, so
+/// the overrun walks into `$C000`, where `copy_to_wram_then_run` placed the
+/// ROM's own code — measured: 2040 bytes of that code overwritten, cartridge
+/// RAM switched off, CPU executing rubbish.  The ROM therefore never reaches
+/// `check_crc`, on any emulator and on hardware.  Tracked in #3115.
+///
+/// The behaviour this ROM tests is covered by [`test_oam_bug_multi_rom`]
+/// instead: the multi-ROM build defines `CUSTOM_PRINT`, does not use the
+/// cartridge-RAM buffer, and reports subtest 7's verdict on screen.
 #[test]
-#[ignore = "failing: OAM corruption not emulated — tracked in #1993"]
+#[ignore = "unusable ROM build: output overruns its own $A004 text buffer into WRAM — tracked in #3115"]
 fn test_oam_bug_7_timing_effect() {
     let mut gb =
         load_gb_rom("roms/gb/automated_tests/blargg/oam_bug/rom_singles/7-timing_effect.gb");
@@ -751,6 +808,22 @@ fn test_oam_bug_7_timing_effect() {
     );
 }
 
+/// The multi-ROM build runs all eight `oam_bug` subtests and reports each one's
+/// verdict on screen, including subtest 7 (`timing_effect`), which the single
+/// ROM cannot report — see [`test_oam_bug_7_timing_effect`].
+#[test]
+fn test_oam_bug_multi_rom() {
+    let mut gb = load_gb_rom("roms/gb/automated_tests/blargg/oam_bug/oam_bug.gb");
+    let output = run_blargg_rom_lcd(&mut gb);
+    // Assert the subtest this suite's single-ROM coverage cannot reach first,
+    // so a regression names it rather than only failing the overall verdict.
+    assert!(
+        output.contains("07:ok"),
+        "oam_bug subtest 7 (timing_effect) must pass, got:\n{output}"
+    );
+    assert!(output.contains("Passed"), "expected Passed, got:\n{output}");
+}
+
 #[test]
 fn test_oam_bug_8_instr_effect() {
     let mut gb =
@@ -759,5 +832,84 @@ fn test_oam_bug_8_instr_effect() {
     assert!(
         output.contains("Passed"),
         "expected Passed, got: {output:?}"
+    );
+}
+
+// ── cartridge-RAM output oracle ───────────────────────────────────────────────
+
+/// The text buffer runs to `$BFFF`, not `$AFFF`.
+///
+/// Long-running ROMs print more than the 4092 bytes below `$AFFF`; stopping the
+/// scan there drops the trailing "Passed" and turns a passing run into a
+/// failing one.  Drives cartridge RAM directly (MBC1 RAM enable at `$0000`)
+/// rather than running a ROM, so the boundary is pinned exactly.
+#[test]
+fn test_cart_ram_output_reads_the_whole_8k_buffer() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/blargg/oam_bug/rom_singles/7-timing_effect.gb");
+    // Fill the buffer to its very last byte, ending with the verdict, so a scan
+    // that stops early cannot see it.  The expected extent is stated as a
+    // literal, from the cartridge geometry ($A004..$BFFF of 8 KB of RAM, minus
+    // the terminator) rather than from CART_RAM_TEXT_END — deriving it from the
+    // constant under test would make this test pass for any value of it.
+    const BUFFER_TEXT_CAPACITY: usize = 0xBFFF - 0xA004; // 8187 chars + NUL
+    let verdict = "\nPassed\n";
+    let mut text = ".".repeat(BUFFER_TEXT_CAPACITY - verdict.len());
+    text.push_str(verdict);
+    plant_cart_ram_output(&mut gb, 0x00, &text);
+
+    let output = read_cart_ram_output(&mut gb).expect("completed run must yield text");
+    assert_eq!(
+        output.len(),
+        BUFFER_TEXT_CAPACITY,
+        "the scan must cover $A004..=$BFFF, not stop at $AFFF"
+    );
+    assert!(
+        output.contains("Passed"),
+        "a verdict written above $AFFF must not be truncated away"
+    );
+}
+
+/// Write blargg's cartridge-RAM output protocol directly: enable MBC1 RAM, set
+/// the status byte and signature, then store `text` zero-terminated at `$A004`.
+///
+/// Uses literal addresses for the same reason as the test above: the helper
+/// must not inherit the bounds it is used to verify.
+fn plant_cart_ram_output(gb: &mut Gb<DmgBus>, status: u8, text: &str) {
+    const TEXT_START: u16 = 0xA004;
+    assert!(
+        text.len() <= (0xBFFF - TEXT_START) as usize,
+        "text plus terminator must fit in $A004..=$BFFF"
+    );
+    gb.cpu.bus.write(0x0000, 0x0A); // MBC1: enable cartridge RAM
+    gb.cpu.bus.write(0xA000, status);
+    for (i, b) in [0xDE, 0xB0, 0x61].iter().enumerate() {
+        gb.cpu.bus.write(0xA001 + i as u16, *b);
+    }
+    for (i, b) in text.bytes().enumerate() {
+        gb.cpu.bus.write(TEXT_START + i as u16, b);
+    }
+    gb.cpu.bus.write(TEXT_START + text.len() as u16, 0x00);
+}
+
+/// A run that exhausts its budget must report how far the ROM actually got.
+///
+/// While `$A000` still reads `$80` the completion protocol yields nothing, so
+/// the old timeout path returned `""` — indistinguishable from a ROM that
+/// produced no output at all.  Planted directly rather than run for real: the
+/// contract is "on timeout, surface the text that is there", and a hard-coded
+/// cycle budget would additionally depend on this ROM's start-up time.
+#[test]
+fn test_cart_ram_timeout_reports_partial_output() {
+    let mut gb =
+        load_gb_rom("roms/gb/automated_tests/blargg/oam_bug/rom_singles/7-timing_effect.gb");
+    plant_cart_ram_output(&mut gb, 0x80, "7-timing_effect\n\npartial");
+
+    // A zero budget times out before stepping, leaving the planted state intact.
+    let output = run_blargg_rom_cart_ram_with_limit(&mut gb, 0);
+    assert_eq!(
+        output,
+        format!("{TIMEOUT_PREFIX}7-timing_effect\n\npartial"),
+        "a timed-out run must be labelled as such and carry the text printed so far"
     );
 }

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -902,10 +902,11 @@ impl Ppu {
     /// The PPU walks the 20 OAM rows from dot 0 of the line, one row per
     /// M-cycle, so the row is `dot / 4`: row 0 = dots 0–3, row 1 = dots 4–7, …,
     /// row 19 = dots 76–79.  This holds on every line, including scan 1 (the
-    /// line right after LCD enable), whose leading `[0,4)` HBlank is only a STAT
-    /// artefact — [`Timing::is_oam_blocked`] documents the physical OAM scan as
-    /// starting at dot 0 there too.  On scan 1 that HBlank hides row 0, which
-    /// costs nothing: row 0 is immune to all three corruption patterns.
+    /// line right after LCD enable): [`Timing::is_oam_blocked`] documents the
+    /// physical OAM scan as running from dot 0 there too, and the `[0,4)` HBlank
+    /// [`Timing::mode`] reports at the head of scan 1 is an artefact of mode
+    /// reporting, not a gap in the scan.  It does hide row 0 on that one line,
+    /// which costs nothing: row 0 is immune to all three corruption patterns.
     ///
     /// Mode 2 never extends past dot 79, so the result is always `<= 19` and the
     /// callers that index OAM by row cannot run off the end.
@@ -1765,10 +1766,12 @@ mod tests {
     // ends at dot 80.
     #[test]
     fn test_current_oam_row_is_1_at_scan_1_mode_2_start() {
-        // Given: Ppu advanced to Mode 2 on scan 1, which begins at dot=4.
-        // Row 0 occupies dots [0,4), reported as the "fake" HBlank on scan 1, so
-        // the first row observable here is 1.  That costs nothing: row 0 is
-        // immune to all three corruption patterns.
+        // Given: Ppu advanced to the first dot of scan 1 that reports Mode 2.
+        // Scan 1 itself starts at dot 0 — it is Mode 2 that is first reported at
+        // dot 4, because `Timing::mode` calls dots [0,4) a "fake" HBlank there.
+        // Row 0 occupies those four dots, so the first row observable on scan 1
+        // is 1.  That costs nothing: row 0 is immune to all three corruption
+        // patterns.
         let mut ppu = Ppu::new();
         advance_to_mode_2(&mut ppu);
         assert_eq!(ppu.timing.mode(), PpuMode::OamScan);

--- a/src/gb/ppu/ppu.rs
+++ b/src/gb/ppu/ppu.rs
@@ -899,20 +899,21 @@ impl Ppu {
     /// Returns `Some(row)` during Mode 2 (OAM Scan) when LCD is enabled.
     /// Returns `None` outside Mode 2 or when LCD is disabled.
     ///
-    /// Scan 1 (second_scanline_after_enable): OamScan starts at dot=4.
-    ///   Row 0 = dots 4–7, row 1 = dots 8–11, …, row 19 = dots 80–83.
-    /// Scan 2+ (regular): OamScan starts at dot=0.
-    ///   Row 0 = dots 0–3, row 1 = dots 4–7, …, row 19 = dots 76–79.
+    /// The PPU walks the 20 OAM rows from dot 0 of the line, one row per
+    /// M-cycle, so the row is `dot / 4`: row 0 = dots 0–3, row 1 = dots 4–7, …,
+    /// row 19 = dots 76–79.  This holds on every line, including scan 1 (the
+    /// line right after LCD enable), whose leading `[0,4)` HBlank is only a STAT
+    /// artefact — [`Timing::is_oam_blocked`] documents the physical OAM scan as
+    /// starting at dot 0 there too.  On scan 1 that HBlank hides row 0, which
+    /// costs nothing: row 0 is immune to all three corruption patterns.
+    ///
+    /// Mode 2 never extends past dot 79, so the result is always `<= 19` and the
+    /// callers that index OAM by row cannot run off the end.
     pub fn current_oam_row(&self) -> Option<usize> {
         if !self.registers.lcd_enabled() || self.timing.mode() != PpuMode::OamScan {
             return None;
         }
-        let oam_scan_offset = if self.timing.is_second_scanline_after_enable() {
-            4 // scan 1: OamScan starts at dot=4
-        } else {
-            0 // scan 2+: OamScan starts at dot=0
-        };
-        Some((self.timing.dot() as usize).saturating_sub(oam_scan_offset) / 4)
+        Some(self.timing.dot() as usize / 4)
     }
 
     /// Apply OAM write corruption to the given row.
@@ -1755,34 +1756,47 @@ mod tests {
 
     // ── OAM corruption: current_oam_row ───────────────────────────────────────
 
+    // NOTE (#3104): the three tests below — and the write_oam/read_oam
+    // corruption tests further down — previously asserted a row numbering
+    // shifted down by one on scan 1, encoding the very defect this issue fixed.
+    // The PPU walks OAM from dot 0 of every line, one row per M-cycle, so the
+    // row is `dot / 4` on every line; scan 1 is not special.  Under the old
+    // `(dot - 4) / 4` the last row (19) was unreachable, because scan 1's Mode 2
+    // ends at dot 80.
     #[test]
-    fn test_current_oam_row_returns_row_0_at_mode_2_start() {
-        // Given: Ppu advanced to Mode 2 on scanline 1, dot=0 → row 0/4 = 0
+    fn test_current_oam_row_is_1_at_scan_1_mode_2_start() {
+        // Given: Ppu advanced to Mode 2 on scan 1, which begins at dot=4.
+        // Row 0 occupies dots [0,4), reported as the "fake" HBlank on scan 1, so
+        // the first row observable here is 1.  That costs nothing: row 0 is
+        // immune to all three corruption patterns.
         let mut ppu = Ppu::new();
         advance_to_mode_2(&mut ppu);
         assert_eq!(ppu.timing.mode(), PpuMode::OamScan);
-        assert_eq!(ppu.current_oam_row(), Some(0));
-    }
-
-    #[test]
-    fn test_current_oam_row_returns_row_1_after_4_dot_ticks() {
-        // Given: Ppu in Mode 2 at dot=4, tick 4 more → dot=8 → row (8-4)/4 = 1
-        let mut ppu = Ppu::new();
-        advance_to_mode_2(&mut ppu);
-        tick_dots(&mut ppu, 4);
-        assert_eq!(ppu.timing.dot(), 8);
+        assert_eq!(ppu.timing.dot(), 4);
         assert_eq!(ppu.current_oam_row(), Some(1));
     }
 
     #[test]
-    fn test_current_oam_row_returns_row_18_at_dot_76() {
-        // On scan 1, OamScan runs [4,80): 19 rows (0-18). Row 18 is the last.
-        // dot=76 → row (76-4)/4 = 18. At dot=80: Mode3 starts, row=None.
+    fn test_current_oam_row_advances_one_row_per_m_cycle() {
+        // Given: Ppu in Mode 2 at dot=4, tick 4 more → dot=8 → row 8/4 = 2
+        let mut ppu = Ppu::new();
+        advance_to_mode_2(&mut ppu);
+        tick_dots(&mut ppu, 4);
+        assert_eq!(ppu.timing.dot(), 8);
+        assert_eq!(ppu.current_oam_row(), Some(2));
+    }
+
+    #[test]
+    fn test_current_oam_row_reaches_row_19_before_mode_3() {
+        // Mode 2 walks all 20 OAM rows (0-19), one per M-cycle.  Row 19 is the
+        // last, at dot=76; Mode 3 starts at dot=80 and the row goes away.
+        // blargg's oam_bug 7-timing_effect sweeps this window and depends on
+        // row 19 being reachable on the line it samples (scan 1).
         let mut ppu = Ppu::new();
         advance_to_mode_2(&mut ppu);
         tick_dots(&mut ppu, 72);
         assert_eq!(ppu.timing.dot(), 76);
-        assert_eq!(ppu.current_oam_row(), Some(18));
+        assert_eq!(ppu.current_oam_row(), Some(19));
         // Also verify dot=80 is Mode3 (None)
         tick_dots(&mut ppu, 4);
         assert_eq!(ppu.timing.dot(), 80);
@@ -2026,9 +2040,9 @@ mod tests {
         let mut ppu = Ppu::new();
         set_row_words(&mut ppu.oam, 1, [0x0002, 0x0003, 0x0004, 0x0005]);
         set_row_words(&mut ppu.oam, 2, [0x0001, 0x00AA, 0x00BB, 0x00CC]);
-        // Advance to Mode 2 on a normal scanline, then tick to row 2
+        // Advance to Mode 2, then tick to row 2 (dot 8, one row per M-cycle).
         advance_to_mode_2(&mut ppu);
-        tick_dots(&mut ppu, 8); // dot 4 + 8 = dot 12 → current_oam_row() = Some(2): (12-4)/4=2
+        tick_dots(&mut ppu, 4); // dot 4 + 4 = dot 8 → current_oam_row() = Some(2): 8/4=2
         assert_eq!(ppu.timing.mode(), PpuMode::OamScan);
         assert_eq!(ppu.current_oam_row(), Some(2));
         // When: CPU writes to any OAM address
@@ -2060,7 +2074,7 @@ mod tests {
         set_row_words(&mut ppu.oam, 1, [0x0002, 0x0003, 0x0004, 0x0005]);
         set_row_words(&mut ppu.oam, 2, [0x0001, 0x00AA, 0x00BB, 0x00CC]);
         advance_to_mode_2(&mut ppu);
-        tick_dots(&mut ppu, 8);
+        tick_dots(&mut ppu, 4); // dot 8 → row 2
         ppu.write_oam(0xFE10, 0xAB); // written value 0xAB must NOT appear in OAM
         // If 0xAB appears anywhere in row 2, that is wrong
         for i in 0..8 {
@@ -2081,7 +2095,7 @@ mod tests {
         set_row_words(&mut ppu.oam, 1, [0x0002, 0x0003, 0x0004, 0x0005]);
         set_row_words(&mut ppu.oam, 2, [0x0001, 0x00AA, 0x00BB, 0x00CC]);
         advance_to_mode_2(&mut ppu);
-        tick_dots(&mut ppu, 8);
+        tick_dots(&mut ppu, 4); // dot 8 → row 2
         assert_eq!(ppu.timing.mode(), PpuMode::OamScan);
         // When: CPU reads from any OAM address during Mode 2
         let result = ppu.read_oam(0xFE10);


### PR DESCRIPTION
Closes #3104.

## The bug

`Ppu::current_oam_row` offset the OAM-scan row by +4 dots on scan 1 — the line right after
the LCD is enabled:

    let oam_scan_offset = if self.timing.is_second_scanline_after_enable() { 4 } else { 0 };
    Some((self.timing.dot() as usize).saturating_sub(oam_scan_offset) / 4)

Scan 1's Mode 2 ends at dot 80, so `(dot - 4) / 4` topped out at row 18 and **row 19 was
unreachable on that line**. Mode 2 walks all 20 OAM rows, one per M-cycle, so 19 of them
(1..=19, row 0 being immune) must be corruptible per line; NESER offered 18.

The offset also contradicted `Timing::is_oam_blocked` two functions away, which already
documents scan 1's physical OAM scan as starting at dot 0 and calls the leading `[0,4)`
HBlank an artefact of STAT. The fix deletes the special case: the row is `dot / 4` on every
line.

## Evidence

Bus-level sweep of the ROM's own sequence — LCD off, fill OAM, `LCDC=$81`, wait N M-cycles,
`INC DE` with `DE=$FE00` — over one scanline:

| | corrupting offsets | rows |
|---|---|---|
| before | 18 | 1..18 |
| after | 19 | 1..19 |

`oam_bug.gb` (multi-ROM), which reports every subtest on screen:

    before:  01:ok 02:ok 03:ok 04:ok 05:ok 06:ok 07:     08:ok    Failed #7
    after:   01:ok 02:ok 03:ok 04:ok 05:ok 06:ok 07:ok  08:ok    Passed

To reproduce the failure: restore the `is_second_scanline_after_enable` offset and run
`test_oam_bug_corrupts_nineteen_consecutive_rows_after_lcd_enable` — it reports the row
progression stopping at 18. All three new tests were mutation-checked this way.

## Nine pre-existing tests encoded the defect

Five in `ppu.rs` and four in `dmg_bus.rs` (via the `enable_lcd_and_tick_to_row` helper)
passed before the fix while asserting the wrong row numbering. They are corrected here as
part of the red bar, with a note saying so, rather than treated as regressions.

## New coverage

- `test_oam_bug_corrupts_nineteen_consecutive_rows_after_lcd_enable` — sweeps the ROM's
  sequence and asserts the whole row progression and that the offsets are consecutive, so a
  wrong row cannot pass as a right total.
- `test_notify_idu_glitch_applies_corruption_at_row_19`
- `test_current_oam_row_reaches_row_19_before_mode_3`
- `test_oam_bug_multi_rom` — asserts `07:ok` first (so a regression names the subtest) and
  then the overall `Passed`.

## Why `test_oam_bug_7_timing_effect` stays ignored

#3104 asked for it to be un-ignored. It cannot be, and that is a property of the ROM build
rather than of the emulator — now tracked in #3115 instead of the closed #1993 it used to
cite.

The ROM prints a 525-byte block per corrupting timing, so correct emulation produces
`17 + 19x525 + 8 = 10 000` bytes of text into the 8188 bytes available at `$A004..$BFFF`.
`write_text_out` has no bounds check, so the overrun walks into `$C000`, where
`copy_to_wram_then_run` placed the ROM's own code — measured: 2040 bytes of it overwritten,
cartridge RAM switched off, CPU executing rubbish. It never reaches `check_crc`. Only 15
blocks fit, so no emulator can complete this build; Mesen2 "completes" it only by corrupting
on zero timings and printing `00000000` / `Failed`.

The multi-ROM build defines `CUSTOM_PRINT`, does not use that buffer, and reports subtest
7's verdict on screen — hence `test_oam_bug_multi_rom`.

## Also fixed: two defects in the cart-RAM oracle

Both mutation-verified (each test fails when the old behaviour is restored):

- `read_cart_ram_output` stopped scanning at `$AFFF`, half the buffer, silently truncating
  any output over 4092 bytes — including a trailing "Passed".
- The timeout path returned `""`, which is exactly what made this issue's symptom
  uninformative. It now returns the ROM's partial text behind a `[timed out, partial output]`
  marker. One consequence is documented in the code: a run timing out in the few instructions
  between the ROM printing its verdict and writing its status byte now passes where it used
  to fail.

## Verification

| check | result |
|---|---|
| `cargo test --no-default-features --lib` | 12830 passed, 0 failed |
| `./scripts/test-dir.sh src/gb` | 1512 passed, 0 failed |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `wasm-pack test --headless --chrome --no-default-features --features wasm` | 94 passed, 0 failed |
| Python: scripts / metadata-scraper / nes-rom-db-scraper | 250 / 113 / 44, all OK |
| `npm test` | 430 passed |

Ground truth: Pan Docs *OAM Corruption Bug* for the corruption model, and Mesen2 forced to
DMG (`--gameBoy.Model=Gameboy`) for cross-checks. Note Mesen2 is **not** a usable oracle for
this particular ROM — it fails `7-timing_effect` itself by corrupting on zero timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
