### PR TITLE
SNES HDMA: $43xA line counter and $213B CGRAM open bus (#3062)

### DIFF
--- a/src/snes/bus/dma.rs
+++ b/src/snes/bus/dma.rs
@@ -973,6 +973,63 @@ mod tests {
         );
     }
 
+    // byuu `test_hdma.smc` sub-test 4: "if $43xa is 0 when an HDMA transfer
+    // begins (before the decrement), it will wrap to 0xff and begin a
+    // continuous transfer". The ROM arms a mode-3 channel mid-frame with
+    // $430A = 0 and its table pointer one byte past the leading terminator,
+    // then lets three lines run and checks that CGRAM ends up holding the
+    // SECOND data pair -- i.e. the first line transfers nothing, and the two
+    // after it each move one 4-byte group (#3062).
+    #[test]
+    fn hdma_zero_counter_wraps_into_a_continuous_transfer() {
+        let mut dma = DmaController::new();
+        let mut bus = RecordingBus::new(0);
+        // Mode 3 (p, p, p+1, p+1) to $2121/$2122, direct addressing.
+        write_hdma_channel(&mut dma, 0, 0x03, 0x21, 0x3000);
+        // Table: a leading $00 the ROM deliberately skips, then two 4-byte groups.
+        bus.a_bus[0x3000] = 0x00;
+        for (offset, byte) in [0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0xBC, 0x9A]
+            .into_iter()
+            .enumerate()
+        {
+            bus.a_bus[0x3001 + offset] = byte;
+        }
+
+        // Frame init runs with HDMA disabled; the CPU then points the table one
+        // byte in and zeroes the counter before enabling $420C.
+        dma.hdma_init(0x00, &mut bus, 0, 0, 8);
+        dma.write_register(0x4308, 0x01);
+        dma.write_register(0x4309, 0x30);
+        dma.write_register(0x430A, 0x00);
+
+        for _ in 0..3 {
+            let base = bus.clock;
+            dma.hdma_do_line(0x01, &mut bus, 0, base, 8);
+        }
+
+        let written: Vec<(u8, u8)> = bus
+            .b_bus_writes
+            .iter()
+            .map(|&(_, port, value)| (port, value))
+            .collect();
+        assert_eq!(
+            written,
+            vec![
+                // Line 1 transfers nothing: DoTransfer is only set by the
+                // decrement that wraps $00 to $FF.
+                (0x21, 0x00),
+                (0x21, 0x00),
+                (0x22, 0x78),
+                (0x22, 0x56),
+                (0x21, 0x00),
+                (0x21, 0x00),
+                (0x22, 0xBC),
+                (0x22, 0x9A),
+            ],
+            "two continuous-mode lines move one 4-byte group each"
+        );
+    }
+
     #[test]
     fn hdma_do_line_expiry_charges_indirect_pointer_load() {
         // A one-line indirect entry followed by a real next entry: on expiry

--- a/src/snes/bus/dma.rs
+++ b/src/snes/bus/dma.rs
@@ -32,8 +32,6 @@ pub struct DmaController {
     regs: [u8; DMA_REG_BYTES],
     hdma_active_mask: u8,
     hdma_do_transfer: [bool; 8],
-    hdma_repeat_mode: [bool; 8],
-    hdma_lines_left: [u16; 8],
 }
 
 impl DmaController {
@@ -42,8 +40,6 @@ impl DmaController {
             regs: [0; DMA_REG_BYTES],
             hdma_active_mask: 0,
             hdma_do_transfer: [false; 8],
-            hdma_repeat_mode: [false; 8],
-            hdma_lines_left: [0; 8],
         }
     }
 
@@ -67,8 +63,6 @@ impl DmaController {
             regs: self.regs.to_vec(),
             hdma_active_mask: self.hdma_active_mask,
             hdma_do_transfer: self.hdma_do_transfer.to_vec(),
-            hdma_repeat_mode: self.hdma_repeat_mode.to_vec(),
-            hdma_lines_left: self.hdma_lines_left.to_vec(),
         }
     }
 
@@ -79,10 +73,7 @@ impl DmaController {
                 state.regs.len()
             ));
         }
-        if state.hdma_do_transfer.len() != 8
-            || state.hdma_repeat_mode.len() != 8
-            || state.hdma_lines_left.len() != 8
-        {
+        if state.hdma_do_transfer.len() != 8 {
             return Err("DMA HDMA state size mismatch".to_string());
         }
 
@@ -90,9 +81,6 @@ impl DmaController {
         self.hdma_active_mask = state.hdma_active_mask;
         self.hdma_do_transfer
             .copy_from_slice(&state.hdma_do_transfer);
-        self.hdma_repeat_mode
-            .copy_from_slice(&state.hdma_repeat_mode);
-        self.hdma_lines_left.copy_from_slice(&state.hdma_lines_left);
         Ok(())
     }
 
@@ -198,8 +186,6 @@ impl DmaController {
         // process, while active_mask only tracks termination (#2943).
         self.hdma_active_mask = 0xFF;
         self.hdma_do_transfer = [false; 8];
-        self.hdma_repeat_mode = [false; 8];
-        self.hdma_lines_left = [0; 8];
 
         if hdmaen == 0 {
             return (0, seed_open_bus);
@@ -236,10 +222,6 @@ impl DmaController {
             if finished {
                 // Terminator: clear this channel's bit so it's not treated as active
                 self.hdma_active_mask &= !(1 << channel);
-            } else {
-                let (repeat_mode, lines_left) = Self::decode_hdma_descriptor(descriptor);
-                self.hdma_repeat_mode[channel as usize] = repeat_mode;
-                self.hdma_lines_left[channel as usize] = lines_left;
             }
 
             if indirect {
@@ -318,15 +300,17 @@ impl DmaController {
                 continue;
             }
             let idx = channel as usize;
-            // Use wrapping_sub to match hardware (0 - 1 = 0xFF, not 0)
-            self.hdma_lines_left[idx] = self.hdma_lines_left[idx].wrapping_sub(1);
-
-            let line_counter =
-                Self::encode_hdma_counter(self.hdma_repeat_mode[idx], self.hdma_lines_left[idx]);
+            // `$43xA` IS the line counter and repeat flag -- there is no separate
+            // internal copy to decrement (Mesen2 `ch.HdmaLineCounterAndRepeat--`).
+            // Keeping one meant a CPU write to `$43xA` was ignored until the next
+            // frame's init, so a ROM that arms HDMA mid-frame decremented a stale
+            // zero to `$FF` instead of the value it had just written (#3062).
+            // Use wrapping_sub to match hardware (0 - 1 = 0xFF, not 0).
+            let line_counter = self.get_reg(channel, 0xA).wrapping_sub(1);
             self.set_reg(channel, 0xA, line_counter);
 
-            // Set do_transfer based on repeat bit (bit 7) of line counter register,
-            // not internal repeat_mode. This allows mid-scanline activation to work (#2943).
+            // Set do_transfer based on repeat bit (bit 7) of line counter register.
+            // This also allows mid-scanline activation to work (#2943).
             self.hdma_do_transfer[idx] = (line_counter & 0x80) != 0;
 
             // Speculative descriptor read (pointer NOT advanced unless consumed).
@@ -336,7 +320,9 @@ impl DmaController {
             abus.dma_tick(4);
             counter += 8;
 
-            if self.hdma_lines_left[idx] == 0 {
+            // Expiry is tested on the low 7 bits only, so a repeat-mode counter
+            // expires at `$80` (Mesen2 `(ch.HdmaLineCounterAndRepeat & 0x7F) == 0`).
+            if (line_counter & 0x7F) == 0 {
                 // Consume the descriptor: advance the table pointer.
                 let next =
                     u16::from_le_bytes([self.get_reg(channel, 0x8), self.get_reg(channel, 0x9)])
@@ -374,12 +360,7 @@ impl DmaController {
                 if descriptor == 0 {
                     self.hdma_active_mask &= !(1 << channel);
                     self.hdma_do_transfer[idx] = false;
-                    self.hdma_repeat_mode[idx] = false;
-                    self.hdma_lines_left[idx] = 0;
                 } else {
-                    let (repeat_mode, lines_left) = Self::decode_hdma_descriptor(descriptor);
-                    self.hdma_repeat_mode[idx] = repeat_mode;
-                    self.hdma_lines_left[idx] = lines_left;
                     self.hdma_do_transfer[idx] = true;
                 }
             }
@@ -531,33 +512,6 @@ impl DmaController {
 
     fn set_reg(&mut self, channel: u8, reg: usize, value: u8) {
         self.regs[(channel as usize) * 0x10 + reg] = value;
-    }
-
-    fn decode_hdma_descriptor(descriptor: u8) -> (bool, u16) {
-        if descriptor == 0 {
-            return (false, 0);
-        }
-        if descriptor <= 0x80 {
-            if descriptor == 0x80 {
-                (false, 128)
-            } else {
-                (false, descriptor as u16)
-            }
-        } else {
-            (true, (descriptor - 0x80) as u16)
-        }
-    }
-
-    fn encode_hdma_counter(repeat_mode: bool, lines_left: u16) -> u8 {
-        if lines_left == 0 {
-            0
-        } else if repeat_mode {
-            0x80 | (lines_left as u8)
-        } else if lines_left == 128 {
-            0x80
-        } else {
-            lines_left as u8
-        }
     }
 
     fn hdma_table_address(&self, channel: u8) -> u32 {
@@ -925,6 +879,97 @@ mod tests {
             dma.get_reg(0, 0xA),
             0x82,
             "counter decremented, not reloaded"
+        );
+    }
+
+    // $43xA IS the line counter -- there is no separate internal copy. A ROM
+    // that arms HDMA mid-frame writes the counter and the table pointer by hand
+    // and enables $420C after the frame's HDMA init has already run, so the
+    // per-line decrement must start from what the CPU wrote (Mesen2 keeps only
+    // `HdmaLineCounterAndRepeat`, decrements it in place, and `$430A` writes
+    // land straight on it).
+    //
+    // This is byuu `test_hdmatiming.smc`'s sub-test 1 as a unit test: counter
+    // 2, no transfer, no line load -- the ROM reads back $430A == $01 (#3062).
+    #[test]
+    fn hdma_line_counter_decrements_the_value_the_cpu_wrote_to_43xa() {
+        let mut dma = DmaController::new();
+        let mut bus = RecordingBus::new(0);
+        write_hdma_channel(&mut dma, 0, 0x00, 0x22, 0x3000);
+        bus.a_bus[0x3000] = 0xAA;
+
+        // Frame init runs with HDMA disabled, exactly as the ROM arranges.
+        dma.hdma_init(0x00, &mut bus, 0, 0, 8);
+
+        // The CPU then writes the table pointer and counter by hand.
+        dma.write_register(0x4308, 0x00);
+        dma.write_register(0x4309, 0x30);
+        dma.write_register(0x430A, 0x02);
+
+        let base = bus.clock;
+        dma.hdma_do_line(0x01, &mut bus, 0, base, 8);
+
+        assert_eq!(
+            dma.get_reg(0, 0xA),
+            0x01,
+            "counter must decrement the CPU-written $430A, not a stale internal copy"
+        );
+    }
+
+    // byuu `test_hdmatiming.smc` sub-test 2: a CPU-written counter of 1 expires
+    // on the first line, so the descriptor is consumed into $43xA and the table
+    // pointer advances.
+    #[test]
+    fn hdma_cpu_written_counter_of_one_consumes_the_descriptor() {
+        let mut dma = DmaController::new();
+        let mut bus = RecordingBus::new(0);
+        write_hdma_channel(&mut dma, 0, 0x00, 0x22, 0x3000);
+        bus.a_bus[0x3000] = 0xAA;
+
+        dma.hdma_init(0x00, &mut bus, 0, 0, 8);
+
+        dma.write_register(0x4308, 0x00);
+        dma.write_register(0x4309, 0x30);
+        dma.write_register(0x430A, 0x01);
+
+        let base = bus.clock;
+        dma.hdma_do_line(0x01, &mut bus, 0, base, 8);
+
+        assert_eq!(
+            dma.get_reg(0, 0xA),
+            0xAA,
+            "an expiring CPU-written counter must load the next descriptor"
+        );
+        assert_eq!(
+            u16::from_le_bytes([dma.get_reg(0, 0x8), dma.get_reg(0, 0x9)]),
+            0x3001,
+            "consuming the descriptor advances the table pointer"
+        );
+    }
+
+    // The expiry test is on the low 7 bits, not the whole byte: a repeat-mode
+    // counter reaches $80 (repeat set, zero lines left) and must consume there
+    // (Mesen2 `if((ch.HdmaLineCounterAndRepeat & 0x7F) == 0)`).
+    #[test]
+    fn hdma_repeat_counter_expires_on_the_low_seven_bits() {
+        let mut dma = DmaController::new();
+        let mut bus = RecordingBus::new(0);
+        write_hdma_channel(&mut dma, 0, 0x00, 0x22, 0x3000);
+        bus.a_bus[0x3000] = 0x05;
+
+        dma.hdma_init(0x00, &mut bus, 0, 0, 8);
+
+        dma.write_register(0x4308, 0x00);
+        dma.write_register(0x4309, 0x30);
+        dma.write_register(0x430A, 0x81); // repeat, one line left
+
+        let base = bus.clock;
+        dma.hdma_do_line(0x01, &mut bus, 0, base, 8);
+
+        assert_eq!(
+            dma.get_reg(0, 0xA),
+            0x05,
+            "$81 decrements to $80, whose low 7 bits are zero, so it expires"
         );
     }
 

--- a/src/snes/bus/system_bus.rs
+++ b/src/snes/bus/system_bus.rs
@@ -913,10 +913,7 @@ impl SnesSystemBus {
                 state.dma.regs.len()
             ));
         }
-        if state.dma.hdma_do_transfer.len() != 8
-            || state.dma.hdma_repeat_mode.len() != 8
-            || state.dma.hdma_lines_left.len() != 8
-        {
+        if state.dma.hdma_do_transfer.len() != 8 {
             return Err("DMA HDMA state size mismatch".to_string());
         }
         if state.sram.len() != self.sram.borrow().len() {

--- a/src/snes/console/save_state.rs
+++ b/src/snes/console/save_state.rs
@@ -21,10 +21,6 @@ fn default_dma_channel_bools() -> Vec<bool> {
     vec![false; 8]
 }
 
-fn default_dma_channel_lines_left() -> Vec<u16> {
-    vec![0; 8]
-}
-
 fn default_last_hperiod() -> u16 {
     1364
 }
@@ -132,7 +128,13 @@ pub struct SnesCpuState {
 
 /// The DMA/HDMA controller's persisted state: the `$4300-$437F` channel
 /// register file plus the per-channel HDMA bookkeeping the registers don't
-/// hold (active mask, do-transfer and repeat flags, remaining line counts).
+/// hold (active mask and do-transfer flags).
+///
+/// Note: `hdma_repeat_mode` and `hdma_lines_left` were persisted here until
+/// #3062. They re-derived the line counter and repeat flag that `$43xA` already
+/// holds, and went stale the moment a ROM wrote that register mid-frame; the
+/// controller now decrements `$43xA` in place, as Mesen2 does, and the two
+/// vectors are gone. Same compatibility story as `bbus_ports` below.
 ///
 /// Note: a `bbus_ports` field (256 bytes) was persisted here until #3061. It
 /// mirrored every A->B byte so B->A transfers could read it back, which is not
@@ -149,10 +151,6 @@ pub struct SnesDmaState {
     pub hdma_active_mask: u8,
     #[serde(default = "default_dma_channel_bools")]
     pub hdma_do_transfer: Vec<bool>,
-    #[serde(default = "default_dma_channel_bools")]
-    pub hdma_repeat_mode: Vec<bool>,
-    #[serde(default = "default_dma_channel_lines_left")]
-    pub hdma_lines_left: Vec<u16>,
 }
 
 /// SA-1 enhancement chip state: control/vector registers (`$2200-$220F`), I-RAM plus its two

--- a/src/snes/console/snes.rs
+++ b/src/snes/console/snes.rs
@@ -1341,7 +1341,7 @@ mod tests {
             .expect("dma object")
             .as_object_mut()
             .expect("dma map")
-            .remove("hdma_lines_left");
+            .remove("hdma_do_transfer");
         {
             let bus = json["bus"].as_object_mut().expect("bus object");
             bus.remove("pending_gpdma");
@@ -1371,7 +1371,7 @@ mod tests {
             loaded.version,
             crate::snes::console::save_state::SNES_SAVESTATE_VERSION
         );
-        assert_eq!(loaded.bus.dma.hdma_lines_left, vec![0; 8]);
+        assert_eq!(loaded.bus.dma.hdma_do_transfer, vec![false; 8]);
         assert!(loaded.bus.pending_gpdma.is_none());
         assert!(loaded.bus.pending_hdma.is_none());
         assert_eq!(loaded.ppu.irq_mode, 0);

--- a/src/snes/integration_tests/jonasquinn_dma_tests.rs
+++ b/src/snes/integration_tests/jonasquinn_dma_tests.rs
@@ -12,12 +12,12 @@
 //! Two ROMs render a pixel-exact (0-pixel diff) match for Mesen2 and are
 //! committed goldens. `test_hdma/test_hdmasync.smc` and
 //! `test_hdma/test_hdmatiming.smc` are byte-identical byuu-suite mirrors of the
-//! KungFuFurby ROMs (md5 `acec8b53...` for the former) and share their
-//! divergence (#3062).
+//! KungFuFurby ROMs (md5 `acec8b53...` for the former); the first now passes,
+//! and the second carries the same single residual as its KungFuFurby twin.
 //!
 //! **Golden convention (#3092).** The remaining `#[ignore]`d *self-check* ROMs
 //! assert the Mesen2-correct blue PASS screen, not NESER's current output, so
-//! they FAIL under `cargo test --include-ignored` until #3062/#3063 land --
+//! they FAIL under `cargo test --include-ignored` until #3063/#3120 land --
 //! the designed state, not a regression. See `kungfufurby_irq_tests`' module
 //! doc for the rationale. `test_dmatiming_matches_mesen2` is deliberately NOT
 //! on this convention: it is a pixel-diff comparison against Mesen2's own
@@ -130,7 +130,7 @@ mod tests {
     /// to a single differing value, row 1's first latch. See
     /// `kungfufurby_hdma_tests::test_hdmatiming_passes` for the measurement.
     #[test]
-    #[ignore = "one residual value (row 1's first latch, 4 master clocks); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
+    #[ignore = "one residual value (row 1's first latch, 4 master clocks); asserts the correct PASS golden so FAILs under --include-ignored until #3120"]
     fn test_hdmatiming_passes() {
         run_rom_screen_crc("test_hdma/test_hdmatiming.smc", 600, 0x8695_BBB0);
     }

--- a/src/snes/integration_tests/jonasquinn_dma_tests.rs
+++ b/src/snes/integration_tests/jonasquinn_dma_tests.rs
@@ -126,11 +126,11 @@ mod tests {
         run_rom_screen_crc("test_hdma/test_hdmasync.smc", 1100, 0x8695_BBB0);
     }
 
-    /// #3062 (byte-identical byuu mirror of KungFuFurby test_hdmatiming): NESER
-    /// self-check FAILs (flat `(255, 0, 0)`, byuu's `fail()` backdrop) where
-    /// Mesen2 PASSes (blue). Read as `(66, 0, 0)` before #3116.
+    /// #3062 (byte-identical byuu mirror of KungFuFurby test_hdmatiming): down
+    /// to a single differing value, row 1's first latch. See
+    /// `kungfufurby_hdma_tests::test_hdmatiming_passes` for the measurement.
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
+    #[ignore = "one residual value (row 1's first latch, 4 master clocks); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdmatiming_passes() {
         run_rom_screen_crc("test_hdma/test_hdmatiming.smc", 600, 0x8695_BBB0);
     }

--- a/src/snes/integration_tests/kungfufurby_hdma_tests.rs
+++ b/src/snes/integration_tests/kungfufurby_hdma_tests.rs
@@ -11,11 +11,11 @@
 //! #3116 NESER ran through that halt and every screen here was post-halt
 //! garbage rather than the ROM's verdict.
 //!
-//! **Golden convention (#3092).** The two still-`#[ignore]`d tests assert the
-//! Mesen2-correct blue PASS screen, not NESER's current output, so they FAIL
-//! under `cargo test --include-ignored` until #3062 lands -- the designed
-//! state, not a regression. See `kungfufurby_irq_tests`' module doc for the
-//! rationale.
+//! **Golden convention (#3092).** `test_hdmatiming_passes`, the one test still
+//! `#[ignore]`d, asserts the Mesen2-correct blue PASS screen rather than
+//! NESER's current output, so it FAILs under `cargo test --include-ignored`
+//! until #3120 lands -- the designed state, not a regression. See
+//! `kungfufurby_irq_tests`' module doc for the rationale.
 
 use super::rom_runner::{RunConfig, RunExitReason, RunOracle, run_rom_with_oracle};
 use std::fs;
@@ -57,7 +57,7 @@ mod tests {
 
     // All three goldens below are the Mesen2-approved blue PASS screen,
     // verified by a fresh headless capture at each test's own sample frame.
-    // Un-ignore each one once NESER renders the PASS backdrop (#3062).
+    // Two of the three now render it; un-ignore the last once it does too.
 
     /// Four sub-tests covering HDMA init semantics. Passes since #3062, which
     /// took two fixes, both found by reading the sub-test number the ROM leaves
@@ -108,7 +108,7 @@ mod tests {
     /// they do not affect the verdict -- they are the unmodelled
     /// HDMA-during-GPDMA nesting noted in `src/snes/bus/dma.rs`.
     #[test]
-    #[ignore = "one residual value (row 1's first latch, 4 master clocks); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
+    #[ignore = "one residual value (row 1's first latch, 4 master clocks); asserts the correct PASS golden so FAILs under --include-ignored until #3120"]
     fn test_hdmatiming_passes() {
         run_rom_screen_crc("test_hdmatiming.smc", 600, 0x8695_BBB0);
     }

--- a/src/snes/integration_tests/kungfufurby_hdma_tests.rs
+++ b/src/snes/integration_tests/kungfufurby_hdma_tests.rs
@@ -59,17 +59,21 @@ mod tests {
     // verified by a fresh headless capture at each test's own sample frame.
     // Un-ignore each one once NESER renders the PASS backdrop (#3062).
 
-    /// #3062: the ROM's self-check FAILs -- a flat `(255, 0, 0)` fill, byuu's
-    /// `fail()` backdrop. Its four sub-tests cover HDMA init semantics, so the
-    /// verdict is now a usable HDMA finding: the ROM records which one failed
-    /// in SRAM byte 0 (`!test_number`; 0 = pass, 1-4 = the failing sub-test),
-    /// readable from the emitted `.sav`.
+    /// Four sub-tests covering HDMA init semantics. Passes since #3062, which
+    /// took two fixes, both found by reading the sub-test number the ROM leaves
+    /// in SRAM byte 0 (`!test_number`; 0 = pass, 1-4 = the failing sub-test):
     ///
-    /// Before #3116 this settled on solid black instead, because STP did not
-    /// halt: `pass()`/`fail()` ran on into `get_dma_counter`, which starts a
-    /// GPDMA and then `rts` on a stack it never set up.
+    /// - `$43xA` is the line counter itself, not an internal copy, so the
+    ///   counter a ROM writes by hand before enabling `$420C` mid-frame is the
+    ///   one that gets decremented.
+    /// - `$213B` reads of a CGRAM high byte take bit 7 from PPU2 open bus.
+    ///   Sub-test 4 HDMAs `$9ABC` into CGRAM and reads it back as `$BC, $9A`;
+    ///   CGRAM only stores 15 bits, so without the open-bus bit it read `$1A`.
+    ///
+    /// Before #3116 it settled on solid black, because STP did not halt:
+    /// `pass()`/`fail()` ran on into `get_dma_counter`, which starts a GPDMA
+    /// and then `rts` on a stack it never set up.
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdma_passes() {
         run_rom_screen_crc("test_hdma.smc", 600, 0x8695_BBB0);
     }
@@ -88,17 +92,23 @@ mod tests {
         run_rom_screen_crc("test_hdmasync.smc", 1100, 0x8695_BBB0);
     }
 
-    /// #3062: the ROM's self-check FAILs -- a flat `(255, 0, 0)` fill, byuu's
-    /// `fail()` backdrop -- where Mesen2 PASSes. A real HDMA timing divergence:
-    /// the ROM compares 8 rows of latched H positions and channel registers
-    /// against an in-ROM `compdata` table, and leaves both in SRAM `$00..$3F`,
-    /// so the failing row is readable from the emitted `.sav`.
+    /// #3062: the ROM compares 8 rows of latched H positions and channel
+    /// registers against an in-ROM `compdata` table (ROM offset `0x153D`) and
+    /// leaves both in SRAM `$00..$3F`, so the failing row is readable from the
+    /// emitted `.sav`.
     ///
-    /// Before #3116 this settled on a flat `(66, 0, 0)` instead -- not a FAIL
-    /// shade at all, but whatever the `compdata` bytes did when executed as
-    /// code past the unimplemented `stp`.
+    /// Down to **one** differing value. Rows 2-8 match exactly, including the
+    /// H=1104 trigger and `$2137` latch checks in rows 7-8. Row 1 differs only
+    /// in its first latch -- `want $014E, got $014F` -- while the second latch
+    /// in the same row matches, so it is a 4-master-clock CPU arrival
+    /// difference at one alignment, not an HDMA envelope error: `SyncStartDma`
+    /// and `SyncEndDma` are already formula-identical to Mesen2's. That places
+    /// it in the #3050 CPU-alignment family. Rows 9-12 also differ but the ROM
+    /// records them without comparing them (`cpx.w #64` stops at row 8), so
+    /// they do not affect the verdict -- they are the unmodelled
+    /// HDMA-during-GPDMA nesting noted in `src/snes/bus/dma.rs`.
     #[test]
-    #[ignore = "self-check FAILs (red) where Mesen2 PASSes (blue); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
+    #[ignore = "one residual value (row 1's first latch, 4 master clocks); asserts the correct PASS golden so FAILs under --include-ignored until #3062"]
     fn test_hdmatiming_passes() {
         run_rom_screen_crc("test_hdmatiming.smc", 600, 0x8695_BBB0);
     }

--- a/src/snes/ppu/registers.rs
+++ b/src/snes/ppu/registers.rs
@@ -359,7 +359,19 @@ impl Ppu {
             // open bus like the other $213B/$213C/$213D/$213F reads (see OPHCT below).
             0x213B => {
                 let index = self.cgram_index();
-                let value = self.cgram[index];
+                // CGRAM stores 15-bit colours, so the high byte's bit 7 does not
+                // exist to be read back: PPU2 open bus drives it instead (Mesen2
+                // `((_cgram[cgAddr] >> 8) & 0x7F) | (_state.Ppu2OpenBus & 0x80)`).
+                // Since the preceding low-byte read leaves that byte on the open
+                // bus, a colour whose low byte has bit 7 set reads its high byte
+                // back with bit 7 set too -- which byuu's `test_hdma.smc`
+                // sub-test 4 checks by HDMA-ing $9ABC into CGRAM and reading it
+                // back as $BC, $9A (#3062).
+                let value = if index & 1 == 1 {
+                    (self.cgram[index] & 0x7F) | (self.ppu2_open_bus & 0x80)
+                } else {
+                    self.cgram[index]
+                };
                 self.increment_cgram_address();
                 self.ppu2_open_bus = value;
                 value
@@ -894,6 +906,48 @@ mod tests {
         ppu.write_register(0x2121, 0x10);
         assert_eq!(ppu.read_register(0x213B), 0x34);
         assert_eq!(ppu.read_register(0x213B), 0x12);
+    }
+
+    // CGRAM holds 15-bit colours, so bit 15 does not exist to be read back.
+    // Reading the odd byte returns the 7 stored bits with PPU2 open bus
+    // supplying bit 7 (Mesen2 `SnesPpu.cpp` $213B:
+    // `((_cgram[cgAddr] >> 8) & 0x7F) | (_state.Ppu2OpenBus & 0x80)`).
+    //
+    // byuu's `test_hdma.smc` sub-test 4 depends on exactly this: it HDMAs
+    // $9ABC into CGRAM[0] and reads it back as $BC, $9A. The first read
+    // leaves $BC on PPU2 open bus, whose bit 7 then completes the second
+    // (#3062). `cgram_reads_should_return_stored_bytes_and_increment` above
+    // never caught it because both its bytes have bit 7 clear.
+    #[test]
+    fn cgram_high_byte_read_takes_bit_7_from_ppu2_open_bus() {
+        let mut ppu = Ppu::new();
+        // Both colours store the SAME high byte ($9A and $1A are identical once
+        // masked to 15 bits); only their low bytes differ, and with them the
+        // open-bus value left behind by the preceding read.
+        ppu.write_register(0x2121, 0x00);
+        ppu.write_register(0x2122, 0xBC);
+        ppu.write_register(0x2122, 0x9A);
+        ppu.write_register(0x2122, 0x34);
+        ppu.write_register(0x2122, 0x1A);
+
+        ppu.write_register(0x2121, 0x00);
+        assert_eq!(ppu.read_register(0x213B), 0xBC, "low byte is stored whole");
+        assert_eq!(
+            ppu.read_register(0x213B),
+            0x9A,
+            "high byte takes bit 7 from the $BC left on PPU2 open bus"
+        );
+
+        // Control: same stored high byte, but the preceding read leaves bit 7
+        // clear, so it reads back without it. The bit comes from the open bus,
+        // not from anything CGRAM retained across the write.
+        ppu.write_register(0x2121, 0x01);
+        assert_eq!(ppu.read_register(0x213B), 0x34);
+        assert_eq!(
+            ppu.read_register(0x213B),
+            0x1A,
+            "bit 7 stays clear when the open bus has it clear"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #3062

Two independent root causes, both found by reading the ROMs' own results out of
SRAM instead of squinting at the screen. The issue's original framing — HDMA
H-position timing, "the ROM verifies hdma begins at H=1104" — turned out to be
wrong: those checks (`test_hdmatiming` rows 7-8) were already passing.

## How they were found

These ROMs declare 32 KB SRAM and write machine-readable verdicts to bank `$70`:
`test_hdma.smc` a failing sub-test number, `test_hdmatiming.smc` 8 rows of
measurements it compares against an in-ROM `compdata` table. A throwaway test
that runs the ROM and dumps `$70:0000..003F` named both defects directly.

Starting point: `test_hdma` reported sub-test **4**, and `test_hdmatiming` failed
rows **1-6** while rows 7-8 matched exactly.

## Fix 1 — `$43xA` is the HDMA line counter, not an internal copy

NESER kept the counter and repeat flag in `hdma_lines_left: [u16; 8]` and
`hdma_repeat_mode: [bool; 8]`, which `hdma_do_line` decremented and then wrote
the register *from*. `write_register` updates only the register file, so a CPU
write to `$43xA` was invisible to the very next scanline.

That breaks every ROM arming HDMA mid-frame: it writes the pointer and counter by
hand, then sets `$420C` after the frame's HDMA init has run. The copy was still
zero, so `0 - 1` wrapped to `$FF` instead of decrementing what the CPU wrote, and
since it never reached zero the descriptor was never consumed — so indirect
addresses never loaded either.

Mesen2 keeps no copy (`SnesDmaController.cpp:277`): `ch.HdmaLineCounterAndRepeat--`
operates on `$43xA` directly, `case 0x430A:` writes straight to it, and expiry is
tested on the low seven bits so a repeat-mode counter expires at `$80`. Same here;
`decode_hdma_descriptor`/`encode_hdma_counter` existed only to convert between the
register and the copy and are gone.

Result: `test_hdmatiming` rows 2-6 became exact.

## Fix 2 — `$213B` CGRAM high-byte reads take bit 7 from PPU2 open bus

CGRAM stores 15-bit colours, so the high byte's bit 7 does not exist to be read
back; hardware drives it from PPU2 open bus. Since the preceding low-byte read
leaves that byte on the bus, a colour whose low byte has bit 7 set reads its high
byte back with bit 7 set too (Mesen2 `SnesPpu.cpp` $213B:
`((_cgram[cgAddr] >> 8) & 0x7F) | (_state.Ppu2OpenBus & 0x80)`).

NESER returned the stored byte verbatim, so bit 7 always read back as 0.
`test_hdma` sub-test 4 HDMAs `$9ABC` into CGRAM[0] and reads it back as `$BC, $9A`;
NESER read `$BC, $1A`. Logging the HDMA B-bus writes alongside the `$213B` reads
showed the transfers were already correct byte for byte — the divergence was
entirely in the read path.

`cgram_reads_should_return_stored_bytes_and_increment` never caught this because
both bytes of the colour it reads have bit 7 clear.

## Result

| test | before | after |
| --- | --- | --- |
| `kungfufurby_hdma_tests::test_hdma_passes` | sub-test 4 FAIL | **PASS, un-ignored** |
| `kungfufurby_hdma_tests::test_hdmasync_passes` | (already green via #3116) | PASS |
| `kungfufurby_hdma_tests::test_hdmatiming_passes` | rows 1-6 wrong | one value left, still ignored |

`test_hdma.smc` now reports `!test_number = 0` in SRAM and renders the blue PASS
backdrop.

## What is left, and why it is not this issue

`test_hdmatiming` is down from 6 failing rows to **one differing value**: row 1's
first `$2137` latch reads `$014F` where hardware reads `$014E`. The *second* latch
in the same row matches, rows 2-6 exercise the same per-channel overheads at other
CPU sync phases and all match, and `SyncStartDma`/`SyncEndDma` are already
formula-identical to Mesen2's. So it is a 4-master-clock CPU arrival difference at
one alignment — the #3050 family, a different subsystem. Split out as issue 3120
with the full measurement table; the test stays `#[ignore]`d pointing there.

Rows 9-12 of the same ROM also differ, but it records them without comparing them
(`cpx.w #64` stops at row 8), so they do not affect the verdict. They need the
HDMA-during-GPDMA nesting `src/snes/bus/dma.rs` documents as deliberately
unmodelled.

## Tests

- `hdma_line_counter_decrements_the_value_the_cpu_wrote_to_43xa` — the ROM's
  sub-test 1 at unit level.
- `hdma_cpu_written_counter_of_one_consumes_the_descriptor` — its sub-test 2.
- `hdma_repeat_counter_expires_on_the_low_seven_bits` — pins Mesen2's `& 0x7F`.
- `hdma_zero_counter_wraps_into_a_continuous_transfer` — `test_hdma` sub-test 4 at
  controller level. Written after the fix, so mutation-checked: making the
  decrement saturating instead of wrapping produces zero transfers and it fails.
- `cgram_high_byte_read_takes_bit_7_from_ppu2_open_bus` — with a control that
  reads the *same* stored high byte after a low byte with bit 7 clear, so the bit
  is shown to come from the open bus rather than from anything CGRAM retained.

`hdma_repeat_mode` and `hdma_lines_left` leave `SnesDmaState`. Older save states
still carry the keys and load fine (serde ignores unknown fields) — the same
compatibility story as `bbus_ports` in #3061, so no version bump.

## Checks

Full pre-merge gate run locally; results in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
