### PR TITLE
DO NOT MERGE: validate the #3103 clippy gate blocks test-code lints

### DIFF
--- a/src/snes/ppu/background.rs
+++ b/src/snes/ppu/background.rs
@@ -3815,4 +3815,16 @@ mod tests {
             "x=1: fine_x=1 → black (no mosaic)"
         );
     }
+
+    // Deliberate clippy violation in test code, to prove the CI gate blocks it.
+    // This PR must never be merged (issue #3103 validation).
+    #[test]
+    fn gate_validation_needless_range_loop() {
+        let values = [1u32, 2, 3];
+        let mut sum = 0u32;
+        for i in 0..values.len() {
+            sum += values[i];
+        }
+        assert_eq!(sum, 6);
+    }
 }


### PR DESCRIPTION
Validation scratch PR for #3103. **Do not merge — this will be closed.**

Adds a deliberate `clippy::needless_range_loop` inside a `#[cfg(test)]` module, the same lint class that escaped via #3095.

Expected: `rust-lint` fails, and branch protection reports the PR as unmergeable. The old `rust-lint-pr` job would have passed this, because without `--all-targets` clippy never compiled test code.