### PR TITLE
test(gb): drop the unusable oam_bug 7-timing_effect single-ROM test (#3115)

### DIFF
--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -780,43 +780,24 @@ fn test_oam_bug_6_timing_no_bug() {
     );
 }
 
-/// `7-timing_effect` cannot report a result through the cartridge-RAM channel.
-///
-/// For every sweep timing that corrupts, the ROM prints a 525-byte block — the
-/// sweep index, then a full 521-byte OAM dump — and a correct DMG corrupts on 19
-/// of them (Mode 2 walks 20 OAM rows, one per M-cycle, and row 0 is immune).
-/// That is `17 + 19×525 + 8 = 10 000` bytes of text against the 8188 available
-/// at `$A004..$BFFF`.
-/// `write_text_out` (`oam_bug/source/common/shell.s`) has no bounds check, so
-/// the overrun walks into `$C000`, where `copy_to_wram_then_run` placed the
-/// ROM's own code — measured: 2040 bytes of that code overwritten, cartridge
-/// RAM switched off, CPU executing rubbish.  The ROM therefore never reaches
-/// `check_crc`, on any emulator and on hardware.  Tracked in #3115.
-///
-/// The behaviour this ROM tests is covered by [`test_oam_bug_multi_rom`]
-/// instead: the multi-ROM build defines `CUSTOM_PRINT`, does not use the
-/// cartridge-RAM buffer, and reports subtest 7's verdict on screen.
-#[test]
-#[ignore = "unusable ROM build: output overruns its own $A004 text buffer into WRAM — tracked in #3115"]
-fn test_oam_bug_7_timing_effect() {
-    let mut gb =
-        load_gb_rom("roms/gb/automated_tests/blargg/oam_bug/rom_singles/7-timing_effect.gb");
-    let output = run_blargg_rom_cart_ram(&mut gb);
-    assert!(
-        output.contains("Passed"),
-        "expected Passed, got: {output:?}"
-    );
-}
-
 /// The multi-ROM build runs all eight `oam_bug` subtests and reports each one's
-/// verdict on screen, including subtest 7 (`timing_effect`), which the single
-/// ROM cannot report — see [`test_oam_bug_7_timing_effect`].
+/// verdict on screen.
+///
+/// This is the only place subtest 7 (`timing_effect`) is checked, and there is
+/// no single-ROM test for it: `rom_singles/7-timing_effect.gb` prints far more
+/// text than the 8188-byte `$A004..$BFFF` buffer it writes into, and
+/// `write_text_out` (`oam_bug/source/common/shell.s`) has no bounds check, so
+/// the overrun walks into `$C000` — WRAM, where `copy_to_wram_then_run` placed
+/// the code the ROM is executing.  It therefore never reaches `check_crc`, on
+/// any emulator and on hardware; measurements in #3115.  The multi-ROM build
+/// defines `CUSTOM_PRINT`, uses no cartridge-RAM buffer, and is unaffected.
 #[test]
 fn test_oam_bug_multi_rom() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/blargg/oam_bug/oam_bug.gb");
     let output = run_blargg_rom_lcd(&mut gb);
-    // Assert the subtest this suite's single-ROM coverage cannot reach first,
-    // so a regression names it rather than only failing the overall verdict.
+    // Assert subtest 7 before the overall verdict so a regression names it.
+    // This discriminates: making `Ppu::current_oam_row` top out at row 18
+    // leaves every other subtest reporting `ok` and fails only this one.
     assert!(
         output.contains("07:ok"),
         "oam_bug subtest 7 (timing_effect) must pass, got:\n{output}"

--- a/src/gb/integration_tests/blargg_tests.rs
+++ b/src/gb/integration_tests/blargg_tests.rs
@@ -783,14 +783,21 @@ fn test_oam_bug_6_timing_no_bug() {
 /// The multi-ROM build runs all eight `oam_bug` subtests and reports each one's
 /// verdict on screen.
 ///
-/// This is the only place subtest 7 (`timing_effect`) is checked, and there is
-/// no single-ROM test for it: `rom_singles/7-timing_effect.gb` prints far more
-/// text than the 8188-byte `$A004..$BFFF` buffer it writes into, and
-/// `write_text_out` (`oam_bug/source/common/shell.s`) has no bounds check, so
-/// the overrun walks into `$C000` — WRAM, where `copy_to_wram_then_run` placed
-/// the code the ROM is executing.  It therefore never reaches `check_crc`, on
-/// any emulator and on hardware; measurements in #3115.  The multi-ROM build
-/// defines `CUSTOM_PRINT`, uses no cartridge-RAM buffer, and is unaffected.
+/// It is the only place blargg's *verdict* for subtest 7 (`timing_effect`) is
+/// asserted, because the single-ROM build cannot report one:
+/// `rom_singles/7-timing_effect.gb` prints far more text than the 8188-byte
+/// `$A004..$BFFF` buffer it writes into, `write_text_out`
+/// (`oam_bug/source/common/shell.s`) has no bounds check, and the overrun walks
+/// into `$C000` — WRAM, where `copy_to_wram_then_run` placed the code the ROM is
+/// executing.  It therefore never reaches `check_crc`, on any emulator and on
+/// hardware; measurements in #3115.  The multi-ROM build defines `CUSTOM_PRINT`,
+/// uses no cartridge-RAM buffer, and is unaffected.
+///
+/// The behaviour behind that subtest is covered separately: `Ppu::current_oam_row`
+/// and the corruption patterns have unit tests in `gb::bus::dmg_bus` (see
+/// `test_notify_idu_glitch_applies_corruption_at_row_19`).  And the two
+/// cartridge-RAM oracle tests below load `7-timing_effect.gb` only as an MBC1
+/// 8 KB cartridge to plant bytes in — they never execute it.
 #[test]
 fn test_oam_bug_multi_rom() {
     let mut gb = load_gb_rom("roms/gb/automated_tests/blargg/oam_bug/oam_bug.gb");


### PR DESCRIPTION
## Summary

Closes #3115.

`rom_singles/7-timing_effect.gb` cannot report a verdict on any emulator or on hardware, so `test_oam_bug_7_timing_effect` was `#[ignore]`d against an issue with no resolution that produces a working single-ROM test — i.e. it would have stayed open forever, which is the stale-ignore pattern #3097 set out to remove.

This PR deletes the test and folds the reason into `test_oam_bug_multi_rom`'s doc comment.

## Why the ROM is unusable

Every claim in #3115 was re-verified against the current tree:

- Cart header: `$147 = $03` (MBC1+RAM+BATTERY), `$149 = $02` (8 KB) → the text buffer is `$A004..$BFFF`, **8188 bytes**.
- `write_text_out` (`oam_bug/source/common/shell.s`) appends and increments with no bounds check, and `copy_to_wram_then_run` runs the ROM's own code from `$C000` — which is **WRAM**, not cartridge — so the overrun clobbers live code regardless of MBC state. It never reaches `check_crc`.
- The verdict is `check_crc $7D792E7C` over *printed characters*, not over the buffer. Since `test_oam_bug_multi_rom` passes `07:ok` against blargg's own CRC, our subtest-7 character stream is byte-identical to real hardware's — so the output volume genuinely exceeds the buffer on hardware too. This is a ROM build defect, not an emulation gap.
- Current behaviour: the test returned `"[timed out, partial output] "` with an *empty* partial, because the runaway code disables cartridge RAM before the harness can read it.

One point #3115 does not draw out, which closes off its second option: **a bounds check would not have helped**. `"\nPassed"` is printed *last*, so it is precisely what such a check would drop — the cart-RAM channel still reports nothing. The only build that can report a verdict is `CUSTOM_PRINT` + screen output, which is exactly what `oam_bug.gb` already is.

## The coverage claim was proven, not asserted

Deleting a test on the grounds that another one covers it needs evidence, so that was the red bar. Mutating `Ppu::current_oam_row`:

| Mutation | Multi-ROM result |
|---|---|
| baseline | `ok` |
| pre-#3104 numbering, `(dot-4)/4` | FAILED on `07:ok` — `04:`, `05:`, `07:`, `08:` blank; ROM says `Failed #4` |
| lose only row 19, `(dot/4).min(18)` | FAILED on `07:ok` — `01..06:ok`, `08:ok`, only `07:` blank; ROM says **`Failed #7`** |

The third row is the decisive one: removing *only* OAM row 19 — the exact defect #3104 fixed — fails *only* subtest 7, the ROM's own verdict agrees, and the `07:ok` assertion fires and names it. So the multi-ROM genuinely covers subtest 7, and its `07:ok` assertion is load-bearing rather than decorative. It also confirms the marker is really visible in the 20x18 tile map rather than scrolled away.

That evidence is now recorded inline above the assertion. Both mutations were reverted.

Subtest 7's discriminating behaviour additionally has ROM-independent unit coverage in `test_notify_idu_glitch_applies_corruption_at_row_19` (`src/gb/bus/dmg_bus.rs`).

## Notes

- **The ROM file stays.** Beyond the vendored-ROM rule, two cartridge-RAM oracle tests — `test_cart_ram_output_reads_the_whole_8k_buffer` and `test_cart_ram_timeout_reports_partial_output` — load it as an MBC1 8 KB cartridge and plant cart RAM directly without ever executing it.
- **No production code changes.** One file, 12 insertions / 31 deletions.
- **No dead code**: `run_blargg_rom_cart_ram` keeps 40 references; `TIMEOUT_PREFIX` and the cart-RAM helpers are all still used.
- **Ignore audit**: `src/gb` goes from 10 ignored tests to 9 — eight screenshot helpers and one fixture regenerator. **None of the nine cites an issue**, open or closed.
- `architecture.md` has no entry for `blargg_tests.rs`, and `README-GB.md:111` describes the suite as "Blargg CPU, timing, OAM bug, and sound tests", which stays true — so no doc updates.

## Pre-merge checks

| Check | Result |
|---|---|
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `cargo test --no-default-features --lib` | 12847 passed, 0 failed, 23 ignored (was 24) |
| `./scripts/test-dir.sh src/gb` | 1513 passed, 0 failed, 9 ignored (was 10) |
| `gb::integration_tests::blargg_tests` | 56 passed, 0 failed, 0 ignored |
| `wasm-pack test --headless --chrome --no-default-features --features wasm` | 94 passed, 0 failed |
| Python suites (scripts, metadata-scraper, nes-rom-db-scraper) | 250 + 113 + 44, all OK |
| `npm test` | 430 passed (49 files) |
| `cargo doc` | no rustdoc warning in the changed file; no dangling reference to the deleted test anywhere |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
