### PR TITLE
DO NOT MERGE: validate the #3133 wasm clippy gate

### DIFF
--- a/src/frontends/web/wasm_tests.rs
+++ b/src/frontends/web/wasm_tests.rs
@@ -1444,4 +1444,14 @@ fn wasm_snes_get_audio_samples_stereo_returns_vec() {
     let samples = snes.get_audio_samples_stereo();
     // Should return a Vec<f32> (stereo samples are interleaved L, R, L, R, ...)
     assert!(samples.len().is_multiple_of(2));
+
+    // Deliberate clippy violation in wasm-only test code, to prove the wasm CI
+    // gate blocks it while the host rust-lint job stays green (issue #3133
+    // validation). This PR must never be merged.
+    let probe = [1u32, 2, 3];
+    let mut total = 0u32;
+    for i in 0..probe.len() {
+        total += probe[i];
+    }
+    assert_eq!(total, 6);
 }


### PR DESCRIPTION
Validation scratch PR for #3133. **Do not merge — will be closed.**

Adds a deliberate `clippy::needless_range_loop` inside `src/frontends/web/wasm_tests.rs`, which only compiles for `wasm32`.

Expected outcome, and the point of the exercise:
- `rust-lint` **passes** — the host gate cannot see this file at all
- `wasm` **fails** — the new gate catches it
- the PR reports as unmergeable

If `rust-lint` also failed, the probe would be in the wrong place and would prove nothing about the new gate.