### PR TITLE
docs(skills): record the #3137 retrospective in snes-hardware-research

### DIFF
--- a/.github/skills/snes-hardware-research/SKILL.md
+++ b/.github/skills/snes-hardware-research/SKILL.md
@@ -448,6 +448,20 @@ epic-#2724 visual suites (#2879, #2880, #2881, #2883, #2884):
    scene under test; parking at X=256 with a Y clear of any visible
    line is safe at every size (this interaction is also how #3003 was
    found).
+7b. **Spec-check every cartridge-header field you hand-write in a
+   synthetic ROM, including the ones nothing seems to read** (from
+   #3137). Header bytes get copied between test ROMs and drift from the
+   image they describe, and an emulator that ignores a field today may
+   use it tomorrow -- at which point the fixture is quietly wrong and
+   the failure looks like an emulator bug. `minimal_snes_rom` declared
+   ROM size `$07` on a 64 KB buffer; fullsnes ("Cartridge Header") gives
+   `$FFD7` as `(1 SHL n)` KB, so `$07` claims 128 KB and the correct
+   value is `$06`. Note the trap in the fix: a reviewer offered "reword
+   the comment or correct the value" and the comment was *accurate* about
+   what `$07` means -- rewording would have preserved a header that lies
+   about the ROM. Check the field against fullsnes and correct the
+   value. Rounding-up in that entry applies only to non-power-of-two
+   carts, so an exact power of two has an exact `n`.
 8. **Verify upstream test-ROM naming against official spec terminology
    before documenting it.** Test-ROM sources can invert or localize the
    official names: undisbeliever's `object-dropout-test.asm` calls the


### PR DESCRIPTION
Retrospective follow-up to #3137 (merged as #3158), per the Definition of Done.

Adds one test-ROM authoring note to `snes-hardware-research`: spec-check every cartridge-header field you hand-write in a synthetic ROM, including the ones nothing currently reads.

`minimal_snes_rom` declared ROM size `$07` on a 64 KB buffer. fullsnes ("Cartridge Header") gives `$FFD7` as `(1 SHL n)` KB, so `$07` claims 128 KB; the correct value for 64 KB is `$06`. Nothing read the field, so nothing failed — it was caught by review, not by tests.

The note records the trap alongside the fact. The reviewer offered two fixes — reword the comment, or correct the value — and the comment was *accurate* about what `$07` means, so rewording would have preserved a header that lies about the ROM. Checking the spec rather than taking the cheaper option is the transferable part.

Also updated in this retrospective, but not in this PR because it lives outside the repo (`~/.claude/skills/`), five additions to `test-driven-development`:

- exit **127**/**126** means the check never ran — neither pass nor failure; re-run it correctly (three linters returned 127 by being invoked outside the project venv)
- re-check the base branch before trusting a **passing** gate, not just a failing one (the full gate went green against a tree `origin/main` had moved 9 commits past)
- mutate the **call site**, not just the function — nine tests covered a helper exhaustively while its caller could ignore the CLI flag entirely
- measure a fixture's range along the axis under test before asserting on it (synthetic ROMs render identically every frame; the chosen Game Boy ROM is blank until frame ~60)
- a control test must use a value **no default can produce** (a control asserting "not Zero" passed whether or not the config file was ever read, because the default is already non-zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
