### PR TITLE
test(gb): verify CH1 Round-3 sweep overflow timing through the APU (#3105, #3097)

### DIFF
--- a/src/gb/apu/apu.rs
+++ b/src/gb/apu/apu.rs
@@ -773,6 +773,7 @@ impl Default for Apu {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gb::timer::DIV_APU_BIT_NORMAL;
 
     fn powered_apu() -> Apu {
         let mut apu = Apu::new(false);
@@ -1356,4 +1357,201 @@ mod tests {
     // is actually 1 tick shorter. The countdown for the next sample is reset,
     // but the new pulse's first sample will be the next sample the old pulse
     // would have played (i.e. the current sample index or phase does not reset)"
+
+    // ── SameSuite channel_1_sweep Round 3 ─────────────────────────────────
+
+    /// Drives an [`Apu`] the way `CgbBus::tick_before_ppu` / `tick_after_ppu`
+    /// do: a simulated 16-bit DIV counter advancing 4 T-cycles per M-cycle,
+    /// with the DIV-APU edge events dispatched *before* that M-cycle's `tick`.
+    ///
+    /// This is what lets a unit test reproduce a SameSuite `SubTest` faithfully:
+    /// the frame sequencer advances because DIV bit 12 falls, not because the
+    /// test counted FS steps by hand.
+    ///
+    /// `CgbBus` batches a whole instruction's M-cycles into one `Apu::tick`
+    /// after dispatching that instruction's DIV-APU edges, so stepping one
+    /// M-cycle at a time is only equivalent while no edge falls part-way
+    /// through a multi-M-cycle instruction. In the window these tests measure
+    /// the ROM is executing `nop`s, which are one M-cycle each, so the two
+    /// orderings coincide.
+    struct DivDrivenApu {
+        apu: Apu,
+        div: u16,
+    }
+
+    impl DivDrivenApu {
+        /// Powered-off CGB APU with a DIV counter at 0, i.e. immediately after
+        /// the `ld [rDIV], a` that opens SameSuite's `SubTest` macro.
+        fn new(model: CgbModel) -> Self {
+            let mut apu = Apu::new(true);
+            apu.set_cgb_model(model);
+            Self { apu, div: 0 }
+        }
+
+        /// One CPU M-cycle.
+        fn step(&mut self) {
+            let old = self.div;
+            self.div = self.div.wrapping_add(4);
+            if old & DIV_APU_BIT_NORMAL == 0 && self.div & DIV_APU_BIT_NORMAL != 0 {
+                self.apu.clock_div_apu_secondary();
+            }
+            if old & DIV_APU_BIT_NORMAL != 0 && self.div & DIV_APU_BIT_NORMAL == 0 {
+                self.apu.clock_div_apu();
+            }
+            self.apu.tick(1);
+        }
+
+        fn run(&mut self, m_cycles: u32) {
+            for _ in 0..m_cycles {
+                self.step();
+            }
+        }
+
+        /// `ld [rDIV], a` — clears the counter, reporting a falling edge if the
+        /// DIV-APU bit was high (mirrors `Timer::write` for $FF04).
+        fn reset_div(&mut self) {
+            if self.div & DIV_APU_BIT_NORMAL != 0 {
+                self.apu.clock_div_apu();
+            }
+            self.div = 0;
+        }
+
+        /// `ldh [n], a` into an APU register, carrying the live DIV counter the
+        /// CPU would have presented at that instruction.
+        fn write(&mut self, addr: u16, val: u8) {
+            self.apu
+                .write_register_with_apu_phase_and_div_counter(addr, val, None, Some(self.div));
+        }
+
+        /// `ldh [rNR52], a` — routed the way `CgbBus` routes it, so a power-on
+        /// while the DIV-APU bit is high arms the skipped first FS event.
+        fn write_nr52(&mut self, val: u8) {
+            let div_apu_bit_high = self.div & DIV_APU_BIT_NORMAL != 0;
+            self.apu.write_nr52_with_div_state(val, div_apu_bit_high);
+        }
+
+        fn ch1_pcm(&self) -> u8 {
+            self.apu.read_pcm12() & 0x0F
+        }
+    }
+
+    /// Round 3 of `roms/gb/automated_tests/SameSuite/apu/channel_1/channel_1_sweep.asm`,
+    /// replayed one M-cycle at a time.
+    ///
+    /// Each `SubTest` resets DIV, power-cycles the APU, waits `$800` NOPs so the
+    /// APU is aligned to a known DIV-APU tick, then writes — in this order —
+    /// `NR10=$27` (period 2, shift 7), `NR11=$80`, `NR13=$f0`, `NR12=$80`
+    /// (volume 8) and `NR14=$87` (trigger, freq `$7f0`), resets DIV again, waits
+    /// N M-cycles and samples `rPCM12`.
+    ///
+    /// Ground truth is that ROM's own `CorrectResults` table. Round 3 occupies
+    /// its last six rows; the two that matter here are
+    ///
+    /// * row 16, delays `$2ffe..$3005` — all `$08` (channel still audible), with
+    ///   `$2ffe` carrying the ROM's comment "DIV ticks the APU at this moment";
+    /// * row 17, delays `$3006..$300d` — all `$00` (sweep overflow has muted it).
+    ///
+    /// A `ld a, [hl]` costs 2 M-cycles, so a sample taken at delay `$3005`
+    /// observes the APU at 7 M-cycles past that DIV-APU tick and one at `$3006`
+    /// observes it at 8. That eight-M-cycle gap is what this test pins.
+    ///
+    /// PCM12 is the observation point on purpose. It is what the ROM measures,
+    /// and it is not the same instant as the `is_active` edge: neser completes
+    /// the overflow calculation a few M-cycles earlier and keeps the output
+    /// alive across the remainder via `sweep_overflow_output_linger`. Only the
+    /// composite is ground truth here — the split between the two is an
+    /// implementation detail this ROM does not constrain.
+    ///
+    /// The end-to-end verdict lives in `test_samesuite_apu_channel_1_sweep`;
+    /// this test exists to name the M-cycle when that ROM regresses.
+    #[test]
+    fn test_samesuite_round3_sweep_overflow_mutes_pcm12_eight_mcycles_after_arm() {
+        let mut d = DivDrivenApu::new(CgbModel::CgbE);
+
+        // `xor a` / `ldh [rNR52], a` — power off (already off).
+        d.run(4);
+        d.write_nr52(0x00);
+        // `cpl` / `ldh [rNR52], a` — power on.
+        d.run(4);
+        d.write_nr52(0xFF);
+        // `ld a, \2` + `nops $800` + `ldh [rNR10], a`. The DIV-APU bit falls at
+        // T=$2000 (M-cycle 2048) inside this window, giving the single alignment
+        // tick the ROM's comment describes.
+        d.run(2053);
+        d.write(0xFF10, 0x27);
+        d.run(5);
+        d.write(0xFF11, 0x80);
+        d.run(5);
+        d.write(0xFF13, 0xF0);
+        d.run(5);
+        d.write(0xFF12, 0x80);
+        d.run(5);
+        // The trigger lands with DIV at $2084 — the exact counter value
+        // `Channel1::trigger` keys its DIV-reset sweep-timing window on, which
+        // independently confirms this replay's instruction timing.
+        assert_eq!(
+            d.div, 0x2084,
+            "NR14 trigger must land on the ROM's DIV-reset alignment"
+        );
+        d.write(0xFF14, 0x87);
+        // `ld [rDIV], a` — delays below are counted from here, as the ROM's
+        // `nops \1` are.
+        d.run(3);
+        d.reset_div();
+
+        assert_eq!(d.apu.ch1.freq, 0x7F0, "trigger loads freq from NR13/NR14");
+
+        // DIV-APU falling edges land every 2048 M-cycles. `sweep_countdown` is
+        // loaded to (period ^ 7) & 7 = 5 on trigger, so the sweep steps at FS
+        // step 2 (M-cycle 4096) only bumps it to 6; the step at FS step 6
+        // (M-cycle 12288) wraps it to 7 and arms the overflowing calculation.
+        d.run(12287);
+        assert_eq!(
+            d.apu.ch1.freq, 0x7F0,
+            "no sweep writeback before the arming step"
+        );
+        d.step();
+
+        // Harness self-check: this M-cycle carried the arming sweep step, which
+        // writes back the completed addend ($7f0 >> 7 = $f) → $7ff. The next
+        // calculation, $7ff + ($7ff >> 7) = $87e, is the one that overflows.
+        // If this trips, the replay is mis-phased — the model is not at fault.
+        assert_eq!(
+            d.apu.ch1.freq, 0x7FF,
+            "arming sweep step writes back the completed addend"
+        );
+        assert!(
+            d.apu.ch1.is_active(),
+            "channel is still audible at the arming step"
+        );
+
+        // CorrectResults row 16: audible through delay $3005 = arm + 7.
+        for n in 1..=7 {
+            d.step();
+            assert_eq!(
+                d.ch1_pcm(),
+                0x08,
+                "PCM12 must still read $08 at arm + {n} M-cycles (ROM delay ${:04x})",
+                0x2ffe + n
+            );
+        }
+
+        // CorrectResults row 17: muted from delay $3006 = arm + 8, and it stays
+        // muted for the rest of rows 17 and 18 ($3006..$3015).
+        d.step();
+        assert_eq!(
+            d.ch1_pcm(),
+            0x00,
+            "sweep overflow must mute PCM12 at arm + 8 M-cycles (ROM delay $3006)"
+        );
+        for n in 9..=23 {
+            d.step();
+            assert_eq!(
+                d.ch1_pcm(),
+                0x00,
+                "PCM12 must stay muted at arm + {n} M-cycles (ROM delay ${:04x})",
+                0x2ffe + n
+            );
+        }
+    }
 }

--- a/src/gb/apu/channel1.rs
+++ b/src/gb/apu/channel1.rs
@@ -100,7 +100,10 @@ pub struct Channel1 {
     env_period: u8, // bits 2-0 (0-7)
 
     // NR13/NR14 fields
-    freq: u16, // 11-bit frequency (NR13 low + NR14 bits 2-0 high)
+    /// 11-bit frequency (NR13 low + NR14 bits 2-0 high). Visible to the rest of
+    /// `gb::apu` so sweep-timing tests can observe the writeback the sweep step
+    /// performs, like the other deferred-sweep fields below.
+    pub(super) freq: u16,
     length_en: bool,
 
     // Internal state
@@ -344,8 +347,10 @@ impl Channel1 {
                 self.nr10_written_since_trigger = false;
             }
         }
-        // Sweep restart hold drains even if NRx2=$00 stopped the channel by
-        // disabling the DAC; the duty phase itself remains frozen while stopped.
+        // Only the duty phase freezes while stopped — including when NRx2=$00
+        // stopped the channel by disabling the DAC. The sweep restart hold is
+        // drained unconditionally by `sweep_tick`, which the APU calls
+        // separately each M-cycle, so returning here does not stall it.
         if !self.active {
             return;
         }
@@ -2728,94 +2733,6 @@ mod tests {
             ch.duty_pos,
             (duty_before + 1) & 7,
             "duty_pos should advance once"
-        );
-    }
-
-    #[test]
-    #[ignore = "#2293: traces overflow timing for Round 3 second sweep"]
-    fn test_round3_second_sweep_overflow_timing() {
-        // Replicate SameSuite channel_1_sweep Round 3 second sweep arm.
-        // Round 3: NR10=$27 (period=2, shift=7), NR13=$f0 (freq=$7f0).
-        // First sweep writeback → freq=$7ff.
-        // Second sweep: $7ff + ($7ff >> 7) = $7ff + $7f = $87e (overflow).
-        // ROM expects overflow to fire at M-cycle $3006-$3008 after second arm.
-        let mut ch = Channel1::new();
-        ch.set_model(true, CgbModel::CgbE);
-        ch.write_nr12(0x80); // volume=8
-        ch.write_nr10(0x27, false); // period=2, shift=7
-        ch.write_nr13(0xf0);
-        ch.write_nr14(0x87, false, false); // trigger, freq=$7f0
-        // Let trigger mechanics settle (restart_hold drains).
-        // CGB-E: restart_hold = 2 - lf_div + 2 = 4 (assuming lf_div=0)
-        for _ in 0..20 {
-            ch.tick();
-        }
-        assert_eq!(ch.restart_hold, 0, "restart_hold should have drained");
-        // First FS sweep arm: applies completed_addend=0 (no-op writeback),
-        // then arms calc. After drain, completed_addend becomes $f.
-        ch.clock_sweep(false);
-        drain_sweep(&mut ch);
-        println!(
-            "After first sweep cycle: freq={:#03x}, completed_addend={:#03x}",
-            ch.freq, ch.completed_addend
-        );
-        assert_eq!(
-            ch.completed_addend, 0xf,
-            "completed_addend should be $f after first calc"
-        );
-        // Second FS sweep arm: applies completed_addend=$f → freq=$7f0+$f=$7ff.
-        ch.clock_sweep(false);
-        println!("After second arm: freq={:#03x}", ch.freq);
-        assert_eq!(
-            ch.freq, 0x7ff,
-            "second arm should apply completed_addend=$f"
-        );
-        assert_eq!(
-            ch.freq, 0x7ff,
-            "second arm should apply completed_addend=$f"
-        );
-        assert!(
-            ch.is_active(),
-            "CH1 should be active after first full sweep"
-        );
-
-        // Third FS sweep arm (the one that overflows).
-        // This arms a calc for $7ff + ($7ff >> 7) = $7ff + $7f = $87e (overflow).
-        ch.clock_sweep(false); // arm at "M-cycle 0"
-        println!(
-            "After third arm: countdown={}, reload_timer={}",
-            ch.sweep_calc_countdown, ch.sweep_calc_reload_timer
-        );
-        // Count M-cycles until overflow fires (ch.active becomes false).
-        let mut m_cycle = 0;
-        for i in 0..20 {
-            let was_active = ch.is_active();
-            ch.sweep_tick();
-            let now_active = ch.is_active();
-            if i < 10 {
-                println!(
-                    "M-cycle {}: countdown={}, reload_timer={}, active={}",
-                    i + 1,
-                    ch.sweep_calc_countdown,
-                    ch.sweep_calc_reload_timer,
-                    now_active
-                );
-            }
-            if was_active && !now_active {
-                m_cycle = i + 1;
-                break;
-            }
-        }
-        println!("Round 3 overflow: fired at M-cycle {m_cycle} after third arm");
-        println!("  ROM expects overflow between M-cycle 8 and 9");
-        if m_cycle > 0 && m_cycle < 8 {
-            println!("  Observed drift: {} M-cycles too early", 8 - m_cycle);
-        }
-        // ROM expects overflow at ~M-cycle 8 (SubTest $3006-$3008 pass, $3009 fails).
-        // If neser fires at M-cycle 3-5, drift is ~5-6 M-cycles.
-        assert!(
-            (8..=9).contains(&m_cycle),
-            "overflow should fire at M-cycle 8-9, got {m_cycle}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #3105 and #3097.

`gb::apu::channel1::tests::test_round3_second_sweep_overflow_timing` was `#[ignore]`d against **#2293, which is closed**. Running it with `--include-ignored` showed it could never pass regardless of emulator correctness: it drove the channel with `tick()`, but `restart_hold` is only ever drained by `sweep_tick()`, so it failed on its own setup assertion (`restart_hold should have drained: left: 4, right: 0`) before reaching any of the overflow timing it was named for.

The investigation found the expectation was wrong as well. The test asserted that `is_active()` clears 8-9 M-cycles after the third `clock_sweep()`. That "8" comes from the ROM, but it is a **PCM12 observation offset**, not the `is_active` edge: neser completes the overflow calculation a few M-cycles earlier and keeps the output alive across the remainder via `sweep_overflow_output_linger`. Un-mis-driving the test would not have made that assertion meaningful.

## What this PR does

- **Deletes** the dead test. Everything it could legitimately have asserted at the `Channel1` level is already covered by `test_sweep_tick_drains_calc_countdown_two_per_mcycle_when_reload_zero` and `test_deferred_overflow_lingers_pcm_output_for_div_reset_window`.
- **Adds** `test_samesuite_round3_sweep_overflow_mutes_pcm12_eight_mcycles_after_arm` in `apu.rs`, replaying SameSuite `channel_1_sweep` Round 3 through the real `Apu`. A simulated 16-bit DIV counter dispatches the DIV-APU edges the way `CgbBus` does, and `rPCM12` is sampled at the delays the ROM samples.
- **Rewords** the `tick()` comment at `channel1.rs:345`, which claimed the sweep restart hold drains there. It drains in `sweep_tick()`, which the APU calls separately each M-cycle.

## Ground truth, not a golden

Expected values come from the ROM's own `CorrectResults` table, so the test cannot encode the implementation:

- row 16, delays `$2ffe..$3005` - all `$08`, with `$2ffe` carrying the ROM's comment "DIV ticks the APU at this moment"
- row 17, delays `$3006..$300d` - all `$00`

A `ld a, [hl]` costs 2 M-cycles, so `$3005` observes the APU at arm + 7 and `$3006` at arm + 8.

Two independent checks confirm the replay is phased correctly rather than agreeing by accident, both asserted in the test:

1. Counting the `SubTest` macro's instruction cycles puts the NR14 trigger at DIV **`$2084`** - the exact constant `Channel1::trigger` keys its DIV-reset sweep-timing window on.
2. The arming sweep step lands on the DIV-APU tick at M-cycle **12288**, matching the ROM's `$2ffe` marker, and writes `freq` back `$7f0 -> $7ff` as the sweep arithmetic requires.

## Test power

The test passes on its first run, so discrimination was proven by mutation rather than assumed:

| Mutation | Result |
|---|---|
| `sweep_overflow_output_linger` 5 -> 4 | FAILED - `PCM12 must still read $08 at arm + 7 M-cycles (ROM delay $3005)` |
| `sweep_overflow_output_linger` 5 -> 6 | FAILED - `sweep overflow must mute PCM12 at arm + 8 M-cycles (ROM delay $3006)` |
| `sweep_calc_reload_timer` `1 + lf_div` -> `2 + lf_div` | FAILED - same assertion |

All mutations reverted; the last one was re-run after the refactor to confirm the refactor did not weaken the test.

## Notes

- **No emulator behaviour changes.** The only production edit is `Channel1::freq` becoming `pub(super)` so the harness self-check can observe the sweep writeback, alongside the two comment changes.
- `#3097` acceptance: no `#[ignore]` in `src/gb` cites a closed issue any more. The blargg `7-timing_effect` half was already handled by #3117, which repointed it at the open #3115.
- Non-ignored Game Boy test count is **+1** (1512 -> 1513): the diff removes exactly one `#[test]` (the ignored one) and adds one.

## Pre-merge checks

| Check | Result |
|---|---|
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `cargo test --no-default-features --lib` | 12838 passed, 0 failed, 29 ignored |
| `./scripts/test-dir.sh src/gb` | 1513 passed, 0 failed, 10 ignored |
| `gb::integration_tests::samesuite_apu_tests` | 70 passed, 0 failed (all five `channel_1_sweep*` ROM tests) |
| `wasm-pack test --headless --chrome --no-default-features --features wasm` | 94 passed, 0 failed |
| Python suites (scripts, metadata-scraper, nes-rom-db-scraper) | 250 + 113 + 44, all OK |
| `npm test` | 430 passed (49 files) |

`--include-ignored` validation for #3097: `gb::apu::channel1` 86 passed / 0 ignored; `gb::integration_tests::blargg_tests` 56 passed / 1 failed - `test_oam_bug_7_timing_effect`, the #3115 unusable-ROM case, correctly ignored against an open issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
