### PR TITLE
Fix the 6 failing doctests and add cargo test --doc to the pre-merge gate (#3175)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,6 +83,7 @@ Before merging or committing to main, the following checkpoint shall pass:
   ./scripts/test-dir.sh src/nes --skip-integration # NES changes, fast iteration
   ```
 - Run `cargo test --no-default-features --lib` to verify the full test suite passes before creating a PR
+- Run `cargo test --doc` and fix all failures. Doctests are compiled only by this command, so a doc example can rot indefinitely while still looking authoritative: six of them had been failing on main until #3175, three importing the nonexistent path `neser::cartridge` and three being ASCII register diagrams rustdoc tried to compile as Rust. Fence prose blocks as ` ```text `; never silence a real example with `ignore`/`no_run` just to make the gate pass
 - Run `cargo clippy --target wasm32-unknown-unknown --no-default-features --features wasm --all-targets -- -D warnings` and fix all findings (the host clippy run above cannot see `#[cfg(target_arch = "wasm32")]` code)
 - Run `cargo clippy --no-default-features --features frontend --all-targets -- -D warnings` and fix all findings (the `neser` binary requires only `frontend`, so this is a buildable configuration, but neither run above covers it — the host one enables `native`, and the wasm one is a different target. Three warnings sat unnoticed in that gap until #3137)
 - Run `wasm-pack test --headless --chrome --no-default-features --features wasm` and fix all warnings and ensure all tests pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,14 @@ jobs:
         # former enables `native`, the latter is a different target. Three
         # warnings sat unnoticed in that gap until #3137.
         run: cargo clippy --no-default-features --features frontend --all-targets -- -D warnings
+      - name: Run doctests
+        # Doctests are compiled only by `cargo test --doc`; the `--lib` runs in the
+        # rust-test jobs never touch them. Six had been failing on main until #3175
+        # (three importing the nonexistent path `neser::cartridge`, three ASCII
+        # register diagrams rustdoc tried to compile as Rust) because nothing ran
+        # this command. Fence prose blocks as ```text rather than silencing real
+        # examples with ignore/no_run.
+        run: cargo test --doc
       - name: Check formatting
         run: cargo fmt -- --check
 

--- a/src/nes/cartridge/common.rs
+++ b/src/nes/cartridge/common.rs
@@ -28,7 +28,7 @@
 /// ## Simple Register Set
 ///
 /// ```rust
-/// use neser::cartridge::StateSnapshot;
+/// use neser::nes::cartridge::StateSnapshot;
 ///
 /// struct ShiftRegister {
 ///     value: u8,
@@ -53,7 +53,7 @@
 /// ## Composite Register Structure
 ///
 /// ```rust
-/// use neser::cartridge::StateSnapshot;
+/// use neser::nes::cartridge::StateSnapshot;
 ///
 /// struct BankRegisters {
 ///     prg_bank: u8,
@@ -88,7 +88,7 @@
 /// ## Integration with `Mapper::registers_snapshot()`
 ///
 /// ```rust,ignore
-/// use neser::cartridge::{Mapper, StateSnapshot};
+/// use neser::nes::cartridge::{Mapper, StateSnapshot};
 ///
 /// struct MyMapper {
 ///     registers: MyRegisterSet,
@@ -138,7 +138,7 @@ pub const DEFAULT_CHR_RAM_SIZE: usize = 8192;
 ///
 /// # Example
 /// ```rust
-/// use neser::cartridge::PrgRam;
+/// use neser::nes::cartridge::PrgRam;
 ///
 /// struct MyMapper {
 ///     prg_ram: PrgRam,
@@ -390,7 +390,7 @@ impl StateSnapshot for ChrMemory {
 ///
 /// # Example
 /// ```ignore
-/// use neser::cartridge::BankedRom;
+/// use neser::nes::cartridge::BankedRom;
 ///
 /// let prg_rom = vec![0u8; 0x8000];
 /// let bank = 3usize;
@@ -495,7 +495,7 @@ impl BankedRom {
 ///
 /// # Example
 /// ```ignore
-/// use neser::cartridge::BankSwitch;
+/// use neser::nes::cartridge::BankSwitch;
 ///
 /// // PRG-ROM with 128KB (4 banks of 32KB)
 /// let prg_bank = BankSwitch::new(4);

--- a/src/nes/cartridge/unlicensed/mapper163.rs
+++ b/src/nes/cartridge/unlicensed/mapper163.rs
@@ -36,7 +36,7 @@
 //!
 //! ## PRG Banking (Mesen formula)
 //!
-//! ```
+//! ```text
 //! bank = (reg0 & 0x0F) | ((reg2 & 0x0F) << 4)
 //! ```
 //!

--- a/src/nes/cartridge/unlicensed/mapper291.rs
+++ b/src/nes/cartridge/unlicensed/mapper291.rs
@@ -12,7 +12,7 @@
 //! - PRG-RAM: None
 //!
 //! Outer Bank Register ($6000), write (mask: $E000):
-//! ```
+//! ```text
 //! 7654 3210
 //! ---------
 //! ?OM. .PP.

--- a/src/nes/cartridge/unlicensed/mapper296.rs
+++ b/src/nes/cartridge/unlicensed/mapper296.rs
@@ -12,7 +12,7 @@
 //! - Audio: Two-channel PCM expansion (not implemented; see Known Limitations)
 //!
 //! Register map:
-//! ```
+//! ```text
 //! $411D – Mapper Configuration (write)
 //! 7654 3210
 //! ---- -CMM


### PR DESCRIPTION
Closes #3175.

## What

`cargo test --doc` had **6 failures on `main`**. The command is not in the pre-merge
checklist, so nothing had been running it and the failures were free to accumulate.
This fixes all six and closes the process gap.

**Before:** `test result: FAILED. 6 passed; 6 failed; 9 ignored`
**After:** `test result: ok. 9 passed; 0 failed; 9 ignored`

The collected count drops 12 → 9 exactly as intended: the three prose blocks stop
being tests, and the three real examples start passing.

## Two independent causes

**1. ASCII register diagrams compiled as Rust (3 failures)**

Bare ` ``` ` fences in `//!` module docs, so rustdoc tried to compile them:

| File | Failed on |
| --- | --- |
| `unlicensed/mapper291.rs:15` | en-dash in `bits 2:1) – used when M=1` |
| `unlicensed/mapper296.rs:15` | en-dash in `$411D – Mapper Configuration` |
| `unlicensed/mapper163.rs:39` | `bank = (reg0 & 0x0F) \| …` — undefined identifiers |

Fenced as ` ```text `, which is what they always were. No behaviour or rendering change
beyond rustdoc no longer treating prose as code.

**2. Doc examples importing a module that does not exist (3 failures)**

`cartridge/common.rs:30`, `:55`, `:140` all used `use neser::cartridge::…`. There is no
top-level `cartridge` module — `src/lib.rs` exposes `pub mod nes;` and `cartridge` lives
under it. Repointed at `neser::nes::cartridge`.

Worth noting: they pass with **only** the path corrected, so the documented API had not
drifted — but nobody could have known that, because the examples had never compiled. This
is the same defect class as the `platform/ram_init.rs` example fixed in #3128, which had
pointed at a nonexistent `neser::console`. Two independent instances of "a doc example
that has never once been executed" is what motivated the checklist change below.

## Closing the gap

`cargo test --doc` added to:

- the pre-merge checkpoint in the project instructions, and
- CI's `rust-lint` job, so it is enforced rather than merely documented.

Both notes say to fence prose as ` ```text ` rather than silencing a real example with
`ignore`/`no_run`, since that would recreate exactly the invisible rot this fixes.

One gotcha recorded in the commit: **`CLAUDE.md` is a symlink to
`.github/copilot-instructions.md`**, not a second copy. Editing "both" duplicates the
line, and `git status` never reports `CLAUDE.md`, which makes the edit look lost. The
checklist is therefore edited once.

## Checks

`cargo test --doc` → 9 passed / 0 failed; `cargo fmt --check` clean; `clippy` clean on all
three configurations (all-features, wasm32, frontend-only); `cargo test
--no-default-features --lib` → **13012 passed / 0 failed**; `wasm-pack test --headless
--chrome` → 94 passed; `python -m unittest` → 446 passed; `ruff check` / `ruff format` /
`mypy` clean; `npm test` → 430 passed. `ci.yml` validated by parsing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
