### PR TITLE
docs: define the vendored submodule refresh policy, and run its checks in CI (#2848)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
               # scripts/test_package_release.py. See docs/VENDOR_SUBMODULES.md.
               - 'vendor/slang-shaders'
               - 'src/platform/shaders.rs'
+              - '.github/workflows/ci.yml'
             rust:
               - 'src/**'
               - 'Cargo.toml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,12 +62,16 @@ jobs:
             python:
               - 'scripts/**/*.py'
             shader_assets:
-              # Bare path entry detects submodule (gitlink) pointer bumps.
               # Release packaging only ships shader files reachable from the
-              # presets in src/platform/shaders.rs, so both the pin and the
-              # preset list must re-run the reachability tests in
-              # scripts/test_package_release.py. See docs/VENDOR_SUBMODULES.md.
+              # presets in src/platform/shaders.rs, so anything that can change
+              # that graph must re-run the reachability and exact-case tests in
+              # scripts/test_package_release.py. That means the preset list, the
+              # vendored presets, and the local ones under shaders/ — which
+              # SHADER_PRESETS also points at (stock.slangp, gba-lcd.slangp).
+              # The bare vendor path detects submodule (gitlink) pointer bumps.
+              # See docs/VENDOR_SUBMODULES.md.
               - 'vendor/slang-shaders'
+              - 'shaders/**'
               - 'src/platform/shaders.rs'
               - '.github/workflows/ci.yml'
             rust:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
               # scripts/test_package_release.py. See docs/VENDOR_SUBMODULES.md.
               - 'vendor/slang-shaders'
               - 'src/platform/shaders.rs'
-              - '.github/workflows/ci.yml'
             rust:
               - 'src/**'
               - 'Cargo.toml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
       web_integration: ${{ steps.filter.outputs.web_integration }}
       python: ${{ steps.filter.outputs.python }}
+      shader_assets: ${{ steps.filter.outputs.shader_assets }}
       rust: ${{ steps.filter.outputs.rust }}
       nes: ${{ steps.filter.outputs.nes }}
       gb: ${{ steps.filter.outputs.gb }}
@@ -60,6 +61,15 @@ jobs:
               - '.github/workflows/ci.yml'
             python:
               - 'scripts/**/*.py'
+            shader_assets:
+              # Bare path entry detects submodule (gitlink) pointer bumps.
+              # Release packaging only ships shader files reachable from the
+              # presets in src/platform/shaders.rs, so both the pin and the
+              # preset list must re-run the reachability tests in
+              # scripts/test_package_release.py. See docs/VENDOR_SUBMODULES.md.
+              - 'vendor/slang-shaders'
+              - 'src/platform/shaders.rs'
+              - '.github/workflows/ci.yml'
             rust:
               - 'src/**'
               - 'Cargo.toml'
@@ -94,7 +104,10 @@ jobs:
   python-tests:
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.python == 'true' || github.event_name == 'workflow_call'
+    if: >-
+      needs.changes.outputs.python == 'true'
+      || needs.changes.outputs.shader_assets == 'true'
+      || github.event_name == 'workflow_call'
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ python -m unittest discover -s scripts/nes-rom-db-scraper -t scripts/nes-rom-db-
 - `roms/` contains automated test ROMs and test assets.
 - `scripts/` contains build, packaging, test, ROM management, and metadata tools.
 - `shaders/` and `vendor/slang-shaders/` contain shader presets used by the native frontend.
+  `vendor/slang-shaders/` is a pinned submodule; see
+  [docs/VENDOR_SUBMODULES.md](docs/VENDOR_SUBMODULES.md) for when and how to move the pin, and
+  how to re-verify shader reachability afterwards.
 - [architecture.md](architecture.md) describes the codebase structure in more detail.
 
 ## License

--- a/architecture.md
+++ b/architecture.md
@@ -554,6 +554,9 @@ Shader presets using the Slang shading language, loaded via librashader:
 | `docs/MAPPER_CAPABILITIES.md` | Per-mapper capability matrix (banking, IRQ, audio expansion, etc.). |
 | `docs/MAPPERTOOL_UI_DESIGN.md` | Design document for the mappertool TUI. |
 | `docs/architecture-diagrams.md` | Save-state architecture diagrams (current vs proposed). |
+| `docs/SNES_TEST_ASSET_POLICY.md` | Intake, provenance, and validation rules for SNES automated-test assets. |
+| `docs/VENDOR_SUBMODULES.md` | When and how to move the vendored submodule pins (`vendor/slang-shaders`, `snes_test_roms`), how to avoid moving them by accident, and how to re-verify shader-preset reachability afterwards. |
+| `docs/improvement-plan.md` | Tracked codebase-improvement initiatives (epic #2825). |
 
 ### `.github/` — CI/CD and Automation
 

--- a/docs/VENDOR_SUBMODULES.md
+++ b/docs/VENDOR_SUBMODULES.md
@@ -1,0 +1,107 @@
+# Vendored Submodule Refresh Policy
+
+This document defines when and how NESER's vendored Git submodules are updated, and how to
+re-verify the repository afterwards.
+
+NESER vendors two submodules (see `.gitmodules`):
+
+| Path | Upstream | Used by |
+| ---- | -------- | ------- |
+| `vendor/slang-shaders` | [libretro/slang-shaders](https://github.com/libretro/slang-shaders) | Native-frontend shader presets |
+| `roms/snes/automated_tests/snes_test_roms` | [rmstdope/snes-test-roms](https://github.com/rmstdope/snes-test-roms) | SNES automated tests |
+
+## Why they are pinned
+
+The pin is the point. Release archives ship only the shader files reachable from the presets
+configured in `src/platform/shaders.rs`, so the pinned commit determines exactly what a release
+contains and how those presets look. Nothing in the build wants a newer upstream, and no test
+checks that a preset still *renders* correctly, so moving the pin changes user-visible output
+with no automatic signal.
+
+## Cadence: on demand, never scheduled
+
+There is no periodic refresh. Bump a submodule only when there is a specific reason:
+
+- a new preset is being added to `SHADER_PRESETS`, and it needs a file the current pin lacks;
+- a specific upstream fix is needed;
+- for `snes_test_roms`, new test assets have been merged upstream.
+
+**An unexplained pin move in an unrelated PR is a defect. Revert it rather than rationalising
+it.** This is not hypothetical — it is the failure mode that has actually occurred here.
+`vendor/slang-shaders` has oscillated between two commits, twice moving as a side effect of an
+unrelated SNES change (`3bc2edee`, `884a64ec`), with one deliberate "bump" (`16068cd9`) moving it
+*backwards*. `snes_test_roms` had the same problem in `fe38cd50`, restored by `e62d5fc4`.
+
+## Bumping deliberately
+
+```bash
+git -C vendor/slang-shaders fetch origin
+git -C vendor/slang-shaders checkout <upstream-sha>
+git add vendor/slang-shaders
+```
+
+Stage the gitlink on its own, in a commit that does nothing else, and say in the commit message
+which upstream commit you moved to and why. A pin move that is easy to review is a pin move that
+stays correct.
+
+## Avoiding accidental moves
+
+A submodule worktree that is out of date with the pin will be staged as a pin *regression* if you
+`git add -A`. Two habits prevent it:
+
+```bash
+git submodule update --init --recursive   # after every pull or branch switch
+git submodule status                      # before committing — expect no leading +/-
+git diff --cached --submodule             # shows any staged gitlink move explicitly
+```
+
+A leading `+` in `git submodule status` means the checked-out commit differs from the pin. Resolve
+that before committing, in whichever direction is correct.
+
+CI helps too: `.github/workflows/ci.yml` has a `shader_assets` filter whose bare
+`vendor/slang-shaders` entry matches a gitlink-only change, so moving the pin runs the
+verification below. Without that entry a pin move matches no filter and runs almost no CI at all.
+
+## Verifying after a bump
+
+```bash
+python -m unittest discover -s scripts -t scripts -p "test_package_release.py"
+```
+
+Two of those tests run against the real repository tree:
+
+- `test_repository_shader_dependencies_are_collectable` walks every `.slangp` reachable from
+  `SHADER_PRESETS` and follows its `shader0=`, `#reference` and `#include` edges.
+  `_collect_shader_file` raises `FileNotFoundError` on a missing target, so a moved or renamed
+  shader file fails here — and, if it ever got past here, would fail the release build.
+- `test_repository_shader_preset_paths_match_exact_vendor_casing` checks each configured preset
+  path component-by-component with exact case. macOS filesystems are case-insensitive by default,
+  so an upstream rename that only changes capitalisation would otherwise work locally and break on
+  Linux.
+
+### What this does not prove
+
+- **Textures are not covered.** `_collect_existing_lut` finds textures with a loose regex and then
+  filters on `exists()`, which cannot distinguish a renamed texture from a regex false positive —
+  so a preset can package and ship without its lookup table, silently. Tracked in
+  [#3123](https://github.com/rmstdope/neser/issues/3123).
+- **Appearance is not covered.** No test renders through a shader. If a bump changes how a preset
+  looks, only running the emulator will show it. Check the presets you care about by hand.
+- **Preset paths are duplicated.** `src/platform/shaders.rs` is the source of truth, but the same
+  paths appear as string literals in `src/nes/console/config/cli.rs` tests. If an upstream rename
+  forces a path change, update both.
+
+## Per-submodule notes
+
+### `vendor/slang-shaders`
+
+Everything above applies. Note the clone is `shallow = true`, so `git -C vendor/slang-shaders log`
+shows only recent history; fetch more depth if you need to inspect an older commit.
+
+### `roms/snes/automated_tests/snes_test_roms`
+
+Bump mechanics and the accidental-move guidance above apply unchanged. Provenance, manifest
+metadata, licensing and the committed-CI-subset rules are **not** repeated here — they are
+specified in [SNES_TEST_ASSET_POLICY.md](SNES_TEST_ASSET_POLICY.md), which is the authority for
+that submodule's contents. SNES test commands and the golden-baseline approval workflow are in
+[README-SNES.md](../README-SNES.md).


### PR DESCRIPTION
## Summary

Closes #2848 (epic #2825, item I5.3).

Adds `docs/VENDOR_SUBMODULES.md` defining when and how the vendored submodule pins move and how to re-verify afterwards, links it from `README.md` and `architecture.md`, and adds a `shader_assets` paths-filter so a pin move actually runs the verification.

## What the investigation changed

**The re-verification tooling already existed.** `scripts/test_package_release.py` has two tests that run against the real repo tree — `test_repository_shader_dependencies_are_collectable` (walks every `.slangp` reachable from `SHADER_PRESETS`, following `shader0=` / `#reference` / `#include`; `_collect_shader_file` raises `FileNotFoundError` on a missing target) and `test_repository_shader_preset_paths_match_exact_vendor_casing` (exact-case check, so an upstream capitalisation rename can't pass on case-insensitive macOS and break Linux). Both pass at the current pin, so there is no live drift. The doc names them rather than building anything.

**CI never ran them on the change that needs them.** A gitlink-only bump reports as the bare path `vendor/slang-shaders` (confirmed against `884a64ec`), which matched **no** filter in `ci.yml` — so moving the pin ran almost no CI at all. The `snes_test_assets` filter has carried a bare path entry commented "detects submodule (gitlink) pointer bumps" for the *other* submodule; the shader submodule never got the equivalent. This PR adds it.

**The real failure mode is accidental movement, not upstream drift.** The pin has oscillated between two commits, twice moving as a side effect of an unrelated SNES change:

| Commit | Date | Move |
| --- | --- | --- |
| `16925a1a` | 06-22 | `eda1f16a` -> `cef2de61` |
| `751ea4f5` | 06-22 | back to `eda1f16a`, same day |
| `3bc2edee` "Merge SNES ROM header and APU fixes" | 06-24 | -> `cb8e5341` (rode along) |
| `16068cd9` "Retrospective and bumped slang-shaders" | 07-03 | -> `eda1f16a` (moved it *backwards*) |
| `884a64ec` "fix(snes): mid-scanline HDMA activation" | 07-10 | -> `cb8e5341` (rode along) |

The current pin arrived via an accidental bump inside an SNES fix. `snes_test_roms` had the same problem in `fe38cd50`, restored by `e62d5fc4`. So the policy states plainly that an unexplained pin move in an unrelated PR is a defect to revert.

## Cadence

On demand, never scheduled. The pin exists for reproducible release output; nothing in the build wants a newer upstream, and no test checks that a preset still *renders* correctly.

## What the note says verification cannot see

- **Textures.** `_collect_existing_lut` matches them with a loose regex and then filters on `exists()`, which cannot distinguish a renamed texture from a regex false positive — so a preset can ship without its lookup table, silently. Filed as #3123.
- **Appearance.** No test renders through a shader.
- **Duplication.** Preset paths also appear as string literals in `src/nes/console/config/cli.rs` tests.

## Verification

A paths-filter cannot be unit-tested, so both halves of the filter are proven by observation:

1. **Wiring** — this commit touches `.github/workflows/ci.yml`, which the new filter lists, so `python-tests` must run on it. (The `python` filter alone would not have matched: it is `scripts/**/*.py`.)
2. **Gitlink half** — a following commit temporarily moves the pin to a neighbouring upstream commit with nothing else touched, to confirm `python-tests` fires on the bare path; it is then reverted. Squash-merge means the merged commit contains **no** gitlink change. I will confirm `git diff origin/main -- vendor/slang-shaders` is empty immediately before merge.

Run URLs for both will be recorded in a comment below.

Also verified locally: the two repository shader tests are among the 250 that pass, every relative link in the new and edited docs resolves, and the workflow YAML parses with the expected `python-tests` condition and filter contents.

## Notes

- No Rust or Python source changes.
- `python-tests` will now also run on any `ci.yml` edit, consistent with how the `rust` and `web` filters already treat that file.
- `architecture.md`'s `docs/` table was missing `SNES_TEST_ASSET_POLICY.md` and `improvement-plan.md`; backfilled alongside the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
