### PR TITLE
fix(packaging): resolve declared shader textures strictly (#3123)

### DIFF
--- a/docs/VENDOR_SUBMODULES.md
+++ b/docs/VENDOR_SUBMODULES.md
@@ -79,12 +79,16 @@ Two of those tests run against the real repository tree:
   so an upstream rename that only changes capitalisation would otherwise work locally and break on
   Linux.
 
+Textures a preset *declares* are covered too. A libretro preset names its textures
+(`textures = "SamplerLUT1;SamplerLUT2"`) and gives each a path on its own line, and those paths are
+resolved as strictly as shader stages: a renamed texture raises rather than being skipped (#3123).
+
 ### What this does not prove
 
-- **Textures are not covered.** `_collect_existing_lut` finds textures with a loose regex and then
-  filters on `exists()`, which cannot distinguish a renamed texture from a regex false positive —
-  so a preset can package and ship without its lookup table, silently. Tracked in
-  [#3123](https://github.com/rmstdope/neser/issues/3123).
+- **Undeclared image references are still best-effort.** An image path that appears somewhere other
+  than a `textures` declaration is matched by a loose regex and collected only if it exists, because
+  that pattern also matches strings that are not references at all. No preset in the tree relies on
+  this today.
 - **Appearance is not covered.** No test renders through a shader. If a bump changes how a preset
   looks, only running the emulator will show it. Check the presets you care about by hand.
 - **Preset paths are duplicated.** `src/platform/shaders.rs` is the source of truth, but the same

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -86,6 +86,8 @@ _SHADER_RE = re.compile(r"^\s*shader\d+\s*=\s*(.+)$")
 _INCLUDE_RE = re.compile(r'^\s*#include\s+"([^"]+)"')
 _LUT_QUOTED_RE = re.compile(r'"([^"]+\.(?:png|jpg|jpeg))"', re.IGNORECASE)
 _LUT_BARE_RE = re.compile(r"=\s*([^\s]+\.(?:png|jpg|jpeg))", re.IGNORECASE)
+_TEXTURES_RE = re.compile(r"^\s*textures\s*=\s*(.+?)\s*$", re.IGNORECASE)
+_KEY_VALUE_RE = re.compile(r"^\s*([^\s=]+)\s*=\s*(.+?)\s*$")
 
 
 def _read_shader_preset_paths(shaders_rs_path: Path) -> list[Path]:
@@ -122,13 +124,38 @@ def _collect_shader_file(
         processing.remove(path)
 
 
+def _read_texture_names(lines: list[str]) -> set[str]:
+    """Return the texture names a preset declares in its `textures` key(s).
+
+    A libretro preset names its textures rather than listing their paths:
+
+        textures = "SamplerLUT1;SamplerLUT2"
+        SamplerLUT1 = shaders/lut/a.png
+
+    so the names collected here are what turns a later `SamplerLUT1 = ...` line
+    into a known-real reference rather than a string that merely looks like one.
+    """
+
+    names: set[str] = set()
+    for line in lines:
+        match = _TEXTURES_RE.match(line)
+        if match:
+            value = _clean_path(match.group(1))
+            names.update(name.strip() for name in value.split(";") if name.strip())
+    return names
+
+
 def _collect_preset_dependencies(
     repo_root: Path,
     path: Path,
     dependencies: set[Path],
     processing: set[Path],
 ) -> None:
-    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+    lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    texture_names = _read_texture_names(lines)
+    resolved_textures: set[str] = set()
+
+    for line in lines:
         reference_match = _REFERENCE_RE.match(line)
         if reference_match:
             _collect_relative_shader_file(repo_root, path, reference_match.group(1), dependencies, processing)
@@ -146,6 +173,19 @@ def _collect_preset_dependencies(
                 )
                 continue
 
+        # A declared texture is as required as any shader stage, so resolve it
+        # through _collect_shader_file, which raises when the target is gone.
+        # The key must match a declared name exactly: presets interleave
+        # `<name>_linear` / `_mipmap` / `_wrap_mode` option lines with the paths.
+        key_value_match = _KEY_VALUE_RE.match(line)
+        if key_value_match and key_value_match.group(1) in texture_names:
+            _collect_relative_shader_file(repo_root, path, key_value_match.group(2), dependencies, processing)
+            resolved_textures.add(key_value_match.group(1))
+            continue
+
+        # Fallback for images referenced some other way. Best-effort by
+        # necessity: these patterns also match strings that are not references,
+        # so a match that does not exist is skipped rather than raised.
         for lut_path in _LUT_QUOTED_RE.findall(line):
             _collect_existing_lut(repo_root, path, lut_path, dependencies, processing)
         bare_lut_match = _LUT_BARE_RE.search(line)
@@ -157,6 +197,10 @@ def _collect_preset_dependencies(
                 dependencies,
                 processing,
             )
+
+    unassigned_textures = texture_names - resolved_textures
+    if unassigned_textures:
+        raise ValueError(f"{path}: textures declared but never assigned a path: {sorted(unassigned_textures)}")
 
 
 def _collect_include_dependencies(

--- a/scripts/test_package_release.py
+++ b/scripts/test_package_release.py
@@ -82,9 +82,12 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
 ];
 """,
             )
+            # `textures` lists texture *names*; each name then has its own line
+            # giving the path. Earlier revisions of this fixture wrote
+            # `textures = "lut.png"`, which no real preset does.
             write_text(
                 repo_root / "vendor/slang-shaders/crt/preset.slangp",
-                '#reference "../common/base.slangp"\nshader0 = pass.slang\ntextures = "lut.png"\n',
+                '#reference "../common/base.slangp"\nshader0 = pass.slang\ntextures = "LUT"\nLUT = lut.png\n',
             )
             write_text(
                 repo_root / "vendor/slang-shaders/crt/pass.slang",
@@ -111,6 +114,110 @@ pub const SHADER_PRESETS: &[(&str, &str)] = &[
                     Path("vendor/slang-shaders/common/base.slang"),
                 },
             )
+
+    def _write_preset_repo(self, repo_root: Path, preset_body: str) -> None:
+        """Write a minimal repo whose single configured preset has `preset_body`."""
+
+        write_text(
+            repo_root / "src/platform/shaders.rs",
+            "pub const SHADER_PRESETS: &[(&str, &str)] = &[\n"
+            '    ("crt", "vendor/slang-shaders/crt/preset.slangp"),\n'
+            "];\n",
+        )
+        write_text(repo_root / "vendor/slang-shaders/crt/preset.slangp", preset_body)
+        write_text(repo_root / "vendor/slang-shaders/crt/pass.slang", "void main() {}\n")
+
+    def test_declared_texture_that_is_missing_fails_collection(self) -> None:
+        """A texture the preset declares must resolve, like any other reference.
+
+        Missing `.slangp`/`.slang`/`.inc` targets already raise. Textures used to
+        be matched by a loose regex and then filtered on `exists()`, which cannot
+        tell a renamed texture from a regex false positive -- so a preset could be
+        packaged without its lookup table, silently (#3123).
+        """
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            repo_root = Path(temp_dir_str)
+            self._write_preset_repo(
+                repo_root,
+                "shader0 = pass.slang\ntextures = LUT\nLUT = lut/renamed-away.png\n",
+            )
+
+            with self.assertRaises(FileNotFoundError) as caught:
+                collect_shader_dependencies(repo_root)
+
+            self.assertIn("renamed-away.png", str(caught.exception))
+
+    def test_quoted_textures_declaration_resolves_paths_and_ignores_option_keys(self) -> None:
+        """Quoted `textures = "A;B"` resolves both paths, not the adjacent option keys.
+
+        Real presets interleave `<name>_linear`, `<name>_mipmap` and
+        `<name>_wrap_mode` with the path lines, so a declared name has to match a
+        key exactly rather than as a prefix.
+        """
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            repo_root = Path(temp_dir_str)
+            self._write_preset_repo(
+                repo_root,
+                "shader0 = pass.slang\n"
+                'textures = "SamplerLUT1;SamplerLUT2"\n'
+                "SamplerLUT1 = lut/first.png\n"
+                'SamplerLUT1_mipmap = "false"\n'
+                'SamplerLUT1_linear = "true"\n'
+                'SamplerLUT1_wrap_mode = "clamp_to_border"\n'
+                # Deliberately before SamplerLUT2's own line: a parser that
+                # matched a declared name as a prefix would resolve "true" as
+                # the path here instead of the .png below.
+                'SamplerLUT2_linear = "true"\n'
+                'SamplerLUT2 = "lut/second one.png"\n',
+            )
+            write_bytes(repo_root / "vendor/slang-shaders/crt/lut/first.png")
+            write_bytes(repo_root / "vendor/slang-shaders/crt/lut/second one.png")
+
+            dependencies = collect_shader_dependencies(repo_root)
+
+            self.assertIn(Path("vendor/slang-shaders/crt/lut/first.png"), dependencies)
+            self.assertIn(Path("vendor/slang-shaders/crt/lut/second one.png"), dependencies)
+
+    def test_undeclared_image_line_does_not_fail_collection(self) -> None:
+        """A line that merely looks like an image path stays best-effort.
+
+        The loose regexes remain as a fallback for images referenced some other
+        way, so an absent one is skipped rather than raising -- only *declared*
+        textures are strict.
+        """
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            repo_root = Path(temp_dir_str)
+            self._write_preset_repo(
+                repo_root,
+                "shader0 = pass.slang\nsome_unrelated_key = not-a-texture.png\n",
+            )
+
+            dependencies = collect_shader_dependencies(repo_root)
+
+            self.assertNotIn(Path("vendor/slang-shaders/crt/not-a-texture.png"), dependencies)
+
+    def test_declared_texture_without_a_path_line_fails_collection(self) -> None:
+        """A declared name that is never assigned a path is a broken declaration.
+
+        Resolving only the `<name> = path` lines that happen to be present would
+        leave this silent, which is the failure mode #3123 exists to remove: the
+        preset promises a texture and packaging ships without it.
+        """
+
+        with tempfile.TemporaryDirectory() as temp_dir_str:
+            repo_root = Path(temp_dir_str)
+            self._write_preset_repo(
+                repo_root,
+                'shader0 = pass.slang\ntextures = LUT\nLUT_linear = "true"\n',
+            )
+
+            with self.assertRaises(ValueError) as caught:
+                collect_shader_dependencies(repo_root)
+
+            self.assertIn("LUT", str(caught.exception))
 
     def test_create_tar_gz_archive_uses_release_layout_and_excludes_scripts(
         self,


### PR DESCRIPTION
## Summary

Closes #3123.

Release packaging found shader textures with two loose regexes and then filtered the result on `exists()`. That check did double duty: it correctly discarded regex false positives, but it also discarded real references whose target had moved — and the two are indistinguishable. A texture that upstream renamed was dropped from the archive **with no error**, while the `.slangp` / `.slang` / `.inc` graph around it failed loudly. Nothing downstream caught it either: `verify_release_package.py` only requires the local stock shader, and no test renders through a shader.

## The fix

A libretro preset names its textures rather than listing their paths:

```
textures = "SamplerLUT1;SamplerLUT2"
SamplerLUT1 = shaders/lut/a.png
SamplerLUT1_linear = "true"
```

`_collect_preset_dependencies` now reads the declared names first, then resolves a line whose key matches a declared name **exactly** through `_collect_shader_file`, which raises when the target is gone. Exact matching matters because presets interleave `_linear` / `_mipmap` / `_wrap_mode` option lines with the paths.

Declared texture lines are consumed the way `#reference` and `shaderN=` lines already are, so the loose regexes no longer see them — which incidentally removes the leading-quote false positive they produced on every quoted declaration (`_LUT_BARE_RE` was capturing `"shaders/…png` including the quote, and `exists()` was silently swallowing it). The regexes stay as a lenient fallback for images referenced some other way, so **the change cannot regress packaging output in either direction**.

A declared name that is never assigned a path at all now raises too. That was a gap between the plan and my first implementation, caught in self-review: the preset promises a texture and packaging would ship without it, silently — the very failure mode this issue is about.

## Evidence

**Output is unchanged at the current pin.** Captured `collect_shader_dependencies(repo_root)` before and after: identical sets, 57 files, 9 of them images. Not inferred — compared directly, and re-checked after the follow-up change.

**Red bar.** `test_declared_texture_that_is_missing_fails_collection` failed with `FileNotFoundError not raised` before the fix; `test_declared_texture_without_a_path_line_fails_collection` failed with `ValueError not raised` before its follow-up.

**Mutation-checked**, because two of the four tests pass pre-change and a test that has never failed has not been shown to discriminate:

| Mutation | Result |
| --- | --- |
| exact match -> prefix match | 2 errors: `SamplerLUT1_mipmap = "false"` resolved as a path named `false` — caught by the fixture test *and* by the repository-level test on the real tree |
| strict branch disabled | FAIL: `FileNotFoundError not raised` — back to the original bug |

The option-key fixture deliberately places `SamplerLUT2_linear` *before* `SamplerLUT2`'s own line, so a prefix-matching parser resolves `"true"` as the path. Without that ordering the test would have passed under the mutation.

## A fixture that encoded the wrong format

`test_collect_shader_dependencies_resolves_configured_preset_graph` wrote `textures = "lut.png"`, treating the value as a *path*. No real preset does this — all nine declarations in the vendored tree list texture *names* (`SamplerLUT1`, `BORDER`, `COLOR_PALETTE`). Left alone it would have turned red here and looked like a regression I had caused, so it is corrected to the real form with a comment saying why.

## Scope notes

- `docs/VENDOR_SUBMODULES.md` described this as a live limitation (added in #3124); that paragraph now states declared textures are strict and narrows the caveat to undeclared image references.
- **Not** addressed, and still documented as such: an image referenced outside a `textures` declaration remains best-effort, because that regex also matches strings that are not references. No preset in the tree relies on it.
- I verified across the **entire** vendored tree, not just the reachable subset, that zero presets declare a texture name whose path line lives in a different file — so `#reference` inheritance never splits a declaration and the strict check is safe.

## Pre-merge checks

| Check | Result |
| --- | --- |
| `ruff check` / `ruff format --check` / `mypy` | clean, 60 files |
| `python -m unittest discover -s scripts -t . -p "test_*.py"` | 418 passed |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `cargo test --no-default-features --lib` | 12853 passed, 0 failed, 22 ignored |
| `wasm-pack test --headless --chrome` | 94 passed |
| `npm test` | 430 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
